### PR TITLE
fix: mark manual cron runs active

### DIFF
--- a/src/cron/service/ops.regression.test.ts
+++ b/src/cron/service/ops.regression.test.ts
@@ -16,6 +16,7 @@ import {
   waitForActiveTasks,
 } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
+import { isCronJobActive } from "../active-jobs.js";
 import { enqueueRun, run, start } from "./ops.js";
 import type { CronEvent } from "./state.js";
 import { createCronServiceState } from "./state.js";
@@ -226,6 +227,43 @@ describe("cron service ops regressions", () => {
     const staleExecuted = jobs.find((entry) => entry.id === "unrelated-stale-executed");
     expect(unrelated?.state.nextRunAtMs).toBe(dueNextRunAtMs);
     expect((staleExecuted?.state.nextRunAtMs ?? 0) > nowMs).toBe(true);
+  });
+
+  it("tracks manual cron.run as an active cron job until execution finishes", async () => {
+    const store = opsRegressionFixtures.makeStorePath();
+    const now = Date.parse("2026-02-06T10:05:00.000Z");
+    const job = createIsolatedRegressionJob({
+      id: "manual-active-job",
+      name: "manual active job",
+      scheduledAt: now,
+      schedule: { kind: "at", at: new Date(now).toISOString() },
+      payload: { kind: "agentTurn", message: "long manual task" },
+      state: { nextRunAtMs: now },
+    });
+    await writeCronJobs(store.storePath, [job]);
+
+    const runStarted = createDeferred<void>();
+    const runResult = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => {
+        runStarted.resolve();
+        return await runResult.promise;
+      }),
+    });
+
+    const manualRun = run(state, job.id, "force");
+    await runStarted.promise;
+    expect(isCronJobActive(job.id)).toBe(true);
+
+    runResult.resolve({ status: "ok", summary: "done" });
+    await expect(manualRun).resolves.toEqual({ ok: true, ran: true });
+    expect(isCronJobActive(job.id)).toBe(false);
   });
 
   it("applies timeoutSeconds to manual cron.run isolated executions", async () => {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -7,6 +7,7 @@ import {
   createRunningTaskRun,
   failTaskRunByRunId,
 } from "../../tasks/detached-task-runtime.js";
+import { clearCronJobActive, markCronJobActive } from "../active-jobs.js";
 import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
 import { createCronExecutionId } from "../run-id.js";
 import type { CronJob, CronJobCreate, CronJobPatch } from "../types.js";
@@ -680,6 +681,7 @@ async function prepareManualRun(
     // Persist the running marker before releasing lock so timer ticks that
     // force-reload from disk cannot start the same job concurrently.
     await persist(state);
+    markCronJobActive(job.id);
     emit(state, { jobId: job.id, action: "started", job, runAtMs: preflight.now });
     const taskRunId = tryCreateManualTaskRun({
       state,
@@ -710,92 +712,96 @@ async function finishPreparedManualRun(
   const taskRunId = prepared.taskRunId;
   const runId = prepared.runId;
 
-  let coreResult: Awaited<ReturnType<typeof executeJobCoreWithTimeout>>;
   try {
-    coreResult = await executeJobCoreWithTimeout(state, executionJob);
-  } catch (err) {
-    coreResult = { status: "error", error: normalizeCronRunErrorText(err) };
-  }
-  const endedAt = state.deps.nowMs();
-  tryFinishManualTaskRun(state, {
-    taskRunId,
-    coreResult,
-    endedAt,
-  });
-
-  await locked(state, async () => {
-    await ensureLoaded(state, { skipRecompute: true });
-    const job = state.store?.jobs.find((entry) => entry.id === jobId);
-    if (!job) {
-      return;
+    let coreResult: Awaited<ReturnType<typeof executeJobCoreWithTimeout>>;
+    try {
+      coreResult = await executeJobCoreWithTimeout(state, executionJob);
+    } catch (err) {
+      coreResult = { status: "error", error: normalizeCronRunErrorText(err) };
     }
+    const endedAt = state.deps.nowMs();
+    tryFinishManualTaskRun(state, {
+      taskRunId,
+      coreResult,
+      endedAt,
+    });
 
-    const shouldDelete = applyJobResult(
-      state,
-      job,
-      {
+    await locked(state, async () => {
+      await ensureLoaded(state, { skipRecompute: true });
+      const job = state.store?.jobs.find((entry) => entry.id === jobId);
+      if (!job) {
+        return;
+      }
+
+      const shouldDelete = applyJobResult(
+        state,
+        job,
+        {
+          status: coreResult.status,
+          error: coreResult.error,
+          diagnostics: coreResult.diagnostics,
+          delivered: coreResult.delivered,
+          startedAt,
+          endedAt,
+        },
+        { preserveSchedule: mode === "force" },
+      );
+
+      emit(state, {
+        jobId: job.id,
+        action: "finished",
+        job,
         status: coreResult.status,
         error: coreResult.error,
+        summary: coreResult.summary,
         diagnostics: coreResult.diagnostics,
         delivered: coreResult.delivered,
-        startedAt,
-        endedAt,
-      },
-      { preserveSchedule: mode === "force" },
-    );
+        deliveryStatus: job.state.lastDeliveryStatus,
+        deliveryError: job.state.lastDeliveryError,
+        delivery: coreResult.delivery,
+        sessionId: coreResult.sessionId,
+        sessionKey: coreResult.sessionKey,
+        runId,
+        runAtMs: startedAt,
+        durationMs: job.state.lastDurationMs,
+        nextRunAtMs: job.state.nextRunAtMs,
+        model: coreResult.model,
+        provider: coreResult.provider,
+        usage: coreResult.usage,
+      });
 
-    emit(state, {
-      jobId: job.id,
-      action: "finished",
-      job,
-      status: coreResult.status,
-      error: coreResult.error,
-      summary: coreResult.summary,
-      diagnostics: coreResult.diagnostics,
-      delivered: coreResult.delivered,
-      deliveryStatus: job.state.lastDeliveryStatus,
-      deliveryError: job.state.lastDeliveryError,
-      delivery: coreResult.delivery,
-      sessionId: coreResult.sessionId,
-      sessionKey: coreResult.sessionKey,
-      runId,
-      runAtMs: startedAt,
-      durationMs: job.state.lastDurationMs,
-      nextRunAtMs: job.state.nextRunAtMs,
-      model: coreResult.model,
-      provider: coreResult.provider,
-      usage: coreResult.usage,
+      if (shouldDelete && state.store) {
+        state.store.jobs = state.store.jobs.filter((entry) => entry.id !== job.id);
+        emit(state, { jobId: job.id, action: "removed", job });
+      }
+
+      // Manual runs should not advance other due jobs without executing them.
+      // Use maintenance-only recompute to repair missing values while
+      // preserving existing past-due nextRunAtMs entries for future timer ticks.
+      const postRunSnapshot = shouldDelete
+        ? null
+        : {
+            enabled: job.enabled,
+            updatedAtMs: job.updatedAtMs,
+            state: structuredClone(job.state),
+          };
+      const postRunRemoved = shouldDelete;
+      // Isolated Telegram send can persist target writeback directly to disk.
+      // Reload before final persist so manual `cron run` keeps those changes.
+      await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+      mergeManualRunSnapshotAfterReload({
+        state,
+        jobId,
+        snapshot: postRunSnapshot,
+        removed: postRunRemoved,
+      });
+      recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
+      await persist(state);
+      armTimer(state);
     });
-
-    if (shouldDelete && state.store) {
-      state.store.jobs = state.store.jobs.filter((entry) => entry.id !== job.id);
-      emit(state, { jobId: job.id, action: "removed", job });
-    }
-
-    // Manual runs should not advance other due jobs without executing them.
-    // Use maintenance-only recompute to repair missing values while
-    // preserving existing past-due nextRunAtMs entries for future timer ticks.
-    const postRunSnapshot = shouldDelete
-      ? null
-      : {
-          enabled: job.enabled,
-          updatedAtMs: job.updatedAtMs,
-          state: structuredClone(job.state),
-        };
-    const postRunRemoved = shouldDelete;
-    // Isolated Telegram send can persist target writeback directly to disk.
-    // Reload before final persist so manual `cron run` keeps those changes.
-    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
-    mergeManualRunSnapshotAfterReload({
-      state,
-      jobId,
-      snapshot: postRunSnapshot,
-      removed: postRunRemoved,
-    });
-    recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
-    await persist(state);
-    armTimer(state);
-  });
+  } finally {
+    clearCronJobActive(jobId);
+  }
 }
 
 export async function run(


### PR DESCRIPTION
Closes #78233

## Summary
- mark manual `cron run` executions active in the process-local cron runtime tracker after the durable running marker is persisted
- clear the active marker in `finishPreparedManualRun` with `finally`, including missing-job or persist-failure exits
- add a regression test covering manual-run active tracking while the isolated job is still running

## Verification
- `PATH="/tank/development/linus/openclaw/node_modules/.bin:/tmp/openclaw-pnpm-shim:$PATH" pnpm format:check src/cron/service/ops.ts src/cron/service/ops.regression.test.ts` ✅
- `git diff --check` ✅
- `PATH="/tank/development/linus/openclaw/node_modules/.bin:/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` ⚠️ blocked by unrelated existing core typecheck errors, primarily missing `@openclaw/fs-safe/*` packages plus strictness diagnostics outside this patch
- targeted vitest for `src/cron/service/ops.regression.test.ts -t "tracks manual cron.run as an active cron job"` ⚠️ attempted with parent `node_modules`; Vitest produced no test output and was killed by the 120s timeout before running/reporting tests in this worktree
