### PR TITLE
[AI-assisted] fix(image): discover allowlisted fal provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ Docs: https://docs.openclaw.ai
 - Codex/plugins: enable migrated source-installed `openai-curated` Codex plugins in the same Codex harness thread with explicit `codexPlugins` config, cached app readiness, and fail-closed destructive-action policy. Thanks @kevinslin.
 - Codex/plugins: enforce native plugin destructive-action policy with Codex app-level `destructive_enabled` config instead of OpenClaw-maintained per-tool deny lists, leave plugin app `open_world_enabled` on by default, and invalidate existing plugin app thread bindings so old generated app config is rebuilt. Thanks @kevinslin.
 - QQBot/Skills: translate QQBot skill descriptions surfaced in the Skills UI so English-language users no longer see Chinese metadata. Fixes #77810. Thanks @eabase.
+- Image generation: include enabled generation providers such as fal in provider discovery even when another image provider is already active. Fixes #78141. Thanks @leoge007.
 - PR triage: mark external pull requests with `proof: supplied` when Barnacle finds structured real behavior proof, keep stale negative proof labels in sync across CRLF-edited PR bodies, and let ClawSweeper own the stronger `proof: sufficient` judgement.
 - ACPX/Codex: preserve trusted Codex project declarations when launching isolated Codex ACP sessions, avoiding interactive trust prompts in headless runs. Thanks @Stedyclaw.
 - ACPX/Codex: reap stale OpenClaw-owned ACPX/Codex ACP process trees on startup and after ACP session close, preventing orphaned harness processes from slowing the Gateway. Thanks @91wan.

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -477,6 +477,62 @@ describe("resolvePluginCapabilityProviders", () => {
     expect(mocks.loadBundledCapabilityRuntimeRegistry).not.toHaveBeenCalled();
   });
 
+  it("merges enabled generation providers missing from the active registry", () => {
+    const active = createEmptyPluginRegistry();
+    active.imageGenerationProviders.push({
+      pluginId: "xai",
+      pluginName: "xai",
+      source: "test",
+      provider: {
+        id: "xai",
+        defaultModel: "grok-2-image",
+        models: ["grok-2-image"],
+        isConfigured: () => true,
+        generateImage: async () => ({ images: [] }),
+      },
+    } as never);
+    const loaded = createEmptyPluginRegistry();
+    loaded.imageGenerationProviders.push({
+      pluginId: "fal",
+      pluginName: "fal",
+      source: "test",
+      provider: {
+        id: "fal",
+        defaultModel: "fal-ai/flux/dev",
+        models: ["fal-ai/flux/dev"],
+        isConfigured: () => true,
+        generateImage: async () => ({ images: [] }),
+      },
+    } as never);
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "fal",
+          origin: "bundled",
+          contracts: { imageGenerationProviders: ["fal"] },
+        },
+        {
+          id: "xai",
+          origin: "bundled",
+          contracts: { imageGenerationProviders: ["xai"] },
+        },
+      ] as never,
+      diagnostics: [],
+    });
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+      params === undefined ? active : loaded,
+    );
+
+    const providers = resolvePluginCapabilityProviders({
+      key: "imageGenerationProviders",
+      cfg: { plugins: { allow: ["fal", "xai"] } } as OpenClawConfig,
+    });
+
+    expectResolvedCapabilityProviderIds(providers, ["xai", "fal"]);
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith();
+    expectActiveRegistryLookup(["fal", "xai"]);
+  });
+
   it("cold-loads enabled external manifest-contract providers missing from startup registry", () => {
     const loaded = createEmptyPluginRegistry();
     loaded.speechProviders.push({

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -70,6 +70,14 @@ function shouldResolveWhenPluginsAreGloballyDisabled(key: CapabilityProviderRegi
   return key === "speechProviders";
 }
 
+function shouldMergeManifestProvidersWhenActive(key: CapabilityProviderRegistryKey): boolean {
+  return (
+    key === "imageGenerationProviders" ||
+    key === "videoGenerationProviders" ||
+    key === "musicGenerationProviders"
+  );
+}
+
 function shouldSkipCapabilityResolution(params: {
   key: CapabilityProviderRegistryKey;
   cfg?: OpenClawConfig;
@@ -546,12 +554,14 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
       ? collectRequestedCapabilityProviderIds({ key: params.key, cfg: params.cfg })
       : undefined;
   if (activeProviders.length > 0 && params.key !== "memoryEmbeddingProviders") {
-    if (!missingRequestedProviders) {
+    if (!missingRequestedProviders && !shouldMergeManifestProvidersWhenActive(params.key)) {
       return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
     }
-    removeActiveProviderIds(missingRequestedProviders, activeProviders);
-    if (missingRequestedProviders.size === 0) {
-      return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
+    if (missingRequestedProviders) {
+      removeActiveProviderIds(missingRequestedProviders, activeProviders);
+      if (missingRequestedProviders.size === 0) {
+        return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
+      }
     }
   }
   let requestedProviders: Set<string> | undefined;
@@ -590,10 +600,10 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
   });
   if (params.key !== "memoryEmbeddingProviders") {
     const mergeLoadedProviders =
-      activeProviders.length > 0
+      activeProviders.length > 0 && missingRequestedProviders
         ? filterLoadedProvidersForRequestedConfig({
             key: params.key,
-            requested: missingRequestedProviders ?? new Set(),
+            requested: missingRequestedProviders,
             entries: loadedProviders,
           })
         : loadedProviders;


### PR DESCRIPTION
## Summary

Fixes #78141 by letting generation provider discovery merge enabled manifest-backed providers even when another generation provider is already active.

## Root Cause

`resolvePluginCapabilityProviders` returned the active registry immediately for non-memory capabilities when no requested-provider collector existed. Image, video, and music generation providers had no collector, so an already-active provider such as xai could hide another enabled/allowlisted provider such as fal from `image_generate action=list` and provider lookup.

## Changes

- Continue manifest-backed loading for image, video, and music generation providers even when active providers already exist.
- Preserve the active-only fast path for other capability families.
- Add a regression that starts with active xai and verifies allowlisted fal is merged into image-generation provider discovery.

## Validation

- `corepack pnpm test src/plugins/capability-provider-runtime.test.ts src/image-generation/provider-registry.test.ts src/agents/tools/image-generate-tool.test.ts`
- `corepack pnpm exec oxfmt --check --threads=1 src/plugins/capability-provider-runtime.ts src/plugins/capability-provider-runtime.test.ts CHANGELOG.md`
- `corepack pnpm check:changed`
- `git diff --check`
## Real behavior proof

Behavior or issue addressed: `image_generate action=list` and the equivalent image-generation provider lookup no longer stop at an already-active image provider. Enabled manifest-backed providers such as fal can be discovered and listed alongside an active provider such as xai.

Real environment tested: Windows local checkout of PR head `a36d66fe115f431434ce255a4f5d43ef78bf8866` on branch `fix-fal-image-provider-discovery`. No external fal or xAI API request was made; this exercises the local runtime plugin loader and provider lookup surface only.

Exact steps or command run after this patch:

```powershell
corepack pnpm exec tsx -e "import { resolveRuntimePluginRegistry } from './src/plugins/loader.ts'; import { setActivePluginRegistry } from './src/plugins/runtime.ts'; import { listImageGenerationProviders } from './src/image-generation/provider-registry.ts'; const cfg={plugins:{allow:['xai','fal']}}; const active=resolveRuntimePluginRegistry({onlyPluginIds:['xai'],activate:false,workspaceDir:process.cwd(),config:cfg}); if(!active) throw new Error('xai active registry did not load'); setActivePluginRegistry(active, 'proof-active-xai', 'default', process.cwd()); const providers=listImageGenerationProviders(cfg).map((p)=>({id:p.id, defaultModel:p.defaultModel, configured:p.configured?.({config:cfg})})); console.log(JSON.stringify({branch:'fix-fal-image-provider-discovery', head:'a36d66fe115f431434ce255a4f5d43ef78bf8866', activeRegistry:active.imageGenerationProviders.map((e)=>e.provider.id), allowlist:cfg.plugins.allow, resolvedProviders:providers}, null, 2));"
```

Evidence after fix:

```json
{
  "branch": "fix-fal-image-provider-discovery",
  "head": "a36d66fe115f431434ce255a4f5d43ef78bf8866",
  "activeRegistry": [
    "xai"
  ],
  "allowlist": [
    "xai",
    "fal"
  ],
  "resolvedProviders": [
    {
      "id": "xai",
      "defaultModel": "grok-imagine-image"
    },
    {
      "id": "fal",
      "defaultModel": "fal-ai/flux/dev"
    }
  ]
}
```

Observed result after fix: the local runtime provider lookup returned both the already-active `xai` image provider and the allowlisted manifest-backed `fal` provider, proving the changed discovery path now merges generation providers instead of returning only the active registry.

What was not tested: I did not run a live gateway with real FAL/xAI credentials or call either external image-generation API.

## Focused validation after proof run

```text
corepack pnpm test src/plugins/capability-provider-runtime.test.ts src/image-generation/provider-registry.test.ts src/agents/tools/image-generate-tool.test.ts
```

Result: passed 3 Vitest shards: `src/plugins/capability-provider-runtime.test.ts` (3 tests), `src/image-generation/provider-registry.test.ts` (30 tests), and `src/agents/tools/image-generate-tool.test.ts` (39 tests).
