### PR TITLE
test: guard websocket stale final turn lineage

### DIFF
--- a/src/agents/openai-ws-connection.ts
+++ b/src/agents/openai-ws-connection.ts
@@ -41,6 +41,7 @@ export interface ResponseObject {
   created_at: number;
   status: "in_progress" | "completed" | "failed" | "cancelled" | "incomplete";
   model: string;
+  metadata?: Record<string, string>;
   output: OutputItem[];
   usage?: UsageInfo;
   error?: { code: string; message: string };

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -3072,6 +3072,91 @@ describe("createOpenAIWebSocketStreamFn", () => {
     expect(sent2.input).toEqual([{ type: "message", role: "user", content: "What can you do?" }]);
   });
 
+  it("ignores stale completed events from a previous websocket turn when metadata proves the lineage mismatch", async () => {
+    const sessionId = "sess-stale-final-lineage";
+    const streamFn = createOpenAIWebSocketStreamFn("sk-test", sessionId);
+
+    const ctx1 = {
+      systemPrompt: "You are helpful.",
+      messages: [userMsg("Question A")] as Parameters<typeof convertMessagesToInputItems>[0],
+      tools: [],
+    };
+
+    const stream1 = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      ctx1 as Parameters<typeof streamFn>[1],
+    );
+    const done1 = (async () => {
+      for await (const _ of await resolveStream(stream1)) {
+        /* consume */
+      }
+    })();
+
+    await new Promise((r) => setImmediate(r));
+    const manager = MockManager.lastInstance!;
+    const sent1 = manager.sentEvents[0] as { metadata?: Record<string, string> };
+    const turn1Response = {
+      ...makeResponseObject("resp_turn_a", "Answer A"),
+      metadata: sent1.metadata,
+    };
+    manager.simulateEvent({ type: "response.completed", response: turn1Response });
+    await done1;
+
+    const ctx2 = {
+      systemPrompt: "You are helpful.",
+      messages: [
+        userMsg("Question A"),
+        buildAssistantMessageFromResponse(turn1Response, modelStub),
+        userMsg("Question B: use the tool, then answer B"),
+      ] as Parameters<typeof convertMessagesToInputItems>[0],
+      tools: [],
+    };
+
+    const stream2 = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      ctx2 as Parameters<typeof streamFn>[1],
+    );
+    const events2: Array<{ type?: string; message?: { content?: Array<{ text?: string }> } }> = [];
+    const done2 = (async () => {
+      for await (const ev of await resolveStream(stream2)) {
+        events2.push(ev as { type?: string; message?: { content?: Array<{ text?: string }> } });
+      }
+    })();
+
+    await new Promise((r) => setImmediate(r));
+    const sent2 = manager.sentEvents[1] as {
+      metadata?: Record<string, string>;
+      previous_response_id?: string;
+      input?: Array<{ type: string; role?: string; content?: unknown }>;
+    };
+    expect(sent2.previous_response_id).toBe("resp_turn_a");
+    expect(sent2.input).toEqual([
+      { type: "message", role: "user", content: "Question B: use the tool, then answer B" },
+    ]);
+
+    manager.simulateEvent({
+      type: "response.completed",
+      response: {
+        ...makeResponseObject("resp_stale_replay", "Answer A"),
+        metadata: sent1.metadata,
+      },
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(events2.some((event) => event.type === "done")).toBe(false);
+
+    manager.simulateEvent({
+      type: "response.completed",
+      response: {
+        ...makeResponseObject("resp_turn_b", "Answer B after tool work"),
+        metadata: sent2.metadata,
+      },
+    });
+    await done2;
+
+    const doneEvent = events2.find((event) => event.type === "done");
+    expect(doneEvent?.message?.content?.[0]?.text).toBe("Answer B after tool work");
+  });
+
   it("uses an empty incremental payload when replay context exactly matches the response chain", async () => {
     const sessionId = "sess-full-context-replay";
     const streamFn = createOpenAIWebSocketStreamFn("sk-test", sessionId);

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -3157,6 +3157,159 @@ describe("createOpenAIWebSocketStreamFn", () => {
     expect(doneEvent?.message?.content?.[0]?.text).toBe("Answer B after tool work");
   });
 
+  it("preserves active turn text deltas when a stale completed event arrives between deltas", async () => {
+    const sessionId = "sess-stale-final-interleaved";
+    const streamFn = createOpenAIWebSocketStreamFn("sk-test", sessionId);
+
+    const ctx1 = {
+      systemPrompt: "You are helpful.",
+      messages: [userMsg("Question A")] as Parameters<typeof convertMessagesToInputItems>[0],
+      tools: [],
+    };
+
+    const stream1 = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      ctx1 as Parameters<typeof streamFn>[1],
+    );
+    const done1 = (async () => {
+      for await (const _ of await resolveStream(stream1)) {
+        /* consume */
+      }
+    })();
+
+    await new Promise((r) => setImmediate(r));
+    const manager = MockManager.lastInstance!;
+    const sent1 = manager.sentEvents[0] as { metadata?: Record<string, string> };
+    const turn1Response = {
+      ...makeResponseObject("resp_turn_a", "Answer A"),
+      metadata: sent1.metadata,
+    };
+    manager.simulateEvent({ type: "response.completed", response: turn1Response });
+    await done1;
+
+    const ctx2 = {
+      systemPrompt: "You are helpful.",
+      messages: [
+        userMsg("Question A"),
+        buildAssistantMessageFromResponse(turn1Response, modelStub),
+        userMsg("Question B"),
+      ] as Parameters<typeof convertMessagesToInputItems>[0],
+      tools: [],
+    };
+
+    const stream2 = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      ctx2 as Parameters<typeof streamFn>[1],
+    );
+    type CapturedEvent = {
+      type?: string;
+      delta?: string;
+      message?: { content?: Array<{ text?: string }> };
+    };
+    const events2: CapturedEvent[] = [];
+    const done2 = (async () => {
+      for await (const ev of await resolveStream(stream2)) {
+        events2.push(ev as CapturedEvent);
+      }
+    })();
+
+    await new Promise((r) => setImmediate(r));
+    const sent2 = manager.sentEvents[1] as { metadata?: Record<string, string> };
+
+    // Turn B starts streaming output deltas for the active answer.
+    manager.simulateEvent({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: {
+        type: "message",
+        id: "item_b",
+        role: "assistant",
+        phase: "final_answer",
+        content: [],
+      },
+    });
+    manager.simulateEvent({
+      type: "response.output_text.delta",
+      item_id: "item_b",
+      output_index: 0,
+      content_index: 0,
+      delta: "Hello ",
+    });
+    manager.simulateEvent({
+      type: "response.output_text.delta",
+      item_id: "item_b",
+      output_index: 0,
+      content_index: 0,
+      delta: "world",
+    });
+
+    // Stale response.completed for turn A arrives mid-stream. The handler must
+    // ignore it WITHOUT clearing the active turn-B output buffers; otherwise a
+    // subsequent delta would either be silently dropped (phase metadata gone)
+    // or duplicate previously emitted text (emitted-text tracker gone).
+    manager.simulateEvent({
+      type: "response.completed",
+      response: {
+        ...makeResponseObject("resp_stale_replay", "Answer A"),
+        metadata: sent1.metadata,
+      },
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(events2.some((event) => event.type === "done")).toBe(false);
+
+    // Another delta arrives after the stale event. It must still be emitted to
+    // the consumer with the correct accumulated full text — proving phase and
+    // emitted-text state survived the stale ignore.
+    manager.simulateEvent({
+      type: "response.output_text.delta",
+      item_id: "item_b",
+      output_index: 0,
+      content_index: 0,
+      delta: "!",
+    });
+    await new Promise((r) => setImmediate(r));
+
+    manager.simulateEvent({
+      type: "response.output_text.done",
+      item_id: "item_b",
+      output_index: 0,
+      content_index: 0,
+      text: "Hello world!",
+    });
+    manager.simulateEvent({
+      type: "response.completed",
+      response: {
+        id: "resp_turn_b",
+        object: "response",
+        created_at: Date.now(),
+        status: "completed",
+        model: "gpt-5.4",
+        output: [
+          {
+            type: "message",
+            id: "item_b",
+            role: "assistant",
+            phase: "final_answer",
+            content: [{ type: "output_text", text: "Hello world!" }],
+          },
+        ],
+        usage: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
+        metadata: sent2.metadata,
+      },
+    });
+    await done2;
+
+    const textDeltas = events2
+      .filter((event) => event.type === "text_delta")
+      .map((event) => event.delta ?? "");
+    // Each delta from the active turn must reach the consumer exactly once and
+    // in order — no drops, no duplicates.
+    expect(textDeltas).toEqual(["Hello ", "world", "!"]);
+
+    const doneEvent = events2.find((event) => event.type === "done");
+    expect(doneEvent?.message?.content?.[0]?.text).toBe("Hello world!");
+  });
+
   it("uses an empty incremental payload when replay context exactly matches the response chain", async () => {
     const sessionId = "sess-full-context-replay";
     const streamFn = createOpenAIWebSocketStreamFn("sk-test", sessionId);

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -553,6 +553,15 @@ function resolveProviderTransportTurnState(
   );
 }
 
+function responseMatchesCurrentWsTurn(params: {
+  response: { metadata?: Record<string, string> | null };
+  requestPayload: { metadata?: Record<string, string> };
+}): boolean {
+  const expectedTurnId = params.requestPayload.metadata?.openclaw_turn_id;
+  const actualTurnId = params.response.metadata?.openclaw_turn_id;
+  return !expectedTurnId || !actualTurnId || actualTurnId === expectedTurnId;
+}
+
 function resolveWebSocketSessionPolicy(
   model: Parameters<StreamFn>[0],
   sessionId: string,
@@ -1179,6 +1188,20 @@ export function createOpenAIWebSocketStreamFn(
               }
 
               if (event.type === "response.completed") {
+                if (
+                  !responseMatchesCurrentWsTurn({
+                    response: event.response,
+                    requestPayload,
+                  })
+                ) {
+                  log.warn(
+                    `[ws-stream] session=${sessionId}: ignored response.completed for stale turn metadata response_id=${event.response.id}`,
+                  );
+                  outputItemPhaseById.clear();
+                  outputTextByPart.clear();
+                  emittedTextByPart.clear();
+                  return;
+                }
                 outputItemPhaseById.clear();
                 outputTextByPart.clear();
                 emittedTextByPart.clear();
@@ -1201,6 +1224,20 @@ export function createOpenAIWebSocketStreamFn(
                 eventStream.push({ type: "done", reason, message: assistantMsg });
                 resolve();
               } else if (event.type === "response.failed") {
+                if (
+                  !responseMatchesCurrentWsTurn({
+                    response: event.response,
+                    requestPayload,
+                  })
+                ) {
+                  log.warn(
+                    `[ws-stream] session=${sessionId}: ignored response.failed for stale turn metadata response_id=${event.response.id}`,
+                  );
+                  outputItemPhaseById.clear();
+                  outputTextByPart.clear();
+                  emittedTextByPart.clear();
+                  return;
+                }
                 outputItemPhaseById.clear();
                 outputTextByPart.clear();
                 emittedTextByPart.clear();

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -1197,9 +1197,6 @@ export function createOpenAIWebSocketStreamFn(
                   log.warn(
                     `[ws-stream] session=${sessionId}: ignored response.completed for stale turn metadata response_id=${event.response.id}`,
                   );
-                  outputItemPhaseById.clear();
-                  outputTextByPart.clear();
-                  emittedTextByPart.clear();
                   return;
                 }
                 outputItemPhaseById.clear();
@@ -1233,9 +1230,6 @@ export function createOpenAIWebSocketStreamFn(
                   log.warn(
                     `[ws-stream] session=${sessionId}: ignored response.failed for stale turn metadata response_id=${event.response.id}`,
                   );
-                  outputItemPhaseById.clear();
-                  outputTextByPart.clear();
-                  emittedTextByPart.clear();
                   return;
                 }
                 outputItemPhaseById.clear();


### PR DESCRIPTION
## Summary
- add a regression/protective test for the #78055 stale-final replay shape: final answer A completes, user asks B, WS sends an incremental B suffix, then a stale `response.completed` carrying turn A metadata arrives before the real turn B completion
- add lineage validation for OpenAI WS terminal events when native OpenAI turn metadata is echoed, ignoring stale `response.completed` / `response.failed` events instead of finalizing the active turn
- type `ResponseObject.metadata` so tests and runtime can inspect echoed Responses metadata

## Why
This ties directly to #78055 and the duplicate/stale final-answer after tool-chain report. It also overlaps the incremental / previous_response_id surfaces discussed around #76905, #76888, #77642, #78060, and the broader runtime/finalization issues in #76990 / #77445.

## Verification
- `./node_modules/.bin/tsc --noEmit --pretty false --project tsconfig.core.projects.json` ✅
- `vitest run src/agents/openai-ws-stream.test.ts -t "stale completed" --maxWorkers=1 --no-fileParallelism --reporter=dot` started, the targeted test emitted a passing dot, but the local process was SIGKILLed afterward on this Mac with `/System/Volumes/Data` at 100% / ~121MiB free. Treat full test run as not completed locally.

Fixes #78055.
Refs #76905, #76888, #77642, #78060, #76990, #77445.
