### PR TITLE
fix(channels): discover npm-installed plugins in channels add command

### DIFF
--- a/src/commands/channel-setup/trusted-catalog.ts
+++ b/src/commands/channel-setup/trusted-catalog.ts
@@ -43,6 +43,7 @@ export function getTrustedChannelPluginCatalogEntry(
 ): ChannelPluginCatalogEntry | undefined {
   const candidate = getChannelPluginCatalogEntry(channelId, {
     workspaceDir: params.workspaceDir,
+    env: params.env,
   });
   if (isTrustedWorkspaceChannelCatalogEntry(candidate, params.cfg, params.env)) {
     return candidate;
@@ -50,6 +51,7 @@ export function getTrustedChannelPluginCatalogEntry(
   return getChannelPluginCatalogEntry(channelId, {
     workspaceDir: params.workspaceDir,
     excludeWorkspace: true,
+    env: params.env,
   });
 }
 
@@ -63,11 +65,13 @@ function listChannelPluginCatalogEntriesWithTrustedFallback(
 ): ChannelPluginCatalogEntry[] {
   const unfiltered = listChannelPluginCatalogEntries({
     workspaceDir: params.workspaceDir,
+    env: params.env,
   });
   const fallbackById = new Map(
     listChannelPluginCatalogEntries({
       workspaceDir: params.workspaceDir,
       excludeWorkspace: true,
+      env: params.env,
     }).map((entry) => [entry.id, entry]),
   );
   return unfiltered.flatMap((entry) => {

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -46,7 +46,11 @@ export type ChannelsAddOptions = {
 const CHANNEL_ADD_CONTROL_OPTION_KEYS = new Set(["channel", "account"]);
 const NEXTCLOUD_TALK_CLI_ALIASES = new Set(["nextcloud-talk", "nc-talk", "nc"]);
 
-async function resolveCatalogChannelEntry(raw: string, cfg: OpenClawConfig | null) {
+async function resolveCatalogChannelEntry(
+  raw: string,
+  cfg: OpenClawConfig | null,
+  env?: NodeJS.ProcessEnv,
+) {
   const trimmed = normalizeOptionalLowercaseString(raw);
   if (!trimmed) {
     return undefined;
@@ -57,11 +61,12 @@ async function resolveCatalogChannelEntry(raw: string, cfg: OpenClawConfig | nul
           listTrustedChannelPluginCatalogEntries({
             cfg,
             workspaceDir: resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)),
+            env,
           }),
       )
     : await import("../../channels/plugins/catalog.js").then(
         ({ listChannelPluginCatalogEntries }) =>
-          listChannelPluginCatalogEntries({ excludeWorkspace: true }),
+          listChannelPluginCatalogEntries({ excludeWorkspace: true, env }),
       );
   return entries.find((entry) => {
     if (normalizeOptionalLowercaseString(entry.id) === trimmed) {
@@ -279,7 +284,9 @@ export async function channelsAddCommand(
 
   const rawChannel = opts.channel ?? "";
   let channel = normalizeChannelId(rawChannel);
-  let catalogEntry = channel ? undefined : await resolveCatalogChannelEntry(rawChannel, nextConfig);
+  let catalogEntry = channel
+    ? undefined
+    : await resolveCatalogChannelEntry(rawChannel, nextConfig, process.env);
   const resolveWorkspaceDir = () =>
     resolveAgentWorkspaceDir(nextConfig, resolveDefaultAgentId(nextConfig));
   // May load a scoped plugin when the channel is not already registered.

--- a/src/plugins/channel-catalog-registry.ts
+++ b/src/plugins/channel-catalog-registry.ts
@@ -1,4 +1,5 @@
 import { discoverOpenClawPlugins } from "./discovery.js";
+import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-record-reader.js";
 import {
   loadPluginManifest,
   type PluginPackageChannel,
@@ -23,9 +24,11 @@ export function listChannelCatalogEntries(
     env?: NodeJS.ProcessEnv;
   } = {},
 ): PluginChannelCatalogEntry[] {
+  const installRecords = loadInstalledPluginIndexInstallRecordsSync({ env: params.env });
   return discoverOpenClawPlugins({
     workspaceDir: params.workspaceDir,
     env: params.env,
+    installRecords,
   }).candidates.flatMap((candidate) => {
     if (params.origin && candidate.origin !== params.origin) {
       return [];


### PR DESCRIPTION
## Summary

Fix npm-installed plugins not being discovered by `channels add` command.

Previously, `listChannelCatalogEntries` did not pass `installRecords` to `discoverOpenClawPlugins`, causing npm-installed plugins (installed via `openclaw plugins install <package>`) to be skipped during channel discovery.

## Problem

1. Install a channel plugin from npm: `openclaw plugins install @lansenger/openclaw-channel-lansenger`
2. Plugin appears in `plugins/installs.json` with `installPath: ~/.openclaw/npm/node_modules/@lansenger/openclaw-channel-lansenger`
3. Try to add channel: `openclaw channels add --channel Lansenger --token "..."`
4. Error: `Unknown channel: Lansenger`

## Root Cause

`listChannelCatalogEntries()` called `discoverOpenClawPlugins()` without `installRecords` parameter, so:
- `collectInstalledPluginRecordPaths()` never ran
- npm `installPath` was never added to discovery scan
- npm-installed plugins were silently skipped

## Solution

Load `installRecords` from `plugins/installs.json` and pass to `discoverOpenClawPlugins`:
```ts
const installRecords = loadInstalledPluginIndexInstallRecordsSync({ env: params.env });
return discoverOpenClawPlugins({
  workspaceDir: params.workspaceDir,
  env: params.env,
  installRecords, // <-- added
});
```

## Changes

- Add import: `loadInstalledPluginIndexInstallRecordsSync`
- Load and pass `installRecords` in `listChannelCatalogEntries`

## Test

Existing tests pass (vitest run).

Fixes #78240