### PR TITLE
fix: trace OpenAI WebSocket response lineage

### DIFF
--- a/src/agents/openai-ws-request.ts
+++ b/src/agents/openai-ws-request.ts
@@ -34,6 +34,31 @@ interface PlannedWsTurnInput {
 type PlannedWsRequestPayload = {
   mode: "full_context" | "incremental";
   payload: ResponseCreateEvent;
+  debug: PlannedWsRequestDebug;
+};
+
+export type WsInputItemDebugSummary = {
+  index: number;
+  type: InputItem["type"];
+  role?: string;
+  phase?: string;
+  id?: string;
+  callId?: string;
+  name?: string;
+  contentKind?: "text" | "parts";
+  contentLength?: number;
+  outputLength?: number;
+  argumentsLength?: number;
+  encryptedContentLength?: number;
+};
+
+export type PlannedWsRequestDebug = {
+  mode: "full_context" | "incremental";
+  previousResponseId?: string;
+  baselineLength: number;
+  fullInputLength: number;
+  suffixLength: number;
+  suffixItems: WsInputItemDebugSummary[];
 };
 
 function stringifyStable(value: unknown): string {
@@ -78,6 +103,67 @@ function inputItemsStartWith(input: InputItem[], baseline: InputItem[]): boolean
   return baseline.every((item, index) => stringifyStable(item) === stringifyStable(input[index]));
 }
 
+function summarizeInputItem(item: InputItem, index: number): WsInputItemDebugSummary {
+  if (item.type === "message") {
+    return {
+      index,
+      type: item.type,
+      role: item.role,
+      ...(item.phase ? { phase: item.phase } : {}),
+      contentKind: typeof item.content === "string" ? "text" : "parts",
+      contentLength: typeof item.content === "string" ? item.content.length : item.content.length,
+    };
+  }
+  if (item.type === "function_call") {
+    return {
+      index,
+      type: item.type,
+      ...(item.id ? { id: item.id } : {}),
+      ...(item.call_id ? { callId: item.call_id } : {}),
+      name: item.name,
+      argumentsLength: item.arguments.length,
+    };
+  }
+  if (item.type === "function_call_output") {
+    return {
+      index,
+      type: item.type,
+      callId: item.call_id,
+      outputLength: item.output.length,
+    };
+  }
+  if (item.type === "reasoning") {
+    return {
+      index,
+      type: item.type,
+      ...(item.id ? { id: item.id } : {}),
+      ...(item.encrypted_content ? { encryptedContentLength: item.encrypted_content.length } : {}),
+    };
+  }
+  return {
+    index,
+    type: item.type,
+    id: item.id,
+  };
+}
+
+function buildRequestDebug(params: {
+  mode: "full_context" | "incremental";
+  previousResponseId?: string | null;
+  baselineLength: number;
+  fullInputItems: InputItem[];
+  suffixItems: InputItem[];
+}): PlannedWsRequestDebug {
+  return {
+    mode: params.mode,
+    ...(params.previousResponseId ? { previousResponseId: params.previousResponseId } : {}),
+    baselineLength: params.baselineLength,
+    fullInputLength: params.fullInputItems.length,
+    suffixLength: params.suffixItems.length,
+    suffixItems: params.suffixItems.map((item, index) => summarizeInputItem(item, index)),
+  };
+}
+
 export function planOpenAIWebSocketRequestPayload(params: {
   fullPayload: ResponseCreateEvent;
   previousRequestPayload?: ResponseCreateEvent;
@@ -97,19 +183,37 @@ export function planOpenAIWebSocketRequestPayload(params: {
   ) {
     const baseline = [...previousInputItems, ...previousResponseInputItems];
     if (inputItemsStartWith(fullInputItems, baseline)) {
+      const suffixItems = fullInputItems.slice(baseline.length);
       return {
         mode: "incremental",
         payload: {
           ...params.fullPayload,
           previous_response_id: params.previousResponseId,
-          input: fullInputItems.slice(baseline.length),
+          input: suffixItems,
         },
+        debug: buildRequestDebug({
+          mode: "incremental",
+          previousResponseId: params.previousResponseId,
+          baselineLength: baseline.length,
+          fullInputItems,
+          suffixItems,
+        }),
       };
     }
   }
 
   const { previous_response_id: _previousResponseId, ...payload } = params.fullPayload;
-  return { mode: "full_context", payload };
+  return {
+    mode: "full_context",
+    payload,
+    debug: buildRequestDebug({
+      mode: "full_context",
+      previousResponseId: params.previousResponseId,
+      baselineLength: previousInputItems.length + previousResponseInputItems.length,
+      fullInputItems,
+      suffixItems: fullInputItems,
+    }),
+  };
 }
 
 export function buildOpenAIWebSocketWarmUpPayload(params: {

--- a/src/agents/openai-ws-request.ts
+++ b/src/agents/openai-ws-request.ts
@@ -54,7 +54,10 @@ export type WsInputItemDebugSummary = {
 
 export type PlannedWsRequestDebug = {
   mode: "full_context" | "incremental";
+  /** Set only when the wire payload actually carries previous_response_id (incremental mode). */
   previousResponseId?: string;
+  /** Set when previous_response_id was requested but stripped before send (full_context mode). */
+  requestedPreviousResponseIdStripped?: string;
   baselineLength: number;
   fullInputLength: number;
   suffixLength: number;
@@ -154,9 +157,19 @@ function buildRequestDebug(params: {
   fullInputItems: InputItem[];
   suffixItems: InputItem[];
 }): PlannedWsRequestDebug {
+  // In full_context mode the planner strips previous_response_id from the wire
+  // payload, so the debug record must not advertise a chain that did not go on
+  // the wire. The "requested but stripped" id is reported under a distinct
+  // field so on-call can tell "chain landed" from "chain dropped intentionally".
+  const previousResponseIdField =
+    params.mode === "incremental" && params.previousResponseId
+      ? { previousResponseId: params.previousResponseId }
+      : params.mode === "full_context" && params.previousResponseId
+        ? { requestedPreviousResponseIdStripped: params.previousResponseId }
+        : {};
   return {
     mode: params.mode,
-    ...(params.previousResponseId ? { previousResponseId: params.previousResponseId } : {}),
+    ...previousResponseIdField,
     baselineLength: params.baselineLength,
     fullInputLength: params.fullInputItems.length,
     suffixLength: params.suffixItems.length,

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -1816,6 +1816,22 @@ describe("planOpenAIWebSocketRequestPayload", () => {
     expect(plan.mode).toBe("incremental");
     expect(plan.payload.previous_response_id).toBe("resp_prev");
     expect(plan.payload.input).toEqual([{ type: "message", role: "user", content: "Next" }]);
+    expect(plan.debug).toEqual({
+      mode: "incremental",
+      previousResponseId: "resp_prev",
+      baselineLength: 2,
+      fullInputLength: 3,
+      suffixLength: 1,
+      suffixItems: [
+        {
+          index: 0,
+          type: "message",
+          role: "user",
+          contentKind: "text",
+          contentLength: 4,
+        },
+      ],
+    });
   });
 
   it("falls back to full context when non-input fields differ", () => {
@@ -1847,6 +1863,67 @@ describe("planOpenAIWebSocketRequestPayload", () => {
     expect(plan.mode).toBe("full_context");
     expect(plan.payload.previous_response_id).toBeUndefined();
     expect(plan.payload.input).toEqual(fullPayload.input);
+    expect(plan.debug).toMatchObject({
+      mode: "full_context",
+      previousResponseId: "resp_prev",
+      baselineLength: 2,
+      fullInputLength: 3,
+      suffixLength: 3,
+    });
+  });
+
+  it("records redacted suffix summaries for tool lineage debugging", () => {
+    const previousInputItems: InputItem[] = [{ type: "message", role: "user", content: "Hello" }];
+    const previousRequest: ResponseCreateEvent = {
+      type: "response.create",
+      model: "gpt-5.4",
+      input: previousInputItems,
+    };
+    const fullPayload: ResponseCreateEvent = {
+      type: "response.create",
+      model: "gpt-5.4",
+      input: [
+        ...previousInputItems,
+        {
+          type: "function_call",
+          id: "fc_1",
+          call_id: "call_1",
+          name: "lookup",
+          arguments: '{"secret":true}',
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: "tool output with private data",
+        },
+      ],
+    };
+
+    const plan = planOpenAIWebSocketRequestPayload({
+      fullPayload,
+      previousRequestPayload: previousRequest,
+      previousResponseId: "resp_prev",
+      previousResponseInputItems: [],
+    });
+
+    expect(plan.debug.suffixItems).toEqual([
+      {
+        index: 0,
+        type: "function_call",
+        id: "fc_1",
+        callId: "call_1",
+        name: "lookup",
+        argumentsLength: 15,
+      },
+      {
+        index: 1,
+        type: "function_call_output",
+        callId: "call_1",
+        outputLength: 29,
+      },
+    ]);
+    expect(JSON.stringify(plan.debug)).not.toContain("secret");
+    expect(JSON.stringify(plan.debug)).not.toContain("private data");
   });
 
   it("falls back to full context when the input is not a strict response-chain extension", () => {

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -1863,9 +1863,13 @@ describe("planOpenAIWebSocketRequestPayload", () => {
     expect(plan.mode).toBe("full_context");
     expect(plan.payload.previous_response_id).toBeUndefined();
     expect(plan.payload.input).toEqual(fullPayload.input);
+    // The wire payload strips previous_response_id in full_context mode, so
+    // the debug record must not advertise a chain that did not go on the wire.
+    // The "requested but stripped" id is reported under a distinct field.
+    expect(plan.debug.previousResponseId).toBeUndefined();
     expect(plan.debug).toMatchObject({
       mode: "full_context",
-      previousResponseId: "resp_prev",
+      requestedPreviousResponseIdStripped: "resp_prev",
       baselineLength: 2,
       fullInputLength: 3,
       suffixLength: 3,

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -58,6 +58,7 @@ import {
 import {
   buildOpenAIWebSocketResponseCreatePayload,
   planOpenAIWebSocketRequestPayload,
+  type PlannedWsRequestDebug,
 } from "./openai-ws-request.js";
 import type { ResponseCreateEvent } from "./openai-ws-types.js";
 import { log } from "./pi-embedded-runner/logger.js";
@@ -74,6 +75,85 @@ import { mergeTransportMetadata } from "./transport-stream-shared.js";
 // ─────────────────────────────────────────────────────────────────────────────
 // Per-session state
 // ─────────────────────────────────────────────────────────────────────────────
+
+type WsContextLineageDebug = {
+  contextLength: number;
+  tailRole?: string;
+  tailMessageId?: string;
+  tailParentId?: string;
+  latestUserMessageId?: string;
+};
+
+function readDebugString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function summarizeWsContextLineage(messages: ReadonlyArray<unknown>): WsContextLineageDebug {
+  const tail = messages.at(-1);
+  const tailRecord =
+    tail && typeof tail === "object" ? (tail as Record<string, unknown>) : undefined;
+  const latestUser = [...messages].reverse().find((message) => {
+    if (!message || typeof message !== "object") {
+      return false;
+    }
+    return (message as Record<string, unknown>).role === "user";
+  });
+  const latestUserRecord =
+    latestUser && typeof latestUser === "object"
+      ? (latestUser as Record<string, unknown>)
+      : undefined;
+  return {
+    contextLength: messages.length,
+    ...(readDebugString(tailRecord?.role) ? { tailRole: readDebugString(tailRecord?.role) } : {}),
+    ...(readDebugString(tailRecord?.id) ? { tailMessageId: readDebugString(tailRecord?.id) } : {}),
+    ...(readDebugString(tailRecord?.parentId)
+      ? { tailParentId: readDebugString(tailRecord?.parentId) }
+      : {}),
+    ...(readDebugString(latestUserRecord?.id)
+      ? { latestUserMessageId: readDebugString(latestUserRecord?.id) }
+      : {}),
+  };
+}
+
+function logWsRequestLineage(params: {
+  sessionId: string;
+  requestId: string;
+  debug: PlannedWsRequestDebug;
+  context: WsContextLineageDebug;
+}): void {
+  log.debug(
+    `[ws-stream] session=${params.sessionId} request=${params.requestId}: request lineage ${JSON.stringify(
+      {
+        ...params.debug,
+        ...params.context,
+      },
+    )}`,
+  );
+}
+
+function logWsCompletionLineage(params: {
+  sessionId: string;
+  requestId: string;
+  requestMode: PlannedWsRequestDebug["mode"];
+  requestedPreviousResponseId?: string;
+  acceptedResponseId: string;
+  managerPreviousResponseId?: string | null;
+  acceptedInputItemCount: number;
+  acceptedContextLength: number;
+}): void {
+  log.debug(
+    `[ws-stream] session=${params.sessionId} request=${params.requestId}: accepted response lineage ${JSON.stringify(
+      {
+        requestMode: params.requestMode,
+        requestedPreviousResponseId: params.requestedPreviousResponseId,
+        acceptedResponseId: params.acceptedResponseId,
+        managerPreviousResponseId: params.managerPreviousResponseId ?? undefined,
+        acceptedInputItemCount: params.acceptedInputItemCount,
+        acceptedContextLength: params.acceptedContextLength,
+      },
+    )}`,
+  );
+}
 
 interface WsSession {
   manager: OpenAIWebSocketManager;
@@ -939,6 +1019,13 @@ export function createOpenAIWebSocketStreamFn(
         const plannedInputItems = Array.isArray(plannedPayload.payload.input)
           ? plannedPayload.payload.input
           : [];
+        const requestLineageId = randomUUID();
+        logWsRequestLineage({
+          sessionId,
+          requestId: requestLineageId,
+          debug: plannedPayload.debug,
+          context: summarizeWsContextLineage(context.messages),
+        });
         if (plannedPayload.mode === "incremental") {
           log.debug(
             `[ws-stream] session=${sessionId}: incremental send (${plannedInputItems.length} items) previous_response_id=${plannedPayload.payload.previous_response_id}`,
@@ -1195,6 +1282,16 @@ export function createOpenAIWebSocketStreamFn(
                   api: model.api,
                   provider: model.provider,
                   id: model.id,
+                });
+                logWsCompletionLineage({
+                  sessionId,
+                  requestId: requestLineageId,
+                  requestMode: plannedPayload.debug.mode,
+                  requestedPreviousResponseId: plannedPayload.debug.previousResponseId,
+                  acceptedResponseId: event.response.id,
+                  managerPreviousResponseId: session.manager.previousResponseId,
+                  acceptedInputItemCount: session.lastResponseInputItems.length,
+                  acceptedContextLength: capturedContextLength,
                 });
                 const reason: Extract<StopReason, "stop" | "length" | "toolUse"> =
                   assistantMsg.stopReason === "toolUse" ? "toolUse" : "stop";

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -92,7 +92,7 @@ function summarizeWsContextLineage(messages: ReadonlyArray<unknown>): WsContextL
   const tail = messages.at(-1);
   const tailRecord =
     tail && typeof tail === "object" ? (tail as Record<string, unknown>) : undefined;
-  const latestUser = [...messages].reverse().find((message) => {
+  const latestUser = messages.findLast((message) => {
     if (!message || typeof message !== "object") {
       return false;
     }
@@ -135,7 +135,10 @@ function logWsCompletionLineage(params: {
   sessionId: string;
   requestId: string;
   requestMode: PlannedWsRequestDebug["mode"];
-  requestedPreviousResponseId?: string;
+  /** Set only when previous_response_id actually went on the wire (incremental). */
+  chainedPreviousResponseId?: string;
+  /** Set when previous_response_id was requested but stripped before send (full_context). */
+  requestedPreviousResponseIdStripped?: string;
   acceptedResponseId: string;
   managerPreviousResponseId?: string | null;
   acceptedInputItemCount: number;
@@ -145,7 +148,12 @@ function logWsCompletionLineage(params: {
     `[ws-stream] session=${params.sessionId} request=${params.requestId}: accepted response lineage ${JSON.stringify(
       {
         requestMode: params.requestMode,
-        requestedPreviousResponseId: params.requestedPreviousResponseId,
+        ...(params.chainedPreviousResponseId
+          ? { chainedPreviousResponseId: params.chainedPreviousResponseId }
+          : {}),
+        ...(params.requestedPreviousResponseIdStripped
+          ? { requestedPreviousResponseIdStripped: params.requestedPreviousResponseIdStripped }
+          : {}),
         acceptedResponseId: params.acceptedResponseId,
         managerPreviousResponseId: params.managerPreviousResponseId ?? undefined,
         acceptedInputItemCount: params.acceptedInputItemCount,
@@ -1287,7 +1295,15 @@ export function createOpenAIWebSocketStreamFn(
                   sessionId,
                   requestId: requestLineageId,
                   requestMode: plannedPayload.debug.mode,
-                  requestedPreviousResponseId: plannedPayload.debug.previousResponseId,
+                  ...(plannedPayload.debug.previousResponseId
+                    ? { chainedPreviousResponseId: plannedPayload.debug.previousResponseId }
+                    : {}),
+                  ...(plannedPayload.debug.requestedPreviousResponseIdStripped
+                    ? {
+                        requestedPreviousResponseIdStripped:
+                          plannedPayload.debug.requestedPreviousResponseIdStripped,
+                      }
+                    : {}),
                   acceptedResponseId: event.response.id,
                   managerPreviousResponseId: session.manager.previousResponseId,
                   acceptedInputItemCount: session.lastResponseInputItems.length,


### PR DESCRIPTION
## Summary
- Add redacted debug lineage to OpenAI WebSocket request planning: mode, `previous_response_id`, baseline/full/suffix lengths, and suffix item summaries without prompt/tool-result text.
- Log per-request lineage before send, including context tail role/message id/parent id and latest user id when those ids are present.
- Log completion lineage when a `response.completed` is accepted into the transcript, tying the generated request id to the accepted response id and replay item count.

## Why
This provides safe trajectory evidence for duplicate/stale final-answer replay investigations where the failure appears to involve the OpenAI-Codex WebSocket incremental / `previous_response_id` path.

References/ties: openclaw/openclaw#78055, openclaw/openclaw#76905, openclaw/openclaw#76888, openclaw/openclaw#77642, openclaw/openclaw#78060, openclaw/openclaw#76990, openclaw/openclaw#77445, openclaw/openclaw#67777, openclaw/openclaw#39032.

## Tests
- `node scripts/test-projects.mjs src/agents/openai-ws-stream.test.ts`
- `pnpm exec oxfmt --check src/agents/openai-ws-request.ts src/agents/openai-ws-stream.ts src/agents/openai-ws-stream.test.ts`
- `git diff --check`

## Notes
- `pnpm tsgo:test:src` was attempted, but the process was SIGKILLed in this local worktree before emitting diagnostics.
