### PR TITLE
fix: yield large WhatsApp signal key reads

### DIFF
--- a/extensions/whatsapp/src/session.test.ts
+++ b/extensions/whatsapp/src/session.test.ts
@@ -203,6 +203,35 @@ describe("web session", () => {
     openMock.restore();
   });
 
+  it("batches large Baileys signal key reads so startup can yield", async () => {
+    const get = vi.fn(async (_type: string, ids: string[]) =>
+      Object.fromEntries(ids.map((id) => [id, { id }])),
+    );
+    useMultiFileAuthStateMock.mockResolvedValueOnce({
+      state: {
+        creds: {},
+        keys: { get, set: vi.fn() },
+      } as never,
+      saveCreds: vi.fn(),
+    });
+
+    await createWaSocket(false, false);
+
+    const passed = (baileys.makeWASocket as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+      auth?: { keys?: { get?: (type: string, ids: string[]) => Promise<Record<string, unknown>> } };
+    };
+    const ids = Array.from({ length: 130 }, (_value, index) => `key-${index}`);
+    const result = await passed.auth?.keys?.get?.("session", ids);
+
+    expect(get).toHaveBeenCalledTimes(3);
+    expect(get.mock.calls.map((call) => call[1])).toEqual([
+      ids.slice(0, 64),
+      ids.slice(64, 128),
+      ids.slice(128),
+    ]);
+    expect(result).toMatchObject({ "key-0": { id: "key-0" }, "key-129": { id: "key-129" } });
+  });
+
   it("passes explicit Baileys socket timing overrides", async () => {
     await createWaSocket(false, false, {
       keepAliveIntervalMs: 10_000,

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -67,8 +67,44 @@ export type { CredsQueueWaitResult } from "./creds-persistence.js";
 
 const LOGGED_OUT_STATUS = DisconnectReason?.loggedOut ?? 401;
 const WHATSAPP_WEBSOCKET_PROXY_TARGET = "https://mmg.whatsapp.net/";
+const WHATSAPP_SIGNAL_KEY_GET_YIELD_BATCH_SIZE = 64;
 const CREDS_FLUSH_TIMEOUT_MESSAGE =
   "Queued WhatsApp creds save did not finish before auth bootstrap; skipping repair and continuing with primary creds.";
+
+type WhatsAppAuthState = Awaited<ReturnType<typeof useMultiFileAuthState>>["state"];
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function createYieldingSignalKeyStore(keys: WhatsAppAuthState["keys"]): WhatsAppAuthState["keys"] {
+  const get = (keys as { get?: unknown }).get;
+  if (typeof get !== "function") {
+    return keys;
+  }
+  const yieldingKeys = Object.create(Object.getPrototypeOf(keys)) as WhatsAppAuthState["keys"];
+  Object.assign(yieldingKeys, keys, {
+    get: async (type: unknown, ids: readonly string[]) => {
+      if (!Array.isArray(ids) || ids.length <= WHATSAPP_SIGNAL_KEY_GET_YIELD_BATCH_SIZE) {
+        return await get.call(keys, type, ids);
+      }
+      const result: Record<string, unknown> = {};
+      for (
+        let offset = 0;
+        offset < ids.length;
+        offset += WHATSAPP_SIGNAL_KEY_GET_YIELD_BATCH_SIZE
+      ) {
+        if (offset > 0) {
+          await yieldToEventLoop();
+        }
+        const chunk = ids.slice(offset, offset + WHATSAPP_SIGNAL_KEY_GET_YIELD_BATCH_SIZE);
+        Object.assign(result, await get.call(keys, type, chunk));
+      }
+      return result;
+    },
+  });
+  return yieldingKeys;
+}
 
 function enqueueSaveCreds(
   authDir: string,
@@ -168,7 +204,7 @@ export async function createWaSocket(
   const sock = makeWASocket({
     auth: {
       creds: state.creds,
-      keys: makeCacheableSignalKeyStore(state.keys, logger),
+      keys: makeCacheableSignalKeyStore(createYieldingSignalKeyStore(state.keys), logger),
     },
     version,
     logger,


### PR DESCRIPTION
Fixes #78165.

## Summary
- Wrap WhatsApp/Baileys signal key reads so large `keys.get(type, ids)` requests are split into 64-key chunks.
- Yield to the event loop between chunks with `setImmediate`, preventing large multifile auth stores from monopolizing gateway startup.
- Preserve small-read behavior and existing Baileys auth/socket contracts; no new config knobs.

## Tests
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm test extensions/whatsapp/src/session.test.ts`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm test extensions/whatsapp/src/connection-controller.test.ts extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm exec oxfmt --check extensions/whatsapp/src/session.ts extensions/whatsapp/src/session.test.ts`
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` (typechecks passed; failed on unrelated existing Slack lint `extensions/slack/src/monitor/provider-support.ts:334 preserve-caught-error`)
