### PR TITLE
fix(cron): mark active-jobs on manual-run path to suppress transient lost marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: keep long manual cron runs active in the task registry until completion, preventing transient `lost` markers before durable recovery reconciles. Fixes #78233. (#78243) Thanks @Feelw00.
 - Gateway: clear speculative node wake state when APNs registration is missing, preventing unregistered or mistyped node IDs from retaining wake throttle entries. Fixes #68847. (#68848) Thanks @Feelw00.
 - Auto-reply: keep late follow-up queue drain finalizers from deleting a replacement queue registered after `/stop`, preventing immediate follow-up messages from being orphaned. Fixes #68838. (#68839) Thanks @Feelw00.
 - Feishu: make manual App ID/App Secret setup the default channel-binding path while keeping QR scan-to-create as an optional best-effort flow, and document the manual fallback for domestic Feishu mobile clients that do not react to the QR code. Fixes #80591. Thanks @wei-wei-zhao.

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -255,7 +255,7 @@ describe("runCodexAppServerSideQuestion", () => {
     const forkCall = client.request.mock.calls[0];
     expect(forkCall?.[0]).toBe("thread/fork");
     const forkParams = forkCall?.[1] as Record<string, unknown> | undefined;
-    expect(Object.keys(forkParams ?? {}).sort()).toEqual([
+    expect(Object.keys(forkParams ?? {}).toSorted()).toEqual([
       "approvalPolicy",
       "approvalsReviewer",
       "config",

--- a/src/cron/active-jobs-manual-run.test.ts
+++ b/src/cron/active-jobs-manual-run.test.ts
@@ -1,0 +1,160 @@
+// Regression: upstream commit 7d1575b5df (#60310, 2026-04-04) introduced
+// activeJobIds + markCronJobActive/clearCronJobActive but only wired the pair
+// into runDueJob and executeJob. The manual-run path (cron.run() →
+// prepareManualRun + finishPreparedManualRun in src/cron/service/ops.ts) was
+// left without the mark/clear pair, so task-registry.maintenance.ts
+// hasBackingSession (cron branch under isCronRuntimeAuthoritative()=true)
+// returns false during manual-run executions and reconciles them as `lost`
+// after TASK_RECONCILE_GRACE_MS (5 min).
+//
+// The merged commit 1fae716a04 (resolveDurableCronTaskRecovery) reconciles
+// terminal status retroactively from cron run-log + store.lastRunStatus, but
+// only after the run finishes. This test asserts the producer-side mark/clear
+// pair so the transient `lost` marker plus `Background task lost` system
+// message is suppressed for long manual runs (force-mode `agentTurn` runs can
+// reach AGENT_TURN_SAFETY_TIMEOUT_MS = 60 min).
+//
+// Production hot-path: cron.run("<id>", "force") direct invocation, the same
+// surface used by the `openclaw cron run` CLI / RPC and agent tools. No
+// internal-API rerouting (e.g. deferAgentTurnJobs:false) — the test exercises
+// the same `prepareManualRun` → `finishPreparedManualRun` chain that hits
+// production callers.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { isCronJobActive, resetCronActiveJobsForTests } from "./active-jobs.js";
+import { CronService } from "./service.js";
+import {
+  createDeferred,
+  setupCronServiceSuite,
+  writeCronStoreSnapshot,
+} from "./service.test-harness.js";
+import type { CronJob } from "./types.js";
+
+const { logger, makeStorePath } = setupCronServiceSuite({
+  prefix: "openclaw-cron-active-jobs-manual-run-",
+  baseTimeIso: "2025-12-13T17:00:00.000Z",
+});
+
+type IsolatedRunResult = Awaited<
+  ReturnType<NonNullable<ConstructorParameters<typeof CronService>[0]["runIsolatedAgentJob"]>>
+>;
+
+describe("cron activeJobIds — manual-run mark/clear", () => {
+  beforeEach(() => {
+    resetCronActiveJobsForTests();
+  });
+
+  it("marks the job active during a manual run and clears it on success", async () => {
+    const store = await makeStorePath();
+    const now = Date.parse("2025-12-13T17:00:00.000Z");
+    const futureNext = now + 3_600_000;
+
+    const jobs: CronJob[] = [
+      {
+        id: "manual-isolated-ok",
+        name: "manual isolated ok",
+        enabled: true,
+        createdAtMs: now - 3_600_000,
+        updatedAtMs: now,
+        schedule: { kind: "cron", expr: "0 18 * * *", tz: "UTC" },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "hi" },
+        delivery: { mode: "none" },
+        state: {
+          nextRunAtMs: futureNext,
+        },
+      },
+    ];
+
+    await writeCronStoreSnapshot({ storePath: store.storePath, jobs });
+
+    const entered = createDeferred<void>();
+    const release = createDeferred<IsolatedRunResult>();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: logger,
+      enqueueSystemEvent: () => {},
+      requestHeartbeat: () => {},
+      runIsolatedAgentJob: async () => {
+        entered.resolve();
+        return await release.promise;
+      },
+    });
+
+    try {
+      await cron.start();
+
+      const runPromise = cron.run("manual-isolated-ok", "force");
+      await entered.promise;
+
+      expect(isCronJobActive("manual-isolated-ok")).toBe(true);
+
+      release.resolve({ status: "ok", summary: "ok" });
+      await runPromise;
+
+      expect(isCronJobActive("manual-isolated-ok")).toBe(false);
+    } finally {
+      cron.stop();
+      await store.cleanup();
+    }
+  });
+
+  it("clears the active marker even when the inner agent run throws", async () => {
+    const store = await makeStorePath();
+    const now = Date.parse("2025-12-13T17:00:00.000Z");
+    const futureNext = now + 3_600_000;
+
+    const jobs: CronJob[] = [
+      {
+        id: "manual-isolated-throw",
+        name: "manual isolated throw",
+        enabled: true,
+        createdAtMs: now - 3_600_000,
+        updatedAtMs: now,
+        schedule: { kind: "cron", expr: "0 18 * * *", tz: "UTC" },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "hi" },
+        delivery: { mode: "none" },
+        state: {
+          nextRunAtMs: futureNext,
+        },
+      },
+    ];
+
+    await writeCronStoreSnapshot({ storePath: store.storePath, jobs });
+
+    const entered = createDeferred<void>();
+    const release = createDeferred<IsolatedRunResult>();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: logger,
+      enqueueSystemEvent: () => {},
+      requestHeartbeat: () => {},
+      runIsolatedAgentJob: async () => {
+        entered.resolve();
+        return await release.promise;
+      },
+    });
+
+    try {
+      await cron.start();
+
+      const runPromise = cron.run("manual-isolated-throw", "force");
+      await entered.promise;
+
+      expect(isCronJobActive("manual-isolated-throw")).toBe(true);
+
+      release.reject(new Error("synthetic inner failure"));
+      await runPromise;
+
+      expect(isCronJobActive("manual-isolated-throw")).toBe(false);
+    } finally {
+      cron.stop();
+      await store.cleanup();
+    }
+  });
+});

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -7,6 +7,7 @@ import {
   createRunningTaskRun,
   failTaskRunByRunId,
 } from "../../tasks/detached-task-runtime.js";
+import { clearCronJobActive, markCronJobActive } from "../active-jobs.js";
 import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
 import { createCronExecutionId } from "../run-id.js";
 import type { CronJob, CronJobCreate, CronJobPatch } from "../types.js";
@@ -686,6 +687,7 @@ async function prepareManualRun(
       job,
       startedAt: preflight.now,
     });
+    markCronJobActive(job.id);
     const executionJob = structuredClone(job);
     return {
       ok: true,
@@ -710,92 +712,96 @@ async function finishPreparedManualRun(
   const taskRunId = prepared.taskRunId;
   const runId = prepared.runId;
 
-  let coreResult: Awaited<ReturnType<typeof executeJobCoreWithTimeout>>;
   try {
-    coreResult = await executeJobCoreWithTimeout(state, executionJob);
-  } catch (err) {
-    coreResult = { status: "error", error: normalizeCronRunErrorText(err) };
-  }
-  const endedAt = state.deps.nowMs();
-  tryFinishManualTaskRun(state, {
-    taskRunId,
-    coreResult,
-    endedAt,
-  });
-
-  await locked(state, async () => {
-    await ensureLoaded(state, { skipRecompute: true });
-    const job = state.store?.jobs.find((entry) => entry.id === jobId);
-    if (!job) {
-      return;
+    let coreResult: Awaited<ReturnType<typeof executeJobCoreWithTimeout>>;
+    try {
+      coreResult = await executeJobCoreWithTimeout(state, executionJob);
+    } catch (err) {
+      coreResult = { status: "error", error: normalizeCronRunErrorText(err) };
     }
+    const endedAt = state.deps.nowMs();
+    tryFinishManualTaskRun(state, {
+      taskRunId,
+      coreResult,
+      endedAt,
+    });
 
-    const shouldDelete = applyJobResult(
-      state,
-      job,
-      {
+    await locked(state, async () => {
+      await ensureLoaded(state, { skipRecompute: true });
+      const job = state.store?.jobs.find((entry) => entry.id === jobId);
+      if (!job) {
+        return;
+      }
+
+      const shouldDelete = applyJobResult(
+        state,
+        job,
+        {
+          status: coreResult.status,
+          error: coreResult.error,
+          diagnostics: coreResult.diagnostics,
+          delivered: coreResult.delivered,
+          startedAt,
+          endedAt,
+        },
+        { preserveSchedule: mode === "force" },
+      );
+
+      emit(state, {
+        jobId: job.id,
+        action: "finished",
+        job,
         status: coreResult.status,
         error: coreResult.error,
+        summary: coreResult.summary,
         diagnostics: coreResult.diagnostics,
         delivered: coreResult.delivered,
-        startedAt,
-        endedAt,
-      },
-      { preserveSchedule: mode === "force" },
-    );
+        deliveryStatus: job.state.lastDeliveryStatus,
+        deliveryError: job.state.lastDeliveryError,
+        delivery: coreResult.delivery,
+        sessionId: coreResult.sessionId,
+        sessionKey: coreResult.sessionKey,
+        runId,
+        runAtMs: startedAt,
+        durationMs: job.state.lastDurationMs,
+        nextRunAtMs: job.state.nextRunAtMs,
+        model: coreResult.model,
+        provider: coreResult.provider,
+        usage: coreResult.usage,
+      });
 
-    emit(state, {
-      jobId: job.id,
-      action: "finished",
-      job,
-      status: coreResult.status,
-      error: coreResult.error,
-      summary: coreResult.summary,
-      diagnostics: coreResult.diagnostics,
-      delivered: coreResult.delivered,
-      deliveryStatus: job.state.lastDeliveryStatus,
-      deliveryError: job.state.lastDeliveryError,
-      delivery: coreResult.delivery,
-      sessionId: coreResult.sessionId,
-      sessionKey: coreResult.sessionKey,
-      runId,
-      runAtMs: startedAt,
-      durationMs: job.state.lastDurationMs,
-      nextRunAtMs: job.state.nextRunAtMs,
-      model: coreResult.model,
-      provider: coreResult.provider,
-      usage: coreResult.usage,
+      if (shouldDelete && state.store) {
+        state.store.jobs = state.store.jobs.filter((entry) => entry.id !== job.id);
+        emit(state, { jobId: job.id, action: "removed", job });
+      }
+
+      // Manual runs should not advance other due jobs without executing them.
+      // Use maintenance-only recompute to repair missing values while
+      // preserving existing past-due nextRunAtMs entries for future timer ticks.
+      const postRunSnapshot = shouldDelete
+        ? null
+        : {
+            enabled: job.enabled,
+            updatedAtMs: job.updatedAtMs,
+            state: structuredClone(job.state),
+          };
+      const postRunRemoved = shouldDelete;
+      // Isolated Telegram send can persist target writeback directly to disk.
+      // Reload before final persist so manual `cron run` keeps those changes.
+      await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+      mergeManualRunSnapshotAfterReload({
+        state,
+        jobId,
+        snapshot: postRunSnapshot,
+        removed: postRunRemoved,
+      });
+      recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
+      await persist(state);
+      armTimer(state);
     });
-
-    if (shouldDelete && state.store) {
-      state.store.jobs = state.store.jobs.filter((entry) => entry.id !== job.id);
-      emit(state, { jobId: job.id, action: "removed", job });
-    }
-
-    // Manual runs should not advance other due jobs without executing them.
-    // Use maintenance-only recompute to repair missing values while
-    // preserving existing past-due nextRunAtMs entries for future timer ticks.
-    const postRunSnapshot = shouldDelete
-      ? null
-      : {
-          enabled: job.enabled,
-          updatedAtMs: job.updatedAtMs,
-          state: structuredClone(job.state),
-        };
-    const postRunRemoved = shouldDelete;
-    // Isolated Telegram send can persist target writeback directly to disk.
-    // Reload before final persist so manual `cron run` keeps those changes.
-    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
-    mergeManualRunSnapshotAfterReload({
-      state,
-      jobId,
-      snapshot: postRunSnapshot,
-      removed: postRunRemoved,
-    });
-    recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
-    await persist(state);
-    armTimer(state);
-  });
+  } finally {
+    clearCronJobActive(jobId);
+  }
 }
 
 export async function run(


### PR DESCRIPTION
## Summary
- **Problem**: Manual cron runs (`openclaw cron run <id> --force` and the matching RPC / agent-tool surface) that exceed `TASK_RECONCILE_GRACE_MS` (5 min) surface a transient `lost` task-registry status plus a `Background task lost` system message in the grace window before `resolveDurableCronTaskRecovery` (1fae716a04, merged 2026-04-26) reconciles. Final state is correct, but the user triggering the run sees an inaccurate intermediate state.
- **Why it matters**: Force-mode `agentTurn` manual runs can legitimately run up to `AGENT_TURN_SAFETY_TIMEOUT_MS` (60 min); the default-mode timeout is 10 min — both well past the 5-minute grace.
- **What changed**: Mirror the `markCronJobActive`/`clearCronJobActive` pair (introduced for `runDueJob`/`executeJob` by #60310) into `prepareManualRun` + `finishPreparedManualRun`, so `task-registry.maintenance.ts` `hasBackingSession` returns true for the duration of the manual run.
- **What did NOT change**: `runStartupCatchupCandidate` is intentionally untouched — `deferAgentTurnJobs:true` (7877182b6f) reroutes long-running startup catchups to `runDueJob`/`executeJob` (already wired), and the merged `1fae716a04` covers the residual non-agentTurn case from a different axis. No public API surface change.

## Change Type
- [x] Bug fix

## Scope
- Touched: `src/cron/service/ops.ts` (3 lines added — import + `markCronJobActive` + `try/finally` wrap with `clearCronJobActive`)
- Test: `src/cron/active-jobs-manual-run.test.ts` (new, 160 lines, 2 cases)

## Linked Issue
Fixes #78233

## Root Cause
`task-registry.maintenance.ts` `hasBackingSession` for the cron branch under `isCronRuntimeAuthoritative()=true` (production default) depends solely on `isCronJobActive(jobId)`. `prepareManualRun` (`ops.ts:654`) creates a manual `tryCreateManualTaskRun` task but never calls `markCronJobActive`; `finishPreparedManualRun` (`ops.ts:702`) likewise never clears it. With `TASK_RECONCILE_GRACE_MS = 5 min` and force-mode manual runs reaching up to 60 min, the sweeper marks the still-running task `lost` and emits the `Background task lost` system message before the run completes.

## Regression Test Plan
- New test file: `src/cron/active-jobs-manual-run.test.ts` — two cases against the production hot-path (`cron.run("<id>", "force")` direct invocation, no internal-API rerouting):
  1. Success path: assert `isCronJobActive` transitions `true` (mid-run) → `false` (after run resolves).
  2. Inner-throw path: assert `isCronJobActive` is also cleared by the `finally` block when the inner agent run rejects.
- Existing tests (`src/cron/service.test.ts`, `src/cron/service.restart-catchup.test.ts`) untouched.

## Security Impact
None. Internal cron service state only — no auth, secrets, network, or cross-process surfaces. No CODEOWNERS-restricted paths.

## Repro + Verification
- Local: `pnpm vitest run src/cron/active-jobs-manual-run.test.ts` → 2/2 pass
- Type check: `pnpm tsgo:core:test` → exit 0
- Pre-fix behaviour reproducible by reverting the `ops.ts` change in this PR; the new test then fails because `isCronJobActive` returns `false` mid-run.

## Evidence
Failing test before fix (locally verified by reverting just the `ops.ts` change): both new cases fail at the mid-run `expect(isCronJobActive(...)).toBe(true)` assertion. Passing after fix: both green.

## Human Verification
Code paths traced: `prepareManualRun` → `tryCreateManualTaskRun` → `cron.run` → `finishPreparedManualRun` → `applyJobResult`. Confirmed against `task-registry.maintenance.ts` `hasBackingSession` (cron branch) and `resolveCronJobStateRecovery` (`lastRunAtMs` matching).

## Review Conversations
This is a narrower follow-up to closed PR #71040 (which also touched `runStartupCatchupCandidate`). The full PR was closed after a 5-agent pre-PR cross-review found that `1fae716a04` had already addressed the same axis from the sweeper side, and `deferAgentTurnJobs:true` removed the agentTurn startup-catchup scenario entirely. This PR retains only the producer-side gap that `1fae716a04` does not close: the **transient** lost marker during the 5-minute grace window before sweeper recovery reconciles.

## Compatibility / Migration
None. Internal-only API mirroring an existing contract.

## Risks and Mitigations
- **Concurrent manual runs**: `prepareManualRun` already prevents re-entry (`runningAtMs` guard); even if mark/clear were called twice for the same `jobId` the activeJobIds set is idempotent.
- **Inner throws**: covered by `try/finally` and the dedicated regression test.
- **Interaction with `1fae716a04`**: orthogonal — sweeper recovery still applies; this fix only suppresses the transient `lost` surface inside the grace window.

[AI-assisted, fully tested]


## Real behavior proof

- **Behavior or issue addressed**: Without this patch, manual cron runs that exceed `TASK_RECONCILE_GRACE_MS` (5 min) are marked `lost` by `task-registry.maintenance.ts` `hasBackingSession` (cron branch under `isCronRuntimeAuthoritative()=true`) because no producer-side `markCronJobActive` is called from `prepareManualRun`. With this patch, the same long-running manual run keeps `isCronJobActive=true` for the duration and is never marked `lost` by the sweeper.

- **Real environment tested**: macOS 25.4 (darwin arm64), Node 23.9, OpenClaw 2026.5.5 from this branch, locally built. Local gateway (`openclaw gateway run`, loopback, port 18789) configured with `openclaw onboard --non-interactive --accept-risk --mode local --auth-choice skip`, then OpenAI Codex OAuth bound via `openclaw models auth login --provider openai-codex` (ChatGPT Plus subscription, profile `openai-codex:<email>`, `agentRuntime: codex`, `agents.defaults.model.primary: openai-codex/gpt-5.5`). Same gateway, same cron job, same codex auth across both builds; only `src/cron/service/ops.ts` differs.

- **Exact steps or command run after this patch**:

  ```text
  $ pnpm build                                       # build this branch (with mark/clear)
  $ openclaw cron add --name agentturn-mark-clear-demo \
      --every 1h \
      --message "Run the shell command 'sleep 420 && echo done' using your exec tool, then reply 'completed'." \
      --session isolated --thinking high --timeout-seconds 900 \
      --tools exec --model openai-codex/gpt-5.5
  $ openclaw cron run <job-id>
  # then wait > 5 min and observe sqlite task_runs
  $ sqlite3 ~/.openclaw/tasks/runs.sqlite \
      "SELECT task_id, status, started_at, ended_at, error FROM task_runs \
       WHERE source_id='<job-id>' ORDER BY started_at DESC LIMIT 1"
  ```

  For the without-fix comparison, the same steps were run on a build where `src/cron/service/ops.ts` was reverted to the base commit (`git checkout ea391c6df2 -- src/cron/service/ops.ts`) before `pnpm build`.

- **Evidence after fix**: live `task_runs` rows from `~/.openclaw/tasks/runs.sqlite` (same cron job, two builds).

  ```text
  # Build A — without this patch (ops.ts at base, no markCronJobActive in prepareManualRun)
  task_id     : 3084baa3-b848-4f6c-be8a-9e1a21e925f3
  status      : lost
  started_at  : 1778047111346  (14:58:30)
  ended_at    : 1778047469142  (15:04:29, T0+5m59s)
  last_event_at: 1778047469142
  error       : backing session missing

  # Build B — with this patch (ops.ts with markCronJobActive + try/finally clearCronJobActive)
  task_id     : c583e334-c863-4da7-a637-acd11cdb8393
  status      : failed                       <-- not 'lost'
  started_at  : 1778046431855  (14:47:11)
  ended_at    : 1778046871009  (14:54:31, T0+7m20s)
  last_event_at: 1778046871009
  error       : Channel is required (no configured channels detected)...   <-- unrelated delivery config, the run itself finalized normally
  ```

  Gateway log excerpts (cron + agent activity):

  ```text
  # Build B (with patch) — codex agent stalled at the ChatGPT rate limit, sweeper grace exceeded
  [diagnostic] stalled session: ... age=131s ... lastProgress=codex_app_server:notification:account/rateLimits/updated cronJob="agentturn-mark-clear-demo"
  [diagnostic] stalled session: ... age=161s
  [diagnostic] stalled session: ... age=191s
  [diagnostic] stalled session: ... age=221s
  [diagnostic] stalled session: ... age=251s
  [diagnostic] stalled session: ... age=281s
  # No "Background task lost" message emitted. Run finalized as 'failed' (delivery channel unrelated) without ever flipping to 'lost'.
  ```

- **Observed result after fix**: With the patch, `task_runs.status` for a 7-minute manual cron run stays out of `lost` and finalizes as `failed`/`succeeded` directly. Without the patch, `task-registry.maintenance.ts` `hasBackingSession` returns false at the first sweeper tick after `TASK_RECONCILE_GRACE_MS` (5 min) and marks the still-running cron task `lost` with `error="backing session missing"`. The only difference between the two runs above is the four-line `ops.ts` change in this PR; cron job, codex auth, gateway config, and ChatGPT subscription are identical.

- **What was not tested**: The full chain from `Background task lost` system message to its retroactive reconciliation by `resolveDurableCronTaskRecovery` (`1fae716a04`) was not visually exercised in this setup, since the Codex-driven runs hit the ChatGPT subscription rate limit before normal completion. The producer-side mark/clear gap that this PR closes is fully exercised: the `lost` status flip happens (without patch) or is suppressed (with patch) deterministically at `TASK_RECONCILE_GRACE_MS`, which is the user-visible step the patch targets.
