### PR TITLE
fix: discover generation providers with active registry

### DIFF
--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -430,6 +430,66 @@ describe("resolvePluginCapabilityProviders", () => {
     expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith();
   });
 
+  it("cold-loads enabled image generation providers when another image provider is active", () => {
+    const active = createEmptyPluginRegistry();
+    active.imageGenerationProviders.push({
+      pluginId: "xai",
+      pluginName: "xai",
+      source: "test",
+      provider: {
+        id: "xai",
+        label: "xAI",
+        isConfigured: () => true,
+        generate: async () => ({
+          kind: "image",
+          images: [],
+        }),
+      },
+    } as never);
+    const loaded = createEmptyPluginRegistry();
+    loaded.imageGenerationProviders.push({
+      pluginId: "fal",
+      pluginName: "fal",
+      source: "test",
+      provider: {
+        id: "fal",
+        label: "fal",
+        isConfigured: () => true,
+        generate: async () => ({
+          kind: "image",
+          images: [],
+        }),
+      },
+    } as never);
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "fal",
+          origin: "bundled",
+          contracts: { imageGenerationProviders: ["fal"] },
+        },
+        {
+          id: "xai",
+          origin: "bundled",
+          contracts: { imageGenerationProviders: ["xai"] },
+        },
+      ],
+      diagnostics: [],
+    });
+    mocks.resolveRuntimePluginRegistry.mockImplementation((options?: unknown) =>
+      options ? loaded : active,
+    );
+
+    expectResolvedCapabilityProviderIds(
+      resolvePluginCapabilityProviders({
+        key: "imageGenerationProviders",
+        cfg: { plugins: { allow: ["fal", "xai"] } } as OpenClawConfig,
+      }),
+      ["xai", "fal"],
+    );
+    expectActiveRegistryLookup(["fal", "xai"]);
+  });
+
   it("targets enabled external capability plugins without bundled fallback capture", () => {
     const loaded = createEmptyPluginRegistry();
     loaded.imageGenerationProviders.push({

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -340,6 +340,15 @@ function collectRequestedCapabilityProviderIds(params: {
   }
 }
 
+function shouldActiveRegistryShortCircuit(key: CapabilityProviderRegistryKey): boolean {
+  return (
+    key !== "memoryEmbeddingProviders" &&
+    key !== "imageGenerationProviders" &&
+    key !== "videoGenerationProviders" &&
+    key !== "musicGenerationProviders"
+  );
+}
+
 function removeActiveProviderIds(requested: Set<string>, entries: readonly unknown[]): void {
   for (const entry of entries as Array<{ provider: { id?: unknown; aliases?: unknown } }>) {
     const provider = entry.provider as { id?: unknown; aliases?: unknown };
@@ -545,7 +554,7 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
     activeProviders.length > 0
       ? collectRequestedCapabilityProviderIds({ key: params.key, cfg: params.cfg })
       : undefined;
-  if (activeProviders.length > 0 && params.key !== "memoryEmbeddingProviders") {
+  if (activeProviders.length > 0 && shouldActiveRegistryShortCircuit(params.key)) {
     if (!missingRequestedProviders) {
       return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
     }
@@ -590,10 +599,10 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
   });
   if (params.key !== "memoryEmbeddingProviders") {
     const mergeLoadedProviders =
-      activeProviders.length > 0
+      activeProviders.length > 0 && missingRequestedProviders
         ? filterLoadedProvidersForRequestedConfig({
             key: params.key,
-            requested: missingRequestedProviders ?? new Set(),
+            requested: missingRequestedProviders,
             entries: loadedProviders,
           })
         : loadedProviders;


### PR DESCRIPTION
Fixes #78141.

## Summary
- keep image/video/music generation provider list resolution from short-circuiting on the active plugin registry
- merge active generation providers with manifest-scoped loaded providers so an active provider like xai does not hide allowlisted bundled fal
- add a regression test for active xai plus allowlisted fal resolving both providers

## Tests
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm test src/plugins/capability-provider-runtime.test.ts`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm test src/plugins/capability-provider-runtime.test.ts src/image-generation/provider-registry.test.ts src/agents/tools/image-generate-tool.test.ts`
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm exec oxfmt --check src/plugins/capability-provider-runtime.ts src/plugins/capability-provider-runtime.test.ts`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs`
