### PR TITLE
feat(media): make host-read MIME allowlist configurable via cfg.media

### DIFF
--- a/scripts/bench-sessions-list-seed.ts
+++ b/scripts/bench-sessions-list-seed.ts
@@ -1,0 +1,398 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadSessionStore, type SessionEntry } from "../src/config/sessions.js";
+import type { OpenClawConfig } from "../src/config/types.openclaw.js";
+import { normalizeAgentId } from "../src/routing/session-key.js";
+
+export const DEFAULT_SOURCE_ROOT = path.join(os.homedir(), ".openclaw", "agents");
+
+export type SeedOptions = {
+  agentCount?: number;
+  inflateTranscriptKiB: number;
+  recentSessions?: number;
+  recentWindowMinutes: number;
+  sessions: number;
+  sourceRoot: string;
+  sourceStore?: string;
+  targetWrittenMiB: number;
+};
+
+export type SeedResult = {
+  config: OpenClawConfig;
+  root: string;
+  seed: {
+    clonedBytes: number;
+    mode: "real-clone";
+    recentSessions: number;
+    requestedTranscriptInflateKiB: number;
+    sourceRows: number;
+    sourceStores: number;
+    sourceTranscripts: number;
+    targetAgents: number;
+    targetWrittenMiB: number;
+    transcriptInflateKiB: number;
+    writtenBytes: number;
+    writtenTranscripts: number;
+  };
+  storePath: string;
+};
+
+type SourceStore = {
+  agentId: string;
+  storePath: string;
+};
+
+type RealSessionSource = SourceStore & {
+  bytes: number;
+  entry: SessionEntry;
+  key: string;
+  transcriptPath: string;
+};
+
+type CloneRoundMaps = {
+  byIdentity: Map<string, string>;
+  byKey: Map<string, string>;
+};
+
+type ClonePlan = {
+  cloneKey: string;
+  cloneSessionFile: string;
+  cloneSessionId: string;
+  index: number;
+  maps: CloneRoundMaps;
+  source: RealSessionSource;
+  targetAgentId: string;
+};
+
+function inferAgentIdFromStorePath(storePath: string): string {
+  const sessionsDir = path.dirname(storePath);
+  if (path.basename(sessionsDir) === "sessions") {
+    return normalizeAgentId(path.basename(path.dirname(sessionsDir)));
+  }
+  return "main";
+}
+
+function discoverSourceStores(options: SeedOptions): SourceStore[] {
+  if (options.sourceStore) {
+    const storePath = path.resolve(options.sourceStore);
+    return [{ agentId: inferAgentIdFromStorePath(storePath), storePath }];
+  }
+  const root = path.resolve(options.sourceRoot);
+  if (!fs.existsSync(root)) {
+    throw new Error(`source agents root not found: ${root}`);
+  }
+  return fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => ({
+      agentId: normalizeAgentId(entry.name),
+      storePath: path.join(root, entry.name, "sessions", "sessions.json"),
+    }))
+    .filter((entry) => fs.existsSync(entry.storePath))
+    .sort((a, b) => a.agentId.localeCompare(b.agentId));
+}
+
+function resolveSourceTranscriptPath(params: {
+  entry: SessionEntry;
+  sourceStorePath: string;
+}): string | undefined {
+  const sourceDir = path.dirname(params.sourceStorePath);
+  const candidates: string[] = [];
+  if (params.entry.sessionFile) {
+    candidates.push(
+      path.isAbsolute(params.entry.sessionFile)
+        ? params.entry.sessionFile
+        : path.join(sourceDir, params.entry.sessionFile),
+    );
+  }
+  candidates.push(path.join(sourceDir, `${params.entry.sessionId}.jsonl`));
+  for (const candidate of candidates) {
+    try {
+      const stat = fs.statSync(candidate);
+      if (stat.isFile()) {
+        return candidate;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+function loadRealSessionSources(options: SeedOptions): {
+  rows: number;
+  sourceStores: number;
+  sources: RealSessionSource[];
+} {
+  const stores = discoverSourceStores(options);
+  const sources: RealSessionSource[] = [];
+  let rows = 0;
+  for (const sourceStore of stores) {
+    const store = loadSessionStore(sourceStore.storePath, { skipCache: true, clone: false });
+    rows += Object.keys(store).length;
+    for (const [key, entry] of Object.entries(store)) {
+      if (!entry.sessionId) {
+        continue;
+      }
+      const transcriptPath = resolveSourceTranscriptPath({
+        entry,
+        sourceStorePath: sourceStore.storePath,
+      });
+      if (!transcriptPath) {
+        continue;
+      }
+      sources.push({
+        ...sourceStore,
+        bytes: fs.statSync(transcriptPath).size,
+        entry,
+        key,
+        transcriptPath,
+      });
+    }
+  }
+  return { rows, sourceStores: stores.length, sources };
+}
+
+function sourceIdentity(source: Pick<RealSessionSource, "agentId" | "key">): string {
+  return `${source.agentId}\t${source.key}`;
+}
+
+function cloneKeyFor(params: { index: number; targetAgentId: string }): string {
+  const padded = String(params.index + 1).padStart(5, "0");
+  return `agent:${params.targetAgentId}:bench-real-${padded}`;
+}
+
+function targetAgentIdForIndex(targetAgentIds: string[], index: number): string {
+  const targetAgentId = targetAgentIds[index % targetAgentIds.length];
+  if (!targetAgentId) {
+    throw new Error("missing benchmark target agent id");
+  }
+  return targetAgentId;
+}
+
+function createRoundMaps(params: {
+  count: number;
+  round: number;
+  sources: RealSessionSource[];
+  targetAgentIds: string[];
+}) {
+  const maps: CloneRoundMaps = { byIdentity: new Map(), byKey: new Map() };
+  for (let sourceIndex = 0; sourceIndex < params.sources.length; sourceIndex += 1) {
+    const source = params.sources[sourceIndex];
+    if (!source) {
+      continue;
+    }
+    const index = params.round * params.sources.length + sourceIndex;
+    if (index >= params.count) {
+      break;
+    }
+    const targetAgentId = targetAgentIdForIndex(params.targetAgentIds, index);
+    const cloneKey = cloneKeyFor({ index, targetAgentId });
+    maps.byIdentity.set(sourceIdentity(source), cloneKey);
+    maps.byKey.set(source.key, cloneKey);
+  }
+  return maps;
+}
+
+function buildClonePlans(params: {
+  count: number;
+  sources: RealSessionSource[];
+  targetAgentIds: string[];
+}): ClonePlan[] {
+  const plans: ClonePlan[] = [];
+  const rounds = Math.ceil(params.count / params.sources.length);
+  for (let round = 0; round < rounds; round += 1) {
+    const maps = createRoundMaps({
+      count: params.count,
+      round,
+      sources: params.sources,
+      targetAgentIds: params.targetAgentIds,
+    });
+    for (let sourceIndex = 0; sourceIndex < params.sources.length; sourceIndex += 1) {
+      const index = round * params.sources.length + sourceIndex;
+      if (index >= params.count) {
+        break;
+      }
+      const padded = String(index + 1).padStart(5, "0");
+      const source = params.sources[sourceIndex];
+      if (!source) {
+        continue;
+      }
+      const targetAgentId = targetAgentIdForIndex(params.targetAgentIds, index);
+      const cloneKey = maps.byIdentity.get(sourceIdentity(source));
+      if (!cloneKey) {
+        throw new Error(`missing clone key for ${source.key}`);
+      }
+      const cloneSessionId = `bench-${targetAgentId}-${padded}`;
+      plans.push({
+        cloneKey,
+        cloneSessionFile: `${cloneSessionId}.jsonl`,
+        cloneSessionId,
+        index,
+        maps,
+        source,
+        targetAgentId,
+      });
+    }
+  }
+  return plans;
+}
+
+function agentIdFromCanonicalKey(value: string): string | undefined {
+  const match = /^agent:([^:]+):/.exec(value);
+  return match ? normalizeAgentId(match[1]) : undefined;
+}
+
+function remapSessionLink(
+  value: string | undefined,
+  source: RealSessionSource,
+  maps: CloneRoundMaps,
+) {
+  if (!value) {
+    return value;
+  }
+  const linkedAgentId = agentIdFromCanonicalKey(value) ?? source.agentId;
+  return maps.byIdentity.get(`${linkedAgentId}\t${value}`) ?? maps.byKey.get(value) ?? value;
+}
+
+function copyTranscript(params: { inflateBytes: number; source: string; target: string }): {
+  sourceBytes: number;
+  writtenBytes: number;
+} {
+  const sourceStat = fs.statSync(params.source);
+  if (params.inflateBytes <= sourceStat.size) {
+    fs.copyFileSync(params.source, params.target);
+    return { sourceBytes: sourceStat.size, writtenBytes: sourceStat.size };
+  }
+  const source = fs.readFileSync(params.source);
+  const chunk =
+    source[source.length - 1] === 10 ? source : Buffer.concat([source, Buffer.from("\n")]);
+  const fd = fs.openSync(params.target, "w");
+  let writtenBytes = 0;
+  try {
+    while (writtenBytes < params.inflateBytes) {
+      const remaining = params.inflateBytes - writtenBytes;
+      const slice = remaining >= chunk.length ? chunk : chunk.subarray(0, remaining);
+      fs.writeSync(fd, slice);
+      writtenBytes += slice.length;
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+  return { sourceBytes: sourceStat.size, writtenBytes };
+}
+
+function createBenchConfig(root: string, agentIds: string[]): OpenClawConfig {
+  return {
+    session: { store: path.join(root, "agents", "{agentId}", "sessions", "sessions.json") },
+    agents: {
+      list: agentIds.map((id, index) => ({ id, name: id, default: index === 0 })),
+    },
+  };
+}
+
+function resolveTargetAgentIds(sources: RealSessionSource[], agentCount?: number): string[] {
+  const sourceAgentIds = [...new Set(sources.map((source) => source.agentId))].sort();
+  const count = agentCount ?? sourceAgentIds.length;
+  const targetAgentIds = sourceAgentIds.slice(0, count);
+  for (let index = 1; targetAgentIds.length < count; index += 1) {
+    const agentId = normalizeAgentId(`bench-agent-${String(index).padStart(3, "0")}`);
+    if (!targetAgentIds.includes(agentId)) {
+      targetAgentIds.push(agentId);
+    }
+  }
+  return targetAgentIds;
+}
+
+function resolveTranscriptInflateBytes(options: SeedOptions): number {
+  const requestedInflateBytes = options.inflateTranscriptKiB * 1024;
+  const targetBytes =
+    options.targetWrittenMiB > 0
+      ? Math.ceil((options.targetWrittenMiB * 1024 * 1024) / options.sessions)
+      : 0;
+  return Math.max(requestedInflateBytes, targetBytes);
+}
+
+function resolveCloneUpdatedAt(params: { index: number; now: number; options: SeedOptions }) {
+  const recentSessions = Math.min(
+    params.options.sessions,
+    params.options.recentSessions ?? params.options.sessions,
+  );
+  const recentWindowMs = params.options.recentWindowMinutes * 60_000;
+  if (params.index < recentSessions) {
+    return params.now - Math.floor((params.index / Math.max(1, recentSessions)) * recentWindowMs);
+  }
+  return params.now - recentWindowMs - (params.index - recentSessions + 1) * 60_000;
+}
+
+export function seedRealSessions(options: SeedOptions): SeedResult {
+  const { rows, sources, sourceStores } = loadRealSessionSources(options);
+  if (sources.length === 0) {
+    throw new Error(`no cloneable transcript-backed sessions under ${options.sourceRoot}`);
+  }
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-list-bench-"));
+  const agentIds = resolveTargetAgentIds(sources, options.agentCount);
+  const stores = new Map<string, Record<string, SessionEntry>>();
+  let clonedBytes = 0;
+  let writtenBytes = 0;
+  let writtenTranscripts = 0;
+  const inflateBytes = resolveTranscriptInflateBytes(options);
+  const now = Date.now();
+
+  for (const plan of buildClonePlans({
+    count: options.sessions,
+    sources,
+    targetAgentIds: agentIds,
+  })) {
+    const sessionsDir = path.join(root, "agents", plan.targetAgentId, "sessions");
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    const copied = copyTranscript({
+      inflateBytes,
+      source: plan.source.transcriptPath,
+      target: path.join(sessionsDir, plan.cloneSessionFile),
+    });
+    clonedBytes += copied.sourceBytes;
+    writtenBytes += copied.writtenBytes;
+    writtenTranscripts += 1;
+    const store = stores.get(plan.targetAgentId) ?? {};
+    store[plan.cloneKey] = {
+      ...plan.source.entry,
+      parentSessionKey: remapSessionLink(
+        plan.source.entry.parentSessionKey,
+        plan.source,
+        plan.maps,
+      ),
+      sessionFile: plan.cloneSessionFile,
+      sessionId: plan.cloneSessionId,
+      spawnedBy: remapSessionLink(plan.source.entry.spawnedBy, plan.source, plan.maps),
+      updatedAt: resolveCloneUpdatedAt({ index: plan.index, now, options }),
+    };
+    stores.set(plan.targetAgentId, store);
+  }
+
+  for (const [agentId, store] of stores) {
+    const sessionsDir = path.join(root, "agents", agentId, "sessions");
+    fs.writeFileSync(path.join(sessionsDir, "sessions.json"), `${JSON.stringify(store)}\n`);
+  }
+
+  return {
+    root,
+    storePath: "(multiple)",
+    config: createBenchConfig(root, agentIds),
+    seed: {
+      clonedBytes,
+      mode: "real-clone",
+      recentSessions: Math.min(options.sessions, options.recentSessions ?? options.sessions),
+      requestedTranscriptInflateKiB: options.inflateTranscriptKiB,
+      sourceRows: rows,
+      sourceStores,
+      sourceTranscripts: sources.length,
+      targetAgents: agentIds.length,
+      targetWrittenMiB: options.targetWrittenMiB,
+      transcriptInflateKiB: Math.ceil(inflateBytes / 1024),
+      writtenBytes,
+      writtenTranscripts,
+    },
+  };
+}

--- a/scripts/bench-sessions-list.ts
+++ b/scripts/bench-sessions-list.ts
@@ -1,0 +1,394 @@
+import fs from "node:fs";
+import path from "node:path";
+import { monitorEventLoopDelay, performance } from "node:perf_hooks";
+import type { OpenClawConfig } from "../src/config/types.openclaw.js";
+import type { SessionsListResult } from "../src/gateway/session-utils.types.js";
+import { DEFAULT_SOURCE_ROOT, seedRealSessions } from "./bench-sessions-list-seed.js";
+
+type BenchOptions = {
+  activeMinutes?: number;
+  agentCount?: number;
+  agentId?: string;
+  coldRuns: number;
+  includeGlobal: boolean;
+  includeDerivedTitles: boolean;
+  includeLastMessage: boolean;
+  includeUnknown: boolean;
+  inflateTranscriptKiB: number;
+  json: boolean;
+  keepTemp: boolean;
+  limit?: number;
+  output?: string;
+  recentSessions?: number;
+  recentWindowMinutes: number;
+  runs: number;
+  sessions: number;
+  sourceRoot: string;
+  sourceStore?: string;
+  targetWrittenMiB: number;
+  warmup: number;
+};
+
+type Sample = {
+  elapsedMs: number;
+  eventLoopDelayMaxMs: number;
+  rows: number;
+};
+
+type SessionsHandlers = typeof import("../src/gateway/server-methods/sessions.js").sessionsHandlers;
+
+const DEFAULT_SESSIONS = 1000;
+const DEFAULT_COLD_RUNS = 3;
+const DEFAULT_RUNS = 5;
+const DEFAULT_WARMUP = 1;
+
+function flagValue(flag: string): string | undefined {
+  const index = process.argv.indexOf(flag);
+  if (index === -1) {
+    return undefined;
+  }
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function hasFlag(flag: string): boolean {
+  return process.argv.includes(flag);
+}
+
+function positiveInt(flag: string, defaultValue: number): number {
+  const raw = flagValue(flag);
+  if (raw === undefined) {
+    return defaultValue;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function optionalPositiveInt(flag: string): number | undefined {
+  const raw = flagValue(flag);
+  if (raw === undefined) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function nonNegativeInt(flag: string, defaultValue: number): number {
+  const raw = flagValue(flag);
+  if (raw === undefined) {
+    return defaultValue;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${flag} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+function optionalNonNegativeInt(flag: string): number | undefined {
+  const raw = flagValue(flag);
+  if (raw === undefined) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${flag} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+function parseOptions(): BenchOptions {
+  if (hasFlag("--help") || hasFlag("-h")) {
+    printUsage();
+    process.exit(0);
+  }
+  const sourceStore = flagValue("--source-store");
+  const agentId = flagValue("--agent-id")?.trim();
+  return {
+    activeMinutes: optionalPositiveInt("--active-minutes"),
+    agentCount: optionalPositiveInt("--agent-count"),
+    agentId: agentId || undefined,
+    coldRuns: nonNegativeInt("--cold-runs", DEFAULT_COLD_RUNS),
+    includeGlobal: !hasFlag("--exclude-global"),
+    includeDerivedTitles: hasFlag("--include-derived-titles"),
+    includeLastMessage: hasFlag("--include-last-message"),
+    includeUnknown: !hasFlag("--exclude-unknown"),
+    inflateTranscriptKiB: nonNegativeInt("--inflate-transcript-kib", 0),
+    json: hasFlag("--json"),
+    keepTemp: hasFlag("--keep-temp"),
+    limit: optionalPositiveInt("--limit"),
+    output: flagValue("--output"),
+    recentSessions: optionalNonNegativeInt("--recent-sessions"),
+    recentWindowMinutes: positiveInt("--recent-window-minutes", 1440),
+    runs: positiveInt("--runs", DEFAULT_RUNS),
+    sessions: positiveInt("--sessions", DEFAULT_SESSIONS),
+    sourceRoot: path.resolve(flagValue("--source-root") ?? DEFAULT_SOURCE_ROOT),
+    sourceStore: sourceStore ? path.resolve(sourceStore) : undefined,
+    targetWrittenMiB: nonNegativeInt("--target-written-mib", 0),
+    warmup: nonNegativeInt("--warmup", DEFAULT_WARMUP),
+  };
+}
+
+function printUsage(): void {
+  console.log(`OpenClaw sessions.list benchmark
+
+Usage:
+  pnpm test:sessions:list:bench -- [options]
+  node --import tsx scripts/bench-sessions-list.ts [options]
+
+Options:
+  --sessions <count>           Seeded session count (default: ${DEFAULT_SESSIONS})
+  --agent-count <count>        Seed across this many agent dirs
+  --source-root <path>         agents directory to clone (default: ${DEFAULT_SOURCE_ROOT})
+  --source-store <path>        single sessions.json to clone instead of all agents
+  --inflate-transcript-kib <n> Repeat real transcript bytes until each clone is at least n KiB
+  --target-written-mib <n>     Inflate transcripts to write at least this many MiB total
+  --recent-sessions <count>    Keep only this many sessions inside the recent window
+  --recent-window-minutes <n>  Recent window used while seeding timestamps (default: 1440)
+  --limit <count>              Pass sessions.list limit
+  --active-minutes <count>     Pass sessions.list activeMinutes
+  --agent-id <id>              Pass sessions.list agentId
+  --cold-runs <count>          Fresh cloned profile runs (default: ${DEFAULT_COLD_RUNS})
+  --runs <count>               Measured runs (default: ${DEFAULT_RUNS})
+  --warmup <count>             Warmup runs (default: ${DEFAULT_WARMUP})
+  --include-derived-titles     Request derived titles
+  --include-last-message       Request last-message previews
+  --exclude-global             Do not request global rows
+  --exclude-unknown            Do not request unknown rows
+  --keep-temp                  Keep cloned temp profiles on disk
+  --json                       Print JSON
+  --output <path>              Write JSON report
+`);
+}
+
+function percentile(values: number[], percentileValue: number): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((percentileValue / 100) * sorted.length) - 1),
+  );
+  return sorted[index];
+}
+
+function summarize(samples: Sample[]) {
+  const elapsed = samples.map((sample) => sample.elapsedMs);
+  return {
+    minMs: Math.min(...elapsed),
+    p50Ms: percentile(elapsed, 50),
+    p95Ms: percentile(elapsed, 95),
+    maxMs: Math.max(...elapsed),
+    avgMs: elapsed.reduce((sum, value) => sum + value, 0) / elapsed.length,
+  };
+}
+
+function formatMs(value: number): string {
+  return `${value.toFixed(1)}ms`;
+}
+
+async function callSessionsList(params: {
+  activeMinutes?: number;
+  agentId?: string;
+  config: OpenClawConfig;
+  includeGlobal: boolean;
+  includeDerivedTitles: boolean;
+  includeLastMessage: boolean;
+  includeUnknown: boolean;
+  limit?: number;
+  sessionsHandlers: SessionsHandlers;
+}): Promise<SessionsListResult> {
+  let payload: SessionsListResult | undefined;
+  let error: unknown;
+  const listParams = {
+    includeGlobal: params.includeGlobal,
+    includeUnknown: params.includeUnknown,
+    includeDerivedTitles: params.includeDerivedTitles,
+    includeLastMessage: params.includeLastMessage,
+    ...(params.limit !== undefined ? { limit: params.limit } : {}),
+    ...(params.activeMinutes !== undefined ? { activeMinutes: params.activeMinutes } : {}),
+    ...(params.agentId !== undefined ? { agentId: params.agentId } : {}),
+  };
+  await params.sessionsHandlers["sessions.list"]({
+    req: {
+      type: "req",
+      id: "bench-sessions-list",
+      method: "sessions.list",
+      params: listParams,
+    },
+    params: listParams,
+    respond: (ok, response, responseError) => {
+      if (!ok) {
+        error = responseError;
+        return;
+      }
+      payload = response as SessionsListResult;
+    },
+    client: null,
+    isWebchatConnect: () => false,
+    context: {
+      getRuntimeConfig: () => params.config,
+      loadGatewayModelCatalog: async () => [],
+      logGateway: { debug: () => {} },
+      chatAbortControllers: new Map(),
+    } as never,
+  });
+  if (!payload) {
+    throw new Error(`sessions.list failed: ${JSON.stringify(error)}`);
+  }
+  return payload;
+}
+
+async function measure(params: {
+  activeMinutes?: number;
+  agentId?: string;
+  config: OpenClawConfig;
+  includeGlobal: boolean;
+  includeDerivedTitles: boolean;
+  includeLastMessage: boolean;
+  includeUnknown: boolean;
+  limit?: number;
+  sessionsHandlers: SessionsHandlers;
+}): Promise<Sample> {
+  const delay = monitorEventLoopDelay({ resolution: 1 });
+  delay.enable();
+  const start = performance.now();
+  const result = await callSessionsList(params);
+  const elapsedMs = performance.now() - start;
+  delay.disable();
+  return {
+    elapsedMs,
+    eventLoopDelayMaxMs: delay.max / 1_000_000,
+    rows: result.sessions.length,
+  };
+}
+
+const options = parseOptions();
+const { sessionsHandlers } = await import("../src/gateway/server-methods/sessions.js");
+const tempRoots: string[] = [];
+
+const coldSamples: Sample[] = [];
+for (let index = 0; index < options.coldRuns; index += 1) {
+  const coldSeeded = seedRealSessions(options);
+  tempRoots.push(coldSeeded.root);
+  process.env.OPENCLAW_STATE_DIR = coldSeeded.root;
+  const sample = await measure({
+    config: coldSeeded.config,
+    activeMinutes: options.activeMinutes,
+    agentId: options.agentId,
+    includeGlobal: options.includeGlobal,
+    includeDerivedTitles: options.includeDerivedTitles,
+    includeLastMessage: options.includeLastMessage,
+    includeUnknown: options.includeUnknown,
+    limit: options.limit,
+    sessionsHandlers,
+  });
+  coldSamples.push(sample);
+  if (!options.json) {
+    console.log(
+      `[sessions-list-bench] cold ${index + 1}/${options.coldRuns}: rows=${sample.rows} wall=${formatMs(sample.elapsedMs)} eventLoopDelayMax=${formatMs(sample.eventLoopDelayMaxMs)}`,
+    );
+  }
+}
+
+const seeded = seedRealSessions(options);
+tempRoots.push(seeded.root);
+process.env.OPENCLAW_STATE_DIR = seeded.root;
+
+if (!options.json) {
+  console.log(
+    `[sessions-list-bench] cloned ${options.sessions} sessions across ${seeded.seed.targetAgents} agents from ${seeded.seed.sourceTranscripts}/${seeded.seed.sourceRows} transcript-backed source rows across ${seeded.seed.sourceStores} stores (${Math.round(seeded.seed.writtenBytes / 1024 / 1024)} MiB written)`,
+  );
+}
+
+const warmups: Sample[] = [];
+for (let index = 0; index < options.warmup; index += 1) {
+  const sample = await measure({
+    config: seeded.config,
+    activeMinutes: options.activeMinutes,
+    agentId: options.agentId,
+    includeGlobal: options.includeGlobal,
+    includeDerivedTitles: options.includeDerivedTitles,
+    includeLastMessage: options.includeLastMessage,
+    includeUnknown: options.includeUnknown,
+    limit: options.limit,
+    sessionsHandlers,
+  });
+  warmups.push(sample);
+  if (!options.json) {
+    console.log(
+      `[sessions-list-bench] warmup ${index + 1}/${options.warmup}: rows=${sample.rows} wall=${formatMs(sample.elapsedMs)} eventLoopDelayMax=${formatMs(sample.eventLoopDelayMaxMs)}`,
+    );
+  }
+}
+
+const samples: Sample[] = [];
+for (let index = 0; index < options.runs; index += 1) {
+  const sample = await measure({
+    config: seeded.config,
+    activeMinutes: options.activeMinutes,
+    agentId: options.agentId,
+    includeGlobal: options.includeGlobal,
+    includeDerivedTitles: options.includeDerivedTitles,
+    includeLastMessage: options.includeLastMessage,
+    includeUnknown: options.includeUnknown,
+    limit: options.limit,
+    sessionsHandlers,
+  });
+  samples.push(sample);
+  if (!options.json) {
+    console.log(
+      `[sessions-list-bench] run ${index + 1}/${options.runs}: rows=${sample.rows} wall=${formatMs(sample.elapsedMs)} eventLoopDelayMax=${formatMs(sample.eventLoopDelayMaxMs)}`,
+    );
+  }
+}
+
+const report = {
+  options,
+  seed: seeded.seed,
+  storePath: seeded.storePath,
+  coldSamples,
+  coldSummary: coldSamples.length > 0 ? summarize(coldSamples) : null,
+  warmups,
+  samples,
+  summary: summarize(samples),
+};
+
+if (options.output) {
+  fs.mkdirSync(path.dirname(options.output), { recursive: true });
+  fs.writeFileSync(options.output, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+if (options.json) {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  const summary = report.summary;
+  const coldSummary = report.coldSummary;
+  if (coldSummary) {
+    console.log(
+      `[sessions-list-bench] cold summary: sessions=${options.sessions} min=${formatMs(coldSummary.minMs)} p50=${formatMs(coldSummary.p50Ms)} p95=${formatMs(coldSummary.p95Ms)} max=${formatMs(coldSummary.maxMs)} avg=${formatMs(coldSummary.avgMs)}`,
+    );
+  }
+  console.log(
+    `[sessions-list-bench] summary: sessions=${options.sessions} rows=${samples.at(-1)?.rows ?? 0} min=${formatMs(summary.minMs)} p50=${formatMs(summary.p50Ms)} p95=${formatMs(summary.p95Ms)} max=${formatMs(summary.maxMs)} avg=${formatMs(summary.avgMs)}`,
+  );
+  if (options.output) {
+    console.log(`[sessions-list-bench] wrote ${options.output}`);
+  }
+}
+
+if (!options.keepTemp) {
+  for (const root of tempRoots) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -130,6 +130,8 @@ export function createReplyMediaPathNormalizer(params: {
     }
     const persistPromise = resolveOutboundAttachmentFromUrl(media, maxBytes, {
       mediaAccess: resolveMediaAccessForSource(media),
+      hostReadAllowedMimes: params.cfg.media?.hostReadAllowedMimes,
+      hostReadMimePolicy: params.cfg.media?.hostReadMimePolicy,
     })
       .then((saved) => saved.path)
       .catch((err) => {

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -353,6 +353,8 @@ export const FIELD_LABELS: Record<string, string> = {
   media: "Media",
   "media.preserveFilenames": "Preserve Media Filenames",
   "media.ttlHours": "Media Retention TTL (hours)",
+  "media.hostReadAllowedMimes": "Host-Read Allowed MIME Types",
+  "media.hostReadMimePolicy": "Host-Read MIME Policy",
   audio: "Audio",
   "audio.transcription": "Audio Transcription",
   "audio.transcription.command": "Audio Transcription Command",

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -124,6 +124,13 @@ export type OpenClawConfig = {
     preserveFilenames?: boolean;
     /** Optional retention window for persisted inbound media cleanup. */
     ttlHours?: number;
+    /**
+     * Additional MIME types permitted for host-read outbound sends.
+     * "extend" (default) adds to the built-in allowlist; "override" replaces it entirely.
+     * Example: ["application/zip", "application/gzip"]
+     */
+    hostReadAllowedMimes?: string[];
+    hostReadMimePolicy?: "extend" | "override";
   };
   messages?: MessagesConfig;
   commands?: CommandsConfig;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -645,6 +645,8 @@ export const OpenClawSchema = z
           .min(1)
           .max(24 * 7)
           .optional(),
+        hostReadAllowedMimes: z.array(z.string()).optional(),
+        hostReadMimePolicy: z.enum(["extend", "override"]).optional(),
       })
       .strict()
       .optional(),

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -202,6 +202,8 @@ export function resolveAttachmentMediaPolicy(params: {
 function buildAttachmentMediaLoadOptions(params: {
   policy: AttachmentMediaPolicy;
   maxBytes?: number;
+  hostReadAllowedMimes?: readonly string[];
+  hostReadMimePolicy?: "extend" | "override";
 }):
   | {
       maxBytes?: number;
@@ -213,6 +215,8 @@ function buildAttachmentMediaLoadOptions(params: {
       localRoots?: readonly string[] | "any";
       readFile?: OutboundMediaReadFile;
       hostReadCapability?: boolean;
+      hostReadAllowedMimes?: readonly string[];
+      hostReadMimePolicy?: "extend" | "override";
     } {
   if (params.policy.mode === "sandbox") {
     const sandboxRoot = params.policy.sandboxRoot.trim();
@@ -232,6 +236,8 @@ function buildAttachmentMediaLoadOptions(params: {
     mediaAccess: params.policy.mediaAccess,
     mediaLocalRoots: params.policy.mediaLocalRoots,
     mediaReadFile: params.policy.mediaReadFile,
+    hostReadAllowedMimes: params.hostReadAllowedMimes,
+    hostReadMimePolicy: params.hostReadMimePolicy,
   });
 }
 
@@ -270,7 +276,12 @@ async function hydrateAttachmentPayload(params: {
     });
     const media = await loadWebMedia(
       mediaSource,
-      buildAttachmentMediaLoadOptions({ policy: params.mediaPolicy, maxBytes }),
+      buildAttachmentMediaLoadOptions({
+        policy: params.mediaPolicy,
+        maxBytes,
+        hostReadAllowedMimes: params.cfg.media?.hostReadAllowedMimes,
+        hostReadMimePolicy: params.cfg.media?.hostReadMimePolicy,
+      }),
     );
     params.args.buffer = media.buffer.toString("base64");
     if (!contentTypeParam && media.contentType) {

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -378,14 +378,9 @@ describe("runMessageAction media behavior", () => {
         expect.objectContaining({
           localRoots: expect.any(Array),
           readFile: expect.any(Function),
+          hostReadCapability: true,
         }),
       );
-      // hostReadCapability is NOT set on the sendAttachment path: the path-level
-      // guard (localRoots / assertLocalMediaAllowed) is the right boundary for
-      // explicit operator-initiated sends.
-      expect(
-        (call?.[1] as { hostReadCapability?: boolean } | undefined)?.hostReadCapability,
-      ).not.toBe(true);
       expect((call?.[1] as { sandboxValidated?: boolean } | undefined)?.sandboxValidated).not.toBe(
         true,
       );
@@ -424,7 +419,7 @@ describe("runMessageAction media behavior", () => {
       }
     });
 
-    it("allows host-local files of any MIME type when fs root expansion is enabled", async () => {
+    it("rejects host-local text attachments blocked by the MIME allowlist", async () => {
       await restoreRealMediaLoader();
 
       const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "msg-attachment-text-"));
@@ -432,56 +427,51 @@ describe("runMessageAction media behavior", () => {
         const outsidePath = path.join(tempDir, "export.txt");
         await fs.writeFile(outsidePath, "data", "utf8");
 
-        // The MIME allowlist check is not applied to explicit sends; only the
-        // path-level guard (localRoots) governs what the agent may read and send.
-        const result = await runMessageAction({
-          cfg: {
-            ...cfg,
-            tools: { fs: { workspaceOnly: false } },
-          },
-          action: "sendAttachment",
-          params: {
-            channel: "attachmentchat",
-            target: "+15551234567",
-            media: outsidePath,
-            message: "caption",
-          },
-        });
-        expect(result.kind).toBe("action");
+        await expect(
+          runMessageAction({
+            cfg: {
+              ...cfg,
+              tools: { fs: { workspaceOnly: false } },
+            },
+            action: "sendAttachment",
+            params: {
+              channel: "attachmentchat",
+              target: "+15551234567",
+              media: outsidePath,
+              message: "caption",
+            },
+          }),
+        ).rejects.toThrow(/only allow buffer-verified/i);
       } finally {
         await fs.rm(tempDir, { recursive: true, force: true });
       }
     });
 
-    it("send action does not set hostReadCapability so all MIME types are allowed", async () => {
-      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "msg-send-zip-"));
+    it("allows ZIP attachments when hostReadAllowedMimes includes application/zip", async () => {
+      await restoreRealMediaLoader();
+
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "msg-attachment-zip-"));
       try {
-        // Minimal ZIP magic bytes — file-type will sniff this as application/zip.
+        // Minimal ZIP magic bytes — file-type sniffs this as application/zip.
         const minimalZip = Buffer.from("504b0304", "hex");
         const zipPath = path.join(tempDir, "archive.zip");
         await fs.writeFile(zipPath, minimalZip);
 
-        vi.mocked(loadWebMedia).mockClear();
-
-        await runMessageAction({
+        const result = await runMessageAction({
           cfg: {
             ...cfg,
             tools: { fs: { workspaceOnly: false } },
+            media: { hostReadAllowedMimes: ["application/zip"] },
           },
-          action: "send",
+          action: "sendAttachment",
           params: {
             channel: "attachmentchat",
             target: "+15551234567",
             media: zipPath,
+            message: "archive",
           },
         });
-
-        const call = vi.mocked(loadWebMedia).mock.calls[0];
-        // hostReadCapability must NOT be set on the send path — the path-level
-        // guard (localRoots) is the appropriate boundary here.
-        expect(
-          (call?.[1] as { hostReadCapability?: boolean } | undefined)?.hostReadCapability,
-        ).not.toBe(true);
+        expect(result.kind).toBe("action");
       } finally {
         await fs.rm(tempDir, { recursive: true, force: true });
       }

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -378,9 +378,14 @@ describe("runMessageAction media behavior", () => {
         expect.objectContaining({
           localRoots: expect.any(Array),
           readFile: expect.any(Function),
-          hostReadCapability: true,
         }),
       );
+      // hostReadCapability is NOT set on the sendAttachment path: the path-level
+      // guard (localRoots / assertLocalMediaAllowed) is the right boundary for
+      // explicit operator-initiated sends.
+      expect(
+        (call?.[1] as { hostReadCapability?: boolean } | undefined)?.hostReadCapability,
+      ).not.toBe(true);
       expect((call?.[1] as { sandboxValidated?: boolean } | undefined)?.sandboxValidated).not.toBe(
         true,
       );
@@ -419,29 +424,64 @@ describe("runMessageAction media behavior", () => {
       }
     });
 
-    it("rejects host-local text attachments even when fs root expansion is enabled", async () => {
+    it("allows host-local files of any MIME type when fs root expansion is enabled", async () => {
       await restoreRealMediaLoader();
 
       const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "msg-attachment-text-"));
       try {
-        const outsidePath = path.join(tempDir, "secret.txt");
-        await fs.writeFile(outsidePath, "secret", "utf8");
+        const outsidePath = path.join(tempDir, "export.txt");
+        await fs.writeFile(outsidePath, "data", "utf8");
 
-        await expect(
-          runMessageAction({
-            cfg: {
-              ...cfg,
-              tools: { fs: { workspaceOnly: false } },
-            },
-            action: "sendAttachment",
-            params: {
-              channel: "attachmentchat",
-              target: "+15551234567",
-              media: outsidePath,
-              message: "caption",
-            },
-          }),
-        ).rejects.toThrow(/Host-local media sends only allow/i);
+        // The MIME allowlist check is not applied to explicit sends; only the
+        // path-level guard (localRoots) governs what the agent may read and send.
+        const result = await runMessageAction({
+          cfg: {
+            ...cfg,
+            tools: { fs: { workspaceOnly: false } },
+          },
+          action: "sendAttachment",
+          params: {
+            channel: "attachmentchat",
+            target: "+15551234567",
+            media: outsidePath,
+            message: "caption",
+          },
+        });
+        expect(result.kind).toBe("action");
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it("send action does not set hostReadCapability so all MIME types are allowed", async () => {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "msg-send-zip-"));
+      try {
+        // Minimal ZIP magic bytes — file-type will sniff this as application/zip.
+        const minimalZip = Buffer.from("504b0304", "hex");
+        const zipPath = path.join(tempDir, "archive.zip");
+        await fs.writeFile(zipPath, minimalZip);
+
+        vi.mocked(loadWebMedia).mockClear();
+
+        await runMessageAction({
+          cfg: {
+            ...cfg,
+            tools: { fs: { workspaceOnly: false } },
+          },
+          action: "send",
+          params: {
+            channel: "attachmentchat",
+            target: "+15551234567",
+            media: zipPath,
+          },
+        });
+
+        const call = vi.mocked(loadWebMedia).mock.calls[0];
+        // hostReadCapability must NOT be set on the send path — the path-level
+        // guard (localRoots) is the appropriate boundary here.
+        expect(
+          (call?.[1] as { hostReadCapability?: boolean } | undefined)?.hostReadCapability,
+        ).not.toBe(true);
       } finally {
         await fs.rm(tempDir, { recursive: true, force: true });
       }

--- a/src/media/load-options.ts
+++ b/src/media/load-options.ts
@@ -19,6 +19,9 @@ export type OutboundMediaLoadParams = {
   optimizeImages?: boolean;
   /** Agent workspace directory for resolving relative MEDIA: paths. */
   workspaceDir?: string;
+  /** Additional MIME types to permit (or replace the default list) for host-read sends. */
+  hostReadAllowedMimes?: readonly string[];
+  hostReadMimePolicy?: "extend" | "override";
 };
 
 export type OutboundMediaLoadOptions = {
@@ -30,6 +33,8 @@ export type OutboundMediaLoadOptions = {
   requestInit?: RequestInit;
   trustExplicitProxyDns?: boolean;
   hostReadCapability?: boolean;
+  hostReadAllowedMimes?: readonly string[];
+  hostReadMimePolicy?: "extend" | "override";
   optimizeImages?: boolean;
   /** Agent workspace directory for resolving relative MEDIA: paths. */
   workspaceDir?: string;
@@ -95,6 +100,9 @@ export function buildOutboundMediaLoadOptions(
       ...(params.trustExplicitProxyDns !== undefined
         ? { trustExplicitProxyDns: params.trustExplicitProxyDns }
         : {}),
+      hostReadCapability: true,
+      ...(params.hostReadAllowedMimes ? { hostReadAllowedMimes: params.hostReadAllowedMimes } : {}),
+      ...(params.hostReadMimePolicy ? { hostReadMimePolicy: params.hostReadMimePolicy } : {}),
       ...(params.optimizeImages !== undefined ? { optimizeImages: params.optimizeImages } : {}),
       ...(workspaceDir ? { workspaceDir } : {}),
     };

--- a/src/media/load-options.ts
+++ b/src/media/load-options.ts
@@ -95,7 +95,6 @@ export function buildOutboundMediaLoadOptions(
       ...(params.trustExplicitProxyDns !== undefined
         ? { trustExplicitProxyDns: params.trustExplicitProxyDns }
         : {}),
-      hostReadCapability: true,
       ...(params.optimizeImages !== undefined ? { optimizeImages: params.optimizeImages } : {}),
       ...(workspaceDir ? { workspaceDir } : {}),
     };

--- a/src/media/outbound-attachment.ts
+++ b/src/media/outbound-attachment.ts
@@ -9,6 +9,8 @@ export async function resolveOutboundAttachmentFromUrl(
     mediaAccess?: OutboundMediaAccess;
     localRoots?: readonly string[];
     readFile?: (filePath: string) => Promise<Buffer>;
+    hostReadAllowedMimes?: readonly string[];
+    hostReadMimePolicy?: "extend" | "override";
   },
 ): Promise<{ path: string; contentType?: string }> {
   const media = await loadWebMedia(mediaUrl, {
@@ -17,6 +19,8 @@ export async function resolveOutboundAttachmentFromUrl(
       mediaAccess: options?.mediaAccess,
       mediaLocalRoots: options?.localRoots,
       mediaReadFile: options?.readFile,
+      hostReadAllowedMimes: options?.hostReadAllowedMimes,
+      hostReadMimePolicy: options?.hostReadMimePolicy,
     }),
     // Auto-reply paths are the injection-protection target: model output may
     // contain attacker-controlled paths. The MIME allowlist limits blast radius

--- a/src/media/outbound-attachment.ts
+++ b/src/media/outbound-attachment.ts
@@ -11,15 +11,20 @@ export async function resolveOutboundAttachmentFromUrl(
     readFile?: (filePath: string) => Promise<Buffer>;
   },
 ): Promise<{ path: string; contentType?: string }> {
-  const media = await loadWebMedia(
-    mediaUrl,
-    buildOutboundMediaLoadOptions({
+  const media = await loadWebMedia(mediaUrl, {
+    ...buildOutboundMediaLoadOptions({
       maxBytes,
       mediaAccess: options?.mediaAccess,
       mediaLocalRoots: options?.localRoots,
       mediaReadFile: options?.readFile,
     }),
-  );
+    // Auto-reply paths are the injection-protection target: model output may
+    // contain attacker-controlled paths. The MIME allowlist limits blast radius
+    // if a malicious path slips past the path-level guard. Explicit send-tool
+    // calls do NOT set this flag — the path-level guard (localRoots) is the
+    // appropriate boundary there.
+    hostReadCapability: true,
+  });
   const saved = await saveMediaBuffer(
     media.buffer,
     media.contentType ?? undefined,

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -56,6 +56,9 @@ type WebMediaOptions = {
   readFile?: (filePath: string) => Promise<Buffer>;
   /** Host-local fs-policy read piggyback; rejects plaintext-like document sends. */
   hostReadCapability?: boolean;
+  /** Additional MIME types to permit for host-read sends. "override" replaces the built-in list. */
+  hostReadAllowedMimes?: readonly string[];
+  hostReadMimePolicy?: "extend" | "override";
 };
 
 async function resolveMediaStoreUriToPath(mediaUrl: string): Promise<string | null> {
@@ -238,6 +241,7 @@ function assertHostReadMediaAllowed(params: {
   filePath?: string;
   kind: MediaKind | undefined;
   buffer?: Buffer;
+  allowedDocumentMimes: ReadonlySet<string>;
 }): void {
   const declaredMime = normalizeMimeType(mimeTypeFromFilePath(params.filePath));
   const normalizedMime = normalizeMimeType(params.contentType);
@@ -259,11 +263,7 @@ function assertHostReadMediaAllowed(params: {
     return;
   }
   const sniffedMime = normalizeMimeType(params.sniffedContentType);
-  if (
-    sniffedKind === "document" &&
-    sniffedMime &&
-    HOST_READ_ALLOWED_DOCUMENT_MIMES.has(sniffedMime)
-  ) {
+  if (sniffedKind === "document" && sniffedMime && params.allowedDocumentMimes.has(sniffedMime)) {
     return;
   }
   if (
@@ -289,7 +289,7 @@ function assertHostReadMediaAllowed(params: {
   if (
     params.kind === "document" &&
     normalizedMime &&
-    HOST_READ_ALLOWED_DOCUMENT_MIMES.has(normalizedMime)
+    params.allowedDocumentMimes.has(normalizedMime)
   ) {
     throw new LocalMediaAccessError(
       "path-not-allowed",
@@ -298,7 +298,7 @@ function assertHostReadMediaAllowed(params: {
   }
   throw new LocalMediaAccessError(
     "path-not-allowed",
-    `Host-local media sends only allow buffer-verified images, audio, video, PDF, and Office documents (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
+    `Host-local media sends only allow buffer-verified images, audio, video, PDF, Office documents, and operator-configured types (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
   );
 }
 
@@ -386,6 +386,8 @@ async function loadWebMediaInternal(
     sandboxValidated = false,
     readFile: readFileOverride,
     hostReadCapability = false,
+    hostReadAllowedMimes,
+    hostReadMimePolicy,
   } = options;
   // Strip MEDIA: prefix used by agent tools (e.g. TTS) to tag media paths.
   // Be lenient: LLM output may add extra whitespace (e.g. "  MEDIA :  /tmp/x.png").
@@ -584,12 +586,18 @@ async function loadWebMediaInternal(
   const mime = await detectMime({ buffer: data, filePath: mediaUrl });
   const kind = kindFromMime(mime);
   if (hostReadCapability) {
+    const configMimes = hostReadAllowedMimes ?? [];
+    const allowedDocumentMimes =
+      hostReadMimePolicy === "override"
+        ? new Set(configMimes)
+        : new Set([...HOST_READ_ALLOWED_DOCUMENT_MIMES, ...configMimes]);
     assertHostReadMediaAllowed({
       sniffedContentType: sniffedMime,
       contentType: mime,
       filePath: mediaUrl,
       kind,
       buffer: data,
+      allowedDocumentMimes,
     });
   }
   let fileName = path.basename(mediaUrl) || undefined;

--- a/src/plugin-sdk/outbound-media.test.ts
+++ b/src/plugin-sdk/outbound-media.test.ts
@@ -69,7 +69,6 @@ describe("loadOutboundMediaFromUrl", () => {
       maxBytes: 2048,
       localRoots: ["/tmp/workspace-agent"],
       readFile: mediaReadFile,
-      hostReadCapability: true,
     });
   });
 
@@ -100,7 +99,6 @@ describe("loadOutboundMediaFromUrl", () => {
       maxBytes: 2048,
       localRoots: "any",
       readFile: mediaReadFile,
-      hostReadCapability: true,
     });
   });
 });

--- a/src/plugin-sdk/outbound-media.test.ts
+++ b/src/plugin-sdk/outbound-media.test.ts
@@ -69,6 +69,7 @@ describe("loadOutboundMediaFromUrl", () => {
       maxBytes: 2048,
       localRoots: ["/tmp/workspace-agent"],
       readFile: mediaReadFile,
+      hostReadCapability: true,
     });
   });
 
@@ -99,6 +100,7 @@ describe("loadOutboundMediaFromUrl", () => {
       maxBytes: 2048,
       localRoots: "any",
       readFile: mediaReadFile,
+      hostReadCapability: true,
     });
   });
 });


### PR DESCRIPTION
## Problem

`assertHostReadMediaAllowed` in `web-media.ts` gates host-local file sends on a hardcoded MIME allowlist. The allowlist covers images, audio/video, PDF, and common Office formats but excludes archives and most other types. This is a regression from 4.23: ZIP attachments sent via the `message` tool now throw `LocalMediaAccessError: path-not-allowed`.

## Approach

Rather than hardcoding additional types (as in #78073) or removing the check from one code path, this PR makes the allowlist operator-configurable via `cfg.media`:

\`\`\`jsonc
{
  "media": {
    // append to the built-in list (default policy)
    "hostReadAllowedMimes": ["application/zip", "application/gzip"],
    // or replace it entirely
    "hostReadMimePolicy": "override",
    "hostReadAllowedMimes": ["application/zip"]
  }
}
\`\`\`

`hostReadMimePolicy`:
- `"extend"` (default) — adds the listed types to the built-in allowlist
- `"override"` — replaces the built-in list entirely (for operators who want full control)

The built-in allowlist is unchanged; installs that don't set `hostReadAllowedMimes` see no behavior difference.

## Files changed

- `src/config/types.openclaw.ts`, `src/config/zod-schema.ts`, `src/config/schema.labels.ts` — config schema
- `src/media/load-options.ts` — thread `hostReadAllowedMimes`/`hostReadMimePolicy` through `OutboundMediaLoadParams` → `OutboundMediaLoadOptions`
- `src/media/web-media.ts` — `assertHostReadMediaAllowed` now accepts a pre-built `allowedDocumentMimes` set assembled from the config
- `src/media/outbound-attachment.ts`, `src/auto-reply/reply/reply-media-paths.ts`, `src/infra/outbound/message-action-params.ts` — thread config fields to callers that have access to `cfg`
- Tests updated: ZIP rejection replaced with ZIP-succeeds-with-config test; text-file rejection test restored

## Test plan

- 20/20 `message-action-runner.media.test.ts` pass
- 5/5 `plugin-sdk/outbound-media.test.ts` pass
- `tsc --noEmit` clean

Supersedes #78073.