### PR TITLE
[AI-assisted] fix(cron): surface nested lane timeout result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,7 @@ Docs: https://docs.openclaw.ai
 - QQBot/Skills: translate QQBot skill descriptions surfaced in the Skills UI so English-language users no longer see Chinese metadata. Fixes #77810. Thanks @eabase.
 - Image generation: include enabled generation providers such as fal in provider discovery even when another image provider is already active. Fixes #78141. Thanks @leoge007.
 - Slack: keep Socket Mode's native reconnect enabled so transient ping/pong misses can recover without forcing a full provider rebuild. Fixes #77933. Thanks @bmoran1022 and @brokemac79.
+- Cron: preserve cron timeout results when an isolated agent turn's `cron-nested` lane watchdog fires, preventing internal command-lane or model-fallback timeout text from being persisted. Fixes #77703. (#78168) Thanks @brokemac79 and @transxtech.
 - PR triage: mark external pull requests with `proof: supplied` when Barnacle finds structured real behavior proof, keep stale negative proof labels in sync across CRLF-edited PR bodies, and let ClawSweeper own the stronger `proof: sufficient` judgement.
 - ACPX/Codex: preserve trusted Codex project declarations when launching isolated Codex ACP sessions, avoiding interactive trust prompts in headless runs. Thanks @Stedyclaw.
 - ACPX/Codex: reap stale OpenClaw-owned ACPX/Codex ACP process trees on startup and after ACP session close, preventing orphaned harness processes from slowing the Gateway. Thanks @91wan.

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -9,6 +9,7 @@ import {
   setCurrentPluginMetadataSnapshot,
 } from "../plugins/current-plugin-metadata-snapshot.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { CommandLaneTaskTimeoutError } from "../process/command-queue.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { FailoverError } from "./failover-error.js";
@@ -542,6 +543,22 @@ describe("runWithModelFallback", () => {
     expect(result.attempts).toHaveLength(1);
     expect(result.attempts[0].error).toBe("bad request");
     expect(result.attempts[0].reason).toBe("unknown");
+  });
+
+  it("does not treat command-lane watchdog timeouts as model fallback failures", async () => {
+    const cfg = makeCfg();
+    const timeoutError = new CommandLaneTaskTimeoutError("cron-nested", 330_000);
+    const run = vi.fn().mockRejectedValue(timeoutError);
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        run,
+      }),
+    ).rejects.toBe(timeoutError);
+    expect(run).toHaveBeenCalledTimes(1);
   });
 
   it("keeps raw provider schema errors in fallback summaries", async () => {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitFailoverEvent } from "../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { isCommandLaneTaskTimeoutError } from "../process/command-queue.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { sanitizeForLog } from "../terminal/ansi.js";
@@ -223,6 +224,9 @@ async function runFallbackCandidate<T>(params: {
       result,
     };
   } catch (err) {
+    if (isCommandLaneTaskTimeoutError(err)) {
+      throw err;
+    }
     // Normalize abort-wrapped rate-limit errors (e.g. Google Vertex RESOURCE_EXHAUSTED)
     // so they become FailoverErrors and continue the fallback loop instead of aborting.
     const normalizedFailover = coerceToFailoverError(err, {

--- a/src/cron/isolated-agent/run.meta-error-status.test.ts
+++ b/src/cron/isolated-agent/run.meta-error-status.test.ts
@@ -65,4 +65,23 @@ describe("runCronIsolatedAgentTurn - meta.error status propagation", () => {
     expect(result.error).not.toContain("CommandLaneTaskTimeoutError");
     expect(result.error).not.toContain("cron-nested");
   });
+
+  it("keeps cron timeout result when executor rejects after the cron abort signal fires", async () => {
+    const abortController = new AbortController();
+    abortController.abort("cron: job execution timed out (last phase: model_call_started)");
+    runWithModelFallbackMock.mockRejectedValueOnce(
+      new Error(
+        'All models failed (2): openai-codex/gpt-5.5: Command lane "cron-nested" task timed out after 330000ms (timeout)',
+      ),
+    );
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({ abortSignal: abortController.signal }),
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toBe("cron: job execution timed out (last phase: model_call_started)");
+    expect(result.error).not.toContain("All models failed");
+    expect(result.error).not.toContain("cron-nested");
+  });
 });

--- a/src/cron/isolated-agent/run.meta-error-status.test.ts
+++ b/src/cron/isolated-agent/run.meta-error-status.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { CommandLaneTaskTimeoutError } from "../../process/command-queue.js";
 import {
   makeIsolatedAgentTurnParams,
   setupRunCronIsolatedAgentTurnSuite,
@@ -50,5 +51,18 @@ describe("runCronIsolatedAgentTurn - meta.error status propagation", () => {
     expect(result.status).toBe("error");
     expect(result.error).toBe("cron isolated run failed: retry limit exceeded");
     expect(result.outputText).toBe("cron isolated run failed: retry limit exceeded");
+  });
+
+  it("surfaces cron timeout result when the cron-nested lane watchdog fires", async () => {
+    runWithModelFallbackMock.mockRejectedValueOnce(
+      new CommandLaneTaskTimeoutError("cron-nested", 330_000),
+    );
+
+    const result = await runCronIsolatedAgentTurn(makeIsolatedAgentTurnParams());
+
+    expect(result.status).toBe("error");
+    expect(result.error).toBe("cron: job execution timed out");
+    expect(result.error).not.toContain("CommandLaneTaskTimeoutError");
+    expect(result.error).not.toContain("cron-nested");
   });
 });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -9,6 +9,8 @@ import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
+import { CommandLaneTaskTimeoutError } from "../../process/command-queue.js";
+import { CommandLane } from "../../process/lanes.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { resolveCronDeliveryPlan, type CronDeliveryPlan } from "../delivery-plan.js";
@@ -131,6 +133,16 @@ function hasConfiguredAuthProfiles(cfg: OpenClawConfig): boolean {
 
 function resolveNonNegativeNumber(value: number | undefined): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function isCronNestedLaneTaskTimeoutError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  return (
+    (err instanceof CommandLaneTaskTimeoutError || err.name === "CommandLaneTaskTimeoutError") &&
+    err.message.includes(`Command lane "${CommandLane.CronNested}" task timed out`)
+  );
 }
 
 async function retireRolledCronSessionMcpRuntime(params: {
@@ -1154,10 +1166,15 @@ export async function runCronIsolatedAgentTurn(params: {
       isAborted,
     });
   } catch (err) {
+    const isCronLaneTimeout = isCronNestedLaneTaskTimeoutError(err);
+    const error = isCronLaneTimeout ? abortReason() : String(err);
     return prepared.context.withRunSession({
       status: "error",
-      error: String(err),
-      diagnostics: createCronRunDiagnosticsFromError("agent-run", err),
+      error,
+      diagnostics: createCronRunDiagnosticsFromError(
+        isCronLaneTimeout ? "cron-setup" : "agent-run",
+        isCronLaneTimeout ? error : err,
+      ),
     });
   }
 }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -9,7 +9,7 @@ import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
-import { CommandLaneTaskTimeoutError } from "../../process/command-queue.js";
+import { isCommandLaneTaskTimeoutError } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
@@ -136,13 +136,7 @@ function resolveNonNegativeNumber(value: number | undefined): number | undefined
 }
 
 function isCronNestedLaneTaskTimeoutError(err: unknown): boolean {
-  if (!(err instanceof Error)) {
-    return false;
-  }
-  return (
-    (err instanceof CommandLaneTaskTimeoutError || err.name === "CommandLaneTaskTimeoutError") &&
-    err.message.includes(`Command lane "${CommandLane.CronNested}" task timed out`)
-  );
+  return isCommandLaneTaskTimeoutError(err, CommandLane.CronNested);
 }
 
 async function retireRolledCronSessionMcpRuntime(params: {
@@ -1166,7 +1160,7 @@ export async function runCronIsolatedAgentTurn(params: {
       isAborted,
     });
   } catch (err) {
-    const isCronLaneTimeout = isCronNestedLaneTaskTimeoutError(err);
+    const isCronLaneTimeout = isAborted() || isCronNestedLaneTaskTimeoutError(err);
     const error = isCronLaneTimeout ? abortReason() : String(err);
     return prepared.context.withRunSession({
       status: "error",

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -30,6 +30,16 @@ export class CommandLaneTaskTimeoutError extends Error {
   }
 }
 
+export function isCommandLaneTaskTimeoutError(err: unknown, lane?: string): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  if (!(err instanceof CommandLaneTaskTimeoutError || err.name === "CommandLaneTaskTimeoutError")) {
+    return false;
+  }
+  return lane === undefined || err.message.includes(`Command lane "${lane}" task timed out`);
+}
+
 /**
  * Dedicated error type thrown when a new command is rejected because the
  * gateway is currently draining for restart.


### PR DESCRIPTION
## Summary

Fixes #77703 by preserving cron-owned timeout reporting when the nested command-lane watchdog wins the race. The run result now records cron's existing timeout message and diagnostics instead of leaking `Command lane "cron-nested" task timed out...` or `All models failed...` text.

## Root Cause

The isolated cron runner already has a cron-owned abort reason, but the nested command queue can reject first with `CommandLaneTaskTimeoutError`. That error then passed through model fallback, where generic timeout coercion could treat it as a model/provider failure and wrap it in fallback summary text before cron persisted the result.

## Changes

- Add a shared command-lane timeout detector in `src/process/command-queue.ts`.
- Make `runWithModelFallback` rethrow command-lane watchdog timeouts instead of classifying them as model fallback failures.
- Make the isolated cron catch path map raw `cron-nested` lane timeouts, and already-aborted cron signals, back to the cron timeout result.
- Add regression coverage for fallback bypass and cron timeout preservation.
- Add the changelog note for #78168.

## Validation

- `pnpm test src/agents/model-fallback.test.ts src/process/command-queue.test.ts src/cron/isolated-agent/run.meta-error-status.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/process/command-queue.ts src/agents/model-fallback.ts src/agents/model-fallback.test.ts src/cron/isolated-agent/run.ts src/cron/isolated-agent/run.meta-error-status.test.ts CHANGELOG.md`
- `pnpm lint:extensions:bundled`
- `env -u OPENCLAW_TESTBOX -u OPENCLAW_TESTBOX_REMOTE_RUN -u OPENCLAW_TESTBOX_ID pnpm check:changed`
- `git diff --check`

## Real Behavior Proof

Behavior addressed: An isolated cron agent turn that hits the nested command-lane watchdog now keeps timeout ownership with cron instead of surfacing internal queue or model fallback failure text.

Real environment tested: macOS local OpenClaw checkout on Node 22, branch `fix-cron-lane-timeout-result`, rebased onto `origin/main` at `64370ba2ef`.

Exact steps or command run after this patch: Ran this production-code probe from the repo root with `node --import tsx -e 'import { runWithModelFallback } from "./src/agents/model-fallback.ts"; import { CommandLaneTaskTimeoutError } from "./src/process/command-queue.ts"; let calls = 0; try { await runWithModelFallback({ cfg: undefined, provider: "openai", model: "gpt-5.5", fallbacksOverride: ["anthropic/claude-sonnet-4-6"], run: async () => { calls += 1; throw new CommandLaneTaskTimeoutError("cron-nested", 330000); } }); } catch (err) { console.log(JSON.stringify({ name: err?.name, message: err?.message, calls, preserved: err instanceof CommandLaneTaskTimeoutError })); }'`.

Evidence after fix: Terminal output from the local OpenClaw checkout:

```text
{"name":"CommandLaneTaskTimeoutError","message":"Command lane \"cron-nested\" task timed out after 330000ms","calls":1,"preserved":true}
```

Observed result after fix: The production `runWithModelFallback` path rethrew the command-lane watchdog error directly, called the runner once, and did not execute the configured fallback candidate. The cron regression then verifies this raw preserved error maps back to `cron: job execution timed out` without persisting `All models failed` or `cron-nested` text.

What was not tested: I did not run a live WhatsApp daily prospecting cron job against a real model provider.
