### PR TITLE
fix(telegram): keep no-response DM turns quiet (no silent-reply rewrite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Discord/voice: keep default agent-proxy realtime sessions from auto-speaking filler before the forced OpenClaw consult answer, finish Discord playback on realtime response completion, and queue later exact-speech answers until playback idles to avoid mid-sentence replacement.
 - Gateway: return deterministic `400 invalid_request_error` responses for malformed encoded session-kill HTTP paths instead of letting route-shaped requests fall through to later Gateway handlers. (#72439) Thanks @rubencu.
 - OpenAI/realtime voice: honor disabled input-audio interruption locally so server VAD speech-start events do not clear Discord playback after operators set `interruptResponseOnInputAudio: false`.
+- Telegram: keep no-response DM turns quiet instead of rewriting them into visible silent-reply chatter. Fixes #78188. (#78228) Thanks @Beandon13.
 - Telegram: handle managed select button callbacks before the raw callback fallback while preserving delimiter-containing option values such as `env|prod`. (#79816) Thanks @moeedahmed.
 - OpenAI-compatible models: handle JSON chat-completion bodies returned to streaming requests, preserving reasoning fields and visible text instead of completing an empty agent turn. Fixes #77870.
 - CLI/media: let explicit image description model refs use bundled static provider catalogs and generic model-backed image hooks, so `openclaw infer image describe --model zai/glm-4.6v` works like direct model runs and Anthropic auth probes avoid stale Claude 3 Haiku catalog entries.

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1771,7 +1771,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
-  it("emits a silent-reply fallback when no final reply was queued and nothing was delivered", async () => {
+  it("does not emit a silent-reply fallback for no-response DM turns", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
       queuedFinal: false,
       counts: { block: 0, final: 0, tool: 0 },
@@ -1781,6 +1781,50 @@ describe("dispatchTelegramMessage draft streaming", () => {
       context: createContext({
         ctxPayload: createDirectSessionPayload(),
       }),
+      streamMode: "off",
+    });
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("emits a silent-reply fallback for no-response group turns", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+      counts: { block: 0, final: 0, tool: 0 },
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        chatId: -1001234,
+        isGroup: true,
+        ctxPayload: {
+          SessionKey: "agent:test:telegram:group:-1001234",
+          ChatType: "group",
+        } as TelegramMessageContext["ctxPayload"],
+        primaryCtx: {
+          message: { chat: { id: -1001234, type: "supergroup" } },
+        } as TelegramMessageContext["primaryCtx"],
+        msg: {
+          chat: { id: -1001234, type: "supergroup" },
+          message_id: 456,
+        } as TelegramMessageContext["msg"],
+        threadSpec: { id: undefined, scope: "none" },
+        replyThreadId: undefined,
+      }),
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              direct: "disallow",
+              group: "disallow",
+              internal: "allow",
+            },
+            silentReplyRewrite: {
+              group: true,
+            },
+          },
+        },
+      } as Parameters<typeof dispatchTelegramMessage>[0]["cfg"],
       streamMode: "off",
     });
 

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1618,7 +1618,8 @@ export const dispatchTelegramMessage = async ({
     !dispatchError &&
     !deliverySummary.delivered &&
     !suppressSilentReplyFallback &&
-    !queuedFinal
+    !queuedFinal &&
+    isGroup
   ) {
     const policySessionKey =
       ctxPayload.CommandSource === "native"


### PR DESCRIPTION
Fixes #78188.

## Root cause
`dispatchTelegramMessage` synthesized a `NO_REPLY` payload for a turn that ended with no visible final response. In Telegram DMs, the silent-reply rewrite layer could turn that into visible chatter like "All quiet on my side." even though there was no user-visible answer to send.

## What the fix does
Gate the synthesized silent-reply fallback on group chats. DMs with no queued final response now stay quiet. Group/forum fallback behavior remains available when group policy asks for a visible rewrite.

## Tests
- `pnpm test extensions/telegram/src/bot-message-dispatch.test.ts` — 48 passed.
- `pnpm check:changed` — passed scoped Telegram extension prod/test and changelog gates.

## Real behavior proof
- Behavior addressed: Telegram no-response direct-message turns no longer synthesize a visible silent-reply rewrite; group fallback behavior remains available when group policy requests it.
- Real environment tested: local OpenClaw gateways from `origin/main` and this PR branch, real Telegram bot-to-bot DM transport, mock OpenAI-compatible Responses server on loopback returning `NO_REPLY`, Telegram config with `session.dmScope: "per-channel-peer"` and direct silent-reply rewrite enabled.
- Exact steps or command run after the patch: started the PR gateway with the same temp Telegram/OpenAI config, sent `OPENCLAW_DM_FIX_PR_78228` as the driver bot to `@foremanclawbot`, then polled driver bot updates for 30s.
- Evidence before fix on `origin/main`: the same live DM setup sent `OPENCLAW_DM_REPRO_MAIN_78228B`; the mock returned `NO_REPLY`; Telegram observed a visible SUT reply instead of silence:

```json
{
  "sent": {
    "message_id": 13,
    "chat_id": 8098866274
  },
  "seen": {
    "message_id": 14,
    "text": "No further response from me.",
    "reply_to_message_id": null
  }
}
```

Debug evidence from the `origin/main` probe showed the no-response DM fallback branch was hit:

```json
{"event":"telegram-silent-reply-state","isGroup":false,"queuedFinal":false,"suppressSilentReplyFallback":false,"hasDispatchError":false,"delivered":false,"skippedNonSilent":0,"failedNonSilent":0}
{"event":"telegram-silent-reply-fallback","isGroup":false,"queuedFinal":false,"plannedReplies":1,"sentFallback":true}
```

- Evidence after fix on this PR: the same live DM setup sent `OPENCLAW_DM_FIX_PR_78228`; the mock returned `NO_REPLY`; the driver bot observed no SUT reply for 30s:

```json
{
  "sent": {
    "message_id": 15,
    "chat_id": 8098866274
  },
  "seen": null
}
```

- Observed result after fix: the direct-message no-response path stayed quiet on the PR, while `bot-message-dispatch.test.ts` still covers group no-response fallback behavior.
- What was not tested: live human-account Telegram DM; bot-to-bot DM used the real Telegram Bot API transport end to end.
