### PR TITLE
fix: keep Telegram DM silent fallbacks quiet

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3347,13 +3347,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
   });
 
-  it("rewrites a no-visible-response DM turn through silent-reply fallback", async () => {
+  it("does not rewrite a no-visible-response DM turn through silent-reply fallback", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
       queuedFinal: false,
     });
-    deliverReplies.mockResolvedValueOnce({ delivered: true });
 
     await dispatchWithContext({
       context: createContext({
@@ -3377,11 +3376,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       } as unknown as OpenClawConfig,
     });
 
-    expect(deliverReplies).toHaveBeenCalledTimes(1);
-    const deliveredReplies = deliverReplies.mock.calls[0]?.[0]?.replies;
-    expect(Array.isArray(deliveredReplies)).toBe(true);
-    expect(deliveredReplies?.[0]?.text).toEqual(expect.any(String));
-    expect(deliveredReplies?.[0]?.text?.trim()).not.toBe("NO_REPLY");
+    expect(deliverReplies).not.toHaveBeenCalled();
   });
 
   it("does not add silent-reply fallback for message-tool-only turns", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1520,7 +1520,8 @@ export const dispatchTelegramMessage = async ({
     !sentFallback &&
     !dispatchError &&
     !deliverySummary.delivered &&
-    !suppressSilentReplyFallback
+    !suppressSilentReplyFallback &&
+    isGroup
   ) {
     const policySessionKey =
       ctxPayload.CommandSource === "native"


### PR DESCRIPTION
Fixes #78188.

## Summary
- stop synthesizing Telegram direct-message silent-reply fallback text when a turn ends with no visible final response
- keep Telegram group/forum no-visible-response fallback behavior unchanged
- update the Telegram dispatch regression test so DM turns remain quiet instead of delivering rewritten `NO_REPLY` chatter such as `All quiet on my side.`

## Tests
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/test-projects.mjs extensions/telegram/src/bot-message-dispatch.test.ts`
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" npx oxfmt --check extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` *(fails only in unrelated existing diagnostics-otel lint: duplicate `session.recovery.requested` / `session.recovery.completed` case labels in `extensions/diagnostics-otel/src/service.ts`)*
