### PR TITLE
Allow no-device node exec approvals across backend calls

### DIFF
--- a/src/gateway/node-invoke-system-run-approval.test.ts
+++ b/src/gateway/node-invoke-system-run-approval.test.ts
@@ -426,4 +426,52 @@ describe("sanitizeSystemRunParamsForForwarding", () => {
     });
     expectRejectedForwardingResult(result, "APPROVAL_NODE_MISMATCH", "not valid for this node");
   });
+
+  test("accepts no-device approvals across per-call backend connections", () => {
+    const record = makeRecord("echo SAFE", ["echo", "SAFE"]);
+    record.requestedByConnId = "approval-request-conn";
+    record.requestedByDeviceId = null;
+    record.requestedByClientId = "gateway-client";
+    const result = sanitizeSystemRunParamsForForwarding({
+      rawParams: {
+        command: ["echo", "SAFE"],
+        rawCommand: "echo SAFE",
+        runId: "approval-1",
+        approved: true,
+        approvalDecision: "allow-once",
+      },
+      nodeId: "node-1",
+      client: {
+        connId: "node-invoke-conn",
+        connect: {
+          scopes: ["operator.write"],
+          device: undefined,
+        },
+      },
+      execApprovalManager: manager(record),
+      nowMs: now,
+    });
+    expectAllowOnceForwardingResult(result);
+  });
+
+  test("rejects no-device approvals replayed by a device-bound caller", () => {
+    const record = makeRecord("echo SAFE", ["echo", "SAFE"]);
+    record.requestedByConnId = "approval-request-conn";
+    record.requestedByDeviceId = null;
+    record.requestedByClientId = "gateway-client";
+    const result = sanitizeSystemRunParamsForForwarding({
+      rawParams: {
+        command: ["echo", "SAFE"],
+        rawCommand: "echo SAFE",
+        runId: "approval-1",
+        approved: true,
+        approvalDecision: "allow-once",
+      },
+      nodeId: "node-1",
+      client,
+      execApprovalManager: manager(record),
+      nowMs: now,
+    });
+    expectRejectedForwardingResult(result, "APPROVAL_DEVICE_MISMATCH", "not valid for this device");
+  });
 });

--- a/src/gateway/node-invoke-system-run-approval.ts
+++ b/src/gateway/node-invoke-system-run-approval.ts
@@ -176,8 +176,11 @@ export function sanitizeSystemRunParamsForForwarding(opts: {
     });
   }
 
-  // Prefer binding by device identity (stable across reconnects / per-call clients like callGateway()).
-  // Fallback to connId only when device identity is not available.
+  // Prefer binding by device identity: it is stable across reconnects and per-call clients like
+  // callGateway(). Shared-auth local backend clients intentionally omit device identity, so their
+  // websocket connId is not a stable security boundary. For those records, allow only callers that
+  // also lack a device identity and rely on the approval id, node binding, command binding, and
+  // allow-once consumption below.
   const snapshotDeviceId = snapshot.requestedByDeviceId ?? null;
   const clientDeviceId = opts.client?.connect?.device?.id ?? null;
   if (snapshotDeviceId) {
@@ -188,13 +191,10 @@ export function sanitizeSystemRunParamsForForwarding(opts: {
         details: { runId },
       });
     }
-  } else if (
-    snapshot.requestedByConnId &&
-    snapshot.requestedByConnId !== (opts.client?.connId ?? null)
-  ) {
+  } else if (clientDeviceId) {
     return systemRunApprovalGuardError({
-      code: "APPROVAL_CLIENT_MISMATCH",
-      message: "approval id not valid for this client",
+      code: "APPROVAL_DEVICE_MISMATCH",
+      message: "approval id not valid for this device",
       details: { runId },
     });
   }


### PR DESCRIPTION
Fixes #77656.

## Summary
- stop treating transient websocket `connId` as the approval boundary for no-device node `system.run` approvals
- preserve stable device-id binding when present
- reject device-bound callers replaying no-device approvals
- keep node id, command/binding, expiry, and allow-once consumption enforced

## Verification
- `git diff --check`
- targeted test attempt: `node scripts/test-projects.mjs src/gateway/node-invoke-system-run-approval.test.ts --maxWorkers=1`
  - blocked by unrelated baseline import failure: `Cannot find package '@openclaw/fs-safe/config' imported from src/infra/fs-safe-defaults.ts`

## Security note
No-device shared-auth backend calls do not have a stable device identity and use per-call websocket connections, so `connId` was a fake boundary. Device-bound approvals remain device-bound, and device-bound callers cannot replay no-device approval records.
