### PR TITLE
fix: preserve Matrix room id casing

### DIFF
--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -110,6 +110,24 @@ describe("resolveGroupToolPolicy group context validation", () => {
     ).toEqual({ allow: ["exec", "read", "write", "edit"] });
   });
 
+  it("accepts caller groupId when only Matrix provider-exact case differs from session key", () => {
+    expect(
+      resolveTrustedGroupId({
+        sessionKey: "agent:main:matrix:channel:!mixedroom:example.org",
+        groupId: "!MixedRoom:example.org",
+      }),
+    ).toEqual({ groupId: "!MixedRoom:example.org", dropped: false });
+  });
+
+  it("does not accept case-only groupId variants for non-Matrix sessions", () => {
+    expect(
+      resolveTrustedGroupId({
+        sessionKey: "agent:main:slack:group:MixedRoom",
+        groupId: "mixedroom",
+      }),
+    ).toEqual({ groupId: null, dropped: true });
+  });
+
   it("accepts caller groupId when spawnedBy provides the trusted group context", () => {
     expect(
       resolveTrustedGroupId({

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -309,6 +309,18 @@ function resolveTrustedGroupIdFromContexts(params: {
   if (trustedGroupIds.includes(callerGroupId)) {
     return { groupId: params.groupId, dropped: false };
   }
+  const allowCaseOnlyVariant =
+    params.sessionContext.channel === "matrix" || params.spawnedContext.channel === "matrix";
+  if (
+    allowCaseOnlyVariant &&
+    trustedGroupIds.some(
+      (trustedGroupId) =>
+        normalizeLowercaseStringOrEmpty(trustedGroupId) ===
+        normalizeLowercaseStringOrEmpty(callerGroupId),
+    )
+  ) {
+    return { groupId: params.groupId, dropped: false };
+  }
   return { groupId: null, dropped: true };
 }
 

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -2858,6 +2858,7 @@ describe("gateway agent handler", () => {
       sessionKey: string,
       entry: Record<string, unknown>,
       requestGroupId?: string,
+      requestDelivery?: { channel?: string; to?: string },
     ) {
       mocks.loadSessionEntry.mockReturnValue({
         cfg: {},
@@ -2880,6 +2881,8 @@ describe("gateway agent handler", () => {
         sessionKey,
         idempotencyKey: `group-persist-${sessionKey}-${requestGroupId ?? "none"}`,
         ...(requestGroupId !== undefined ? { groupId: requestGroupId } : {}),
+        ...(requestDelivery?.channel ? { channel: requestDelivery.channel } : {}),
+        ...(requestDelivery?.to ? { to: requestDelivery.to } : {}),
       });
       return capturedEntry;
     }
@@ -2896,6 +2899,26 @@ describe("gateway agent handler", () => {
         "trusted-group",
       );
       expect(entry?.groupId).toBe("trusted-group");
+    });
+
+    it("preserves Matrix provider-exact groupId case when session key only differs by case", async () => {
+      const entry = await captureGroupEntryFields(
+        "agent:main:matrix:channel:!mixedroom:example.org",
+        {},
+        "!MixedRoom:example.org",
+        { channel: "matrix", to: "room:!MixedRoom:example.org" },
+      );
+      expect(entry?.groupId).toBe("!MixedRoom:example.org");
+    });
+
+    it("drops case-only groupId mismatch without a matching Matrix delivery target", async () => {
+      const entry = await captureGroupEntryFields(
+        "agent:main:matrix:channel:!mixedroom:example.org",
+        {},
+        "!MixedRoom:example.org",
+        { channel: "matrix", to: "room:!otherroom:example.org" },
+      );
+      expect(entry?.groupId).toBeUndefined();
     });
 
     it("clears a previously forged groupId from the session entry on reconnection", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -297,6 +297,54 @@ function requestGroupMatchesTrusted(params: {
   return Boolean(params.trustedGroupId && requestGroupId === params.trustedGroupId);
 }
 
+function resolveMatrixRoomTargetId(to?: string): string | undefined {
+  const raw = to?.trim();
+  if (!raw?.toLowerCase().startsWith("room:")) {
+    return undefined;
+  }
+  return normalizeOptionalString(raw.slice("room:".length));
+}
+
+function requestMatrixGroupMatchesTrustedCaseVariant(params: {
+  requestChannel?: string;
+  requestTo?: string;
+  requestGroupId?: string;
+  trustedGroupId?: string;
+}): boolean {
+  const requestGroupId = params.requestGroupId?.trim();
+  const trustedGroupId = params.trustedGroupId?.trim();
+  if (!requestGroupId || !trustedGroupId || requestGroupId === trustedGroupId) {
+    return false;
+  }
+  if (normalizeMessageChannel(params.requestChannel) !== "matrix") {
+    return false;
+  }
+  if (resolveMatrixRoomTargetId(params.requestTo) !== requestGroupId) {
+    return false;
+  }
+  return requestGroupId.toLowerCase() === trustedGroupId.toLowerCase();
+}
+
+function resolveCasePreservedTrustedGroupId(params: {
+  requestGroupId?: string;
+  trustedGroupId?: string;
+  allowCaseVariant?: boolean;
+}): string | undefined {
+  const trustedGroupId = params.trustedGroupId?.trim();
+  if (!trustedGroupId) {
+    return undefined;
+  }
+  const requestGroupId = params.requestGroupId?.trim();
+  if (
+    requestGroupId &&
+    (requestGroupId === trustedGroupId ||
+      (params.allowCaseVariant && requestGroupId.toLowerCase() === trustedGroupId.toLowerCase()))
+  ) {
+    return requestGroupId;
+  }
+  return trustedGroupId;
+}
+
 function emitSessionsChanged(
   context: Pick<
     GatewayRequestHandlerOptions["context"],
@@ -981,6 +1029,12 @@ export const agentHandlers: GatewayRequestHandlers = {
         stored: storedGroup,
         inherited: inheritedGroup,
       });
+      const allowCasePreservedMatrixGroup = requestMatrixGroupMatchesTrustedCaseVariant({
+        requestChannel: request.channel,
+        requestTo: request.to,
+        requestGroupId: normalizedSpawned.groupId,
+        trustedGroupId: trustedGroup.groupId,
+      });
       const validatedGroup = trustedGroup.groupId
         ? resolveTrustedGroupId({
             groupId: trustedGroup.groupId,
@@ -988,18 +1042,23 @@ export const agentHandlers: GatewayRequestHandlers = {
             spawnedBy: spawnedByValue,
           })
         : undefined;
-      if (validatedGroup?.dropped) {
+      if (validatedGroup?.dropped && !allowCasePreservedMatrixGroup) {
         resolvedGroupId = undefined;
         resolvedGroupChannel = undefined;
         resolvedGroupSpace = undefined;
       } else {
         const trustRequestSelectors =
           Boolean(trustedGroup.groupId) &&
-          requestGroupMatchesTrusted({
+          (requestGroupMatchesTrusted({
             requestGroupId: normalizedSpawned.groupId,
             trustedGroupId: trustedGroup.groupId,
-          });
-        resolvedGroupId = trustedGroup.groupId;
+          }) ||
+            allowCasePreservedMatrixGroup);
+        resolvedGroupId = resolveCasePreservedTrustedGroupId({
+          requestGroupId: normalizedSpawned.groupId,
+          trustedGroupId: trustedGroup.groupId,
+          allowCaseVariant: allowCasePreservedMatrixGroup,
+        });
         resolvedGroupChannel =
           trustedGroup.groupChannel ??
           (trustRequestSelectors ? normalizedSpawned.groupChannel : undefined);


### PR DESCRIPTION
Fixes #78206.

## Summary
- preserve provider-exact Matrix room IDs when session-derived group ids differ only by case
- allow Matrix-only case variants through group trust so exact room IDs are not dropped later
- keep non-Matrix case-only variants rejected

## Tests
- oxfmt --check on changed files
- git diff --check
- targeted gateway/agents vitest attempted but blocked before tests by missing local @openclaw/fs-safe/config
- pnpm check:changed passed early lanes, failed on unrelated existing core typecheck issues including missing @openclaw/fs-safe/*
