### PR TITLE
Fix Discord gateway heartbeat ACK timing

### DIFF
--- a/extensions/discord/src/internal/gateway-lifecycle.ts
+++ b/extensions/discord/src/internal/gateway-lifecycle.ts
@@ -13,24 +13,30 @@ export class GatewayHeartbeatTimers {
   }): void {
     this.stop();
     const random = params.random ?? Math.random;
-    this.firstHeartbeatTimeout = setTimeout(
-      params.onHeartbeat,
-      Math.max(0, params.intervalMs * random()),
-    );
-    this.firstHeartbeatTimeout.unref?.();
-    this.heartbeatInterval = setInterval(() => {
-      if (!params.isAcked()) {
-        params.onAckTimeout();
-        return;
-      }
+    const scheduleNextHeartbeatCheck = () => {
+      this.heartbeatInterval = setTimeout(() => {
+        this.heartbeatInterval = undefined;
+        if (!params.isAcked()) {
+          params.onAckTimeout();
+          return;
+        }
+        params.onHeartbeat();
+        scheduleNextHeartbeatCheck();
+      }, params.intervalMs);
+      this.heartbeatInterval.unref?.();
+    };
+
+    this.firstHeartbeatTimeout = setTimeout(() => {
+      this.firstHeartbeatTimeout = undefined;
       params.onHeartbeat();
-    }, params.intervalMs);
-    this.heartbeatInterval.unref?.();
+      scheduleNextHeartbeatCheck();
+    }, Math.max(0, params.intervalMs * random()));
+    this.firstHeartbeatTimeout.unref?.();
   }
 
   stop(): void {
     if (this.heartbeatInterval) {
-      clearInterval(this.heartbeatInterval);
+      clearTimeout(this.heartbeatInterval);
       this.heartbeatInterval = undefined;
     }
     if (this.firstHeartbeatTimeout) {

--- a/extensions/discord/src/internal/gateway.test.ts
+++ b/extensions/discord/src/internal/gateway.test.ts
@@ -10,6 +10,7 @@ import {
 } from "discord-api-types/v10";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { sharedGatewayIdentifyLimiter } from "./gateway-identify-limiter.js";
+import { GatewayHeartbeatTimers } from "./gateway-lifecycle.js";
 import { GatewayPlugin } from "./gateway.js";
 
 function attachOpenSocket(gateway: GatewayPlugin) {
@@ -509,6 +510,36 @@ describe("GatewayPlugin", () => {
 
     expect(gateway.heartbeatInterval).toBeUndefined();
     expect(gateway.firstHeartbeatTimeout).toBeUndefined();
+  });
+
+  it("waits a full interval after the randomized first heartbeat before timing out", () => {
+    vi.useFakeTimers();
+    const timers = new GatewayHeartbeatTimers();
+    const onAckTimeout = vi.fn();
+    const onHeartbeat = vi.fn(() => {
+      acked = false;
+    });
+    let acked = true;
+
+    timers.start({
+      intervalMs: 1_000,
+      isAcked: () => acked,
+      onAckTimeout,
+      onHeartbeat,
+      random: () => 0.95,
+    });
+
+    vi.advanceTimersByTime(950);
+    expect(onHeartbeat).toHaveBeenCalledTimes(1);
+    expect(onAckTimeout).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(999);
+    expect(onAckTimeout).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onAckTimeout).toHaveBeenCalledTimes(1);
+
+    timers.stop();
   });
 
   it("spaces identify sends by gateway max concurrency bucket", async () => {


### PR DESCRIPTION
## Summary

This updates Discord gateway heartbeat scheduling so ACK timeout checks run one full heartbeat interval after each heartbeat send, instead of using a fixed interval that can fire shortly after the randomized first heartbeat.

## Validation

- Ran `extensions/discord/src/internal/gateway.test.ts`
- 21 tests passed

## Notes

This should help avoid false `Gateway heartbeat ACK timeout` errors after heartbeats are being scheduled. In my Windows runtime investigation, the production instability also appeared correlated with gateway event-loop starvation from deferred/missed cron jobs during startup, so this patch may not address every `awaiting gateway readiness` failure mode.

## Real behavior proof

behavior: Discord gateway heartbeat ACK timing after applying this patch.

environment: Windows host running the locally patched OpenClaw build from this branch.

steps: Applied this branch locally, built OpenClaw, started the patched gateway from `O:/openclaw/dist`, waited for startup, then ran `openclaw gateway status --deep --require-rpc`.

evidence: Copied live output from the patched local runtime showed `file:///O:/openclaw/dist/subsystem-DtIxQOmd.js`, `http server listening (2 plugins: discord, memory-core; 66.2s)`, `gateway ready`, `heartbeat: started`, `discord channels resolved`, `discord channel users resolved`, and `status 3402ms`. Gateway status from the same host showed `Runtime: running`, `Read probe: ok`, `Capability: admin-capable`, and `Listening: 127.0.0.1:18789`.

observedResult: The patched local gateway stayed running and responded to RPC health checks. No new `Gateway heartbeat ACK timeout` was observed in the checked runtime window.

notTested: This does not prove the patch fixes every `awaiting gateway readiness` failure mode. My earlier Windows incident also had a separate cron/event-loop starvation component.

