### PR TITLE
fix: suppress leaked reply scaffolding

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -309,6 +309,41 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(input)).toBe("Done. Clean answer only.");
   });
 
+  it("strips leaked current-message scaffolding while preserving reply text", () => {
+    const input = [
+      "Current message priority: high",
+      "[Current message - respond to this]",
+      "[Telegram 2026-05-05T20:20:00Z] Danny: ping",
+      "[from: Danny]",
+      "",
+      "Pong.",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe("Pong.");
+  });
+
+  it("strips copied history/current-message scaffolding blocks", () => {
+    const input = [
+      "[Chat messages since your last reply - for context]",
+      "[Telegram 2026-05-05T20:19:00Z] Danny: previous",
+      "",
+      "[Current message - respond to this]",
+      "[Telegram 2026-05-05T20:20:00Z] Danny: current",
+      "",
+      "Visible reply.",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe("Visible reply.");
+  });
+
+  it("suppresses standalone no-output placeholders without stripping inline mentions", () => {
+    expect(sanitizeUserFacingText("(no output)")).toBe("");
+    expect(sanitizeUserFacingText("Before\n(no output)\nAfter")).toBe("Before\nAfter");
+    expect(sanitizeUserFacingText("The literal (no output) text is relevant.")).toBe(
+      "The literal (no output) text is relevant.",
+    );
+  });
+
   it("strips copied inbound metadata blocks from user-facing assistant text", () => {
     const input = [
       "Conversation info (untrusted metadata):",

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -47,6 +47,11 @@ const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
 const FINAL_TAG_RE = /<\s*\/?\s*final\s*>/gi;
 const TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE = /^[ \t]*\[tool calls omitted\][ \t]*$/i;
+const NO_OUTPUT_PLACEHOLDER_LINE_RE = /^[ \t]*\(no output\)[ \t]*$/i;
+const HISTORY_CONTEXT_MARKER_LINE_RE =
+  /^[ \t]*\[Chat messages since your last reply - for context\][ \t]*$/i;
+const CURRENT_MESSAGE_MARKER_LINE_RE = /^[ \t]*\[Current message - respond to this\][ \t]*$/i;
+const CURRENT_MESSAGE_PRIORITY_LINE_RE = /^[ \t]*Current message priority:[^\n]*$/i;
 const ERROR_PREFIX_RE =
   /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|codex\s*error|request failed|failed|exception)(?:\s+\d{3})?[:\s-]+/i;
 const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
@@ -338,7 +343,7 @@ function stripFinalTagsFromText(text: unknown): string {
   return normalized.replace(FINAL_TAG_RE, "");
 }
 
-function stripToolCallsOmittedPlaceholderLines(text: string): string {
+function stripPlaceholderLines(text: string): string {
   let result = "";
   let start = 0;
   while (start < text.length) {
@@ -346,12 +351,53 @@ function stripToolCallsOmittedPlaceholderLines(text: string): string {
     const end = newlineIndex === -1 ? text.length : newlineIndex + 1;
     const chunk = text.slice(start, end);
     const line = chunk.endsWith("\n") ? chunk.slice(0, -1).replace(/\r$/, "") : chunk;
-    if (!TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE.test(line)) {
+    if (
+      !TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE.test(line) &&
+      !NO_OUTPUT_PLACEHOLDER_LINE_RE.test(line)
+    ) {
       result += chunk;
     }
     start = end;
   }
   return result;
+}
+
+function stripCopiedCurrentMessageScaffolding(text: string): string {
+  const blocks = text.split(/(\n[ \t]*\n)/);
+  let changed = false;
+  const kept: string[] = [];
+
+  for (let index = 0; index < blocks.length; index += 1) {
+    const block = blocks[index];
+    if (/^\n[ \t]*\n$/.test(block)) {
+      kept.push(block);
+      continue;
+    }
+
+    const firstLine = block.split(/\r?\n/, 1)[0] ?? "";
+    const shouldDrop =
+      HISTORY_CONTEXT_MARKER_LINE_RE.test(firstLine) ||
+      CURRENT_MESSAGE_PRIORITY_LINE_RE.test(firstLine) ||
+      CURRENT_MESSAGE_MARKER_LINE_RE.test(firstLine);
+    if (shouldDrop) {
+      changed = true;
+      if (/^\n[ \t]*\n$/.test(blocks[index + 1] ?? "")) {
+        index += 1;
+      }
+      continue;
+    }
+
+    kept.push(block);
+  }
+
+  if (!changed) {
+    return text;
+  }
+
+  return kept
+    .join("")
+    .replace(/^(?:[ \t]*\n)+/, "")
+    .replace(/(?:\n[ \t]*)+$/, "");
 }
 
 function collapseConsecutiveDuplicateBlocks(text: string): string {
@@ -411,8 +457,9 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
   // Replay repair may synthesize this placeholder to keep provider transcripts valid.
   // It is internal scaffolding, so drop standalone placeholder lines before delivery
   // while preserving ordinary inline mentions a user may be discussing.
-  const withoutPlaceholder = stripToolCallsOmittedPlaceholderLines(withoutToolCallXml);
-  const withoutToolCallBlocks = stripLegacyBracketToolCallBlocks(withoutPlaceholder);
+  const withoutPlaceholder = stripPlaceholderLines(withoutToolCallXml);
+  const withoutCurrentMessageScaffolding = stripCopiedCurrentMessageScaffolding(withoutPlaceholder);
+  const withoutToolCallBlocks = stripLegacyBracketToolCallBlocks(withoutCurrentMessageScaffolding);
   const trimmed = withoutToolCallBlocks.trim();
   if (!trimmed) {
     return "";

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -17,7 +17,7 @@ import {
   type ResponsePrefixContext,
 } from "./response-prefix-template.js";
 
-export type NormalizeReplySkipReason = "empty" | "silent" | "heartbeat";
+export type NormalizeReplySkipReason = "empty" | "silent" | "heartbeat" | "empty-tool-output";
 
 export type NormalizeReplyOptions = {
   responsePrefix?: string;
@@ -93,6 +93,11 @@ export function normalizeReplyPayload(
       return null;
     }
     text = stripped.text;
+  }
+
+  if (text?.trim().toLowerCase() === "(no output)") {
+    opts.onSkip?.("empty-tool-output");
+    return null;
   }
 
   if (text) {

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -97,6 +97,17 @@ describe("normalizeReplyPayload", () => {
     expect(normalized?.channelData).toEqual(payload.channelData);
   });
 
+  it("records empty-tool-output for bare no-output placeholders", () => {
+    const reasons: string[] = [];
+    const normalized = normalizeReplyPayload(
+      { text: "  (no output)\n" },
+      { onSkip: (reason) => reasons.push(reason) },
+    );
+
+    expect(normalized).toBeNull();
+    expect(reasons).toEqual(["empty-tool-output"]);
+  });
+
   it("records skip reasons for silent/empty payloads", () => {
     const cases = [
       { name: "silent", payload: { text: SILENT_REPLY_TOKEN }, reason: "silent" },


### PR DESCRIPTION
## Summary

Fix reply delivery sanitization so internal current-message scaffolding and bare `(no output)` placeholders are not delivered to users.

## Changes

- Strip copied current-message/history prompt blocks from `sanitizeUserFacingText` while preserving subsequent visible reply text.
- Drop standalone `(no output)` placeholder lines without removing inline user-visible mentions.
- Treat a bare `(no output)` reply payload as skipped with `empty-tool-output`.
- Add sanitizer and normalizer regression coverage.

## Testing

- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/run-vitest.mjs run src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts src/auto-reply/reply/reply-utils.test.ts` — 166 tests passed
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental false` — passed
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm exec oxfmt --check src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts src/auto-reply/reply/normalize-reply.ts src/auto-reply/reply/reply-utils.test.ts` — passed
- `git diff --check` — passed
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` — passed

Fixes openclaw/openclaw#78177
