### PR TITLE
fix: avoid doctor live gateway restarts

### DIFF
--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -348,6 +348,25 @@ describe("maybeRepairGatewayDaemon", () => {
     );
   });
 
+  it("skips live gateway restart when the running service owns the configured port", async () => {
+    setPlatform("linux");
+    service.readRuntime.mockResolvedValue({ status: "running", pid: 12_345 });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 12_345, command: "openclaw" }],
+      hints: [],
+    });
+
+    await runNonInteractiveRepair();
+
+    expect(service.restart).not.toHaveBeenCalled();
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("Gateway service is already running and owns the configured port."),
+      "Gateway",
+    );
+  });
+
   it("skips gateway restart during non-interactive update repairs", async () => {
     setPlatform("linux");
 

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -12,10 +12,11 @@ import {
   launchAgentPlistExists,
   repairLaunchAgentBootstrap,
 } from "../daemon/launchd.js";
+import type { GatewayServiceRuntime } from "../daemon/service-runtime.js";
 import { describeGatewayServiceRestart, resolveGatewayService } from "../daemon/service.js";
 import { renderSystemdUnavailableHints } from "../daemon/systemd-hints.js";
 import { isSystemdUserServiceAvailable } from "../daemon/systemd.js";
-import { formatPortDiagnostics, inspectPortUsage } from "../infra/ports.js";
+import { formatPortDiagnostics, inspectPortUsage, type PortUsage } from "../infra/ports.js";
 import {
   formatGatewayRestartHandoffDiagnostic,
   readGatewayRestartHandoffSync,
@@ -42,6 +43,17 @@ import {
 import { resolveGatewayInstallToken } from "./gateway-install-token.js";
 import { formatHealthCheckFailure } from "./health-format.js";
 import { healthCommand } from "./health.js";
+
+function portUsageMatchesGatewayService(params: {
+  diagnostics: PortUsage;
+  serviceRuntime?: GatewayServiceRuntime;
+}): boolean {
+  const servicePid = params.serviceRuntime?.pid;
+  if (typeof servicePid !== "number") {
+    return false;
+  }
+  return params.diagnostics.listeners.some((listener) => listener.pid === servicePid);
+}
 
 async function maybeRepairLaunchAgentBootstrap(params: {
   env: Record<string, string | undefined>;
@@ -180,6 +192,20 @@ export async function maybeRepairGatewayDaemon(params: {
     const diagnostics = await inspectPortUsage(port);
     if (diagnostics.status === "busy") {
       note(formatPortDiagnostics(diagnostics).join("\n"), "Gateway port");
+      if (
+        loaded &&
+        serviceRuntime?.status === "running" &&
+        portUsageMatchesGatewayService({ diagnostics, serviceRuntime })
+      ) {
+        note(
+          [
+            "Gateway service is already running and owns the configured port.",
+            "Doctor will not restart a live gateway only because the status RPC timed out.",
+          ].join("\n"),
+          "Gateway",
+        );
+        return;
+      }
     } else if (loaded && serviceRuntime?.status === "running") {
       const lastError = await readLastGatewayErrorLine(process.env);
       if (lastError) {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -514,7 +514,7 @@ async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<voi
   const { healthOk, status } = await checkGatewayHealth({
     runtime: ctx.runtime,
     cfg: ctx.cfg,
-    timeoutMs: ctx.options.nonInteractive === true ? 3000 : 10_000,
+    timeoutMs: 10_000,
   });
   ctx.healthOk = healthOk;
   ctx.gatewayStatus = status;


### PR DESCRIPTION
## Summary

Fixes `doctor --fix --non-interactive` treating a live, supervised gateway as a repair target after a short status RPC timeout.

## Changes

- Use the normal 10s gateway health timeout for non-interactive doctor instead of the previous 3s timeout.
- When the gateway service is loaded/running and owns the configured port, skip doctor-triggered gateway restart after a failed status RPC.
- Add regression coverage for the running-service-owns-port case.

## Testing

- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm exec oxfmt --check src/commands/doctor-gateway-daemon-flow.ts src/commands/doctor-gateway-daemon-flow.test.ts src/flows/doctor-health-contributions.ts`
- `git diff --check`
- Targeted vitest attempted but blocked before tests by missing local `@openclaw/fs-safe/config`.
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` passed early lanes and failed in unrelated existing core typecheck diagnostics including missing `@openclaw/fs-safe/*`.

Fixes openclaw/openclaw#78217
