### PR TITLE
Bind approved exec followups to exact run output

### DIFF
--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -30,11 +30,20 @@ describe("exec approval followup", () => {
     expect(prompt).not.toContain("already approved has completed");
   });
 
-  it("tells the agent to continue the task before replying when the command succeeds", () => {
-    const prompt = buildExecApprovalFollowupPrompt("Exec finished (gateway id=req-1, code 0)\nok");
+  it("tells the agent to continue only from exact completion details when the command succeeds", () => {
+    const prompt = buildExecApprovalFollowupPrompt(
+      "Exec finished (gateway id=req-1, code 0)\nok",
+      "printf ok",
+    );
 
     expect(prompt).toContain("continue from this result before replying to the user");
     expect(prompt).toContain("Continue the task if needed, then reply to the user");
+    expect(prompt).toContain(
+      "The exact completion details below are the only authoritative output",
+    );
+    expect(prompt).toContain("Do not mention, summarize, or reuse output from any earlier run");
+    expect(prompt).toContain("Approved command:\nprintf ok");
+    expect(prompt).toContain("share the relevant output from the exact completion details only");
   });
 
   it("keeps followups internal when no external route is available", async () => {
@@ -89,6 +98,7 @@ describe("exec approval followup", () => {
       turnSourceAccountId: target.accountId,
       turnSourceThreadId: target.threadId,
       resultText: "slack exec approval smoke",
+      command: "printf channel-smoke",
     });
 
     expect(callGatewayTool).toHaveBeenCalledWith(
@@ -103,6 +113,7 @@ describe("exec approval followup", () => {
         accountId: target.accountId,
         threadId: target.threadId,
         idempotencyKey: `exec-approval-followup:req-${target.channel}`,
+        message: expect.stringContaining("Approved command:\nprintf channel-smoke"),
       }),
       { expectFinal: true },
     );

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -22,6 +22,7 @@ type ExecApprovalFollowupParams = {
   turnSourceAccountId?: string;
   turnSourceThreadId?: string | number;
   resultText: string;
+  command?: string;
   direct?: boolean;
 };
 
@@ -55,14 +56,20 @@ function formatUnknownError(error: unknown): string {
   }
 }
 
-export function buildExecApprovalFollowupPrompt(resultText: string): string {
+export function buildExecApprovalFollowupPrompt(resultText: string, command?: string): string {
   const trimmed = resultText.trim();
   if (isExecDeniedResultText(trimmed)) {
     return buildExecDeniedFollowupPrompt(trimmed);
   }
+  const commandText = command?.trim();
   return [
     "An async command the user already approved has completed.",
     "Do not run the command again.",
+    "The exact completion details below are the only authoritative output for this approved command.",
+    "Do not mention, summarize, or reuse output from any earlier run in this session.",
+    commandText ? "Approved command:" : undefined,
+    commandText,
+    commandText ? "" : undefined,
     "If the task requires more steps, continue from this result before replying to the user.",
     "Only ask the user for help if you are actually blocked.",
     "",
@@ -70,9 +77,11 @@ export function buildExecApprovalFollowupPrompt(resultText: string): string {
     trimmed,
     "",
     "Continue the task if needed, then reply to the user in a helpful way.",
-    "If it succeeded, share the relevant output.",
+    "If it succeeded, share the relevant output from the exact completion details only.",
     "If it failed, explain what went wrong.",
-  ].join("\n");
+  ]
+    .filter((line): line is string => line !== undefined)
+    .join("\n");
 }
 
 function shouldSuppressExecDeniedFollowup(sessionKey: string | undefined): boolean {
@@ -143,6 +152,7 @@ function buildAgentFollowupArgs(params: {
   approvalId: string;
   sessionKey: string;
   resultText: string;
+  command?: string;
   deliveryTarget: ExternalBestEffortDeliveryTarget;
   sessionOnlyOriginChannel?: string;
   turnSourceChannel?: string;
@@ -157,7 +167,7 @@ function buildAgentFollowupArgs(params: {
   const fallbackChannel = sessionOnlyOriginChannel ?? params.turnSourceChannel;
   return {
     sessionKey: params.sessionKey,
-    message: buildExecApprovalFollowupPrompt(params.resultText),
+    message: buildExecApprovalFollowupPrompt(params.resultText, params.command),
     deliver: deliveryTarget.deliver,
     ...(deliveryTarget.deliver ? { bestEffortDeliver: true as const } : {}),
     channel: deliveryTarget.deliver ? deliveryTarget.channel : fallbackChannel,
@@ -244,6 +254,7 @@ export async function sendExecApprovalFollowup(
           approvalId: params.approvalId,
           sessionKey,
           resultText,
+          command: params.command,
           deliveryTarget,
           sessionOnlyOriginChannel,
           turnSourceChannel: params.turnSourceChannel,

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -317,6 +317,113 @@ describe("processGatewayAllowlist", () => {
     );
   });
 
+  it("keeps approved followup output bound to its own approval and run", async () => {
+    type Outcome = {
+      status: "completed";
+      exitCode: number;
+      exitSignal: null;
+      durationMs: number;
+      timedOut: false;
+      aggregated: string;
+    };
+    const deferred = <T>() => {
+      let resolve!: (value: T) => void;
+      const promise = new Promise<T>((innerResolve) => {
+        resolve = innerResolve;
+      });
+      return { promise, resolve };
+    };
+    const first = deferred<Outcome>();
+    const second = deferred<Outcome>();
+
+    createAndRegisterDefaultExecApprovalRequestMock
+      .mockResolvedValueOnce({
+        approvalId: "req-first",
+        approvalSlug: "first",
+        warningText: "",
+        expiresAtMs: Date.now() + 60_000,
+        preResolvedDecision: null,
+        initiatingSurface: "origin",
+        sentApproverDms: false,
+        unavailableReason: null,
+      })
+      .mockResolvedValueOnce({
+        approvalId: "req-second",
+        approvalSlug: "second",
+        warningText: "",
+        expiresAtMs: Date.now() + 60_000,
+        preResolvedDecision: null,
+        initiatingSurface: "origin",
+        sentApproverDms: false,
+        unavailableReason: null,
+      });
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("allow-once");
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: false },
+      approvedByAsk: true,
+      deniedReason: null,
+    });
+    runExecProcessMock.mockImplementation(({ command }: { command: string }) => {
+      if (command === "printf first") {
+        return Promise.resolve({ session: { id: "run-first" }, promise: first.promise });
+      }
+      if (command === "printf second") {
+        return Promise.resolve({ session: { id: "run-second" }, promise: second.promise });
+      }
+      throw new Error(`unexpected command: ${command}`);
+    });
+    buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
+
+    await runGatewayAllowlist({ command: "printf first" });
+    await runGatewayAllowlist({ command: "printf second" });
+
+    await vi.waitFor(() => {
+      expect(runExecProcessMock).toHaveBeenCalledTimes(2);
+    });
+
+    second.resolve({
+      status: "completed",
+      exitCode: 0,
+      exitSignal: null,
+      durationMs: 2,
+      timedOut: false,
+      aggregated: "SECOND_OUTPUT",
+    });
+    first.resolve({
+      status: "completed",
+      exitCode: 0,
+      exitSignal: null,
+      durationMs: 1,
+      timedOut: false,
+      aggregated: "FIRST_OUTPUT",
+    });
+
+    await vi.waitFor(() => {
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledTimes(2);
+    });
+
+    expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledWith(
+      expect.objectContaining({ approvalId: "req-first", command: "printf first" }),
+      expect.stringContaining(
+        "Exec finished (gateway id=req-first, session=run-first, code 0)\nFIRST_OUTPUT",
+      ),
+    );
+    expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledWith(
+      expect.objectContaining({ approvalId: "req-second", command: "printf second" }),
+      expect.stringContaining(
+        "Exec finished (gateway id=req-second, session=run-second, code 0)\nSECOND_OUTPUT",
+      ),
+    );
+    for (const [target, text] of sendExecApprovalFollowupResultMock.mock.calls) {
+      if (target?.approvalId === "req-first") {
+        expect(text).not.toContain("SECOND_OUTPUT");
+      }
+      if (target?.approvalId === "req-second") {
+        expect(text).not.toContain("FIRST_OUTPUT");
+      }
+    }
+  });
+
   it("formats diagnostics approvals as direct pasteable followups", async () => {
     resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("allow-once");
     createExecApprovalDecisionStateMock.mockReturnValue({

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -449,6 +449,7 @@ export async function processGatewayAllowlist(
       turnSourceTo: params.turnSourceTo,
       turnSourceAccountId: params.turnSourceAccountId,
       turnSourceThreadId: params.turnSourceThreadId,
+      command: params.command,
       direct: params.approvalFollowupMode === "direct",
     });
 

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -148,6 +148,7 @@ export async function executeNodeHostCommand(
         turnSourceTo: params.turnSourceTo,
         turnSourceAccountId: params.turnSourceAccountId,
         turnSourceThreadId: params.turnSourceThreadId,
+        command: params.command,
       });
 
       void (async () => {

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -88,6 +88,7 @@ export type ExecApprovalFollowupTarget = {
   turnSourceTo?: string;
   turnSourceAccountId?: string;
   turnSourceThreadId?: string | number;
+  command?: string;
   direct?: boolean;
 };
 
@@ -323,6 +324,7 @@ export function buildExecApprovalFollowupTarget(
     turnSourceTo: params.turnSourceTo,
     turnSourceAccountId: params.turnSourceAccountId,
     turnSourceThreadId: params.turnSourceThreadId,
+    command: params.command,
     direct: params.direct,
   };
 }
@@ -416,6 +418,7 @@ export async function sendExecApprovalFollowupResult(
     turnSourceAccountId: target.turnSourceAccountId,
     turnSourceThreadId: target.turnSourceThreadId,
     resultText,
+    command: target.command,
     direct: target.direct,
   }).catch((error) => {
     const message = formatErrorMessage(error);


### PR DESCRIPTION
Fixes #78256.

## Summary
- thread the approved command text into gateway/node exec approval followups
- harden successful followup prompts so exact completion details are the only authoritative output
- add regression coverage for two approved gateway exec runs resolving out of order, proving each followup remains bound to its own approval id, run session id, and output

## Verification
- `git diff --check`
- targeted test attempt: `node scripts/test-projects.mjs src/agents/bash-tools.exec-host-gateway.test.ts src/agents/bash-tools.exec-approval-followup.test.ts --maxWorkers=1`
  - blocked by unrelated baseline import failure: `Cannot find package '@openclaw/fs-safe/config' imported from src/infra/fs-safe-defaults.ts`

## Scope note
This covers the approved-followup association seam and stale-context suppression in the resumed agent prompt. If future reports show wrong bytes already inside the exact completion details, the lower-level `runExecProcess`/supervisor output callbacks need additional runtime diagnostics.
