### PR TITLE
fix: keep Feishu group mentions replyable

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1156,6 +1156,53 @@ describe("handleFeishuMessage command authorization", () => {
       }),
     );
     expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultSourceReplyDeliveryMode: "automatic",
+      }),
+    );
+  });
+
+  it("honors explicit group visibleReplies=message_tool instead of forcing Feishu automatic replies", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      messages: { groupChat: { visibleReplies: "message_tool" } },
+      channels: {
+        feishu: {
+          groupPolicy: "open",
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-allowed",
+        },
+      },
+      message: {
+        message_id: "msg-explicit-message-tool",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        defaultSourceReplyDeliveryMode: "automatic",
+      }),
+    );
   });
 
   it("blocks group sender when global groupSenderAllowFrom excludes sender", async () => {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1246,6 +1246,11 @@ export async function handleFeishuMessage(params: {
           (ctx.suppressReplyTarget ? undefined : ctx.messageId))
         : (ctx.replyTargetMessageId ?? (ctx.suppressReplyTarget ? undefined : ctx.messageId));
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
+    const defaultSourceReplyDeliveryMode =
+      isGroup &&
+      (cfg.messages?.groupChat?.visibleReplies ?? cfg.messages?.visibleReplies) === undefined
+        ? ("automatic" as const)
+        : undefined;
 
     if (broadcastAgents) {
       // Cross-account dedup: in multi-account setups, Feishu delivers the same
@@ -1323,6 +1328,7 @@ export async function handleFeishuMessage(params: {
             mentionTargets: ctx.mentionTargets,
             accountId: account.accountId,
             identity,
+            defaultSourceReplyDeliveryMode,
             messageCreateTimeMs,
           });
 
@@ -1488,6 +1494,7 @@ export async function handleFeishuMessage(params: {
         mentionTargets: ctx.mentionTargets,
         accountId: account.accountId,
         identity,
+        defaultSourceReplyDeliveryMode,
         messageCreateTimeMs,
       });
 

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -297,6 +297,18 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(result.replyOptions).toHaveProperty("disableBlockStreaming", true);
   });
 
+  it("can force automatic source replies for default Feishu group dispatch", async () => {
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+      defaultSourceReplyDeliveryMode: "automatic",
+    });
+
+    expect(result.replyOptions).toHaveProperty("sourceReplyDeliveryMode", "automatic");
+  });
+
   it("enables core block streaming when Feishu blockStreaming is explicitly true", async () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -127,6 +127,7 @@ type CreateFeishuReplyDispatcherParams = {
   mentionTargets?: MentionTarget[];
   accountId?: string;
   identity?: OutboundIdentity;
+  defaultSourceReplyDeliveryMode?: "automatic";
   /** Epoch ms when the inbound message was created. Used to suppress typing
    *  indicators on old/replayed messages after context compaction (#30418). */
   messageCreateTimeMs?: number;
@@ -667,6 +668,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     dispatcher,
     replyOptions: {
       ...replyOptions,
+      ...(params.defaultSourceReplyDeliveryMode
+        ? { sourceReplyDeliveryMode: params.defaultSourceReplyDeliveryMode }
+        : {}),
       onModelSelected: prefixContext.onModelSelected,
       disableBlockStreaming:
         typeof account.config?.blockStreaming === "boolean" ? !account.config.blockStreaming : true,


### PR DESCRIPTION
Fixes #78204.

## Summary
- Default Feishu group turns now keep automatic source replies when no visible-replies preference is explicitly configured.
- Explicit `messages.groupChat.visibleReplies` / `messages.visibleReplies` settings are still honored, including `message_tool`.
- Added regression coverage for Feishu group dispatch and reply dispatcher option propagation.

## Tests
- `git diff --check`
- `/tank/development/linus/openclaw/node_modules/.bin/oxfmt --check extensions/feishu/src/bot.ts extensions/feishu/src/reply-dispatcher.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/reply-dispatcher.test.ts`
- Targeted Feishu vitest attempted with parent repo node_modules, but blocked before tests by missing local `@openclaw/fs-safe/config` from `src/infra/fs-safe-defaults.ts`.
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` passed conflict/changelog/extension wildcard/plugin-sdk wildcard/duplicate lanes; failed typecheck on unrelated existing missing `@openclaw/fs-safe/*` and strictness diagnostics outside this patch.
