### PR TITLE
fix: suppress exec heartbeat ack leaks

### DIFF
--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -643,6 +643,63 @@ describe("Ghost reminder bug (issue #13317)", () => {
     });
   });
 
+  it("suppresses HEARTBEAT_OK for relayable exec completion wakes", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "last",
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = "agent:main:telegram:group:-1003774691294:topic:47";
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:-1003774691294:topic:2175",
+            lastThreadId: 2175,
+          },
+        }),
+      );
+
+      const sendTelegram = vi.fn();
+      const getReplySpy = vi.fn().mockResolvedValue({ text: "HEARTBEAT_OK" });
+      enqueueSystemEvent("Exec completed (review-run, code 0) :: review-worker spawn finished", {
+        sessionKey,
+        trusted: false,
+        deliveryContext: {
+          channel: "telegram",
+          to: "telegram:-1003774691294:topic:47",
+          threadId: 47,
+        },
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey,
+        reason: "exec-event",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(sendTelegram).not.toHaveBeenCalled();
+    });
+  });
+
   it("suppresses metadata-only successful exec completions", async () => {
     await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
       const cfg: OpenClawConfig = {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1686,23 +1686,10 @@ export async function runHeartbeatOnce(opts: {
       : replyPayload
         ? normalizeHeartbeatReply(replyPayload, responsePrefix, ackMaxChars)
         : { shouldSkip: true, text: "", hasMedia: false };
-    // For exec completion events, don't skip even if the response looks like HEARTBEAT_OK.
-    // The model should be responding with exec results, not ack tokens.
-    // Also, if normalized.text is empty due to token stripping but we have exec completion,
-    // fall back to the original reply text.
-    const execFallbackText =
-      !heartbeatToolResponse &&
-      hasRelayableExecCompletion &&
-      !normalized.text.trim() &&
-      replyPayload?.text?.trim()
-        ? replyPayload.text.trim()
-        : null;
-    if (execFallbackText) {
-      normalized.text = execFallbackText;
-      normalized.shouldSkip = false;
-    }
-    const shouldSkipMain =
-      normalized.shouldSkip && !normalized.hasMedia && !hasRelayableExecCompletion;
+    // HEARTBEAT_OK is a protocol ack, not user content. Even relayable exec
+    // completion wakes must swallow a pure ack; real exec summaries still deliver
+    // because normalization leaves shouldSkip=false for non-ack text.
+    const shouldSkipMain = normalized.shouldSkip && !normalized.hasMedia;
     if (shouldSkipMain && reasoningPayloads.length === 0) {
       await restoreHeartbeatUpdatedAt({
         storePath,


### PR DESCRIPTION
Fixes #78197.

## Summary
- keep pure `HEARTBEAT_OK` normalized as a protocol ack for relayable exec-completion heartbeat wakes
- remove the exec-completion fallback that restored stripped ack text as user-visible delivery
- add a regression test for relayable exec completion returning `HEARTBEAT_OK`, while preserving real exec summary delivery coverage

## Verification
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm exec oxfmt --check src/infra/heartbeat-runner.ts src/infra/heartbeat-runner.ghost-reminder.test.ts`
- attempted `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/heartbeat-runner.ghost-reminder.test.ts` — blocked before tests by existing local missing `@openclaw/fs-safe/config` dependency
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` passed conflict/changelog/extension wildcard/duplicate lanes; core typecheck blocked by unrelated existing missing `@openclaw/fs-safe/*` modules and pre-existing strictness diagnostics outside this patch
