### PR TITLE
fix: explain max-turn run stops

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -2236,6 +2236,8 @@ export async function runEmbeddedPiAgent(
             config: params.config,
             isCronTrigger: params.trigger === "cron",
             sessionKey: params.sessionKey ?? params.sessionId,
+            sessionId: params.sessionId,
+            runId: params.runId,
             provider: activeErrorContext.provider,
             model: activeErrorContext.model,
             verboseLevel: params.verboseLevel,

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -69,6 +69,26 @@ describe("buildEmbeddedRunPayloads", () => {
     });
   }
 
+  it("replaces max-turn sentinel with actionable run context", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["[max turns exceeded]"],
+      sessionKey: "agent:main:telegram:direct:u123",
+      sessionId: "sess-123",
+      runId: "run-456",
+      provider: "openai-codex",
+      model: "gpt-5.5",
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toContain("Run stopped: max turns exceeded.");
+    expect(payloads[0]?.text).toContain("Session: agent:main:telegram:direct:u123.");
+    expect(payloads[0]?.text).toContain("Session ID: sess-123.");
+    expect(payloads[0]?.text).toContain("Run: run-456.");
+    expect(payloads[0]?.text).toContain("Model: openai-codex/gpt-5.5.");
+    expect(payloads[0]?.text).toContain("Recovery: inspect the session transcript/logs");
+    expect(payloads[0]?.text).not.toBe("[max turns exceeded]");
+  });
+
   it("suppresses raw API error JSON when the assistant errored", () => {
     const payloads = buildPayloads({
       assistantTexts: [errorJson],

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -112,6 +112,33 @@ function resolveRawAssistantAnswerText(lastAssistant: AssistantMessage | undefin
   );
 }
 
+const MAX_TURNS_EXCEEDED_SENTINEL_RE = /^\[\s*max\s+turns\s+exceeded\s*\]$/iu;
+
+function isMaxTurnsExceededSentinel(text: string): boolean {
+  return MAX_TURNS_EXCEEDED_SENTINEL_RE.test(text.trim());
+}
+
+function formatMaxTurnsExceededDiagnostic(params: {
+  sessionKey: string;
+  sessionId?: string;
+  runId?: string;
+  provider?: string;
+  model?: string;
+}): string {
+  const lines = [
+    "Run stopped: max turns exceeded.",
+    `Session: ${params.sessionKey}.`,
+    params.sessionId && params.sessionId !== params.sessionKey
+      ? `Session ID: ${params.sessionId}.`
+      : undefined,
+    params.runId ? `Run: ${params.runId}.` : undefined,
+    params.provider && params.model ? `Model: ${params.provider}/${params.model}.` : undefined,
+    "State: the runtime guard aborted this turn; no new background work is implied by this message.",
+    "Recovery: inspect the session transcript/logs, then retry with a narrower task or a higher turn budget if configured.",
+  ];
+  return lines.filter((line): line is string => Boolean(line)).join("\n");
+}
+
 function shouldIncludeToolErrorDetails(params: {
   lastToolError: ToolErrorSummary;
   isCronTrigger?: boolean;
@@ -178,6 +205,8 @@ export function buildEmbeddedRunPayloads(params: {
   config?: OpenClawConfig;
   isCronTrigger?: boolean;
   sessionKey: string;
+  sessionId?: string;
+  runId?: string;
   provider?: string;
   model?: string;
   verboseLevel?: VerboseLevel;
@@ -362,16 +391,29 @@ export function buildEmbeddedRunPayloads(params: {
         normalizedAssistantTexts.length > 0 &&
         normalizedAssistantTexts === normalizedRawAnswerText));
   const hasAssistantTextPayload = nonEmptyAssistantTexts.length > 0;
-  const answerTexts = suppressAssistantArtifacts
+  const rawAnswerTexts = suppressAssistantArtifacts
     ? []
-    : (shouldPreferRawAnswerText && fallbackRawAnswerText
-        ? [fallbackRawAnswerText]
-        : hasAssistantTextPayload
-          ? nonEmptyAssistantTexts
-          : fallbackAnswerText
-            ? [fallbackAnswerText]
-            : []
-      ).filter((text) => !shouldSuppressRawErrorText(text));
+    : shouldPreferRawAnswerText && fallbackRawAnswerText
+      ? [fallbackRawAnswerText]
+      : hasAssistantTextPayload
+        ? nonEmptyAssistantTexts
+        : fallbackAnswerText
+          ? [fallbackAnswerText]
+          : [];
+  const hasMaxTurnsExceededSentinel = rawAnswerTexts.some(isMaxTurnsExceededSentinel);
+  const answerTexts = (
+    hasMaxTurnsExceededSentinel
+      ? [
+          formatMaxTurnsExceededDiagnostic({
+            sessionKey: params.sessionKey,
+            sessionId: params.sessionId,
+            runId: params.runId,
+            provider: params.provider,
+            model: params.model,
+          }),
+        ]
+      : rawAnswerTexts
+  ).filter((text) => !shouldSuppressRawErrorText(text));
 
   let hasUserFacingAssistantReply = false;
   const hasUserFacingErrorReply = replyItems.some((item) => item.isError === true);


### PR DESCRIPTION
Fixes #78145.

## Summary
- replace raw `[max turns exceeded]` sentinel with an actionable diagnostic
- include session, session id, run id, provider/model context when available
- pass session/run identifiers into embedded payload construction

## Tests
- PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/run/payloads.errors.test.ts
- git diff --check origin/main...HEAD
- PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs
