### PR TITLE
fix: start explicit legacy hook plugins

### DIFF
--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -330,6 +330,14 @@ function createManifestRegistryFixture(): PluginManifestRegistry {
         cliBackends: [],
       },
       {
+        id: "external-legacy-hook",
+        channels: [],
+        origin: "global",
+        enabledByDefault: undefined,
+        providers: [],
+        cliBackends: [],
+      },
+      {
         id: "lossless-claw",
         kind: "context-engine",
         channels: [],
@@ -931,6 +939,29 @@ describe("resolveGatewayStartupPluginIds", () => {
         memorySlot: "none",
       }),
       expected: ["external-hook-capability"],
+    });
+  });
+
+  it("loads explicitly enabled legacy external hook plugins at startup", () => {
+    expectStartupPluginIdsCase({
+      config: createStartupConfig({
+        enabledPluginIds: ["external-legacy-hook"],
+        allowPluginIds: ["external-legacy-hook"],
+        noConfiguredChannels: true,
+        memorySlot: "none",
+      }),
+      expected: ["external-legacy-hook"],
+    });
+  });
+
+  it("does not ambient-load legacy external hook plugins at startup", () => {
+    expectStartupPluginIdsCase({
+      config: createStartupConfig({
+        allowPluginIds: ["external-legacy-hook"],
+        noConfiguredChannels: true,
+        memorySlot: "none",
+      }),
+      expected: [],
     });
   });
 

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -427,9 +427,11 @@ function hasHookRuntimeStartupIntent(params: {
   if (params.manifest?.activation?.onCapabilities?.includes("hook")) {
     return true;
   }
-  return hasExplicitHookPolicyConfig(
-    params.activationSourcePlugins.entries[params.plugin.pluginId],
-  );
+  const entry = params.activationSourcePlugins.entries[params.plugin.pluginId];
+  if (params.plugin.origin !== "bundled" && entry?.enabled === true) {
+    return true;
+  }
+  return hasExplicitHookPolicyConfig(entry);
 }
 
 function canStartExplicitHookPlugin(params: {


### PR DESCRIPTION
Fixes #78196.

## Summary
- Treat explicitly enabled non-bundled plugins as gateway startup hook intent when they lack newer `activation.onCapabilities: ["hook"]` metadata.
- Keep the existing allow/deny/global-enabled activation checks, so this restores legacy external hook compatibility without ambient-loading merely allowlisted plugins.
- Add startup planner regression coverage for explicit legacy external hook plugins and the ambient-load negative case.

## Verification
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm exec oxfmt --check src/plugins/gateway-startup-plugin-ids.ts src/plugins/channel-plugin-ids.test.ts`
- Targeted tests attempted: `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm test src/plugins/channel-plugin-ids.test.ts src/gateway/server-plugins.test.ts` — blocked before tests by missing local `@openclaw/fs-safe/config` import from `src/infra/fs-safe-defaults.ts`.
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` — passed conflict/changelog/extension wildcard/duplicate lanes; failed unrelated existing core typecheck diagnostics including missing `@openclaw/fs-safe/*` and strictness errors outside this patch.

Notes: `pnpm install --offline --ignore-scripts` in the `/tmp` worktree was attempted to repair missing deps but hit `/tmp` ENOSPC, so subsequent checks used the main repo's existing `node_modules` symlink.
