### PR TITLE
fix: avoid memory watcher write polling

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -437,10 +437,6 @@ export abstract class MemoryManagerSyncOps {
       ignoreInitial: true,
       ignored: (watchPath, stats) =>
         shouldIgnoreMemoryWatchPath(watchPath, stats, this.settings.multimodal),
-      awaitWriteFinish: {
-        stabilityThreshold: this.settings.sync.watchDebounceMs,
-        pollInterval: 100,
-      },
     });
     const markDirty = () => {
       this.dirty = true;

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -175,7 +175,7 @@ describe("memory watcher config", () => {
     );
     expect(watchedPaths.every((watchPath) => !watchPath.includes("*"))).toBe(true);
     expect(options.ignoreInitial).toBe(true);
-    expect(options.awaitWriteFinish).toEqual({ stabilityThreshold: 25, pollInterval: 100 });
+    expect(options).not.toHaveProperty("awaitWriteFinish");
 
     const ignored = options.ignored as WatchIgnoredFn | undefined;
     expect(ignored).toBeTypeOf("function");


### PR DESCRIPTION
## Summary
- stop passing `awaitWriteFinish` to the memorySearch chokidar watcher
- rely on the existing dirty/scheduleWatchSync debounce instead of per-file write-stability polling
- update the watcher config regression test to assert write polling stays disabled

Fixes #78224.

## Tests
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm exec oxfmt --check extensions/memory-core/src/memory/manager-sync-ops.ts extensions/memory-core/src/memory/manager.watcher-config.test.ts`
- `git diff --check`
- attempted: `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/run-vitest.mjs run extensions/memory-core/src/memory/manager.watcher-config.test.ts` — blocked before tests by missing local `@openclaw/fs-safe/config`
- attempted: `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` — early lanes passed; blocked by unrelated existing extension/core typecheck diagnostics including missing `@openclaw/fs-safe/*` and strictness errors outside this patch
