### PR TITLE
fix(doctor): use isDangerousHostInheritedEnvVarName for exec SecretRef passEnv validation

### DIFF
--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -347,6 +347,43 @@ describe("buildGatewayInstallPlan", () => {
     expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBeUndefined();
   });
 
+  it("includes HOME in passEnv for exec SecretRef without a doctor warning", async () => {
+    mockNodeGatewayPlanFixture({
+      serviceEnvironment: {
+        OPENCLAW_PORT: "3000",
+      },
+    });
+
+    const warnings: string[] = [];
+    const plan = await buildGatewayInstallPlan({
+      env: isolatedPlanEnv(),
+      port: 3000,
+      runtime: "node",
+      config: {
+        secrets: {
+          providers: {
+            onepassword: {
+              source: "exec",
+              command: "/usr/bin/op",
+              args: ["read", "op://Private/Discord/password"],
+              passEnv: ["HOME", "OP_SERVICE_ACCOUNT_TOKEN"],
+              allowInsecurePath: true,
+            },
+          },
+        },
+        channels: {
+          discord: {
+            token: { source: "exec", provider: "onepassword", id: "value" },
+          },
+        },
+      },
+      warn: (msg) => warnings.push(msg),
+    });
+
+    expect(warnings.filter((w) => w.includes("HOME"))).toHaveLength(0);
+    expect(plan.environment.HOME).toBe(isolatedHome);
+  });
+
   it("does not include passEnv values for unused exec SecretRef providers", async () => {
     mockNodeGatewayPlanFixture({
       serviceEnvironment: {

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -29,6 +29,7 @@ import type { GatewayServiceEnvironmentValueSource } from "../daemon/service-typ
 import {
   isDangerousHostEnvOverrideVarName,
   isDangerousHostEnvVarName,
+  isDangerousHostInheritedEnvVarName,
   normalizeEnvVarKey,
 } from "../infra/host-env-security.js";
 import { discoverConfigSecretTargets } from "../secrets/target-registry.js";
@@ -212,7 +213,7 @@ function collectExecSecretRefPassEnvServiceEnvVars(params: {
         );
         continue;
       }
-      if (isDangerousHostEnvVarName(key) || isDangerousHostEnvOverrideVarName(key)) {
+      if (isDangerousHostInheritedEnvVarName(key)) {
         params.warn?.(
           `Exec SecretRef passEnv ref "${key}" blocked by host-env security policy`,
           "Config SecretRef",


### PR DESCRIPTION
Fixes #78216

## Problem

`openclaw doctor` emits a false-positive warning for every exec SecretRef
provider that includes `HOME` in `passEnv`:

```
Exec SecretRef passEnv ref "HOME" blocked by host-env security policy
```

`passEnv` entries use **inheritance semantics** — the exec subprocess inherits
the current value of the key from the host environment. This is distinct from
**override semantics** (injecting an arbitrary value via `Environment=KEY=VAL`
in the service unit). The security policy already captures this distinction:
`HOME` is in `blockedOverrideOnlyKeys` but also in
`allowedInheritedOverrideOnlyKeys`, which means `isDangerousHostInheritedEnvVarName("HOME")` correctly returns `false`.

The bug: `collectExecSecretRefPassEnvServiceEnvVars` was calling
`isDangerousHostEnvOverrideVarName` (override semantics) for a passEnv check
(inheritance semantics), causing the false positive.

## Fix

Replace the check at `daemon-install-helpers.ts:215` with
`isDangerousHostInheritedEnvVarName`, which encodes the correct
`allowedInheritedOverrideOnlyKeys` exclusions. Keys like `HOME`,
`SSH_AUTH_SOCK`, `GRADLE_USER_HOME`, `ZDOTDIR` are no longer false-positively
blocked.

## Pre-implement audits

- **A (existing helper):** `isDangerousHostInheritedEnvVarName` already exists
  — reusing it. ✓
- **B (shared-caller check):** `isDangerousHostInheritedEnvVarName` is called
  in 2 files; I'm adding a third call site to `daemon-install-helpers.ts`, not
  mutating its contract. ✓
- **C (rival PR scan):** No open PR targeting #78216 or this function. ✓

## Test

Added: `"includes HOME in passEnv for exec SecretRef without a doctor warning"`