### PR TITLE
fix: skip uninstalled Honcho migration config

### DIFF
--- a/extensions/migrate-hermes/config.test.ts
+++ b/extensions/migrate-hermes/config.test.ts
@@ -15,7 +15,7 @@ describe("Hermes migration config mapping", () => {
     await cleanupTempRoots();
   });
 
-  it("plans provider, MCP, skill, and memory plugin config as plugin-owned items", async () => {
+  it("plans provider, MCP, skill, and memory follow-up without importing Honcho plugin config", async () => {
     const root = await makeTempRoot();
     const source = path.join(root, "hermes");
     const workspaceDir = path.join(root, "workspace");
@@ -58,15 +58,10 @@ describe("Hermes migration config mapping", () => {
     expect(plan.items).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          id: "config:memory-plugin:honcho",
-          kind: "config",
-          action: "merge",
-          target: "plugins.entries.honcho",
-        }),
-        expect.objectContaining({
           id: "manual:memory-provider:honcho",
           kind: "manual",
           status: "skipped",
+          reason: expect.stringContaining("manually adding plugins.entries.honcho"),
         }),
         expect.objectContaining({
           id: "config:model-providers",
@@ -107,9 +102,52 @@ describe("Hermes migration config mapping", () => {
         }),
       ]),
     );
+    expect(plan.items).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          target: "plugins.entries.honcho",
+        }),
+      ]),
+    );
     expect(plan.warnings).toEqual(
       expect.arrayContaining([expect.stringContaining("manual review")]),
     );
+  });
+
+  it("does not write Honcho plugin entries during apply", async () => {
+    const root = await makeTempRoot();
+    const source = path.join(root, "hermes");
+    const workspaceDir = path.join(root, "workspace");
+    const stateDir = path.join(root, "state");
+    const config = {
+      agents: { defaults: { workspace: workspaceDir } },
+    } as OpenClawConfig;
+    await writeFile(
+      path.join(source, "config.yaml"),
+      ["memory:", "  provider: honcho", "  honcho:", "    project: hermes", ""].join("\n"),
+    );
+
+    const provider = buildHermesMigrationProvider();
+    const result = await provider.apply(
+      makeContext({
+        source,
+        stateDir,
+        workspaceDir,
+        runtime: makeConfigRuntime(config),
+      }),
+    );
+
+    expect(result.summary.errors).toBe(0);
+    expect(result.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "manual:memory-provider:honcho",
+          status: "skipped",
+        }),
+      ]),
+    );
+    expect(config.plugins?.entries?.honcho).toBeUndefined();
+    expect(config.plugins?.slots).toMatchObject({ memory: "memory-core" });
   });
 
   it("applies mapped config items through the migration runtime config writer", async () => {

--- a/extensions/migrate-hermes/config.ts
+++ b/extensions/migrate-hermes/config.ts
@@ -200,32 +200,14 @@ export function buildConfigItems(params: {
   }
 
   if (memoryProvider === "honcho") {
-    const value = {
-      honcho: {
-        enabled: true,
-        config: childRecord(memory, "honcho"),
-      },
-    };
-    items.push(
-      createMigrationConfigPatchItem({
-        id: "config:memory-plugin:honcho",
-        target: "plugins.entries.honcho",
-        path: ["plugins", "entries"],
-        value,
-        message: "Preserve Hermes Honcho memory settings as a plugin entry for manual activation.",
-        conflict:
-          !params.ctx.overwrite &&
-          hasMigrationConfigPatchConflict(params.ctx.config, ["plugins", "entries"], value),
-      }),
-    );
     items.push(
       createMigrationManualItem({
         id: "manual:memory-provider:honcho",
         source: "config.yaml:memory.provider",
         message:
-          "Hermes used Honcho memory. OpenClaw keeps built-in memory selected until the matching plugin is installed and reviewed.",
+          "Hermes used Honcho memory. OpenClaw keeps built-in memory selected and does not import Honcho plugin config automatically.",
         recommendation:
-          "Install or review the Honcho memory plugin before selecting it for plugins.slots.memory.",
+          "Install or review an OpenClaw Honcho memory plugin before manually adding plugins.entries.honcho or selecting it for plugins.slots.memory.",
       }),
     );
   } else if (memoryProvider && !["builtin", "file", "files"].includes(memoryProvider)) {


### PR DESCRIPTION
Fixes #78191.

## Summary
- stop Hermes migration from writing `plugins.entries.honcho` for an uninstalled/manual Honcho memory provider
- keep built-in file memory selected and leave Honcho as a skipped manual follow-up
- add regression coverage that plan/apply do not create the dangling plugin entry

## Tests
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm exec oxfmt --write --threads=1 extensions/migrate-hermes/config.ts extensions/migrate-hermes/config.test.ts`
- `git diff --check`
- `node scripts/test-projects.mjs extensions/migrate-hermes/config.test.ts` attempted, blocked before tests by missing local package `@openclaw/fs-safe/config` in this checkout dependency install
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` passed conflict/changelog/export/duplicate lanes, then failed existing extension typecheck diagnostics unrelated to this patch, including missing `@openclaw/fs-safe/*` modules and pre-existing strictness errors in other extensions
