### PR TITLE
fix(sessions): restore Control UI /new hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/sessions: fire the documented `/new` command and lifecycle hooks only for explicit Control UI session creation, restoring session-memory and custom hook capture without changing SDK parent-session creates. Fixes #76957. Thanks @BunsDev.
 - Slack: preserve Socket Mode SDK error context and structured Slack API fields in reconnect logs, so startup failures no longer collapse to a bare `unknown error`.
 - iOS pairing: allow setup-code and manual `ws://` connects for private LAN and `.local` gateways while keeping Tailscale/public routes on `wss://`, and prefer explicit gateway passwords over stale bootstrap tokens in mixed-auth reconnects. Fixes #47887; carries forward #65185. Thanks @draix and @BunsDev.
 - Plugins/diagnostics: make source-only TypeScript package warnings actionable by explaining that missing compiled runtime output is a publisher packaging issue and pointing users to update/reinstall or disable/uninstall the plugin. Fixes #77835. Thanks @googlerest.

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1910,6 +1910,7 @@ public struct SessionsCreateParams: Codable, Sendable {
     public let label: String?
     public let model: String?
     public let parentsessionkey: String?
+    public let emitcommandhooks: Bool?
     public let task: String?
     public let message: String?
 
@@ -1919,6 +1920,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         label: String?,
         model: String?,
         parentsessionkey: String?,
+        emitcommandhooks: Bool?,
         task: String?,
         message: String?)
     {
@@ -1927,6 +1929,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         self.label = label
         self.model = model
         self.parentsessionkey = parentsessionkey
+        self.emitcommandhooks = emitcommandhooks
         self.task = task
         self.message = message
     }
@@ -1937,6 +1940,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         case label
         case model
         case parentsessionkey = "parentSessionKey"
+        case emitcommandhooks = "emitCommandHooks"
         case task
         case message
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1910,6 +1910,7 @@ public struct SessionsCreateParams: Codable, Sendable {
     public let label: String?
     public let model: String?
     public let parentsessionkey: String?
+    public let emitcommandhooks: Bool?
     public let task: String?
     public let message: String?
 
@@ -1919,6 +1920,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         label: String?,
         model: String?,
         parentsessionkey: String?,
+        emitcommandhooks: Bool?,
         task: String?,
         message: String?)
     {
@@ -1927,6 +1929,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         self.label = label
         self.model = model
         self.parentsessionkey = parentsessionkey
+        self.emitcommandhooks = emitcommandhooks
         self.task = task
         self.message = message
     }
@@ -1937,6 +1940,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         case label
         case model
         case parentsessionkey = "parentSessionKey"
+        case emitcommandhooks = "emitCommandHooks"
         case task
         case message
     }

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -113,6 +113,7 @@ export const SessionsCreateParamsSchema = Type.Object(
     label: Type.Optional(SessionLabelString),
     model: Type.Optional(NonEmptyString),
     parentSessionKey: Type.Optional(NonEmptyString),
+    emitCommandHooks: Type.Optional(Type.Boolean()),
     task: Type.Optional(Type.String()),
     message: Type.Optional(Type.String()),
   },

--- a/src/gateway/server-methods/sessions.runtime.ts
+++ b/src/gateway/server-methods/sessions.runtime.ts
@@ -1,7 +1,9 @@
 export {
   archiveSessionTranscriptsForSessionDetailed,
   cleanupSessionBeforeMutation,
+  emitGatewayBeforeResetPluginHook,
   emitGatewaySessionEndPluginHook,
+  emitGatewaySessionStartPluginHook,
   emitSessionUnboundLifecycleEvent,
   performGatewaySessionReset,
 } from "../session-reset-service.js";

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -24,6 +24,7 @@ import {
 } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
+  createInternalHookEvent,
   hasInternalHookListeners,
   triggerInternalHook,
   type SessionPatchHookContext,
@@ -999,6 +1000,36 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       }
       canonicalParentSessionKey = parent.canonicalKey;
     }
+    if (canonicalParentSessionKey && p.emitCommandHooks === true) {
+      const { entry: parentEntry } = loadSessionEntry(canonicalParentSessionKey);
+      const parentAgentId = normalizeAgentId(
+        resolveAgentIdFromSessionKey(canonicalParentSessionKey) ?? resolveDefaultAgentId(cfg),
+      );
+      const workspaceDir = resolveAgentWorkspaceDir(cfg, parentAgentId);
+      if (hasInternalHookListeners("command", "new")) {
+        const hookEvent = createInternalHookEvent("command", "new", canonicalParentSessionKey, {
+          sessionEntry: parentEntry,
+          previousSessionEntry: parentEntry,
+          commandSource: "webchat",
+          cfg,
+          workspaceDir,
+        });
+        await triggerInternalHook(hookEvent);
+      }
+      const parentTarget = resolveGatewaySessionStoreTarget({
+        cfg,
+        key: canonicalParentSessionKey,
+      });
+      const { emitGatewayBeforeResetPluginHook } = await loadSessionsRuntimeModule();
+      await emitGatewayBeforeResetPluginHook({
+        cfg,
+        key: canonicalParentSessionKey,
+        target: parentTarget,
+        storePath: parentTarget.storePath,
+        entry: parentEntry,
+        reason: "new",
+      });
+    }
     const loweredRequestedKey = normalizeOptionalLowercaseString(requestedKey);
     const key = requestedKey
       ? loweredRequestedKey === "global" || loweredRequestedKey === "unknown"
@@ -1140,6 +1171,32 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       emitSessionsChanged(context, {
         sessionKey: target.canonicalKey,
         reason: "send",
+      });
+    }
+    if (canonicalParentSessionKey && p.emitCommandHooks === true) {
+      const { entry: parentEntry } = loadSessionEntry(canonicalParentSessionKey);
+      const parentTarget = resolveGatewaySessionStoreTarget({
+        cfg,
+        key: canonicalParentSessionKey,
+      });
+      const { emitGatewaySessionEndPluginHook, emitGatewaySessionStartPluginHook } =
+        await loadSessionsRuntimeModule();
+      emitGatewaySessionEndPluginHook({
+        cfg,
+        sessionKey: canonicalParentSessionKey,
+        sessionId: parentEntry?.sessionId,
+        storePath: parentTarget.storePath,
+        sessionFile: parentEntry?.sessionFile,
+        agentId: parentTarget.agentId,
+        reason: "new",
+        nextSessionId: createdEntry.sessionId,
+        nextSessionKey: target.canonicalKey,
+      });
+      emitGatewaySessionStartPluginHook({
+        cfg,
+        sessionKey: target.canonicalKey,
+        sessionId: createdEntry.sessionId,
+        resumedFrom: parentEntry?.sessionId,
       });
     }
   },

--- a/src/gateway/server.sessions.reset-hooks.test.ts
+++ b/src/gateway/server.sessions.reset-hooks.test.ts
@@ -296,3 +296,145 @@ test("sessions.reset emits before_reset for the entry actually reset in the writ
     sessionId: "sess-new",
   });
 });
+
+test("sessions.create with emitCommandHooks=true fires command:new hook against parent (#76957)", async () => {
+  const { dir } = await createSessionStoreDir();
+  await writeSingleLineSession(dir, "sess-parent", "hello from parent");
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-parent"),
+    },
+  });
+
+  const result = await directSessionReq<{ ok: boolean; key: string }>("sessions.create", {
+    parentSessionKey: "main",
+    emitCommandHooks: true,
+  });
+  expect(result.ok).toBe(true);
+
+  const commandNewEvents = (
+    sessionHookMocks.triggerInternalHook.mock.calls as unknown as Array<[unknown]>
+  )
+    .map((call) => call[0])
+    .filter(
+      (event): event is { type: string; action: string; context?: { commandSource?: string } } =>
+        Boolean(event) &&
+        typeof event === "object" &&
+        (event as { type?: unknown }).type === "command" &&
+        (event as { action?: unknown }).action === "new",
+    );
+  expect(commandNewEvents).toHaveLength(1);
+  expect(commandNewEvents[0]).toMatchObject({
+    type: "command",
+    action: "new",
+    context: { commandSource: "webchat" },
+  });
+});
+
+test("sessions.create with emitCommandHooks=true emits reset lifecycle hooks against parent (#76957)", async () => {
+  const { dir } = await createSessionStoreDir();
+  const transcriptPath = path.join(dir, "sess-parent-hooks.jsonl");
+  await fs.writeFile(
+    transcriptPath,
+    `${JSON.stringify({
+      type: "message",
+      id: "m1",
+      message: { role: "user", content: "remember this before new" },
+    })}\n`,
+    "utf-8",
+  );
+
+  await writeSessionStore({
+    entries: {
+      main: {
+        sessionId: "sess-parent-hooks",
+        sessionFile: transcriptPath,
+        updatedAt: Date.now(),
+      },
+    },
+  });
+
+  beforeResetHookState.hasBeforeResetHook = true;
+
+  const result = await directSessionReq<{ ok: boolean; key: string }>("sessions.create", {
+    parentSessionKey: "main",
+    emitCommandHooks: true,
+  });
+  expect(result.ok).toBe(true);
+
+  expect(beforeResetHookMocks.runBeforeReset).toHaveBeenCalledTimes(1);
+  const [beforeResetEvent, beforeResetContext] = (
+    beforeResetHookMocks.runBeforeReset.mock.calls as unknown as Array<[unknown, unknown]>
+  )[0] ?? [undefined, undefined];
+  expect(beforeResetEvent).toMatchObject({
+    sessionFile: transcriptPath,
+    reason: "new",
+    messages: [
+      {
+        role: "user",
+        content: "remember this before new",
+      },
+    ],
+  });
+  expect(beforeResetContext).toMatchObject({
+    agentId: "main",
+    sessionKey: "agent:main:main",
+    sessionId: "sess-parent-hooks",
+  });
+
+  expect(sessionLifecycleHookMocks.runSessionEnd).toHaveBeenCalledTimes(1);
+  expect(sessionLifecycleHookMocks.runSessionStart).toHaveBeenCalledTimes(1);
+  const [endEvent] = (
+    sessionLifecycleHookMocks.runSessionEnd.mock.calls as unknown as Array<[unknown, unknown]>
+  )[0] ?? [undefined, undefined];
+  const [startEvent] = (
+    sessionLifecycleHookMocks.runSessionStart.mock.calls as unknown as Array<[unknown, unknown]>
+  )[0] ?? [undefined, undefined];
+  expect(endEvent).toMatchObject({
+    sessionId: "sess-parent-hooks",
+    sessionKey: "agent:main:main",
+    reason: "new",
+    nextSessionId: (startEvent as { sessionId?: string } | undefined)?.sessionId,
+    nextSessionKey: (startEvent as { sessionKey?: string } | undefined)?.sessionKey,
+  });
+  expect(startEvent).toMatchObject({
+    resumedFrom: "sess-parent-hooks",
+  });
+  expect((startEvent as { sessionId?: string } | undefined)?.sessionId).toEqual(expect.any(String));
+  expect((startEvent as { sessionKey?: string } | undefined)?.sessionKey).toMatch(
+    /^agent:main:dashboard:/,
+  );
+});
+
+test("sessions.create without emitCommandHooks does not fire command:new hook (#76957)", async () => {
+  const { dir } = await createSessionStoreDir();
+  await writeSingleLineSession(dir, "sess-parent2", "hello from parent 2");
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-parent2"),
+    },
+  });
+
+  const result = await directSessionReq<{ ok: boolean; key: string }>("sessions.create", {
+    parentSessionKey: "main",
+  });
+  expect(result.ok).toBe(true);
+
+  const commandNewEvents = (
+    sessionHookMocks.triggerInternalHook.mock.calls as unknown as Array<[unknown]>
+  )
+    .map((call) => call[0])
+    .filter(
+      (event): event is { type: string; action: string } =>
+        Boolean(event) &&
+        typeof event === "object" &&
+        (event as { type?: unknown }).type === "command" &&
+        (event as { action?: unknown }).action === "new",
+    );
+  expect(commandNewEvents).toHaveLength(0);
+  expect(beforeResetHookMocks.runBeforeReset).not.toHaveBeenCalled();
+  expect(sessionLifecycleHookMocks.runSessionEnd).not.toHaveBeenCalled();
+  expect(sessionLifecycleHookMocks.runSessionStart).not.toHaveBeenCalled();
+});

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -433,7 +433,7 @@ export async function cleanupSessionBeforeMutation(params: {
   });
 }
 
-async function emitGatewayBeforeResetPluginHook(params: {
+export async function emitGatewayBeforeResetPluginHook(params: {
   cfg: OpenClawConfig;
   key: string;
   target: ReturnType<typeof resolveGatewaySessionStoreTarget>;

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -663,6 +663,7 @@ describe("createChatSession", () => {
       {
         agentId: "ops",
         parentSessionKey: "agent:ops:main",
+        emitCommandHooks: true,
       },
       {
         activeMinutes: 0,

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -637,6 +637,7 @@ export async function createChatSession(state: AppViewState) {
     {
       agentId: resolveAgentIdFromSessionKey(previousSessionKey),
       parentSessionKey,
+      emitCommandHooks: parentSessionKey !== undefined ? true : undefined,
     },
     {
       activeMinutes: 0,

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -44,6 +44,7 @@ type CreateSessionParams = {
   label?: string;
   model?: string;
   parentSessionKey?: string;
+  emitCommandHooks?: boolean;
 };
 
 type CreateSessionResult = {


### PR DESCRIPTION
## Summary

- Fixes #76957 by adding an explicit `emitCommandHooks` opt-in to `sessions.create` and wiring the Control UI typed `/new` flow to send it only when creating from a real parent session.
- Restores the documented `command:new`, `before_reset`, `session_end`, and `session_start` hook chain for Control UI `/new`, so bundled `session-memory` and custom command hooks see the previous session before the UI switches to the new one.
- Keeps ordinary SDK/programmatic `sessions.create` calls with `parentSessionKey` hook-free by default, avoiding the over-broad behavior called out on #77004.
- Regenerates the macOS/shared Swift protocol mirrors and records the user-facing fix in the changelog.

## Triage

- Issue #76957 is still open and still reproducible on current main: Control UI typed `/new` reaches `sessions.create`, which had no `command:new` hook emission path.
- Closed duplicate/superseded items checked: #77562 is already closed as a duplicate of #76957; #76967 and #77004 are closed earlier attempts; #77376 was the focused fix but closed unmerged as stale.
- `gitcrawl` local data was stale for this issue (`threads` returned no target and neighbors required an embedding), so live GitHub was used for current issue/PR state.
- `prtags` is authenticated locally, but duplicate group search returned `request failed (502)`, so I did not write partial duplicate group state. The duplicate relationship is captured here and on the existing GitHub threads instead.
- This replacement follows the narrow fix direction from closed PR #77376 and preserves that provenance in this PR body.

## Verification

- `pnpm docs:list`
- `pnpm protocol:check`
- `pnpm test src/gateway/server.sessions.reset-hooks.test.ts ui/src/ui/app-render.helpers.node.test.ts`
- `pnpm exec oxlint src/gateway/protocol/schema/sessions.ts src/gateway/server-methods/sessions.runtime.ts src/gateway/server-methods/sessions.ts src/gateway/server.sessions.reset-hooks.test.ts src/gateway/session-reset-service.ts ui/src/ui/app-render.helpers.ts ui/src/ui/controllers/sessions.ts ui/src/ui/app-render.helpers.node.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md apps/macos/Sources/OpenClawProtocol/GatewayModels.swift apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift src/gateway/protocol/schema/sessions.ts src/gateway/server-methods/sessions.runtime.ts src/gateway/server-methods/sessions.ts src/gateway/server.sessions.reset-hooks.test.ts src/gateway/session-reset-service.ts ui/src/ui/app-render.helpers.ts ui/src/ui/controllers/sessions.ts ui/src/ui/app-render.helpers.node.test.ts`
- `git diff --check`
- `pnpm changed:lanes --json`
- `OPENCLAW_LOCAL_CHECK=1 OPENCLAW_LOCAL_CHECK_MODE=throttled env NODE_OPTIONS=--max-old-space-size=4096 pnpm check:changed`

## Security

No dependency, package-resolution, permission, credential, network, file-download, or process-execution surface changed. The new protocol flag is additive and defaults to absent/false, so only the Control UI typed `/new` path opts into command/lifecycle hooks; external SDK callers that pass `parentSessionKey` continue to create child sessions without impersonating a webchat command.
