### PR TITLE
fix(models/auth): preserve default model unless --set-default (fixes #78162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -448,6 +448,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Models/auth: keep `agents.defaults.model` when `openclaw models auth login` runs without `--set-default`, so provider onboarding patches add models without silently switching the primary. Fixes #78162. (#78241) Thanks @neeravmakwana.
 - Control UI: surface browser-blocked WebSocket security failures with wss:// and loopback dashboard guidance instead of leaving the connection on a dead security error. Thanks @BunsDev.
 - Gateway/diagnostics: keep active-only transient event-loop max-delay samples as info-level stability telemetry instead of warning-level liveness diagnostics. Thanks @BunsDev.
 - Google/Gemini: default new API-key onboarding to stable `google/gemini-2.5-flash` instead of the preview Pro route, reducing surprise daily quota exhaustion. Fixes #79670. Thanks @HugeBunny.

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -21,7 +21,7 @@ Reference for **LLM/model providers** (not chat channels like WhatsApp/Telegram)
 
   </Accordion>
   <Accordion title="Adding provider auth does not change your primary model">
-    `openclaw configure` preserves an existing `agents.defaults.model.primary` when you add or reauth a provider. Provider plugins may still return a recommended default model in their auth config patch, but configure treats that as "make this model available" when a primary model already exists, not "replace the current primary model."
+    `openclaw configure` preserves an existing `agents.defaults.model.primary` when you add or reauth a provider. `openclaw models auth login` does the same unless you pass `--set-default`. Provider plugins may still return a recommended default model in their auth config patch, but OpenClaw treats that as "make this model available" when a primary model already exists, not "replace the current primary model."
 
     To intentionally switch the default model, use `openclaw models set <provider/model>` or `openclaw models auth login --provider <id> --set-default`.
 

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -162,7 +162,9 @@ vi.mock("../auth-token.js", () => ({
   validateAnthropicSetupToken: vi.fn(() => undefined),
 }));
 
-vi.mock("../../plugins/provider-auth-choice-helpers.js", () => {
+vi.mock("../../plugins/provider-auth-choice-helpers.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../plugins/provider-auth-choice-helpers.js")>();
   const normalize = (value: string | undefined) => value?.trim().toLowerCase() ?? "";
   const isRecord = (value: unknown): value is Record<string, unknown> =>
     Boolean(value && typeof value === "object" && !Array.isArray(value));
@@ -178,6 +180,7 @@ vi.mock("../../plugins/provider-auth-choice-helpers.js", () => {
   };
 
   return {
+    ...actual,
     resolveProviderMatch: vi.fn((providers: ProviderPlugin[], rawProvider?: string) => {
       const requested = normalize(rawProvider);
       return (
@@ -719,6 +722,60 @@ describe("modelsAuthLoginCommand", () => {
       ...existingModels,
       "openai-codex/gpt-5.5": {},
     });
+  });
+
+  it("keeps an existing primary when login omits --set-default and the patch recommends another", async () => {
+    const runtime = createRuntime();
+    currentConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "openai-codex/gpt-5.4", fallbacks: [] },
+          models: {
+            "openai-codex/gpt-5.4": {},
+            "anthropic/claude-sonnet-4-6": {},
+          },
+        },
+      },
+    };
+    runProviderAuth.mockResolvedValue({
+      profiles: [
+        {
+          profileId: "openai:default",
+          credential: { type: "api_key", provider: "openai", key: "sk-demo" },
+        },
+      ],
+      configPatch: {
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-5.5" },
+            models: { "openai/gpt-5.5": { alias: "GPT" } },
+          },
+        },
+      },
+      defaultModel: "openai/gpt-5.5",
+    });
+    mocks.resolvePluginProviders.mockReturnValue([
+      createProvider({
+        id: "openai",
+        label: "OpenAI",
+        run: runProviderAuth as ProviderPlugin["auth"][number]["run"],
+      }),
+    ]);
+
+    await modelsAuthLoginCommand({ provider: "openai" }, runtime);
+
+    expect(lastUpdatedConfig?.agents?.defaults?.model).toEqual({
+      primary: "openai-codex/gpt-5.4",
+      fallbacks: [],
+    });
+    expect(lastUpdatedConfig?.agents?.defaults?.models).toEqual({
+      "openai-codex/gpt-5.4": {},
+      "anthropic/claude-sonnet-4-6": {},
+      "openai/gpt-5.5": { alias: "GPT" },
+    });
+    expect(runtime.log).toHaveBeenCalledWith(
+      "Default model available: openai/gpt-5.5 (use --set-default to apply)",
+    );
   });
 
   it("overwrites an existing primary when login uses --set-default", async () => {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -29,6 +29,7 @@ import {
   applyProviderAuthConfigPatch,
   applyDefaultModel,
   pickAuthMethod,
+  restorePriorAgentsDefaultsModelUnlessOptIn,
   resolveProviderMatch,
 } from "../../plugins/provider-auth-choice-helpers.js";
 import { applyAuthProfileConfig } from "../../plugins/provider-auth-helpers.js";
@@ -260,6 +261,7 @@ async function persistProviderAuthResult(params: {
   }
 
   const updated = await updateConfig((cfg) => {
+    const priorAgentsDefaultsModel = cfg.agents?.defaults?.model;
     let next = cfg;
     if (params.result.configPatch) {
       next = applyProviderAuthConfigPatch(next, params.result.configPatch, {
@@ -273,6 +275,11 @@ async function persistProviderAuthResult(params: {
         mode: credentialMode(profile.credential),
       });
     }
+    next = restorePriorAgentsDefaultsModelUnlessOptIn({
+      cfg: next,
+      priorAgentsDefaultsModel,
+      setDefault: params.setDefault,
+    });
     if (params.setDefault && params.result.defaultModel) {
       next = applyDefaultModel(next, params.result.defaultModel);
     }

--- a/src/plugins/provider-auth-choice-helpers.ts
+++ b/src/plugins/provider-auth-choice-helpers.ts
@@ -5,6 +5,7 @@ import {
   normalizeAgentModelRefForConfig,
 } from "../config/model-input.js";
 import { normalizeProviderConfigForConfigDefaults } from "../config/provider-policy.js";
+import type { AgentModelConfig } from "../config/types.agents-shared.js";
 import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -243,6 +244,30 @@ export function applyProviderAuthConfigPatch(
       },
     },
   });
+}
+
+/**
+ * Restore `agents.defaults.model` after a provider auth config merge when the user did not pass
+ * `--set-default`, so `applyConfig` patches cannot replace the primary without an explicit opt-in.
+ */
+export function restorePriorAgentsDefaultsModelUnlessOptIn(params: {
+  cfg: OpenClawConfig;
+  priorAgentsDefaultsModel?: AgentModelConfig;
+  setDefault?: boolean;
+}): OpenClawConfig {
+  if (params.setDefault || params.priorAgentsDefaultsModel === undefined) {
+    return params.cfg;
+  }
+  return {
+    ...params.cfg,
+    agents: {
+      ...params.cfg.agents,
+      defaults: {
+        ...params.cfg.agents?.defaults,
+        model: params.priorAgentsDefaultsModel,
+      },
+    },
+  };
 }
 
 export function applyDefaultModel(


### PR DESCRIPTION
## Summary
When running `openclaw models auth login` without `--set-default`, merged provider `configPatch` / `applyConfig` output could still overwrite `agents.defaults.model` (for example OpenAI and Gemini helpers call `applyAgentDefaultModelPrimary`). That silently switched the live primary to the provider's recommended tier.

## Root cause
`persistProviderAuthResult` merged the auth `configPatch` before applying `defaultModel`, but only gated the explicit `applyDefaultModel(...)` step on `--set-default`. Patches that embedded `agents.defaults.model` escaped that gate.

## Fix
Snapshot `agents.defaults.model` from the on-disk config at the start of the update mutator and, when `--set-default` is not passed and a prior model section existed, restore it after the patch + auth profile bindings. New configs with no prior `agents.defaults.model` still accept the patch's primary. `--set-default` unchanged: `applyDefaultModel` still runs after restore.

## Why this is safe
- Policy is enforced in config persistence, not prompt wording.
- No OAuth/API credential handling changes; auth profiles and patch merges for allowlists and provider tables behave as before.
- Opt-in `--set-default` path is unchanged.

## Security / runtime controls
Unchanged: gateway auth, SecretRef resolution, auth profile storage, and provider credential flows. This only affects how merged onboarding config applies to `agents.defaults.model` for the models-auth CLI persist path.

## Tests run
- `pnpm test src/commands/models/auth.test.ts` — 17 tests passed.
- `env -u OPENCLAW_TESTBOX pnpm check:changed` — passed changed core/type/lint/guard checks.
- `git diff --check HEAD~1..HEAD` — passed.

## Real behavior proof
Local temp-state CLI run against e72f5c6 with a dummy `OPENAI_API_KEY` and isolated `OPENCLAW_STATE_DIR=/tmp/openclaw-pr78241.GIRhtL/state`:

```text
Before login (no --set-default):
defaultModel: openai-codex/gpt-5.4
resolvedDefault: openai-codex/gpt-5.4
allowed: openai-codex/gpt-5.4, anthropic/claude-sonnet-4-6, anthropic/claude-haiku-4-5

openclaw models auth login --provider openai --method api-key
Auth profile: openai:default (openai/api_key)
Default model available: openai/gpt-5.5 (use --set-default to apply)

After login without --set-default:
defaultModel: openai-codex/gpt-5.4
resolvedDefault: openai-codex/gpt-5.4
allowed: openai-codex/gpt-5.4, anthropic/claude-sonnet-4-6, openai/gpt-5.5, anthropic/claude-haiku-4-5

openclaw models auth login --provider openai --method api-key --set-default
Auth profile: openai:default (openai/api_key)
Default model set to openai/gpt-5.5

After login with --set-default:
defaultModel: openai/gpt-5.5
resolvedDefault: openai/gpt-5.5
allowed: openai-codex/gpt-5.4, anthropic/claude-sonnet-4-6, openai/gpt-5.5, anthropic/claude-haiku-4-5
```

## Out of scope / follow-ups
- Tier labeling (cheap/balanced/premium) from the issue discussion.
- Refactoring individual provider `applyConfig` functions to stop emitting primary in patches (could be redundant after this guard).

Fixes #78162.

Made with [Cursor](https://cursor.com)
