### PR TITLE
fix: guard corrupt session model overrides

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -241,6 +241,8 @@ vi.mock("../sessions/level-overrides.js", () => ({
 
 vi.mock("../sessions/model-overrides.js", () => ({
   applyModelOverrideToSessionEntry: () => ({ updated: false }),
+  shouldClearStoredModelOverride: (params: { allowAnyModel: boolean; modelAllowed: boolean }) =>
+    !params.allowAnyModel && !params.modelAllowed,
 }));
 
 vi.mock("../sessions/send-policy.js", () => ({

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -24,7 +24,10 @@ import {
 } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { applyVerboseOverride } from "../sessions/level-overrides.js";
-import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
+import {
+  applyModelOverrideToSessionEntry,
+  shouldClearStoredModelOverride,
+} from "../sessions/model-overrides.js";
 import { resolveSendPolicy } from "../sessions/send-policy.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
@@ -774,10 +777,18 @@ async function agentCommandInternal(
       if (overrideModel) {
         const normalizedOverride = normalizeModelRef(overrideProvider, overrideModel);
         const key = modelKey(normalizedOverride.provider, normalizedOverride.model);
-        if (!allowAnyModel && !allowedModelKeys.has(key)) {
+        if (
+          shouldClearStoredModelOverride({
+            cfg,
+            provider: normalizedOverride.provider,
+            modelAllowed: allowedModelKeys.has(key),
+            allowAnyModel,
+          })
+        ) {
           const { updated } = applyModelOverrideToSessionEntry({
             entry,
             selection: { provider: defaultProvider, model: defaultModel, isDefault: true },
+            cfg,
           });
           if (updated) {
             await persistSessionEntry({

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -543,6 +543,28 @@ describe("gateway sessions patch", () => {
     expectPatchError(result, "invalid groupActivation");
   });
 
+  test("rejects session model overrides for unconfigured split providers", async () => {
+    const result = await runPatch({
+      cfg: {
+        agents: {
+          defaults: { model: { primary: "openrouter/anthropic/claude-haiku-4.5" } },
+        },
+        models: {
+          providers: {
+            openrouter: { baseUrl: "https://openrouter.ai/api/v1", models: [] },
+          },
+        },
+      } as OpenClawConfig,
+      patch: { key: MAIN_SESSION_KEY, model: "anthropic/claude-haiku-4.5" },
+      loadGatewayModelCatalog: async () => [
+        { provider: "anthropic", id: "claude-haiku-4.5", name: "haiku" },
+        { provider: "openrouter", id: "anthropic/claude-haiku-4.5", name: "haiku via openrouter" },
+      ],
+    });
+
+    expectPatchError(result, "model provider not configured: anthropic");
+  });
+
   test("allows target agent own model for subagent session even when missing from global allowlist", async () => {
     const cfg = makeKimiSubagentCfg({
       agentPrimaryModel: "synthetic/hf:moonshotai/Kimi-K2.5",

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -408,6 +408,7 @@ export async function applySessionsPatchToStore(params: {
           model: resolvedDefault.model,
           isDefault: true,
         },
+        cfg,
         markLiveSwitchPending: true,
       });
     } else if (raw !== undefined) {
@@ -441,15 +442,19 @@ export async function applySessionsPatchToStore(params: {
       const isDefault =
         resolved.ref.provider === resolvedDefault.provider &&
         resolved.ref.model === resolvedDefault.model;
-      applyModelOverrideToSessionEntry({
+      const applied = applyModelOverrideToSessionEntry({
         entry: next,
         selection: {
           provider: resolved.ref.provider,
           model: resolved.ref.model,
           isDefault,
         },
+        cfg,
         markLiveSwitchPending: true,
       });
+      if (applied.error) {
+        return invalid(applied.error);
+      }
     }
   }
 

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
-import { applyModelOverrideToSessionEntry } from "./model-overrides.js";
+import {
+  applyModelOverrideToSessionEntry,
+  shouldClearStoredModelOverride,
+} from "./model-overrides.js";
 
 function applyOpenAiSelection(entry: SessionEntry) {
   return applyModelOverrideToSessionEntry({
@@ -121,6 +124,37 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect((entry.updatedAt ?? 0) > before).toBe(true);
   });
 
+  it("refuses non-default overrides for providers missing from configured providers", () => {
+    const before = Date.now() - 5_000;
+    const entry: SessionEntry = {
+      sessionId: "sess-bad-provider",
+      updatedAt: before,
+    };
+
+    const result = applyModelOverrideToSessionEntry({
+      entry,
+      cfg: {
+        models: {
+          providers: {
+            openrouter: { models: [], baseUrl: "https://openrouter.ai/api/v1" },
+          },
+        },
+      } as never,
+      selection: {
+        provider: "anthropic",
+        model: "claude-haiku-4.5",
+      },
+    });
+
+    expect(result).toEqual({
+      updated: false,
+      error: "model provider not configured: anthropic",
+    });
+    expect(entry.providerOverride).toBeUndefined();
+    expect(entry.modelOverride).toBeUndefined();
+    expect(entry.updatedAt).toBe(before);
+  });
+
   it("marks non-default overrides with the provided source", () => {
     const entry: SessionEntry = {
       sessionId: "sess-5a",
@@ -140,6 +174,40 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect(entry.providerOverride).toBe("anthropic");
     expect(entry.modelOverride).toBe("claude-sonnet-4-6");
     expect(entry.modelOverrideSource).toBe("auto");
+  });
+
+  it("clears stored overrides for unconfigured providers even when all models are allowed", () => {
+    const clear = shouldClearStoredModelOverride({
+      cfg: {
+        models: {
+          providers: {
+            openrouter: { models: [], baseUrl: "https://openrouter.ai/api/v1" },
+          },
+        },
+      } as never,
+      provider: "anthropic",
+      modelAllowed: false,
+      allowAnyModel: true,
+    });
+
+    expect(clear).toBe(true);
+  });
+
+  it("keeps stored overrides for configured providers when all models are allowed", () => {
+    const clear = shouldClearStoredModelOverride({
+      cfg: {
+        models: {
+          providers: {
+            openrouter: { models: [], baseUrl: "https://openrouter.ai/api/v1" },
+          },
+        },
+      } as never,
+      provider: "openrouter",
+      modelAllowed: false,
+      allowAnyModel: true,
+    });
+
+    expect(clear).toBe(false);
   });
 
   it("sets liveModelSwitchPending only when explicitly requested", () => {

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -1,4 +1,5 @@
 import type { SessionEntry } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 
 export type ModelOverrideSelection = {
@@ -10,16 +11,24 @@ export type ModelOverrideSelection = {
 export function applyModelOverrideToSessionEntry(params: {
   entry: SessionEntry;
   selection: ModelOverrideSelection;
+  cfg?: OpenClawConfig;
   profileOverride?: string;
   profileOverrideSource?: "auto" | "user";
   selectionSource?: "auto" | "user";
   markLiveSwitchPending?: boolean;
-}): { updated: boolean } {
+}): { updated: boolean; error?: string } {
   const { entry, selection, profileOverride } = params;
   const profileOverrideSource = params.profileOverrideSource ?? "user";
   const selectionSource = params.selectionSource ?? "user";
   let updated = false;
   let selectionUpdated = false;
+
+  if (!selection.isDefault && !isConfiguredModelProvider(params.cfg, selection.provider)) {
+    return {
+      updated: false,
+      error: `model provider not configured: ${selection.provider}`,
+    };
+  }
 
   if (selection.isDefault) {
     if (entry.providerOverride) {
@@ -124,4 +133,27 @@ export function applyModelOverrideToSessionEntry(params: {
   }
 
   return { updated };
+}
+
+export function isConfiguredModelProvider(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+): boolean {
+  const providers = cfg?.models?.providers;
+  if (!providers || Object.keys(providers).length === 0) {
+    return true;
+  }
+  return Object.prototype.hasOwnProperty.call(providers, provider);
+}
+
+export function shouldClearStoredModelOverride(params: {
+  cfg?: OpenClawConfig;
+  provider: string;
+  modelAllowed: boolean;
+  allowAnyModel: boolean;
+}): boolean {
+  if (!isConfiguredModelProvider(params.cfg, params.provider)) {
+    return true;
+  }
+  return !params.allowAnyModel && !params.modelAllowed;
 }


### PR DESCRIPTION
Fixes #78161.

## Summary
- reject non-default session model overrides whose provider is absent from `cfg.models.providers`
- make `sessions.patch` surface that refusal as an invalid model patch instead of persisting corrupt state
- clear already-stored overrides with unconfigured providers during agent dispatch, even when `allowAnyModel=true`, so old OpenRouter-split sessions fall back to the configured default

## Tests
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/run-vitest.mjs run src/sessions/model-overrides.test.ts src/gateway/sessions-patch.test.ts src/agents/agent-command.live-model-switch.test.ts`
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm oxfmt --check src/sessions/model-overrides.ts src/sessions/model-overrides.test.ts src/gateway/sessions-patch.ts src/gateway/sessions-patch.test.ts src/agents/agent-command.ts src/agents/agent-command.live-model-switch.test.ts`
