### PR TITLE
feat(plugins): allowStateAccess permission for agent_end without conversation content

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1242,7 +1242,9 @@ export const FIELD_HELP: Record<string, string> = {
   "plugins.entries.*.hooks.allowPromptInjection":
     "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
   "plugins.entries.*.hooks.allowConversationAccess":
-    "Controls whether this plugin may read raw conversation content from typed hooks such as `llm_input`, `llm_output`, `before_agent_finalize`, and `agent_end`. Non-bundled plugins must opt in explicitly.",
+    "Controls whether this plugin may read raw conversation content from typed hooks such as `llm_input`, `llm_output`, and `before_agent_finalize`. Non-bundled plugins must opt in explicitly. Also grants access to `agent_end` with the full messages payload.",
+  "plugins.entries.*.hooks.allowStateAccess":
+    "Controls whether this plugin may receive `agent_end` events carrying run-level state (success, durationMs, runId) but without the raw messages payload. Use this for plugins that track run outcomes without needing conversation content. Non-bundled plugins must opt in explicitly.",
   "plugins.entries.*.hooks.timeoutMs":
     "Default timeout in milliseconds for this plugin's typed hooks, capped at 600000. Use this to bound slow plugin hooks without changing plugin code; per-hook values in hooks.timeouts take precedence.",
   "plugins.entries.*.hooks.timeouts":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -928,6 +928,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "plugins.entries.*.enabled": "Plugin Enabled",
   "plugins.entries.*.hooks": "Plugin Hook Policy",
   "plugins.entries.*.hooks.allowConversationAccess": "Allow Conversation Access Hooks",
+  "plugins.entries.*.hooks.allowStateAccess": "Allow State Access Hooks",
   "plugins.entries.*.hooks.allowPromptInjection": "Allow Prompt Injection Hooks",
   "plugins.entries.*.hooks.timeoutMs": "Plugin Hook Timeout (ms)",
   "plugins.entries.*.hooks.timeouts": "Plugin Hook Timeout Overrides",

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -190,6 +190,7 @@ const PluginEntrySchema = z
       .object({
         allowPromptInjection: z.boolean().optional(),
         allowConversationAccess: z.boolean().optional(),
+        allowStateAccess: z.boolean().optional(),
         timeoutMs: z.number().int().positive().max(600_000).optional(),
         timeouts: z.record(z.string(), z.number().int().positive().max(600_000)).optional(),
       })

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -967,4 +967,6 @@ export type PluginHookRegistration<K extends PluginHookName = PluginHookName> = 
   priority?: number;
   timeoutMs?: number;
   source: string;
+  /** When true, the handler registered with allowStateAccess but not allowConversationAccess; agent_end messages field will be stripped before dispatch. */
+  stateOnly?: boolean;
 };

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -171,7 +171,6 @@ export const CONVERSATION_HOOK_NAMES = [
   "llm_input",
   "llm_output",
   "before_agent_finalize",
-  "agent_end",
 ] as const satisfies readonly PluginHookName[];
 
 export type ConversationHookName = (typeof CONVERSATION_HOOK_NAMES)[number];
@@ -180,6 +179,15 @@ const conversationHookNameSet = new Set<PluginHookName>(CONVERSATION_HOOK_NAMES)
 
 export const isConversationHookName = (hookName: PluginHookName): boolean =>
   conversationHookNameSet.has(hookName);
+
+export const STATE_HOOK_NAMES = ["agent_end"] as const satisfies readonly PluginHookName[];
+
+export type StateHookName = (typeof STATE_HOOK_NAMES)[number];
+
+const stateHookNameSet = new Set<PluginHookName>(STATE_HOOK_NAMES);
+
+export const isStateHookName = (hookName: PluginHookName): boolean =>
+  stateHookNameSet.has(hookName);
 
 export type PluginHookAgentContext = {
   runId?: string;

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -845,14 +845,36 @@ export function createHookRunner(
 
   /**
    * Run agent_end hook.
-   * Allows plugins to analyze completed conversations.
-   * Runs in parallel (fire-and-forget).
+   * Plugins with allowConversationAccess receive the full event including messages.
+   * Plugins with only allowStateAccess receive the event with messages stripped to [].
    */
   async function runAgentEnd(
     event: PluginHookAgentEndEvent,
     ctx: PluginHookAgentContext,
   ): Promise<void> {
-    return runVoidHook("agent_end", withAgentRunId(event, ctx), ctx);
+    const hooks = getHooksForName(registry, "agent_end");
+    if (hooks.length === 0) {
+      return;
+    }
+    const fullEvent = withAgentRunId(event, ctx);
+    const stateOnlyEvent: PluginHookAgentEndEvent = { ...fullEvent, messages: [] };
+    const promises = hooks.map(async (hook) => {
+      const hookEvent = hook.stateOnly ? stateOnlyEvent : fullEvent;
+      try {
+        const promise = Promise.resolve(
+          (hook.handler as (event: unknown, ctx: unknown) => Promise<void> | void)(hookEvent, ctx),
+        );
+        const timeoutMs = getVoidHookTimeoutMs("agent_end", hook);
+        if (timeoutMs) {
+          await withHookTimeout(promise, timeoutMs, { unref: true });
+        } else {
+          await promise;
+        }
+      } catch (err) {
+        handleHookError({ hookName: "agent_end", pluginId: hook.pluginId, error: err });
+      }
+    });
+    await Promise.all(promises);
   }
 
   /**

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -5450,12 +5450,47 @@ module.exports = {
     });
 
     expect(registry.typedHooks).toEqual([]);
-    const blockedDiagnostics = registry.diagnostics.filter((diag) =>
+    const conversationBlockedDiagnostics = registry.diagnostics.filter((diag) =>
       diag.message.includes(
         "non-bundled plugins must set plugins.entries.conversation-hooks.hooks.allowConversationAccess=true",
       ),
     );
-    expect(blockedDiagnostics).toHaveLength(4);
+    expect(conversationBlockedDiagnostics).toHaveLength(3);
+    const stateBlockedDiagnostics = registry.diagnostics.filter((diag) =>
+      diag.message.includes(
+        "non-bundled plugins must set plugins.entries.conversation-hooks.hooks.allowStateAccess=true",
+      ),
+    );
+    expect(stateBlockedDiagnostics).toHaveLength(1);
+  });
+
+  it("allows agent_end for non-bundled plugins with only allowStateAccess, stripping messages", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "state-hooks-only",
+      filename: "state-hooks-only.cjs",
+      body: `module.exports = { id: "state-hooks-only", register(api) {
+  api.on("agent_end", () => undefined);
+} };`,
+    });
+
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["state-hooks-only"],
+        entries: {
+          "state-hooks-only": {
+            hooks: {
+              allowStateAccess: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(registry.typedHooks.map((entry) => entry.hookName)).toEqual(["agent_end"]);
+    expect(registry.typedHooks[0]?.stateOnly).toBe(true);
+    expect(registry.diagnostics.filter((d) => d.level === "warn")).toHaveLength(0);
   });
 
   it("allows conversation typed hooks for non-bundled plugins when explicitly enabled", () => {

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -137,6 +137,7 @@ import {
   isConversationHookName,
   isPluginHookName,
   isPromptInjectionHookName,
+  isStateHookName,
   stripPromptMutationFieldsFromLegacyHookResult,
 } from "./types.js";
 import type {
@@ -226,6 +227,7 @@ export type {
 type PluginTypedHookPolicy = {
   allowPromptInjection?: boolean;
   allowConversationAccess?: boolean;
+  allowStateAccess?: boolean;
   timeoutMs?: number;
   timeouts?: Record<string, number>;
 };
@@ -2135,6 +2137,29 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         return;
       }
     }
+    let stateOnly = false;
+    if (isStateHookName(hookName)) {
+      const hasConversationAccess =
+        record.origin === "bundled"
+          ? policy?.allowConversationAccess !== false
+          : policy?.allowConversationAccess === true;
+      const hasStateAccess =
+        record.origin === "bundled"
+          ? policy?.allowStateAccess !== false
+          : policy?.allowStateAccess === true;
+      if (!hasConversationAccess && !hasStateAccess) {
+        pushDiagnostic({
+          level: "warn",
+          pluginId: record.id,
+          source: record.source,
+          message:
+            `typed hook "${hookName}" blocked because non-bundled plugins must set ` +
+            `plugins.entries.${record.id}.hooks.allowStateAccess=true (or allowConversationAccess=true)`,
+        });
+        return;
+      }
+      stateOnly = !hasConversationAccess && hasStateAccess;
+    }
     const timeoutMs = resolveTypedHookTimeoutMs({ hookName, opts, policy });
     record.hookCount += 1;
     registry.typedHooks.push({
@@ -2143,6 +2168,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       handler: effectiveHandler,
       priority: opts?.priority,
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      ...(stateOnly ? { stateOnly: true } : {}),
       source: record.source,
     } as TypedPluginHookRegistration);
   };


### PR DESCRIPTION
Closes #74580

## Problem

Non-bundled plugins that only need run-level outcome data from `agent_end`
(success/failure, duration, runId) are forced to declare
`allowConversationAccess: true` — a flag that also grants access to the raw
conversation payload in `llm_input`, `llm_output`, and `before_agent_finalize`.
This is over-privileged for plugins like the OpenClaw Interaction Bridge that
track agent outcomes for external display without reading messages.

## Solution

Introduce a narrower `allowStateAccess` permission that grants `agent_end`
without exposing conversation content:

```yaml
plugins:
  entries:
    my-status-plugin:
      hooks:
        allowStateAccess: true   # agent_end fires; messages field is []
```

When only `allowStateAccess` is set (without `allowConversationAccess`), the
`agent_end` event is dispatched with `messages: []`. Full conversation access
still requires `allowConversationAccess: true`.

`allowConversationAccess: true` continues to grant `agent_end` with the full
messages payload as before — no breaking change for existing plugins.

## Commits

1. **`feat(plugins/hook-types): introduce STATE_HOOK_NAMES and isStateHookName`**  
   Moves `agent_end` out of `CONVERSATION_HOOK_NAMES` into a new
   `STATE_HOOK_NAMES` array with a matching `isStateHookName` predicate.

2. **`feat(plugins): add allowStateAccess permission gate for agent_end hook`**  
   Extends `PluginTypedHookPolicy` with `allowStateAccess`; updates
   `registerTypedHook` to accept state hooks under either flag; marks
   registrations as `stateOnly` when only `allowStateAccess` is present;
   `runAgentEnd` strips `messages` for `stateOnly` handlers. Config schema,
   help text, and labels updated.

3. **`test(plugins): update and extend typed hook access gate tests`**  
   Updates the "blocks conversation hooks" test to reflect that `agent_end`
   now emits an `allowStateAccess` diagnostic (not `allowConversationAccess`);
   adds new test verifying `allowStateAccess: true` allows `agent_end` with
   `stateOnly: true` set on the registration.

## Pre-implement audits

- **A (existing helper):** No prior `allowStateAccess` or `isStateHookName`
  in codebase — no reuse opportunity missed.
- **B (shared helper callers):** `registerTypedHook` is called from one site
  (`loadRegistryFromPlugin`); no multi-file contract mutation.
- **C (rival PR scan):** No open PR targeting `#74580` or `allowStateAccess`
  found at time of implementation.