### PR TITLE
fix(media): allow buffer-verified ZIP archives in host-read validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ Docs: https://docs.openclaw.ai
 - Plugin skills/Windows: publish plugin-provided skill directories as junctions on Windows so standard users without Developer Mode can register plugin skills without symlink EPERM failures. Fixes #77958. (#77971) Thanks @hclsys and @jarro.
 - Shell env/Windows: hide the login-shell environment probe child window so gateway startup and shell-env refreshes do not flash a console on Windows. Fixes #78159. (#78266) Thanks @BradGroux.
 - MS Teams: surface blocked Bot Framework egress by logging JWKS fetch network failures and adding a Bot Connector send hint for transport-level reply failures. Fixes #77674. (#78081) Thanks @Beandon13.
+- Media/host-read: allow buffer-verified ZIP archives in the host-local media validator so agents can send ZIP attachments via the message tool. Fixes #78057. (#78292) Thanks @Linux2010.
 - Gateway/sessions: fast-path already-qualified model refs while building session-list rows so `openclaw sessions` and Control UI session lists avoid heavyweight model resolution on large stores. (#77902) Thanks @ragesaq.
 - Contributor PRs: remind external contributors to redact private information like IP addresses, API keys, phone numbers, and non-public endpoints from real behavior proof. Thanks @pashpashpash.
 - ACP bridge: relay Gateway exec approval prompts from active ACP turns to the ACP client's `session/request_permission` handler before resolving the Gateway approval. Thanks @amknight.

--- a/src/commands/onboard-non-interactive/local/gateway-config.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.ts
@@ -23,19 +23,18 @@ export function applyNonInteractiveGatewayConfig(params: {
 } | null {
   const { opts, runtime } = params;
 
-  const hasGatewayPort = opts.gatewayPort !== undefined;
+  const gatewayPort = opts.gatewayPort;
+  const hasGatewayPort = gatewayPort !== undefined;
   if (
     hasGatewayPort &&
-    (!Number.isFinite(opts.gatewayPort) ||
-      (opts.gatewayPort ?? 0) <= 0 ||
-      opts.gatewayPort > 65_535)
+    (!Number.isFinite(gatewayPort) || gatewayPort <= 0 || gatewayPort > 65_535)
   ) {
     runtime.error(formatInvalidPortOption("--gateway-port"));
     runtime.exit(1);
     return null;
   }
 
-  const port = hasGatewayPort ? (opts.gatewayPort as number) : params.defaultPort;
+  const port = gatewayPort ?? params.defaultPort;
   let bind = opts.gatewayBind ?? "loopback";
   const authModeRaw = opts.gatewayAuth ?? "token";
   if (authModeRaw !== "token" && authModeRaw !== "password") {

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { formatCliCommand } from "../cli/command-format.js";
 import { formatLookupMiss } from "../cli/error-format.js";
 import { getRuntimeConfig } from "../config/config.js";
 import {

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -376,6 +376,21 @@ describe("loadWebMedia", () => {
     expect(result.contentType).toBe("text/markdown");
   });
 
+  it("allows host-read ZIP files", async () => {
+    const zipFile = path.join(fixtureRoot, "archive.zip");
+    // Write valid ZIP magic bytes (PK\x03\x04) with minimal empty ZIP structure.
+    // file-type detects application/zip from these magic bytes.
+    await fs.writeFile(zipFile, Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+    const result = await loadWebMedia(zipFile, {
+      maxBytes: 1024 * 1024,
+      localRoots: "any",
+      readFile: async (filePath) => await fs.readFile(filePath),
+      hostReadCapability: true,
+    });
+    expect(result.kind).toBe("document");
+    expect(result.contentType).toBe("application/zip");
+  });
+
   it("rejects binary data disguised as a CSV file", async () => {
     const fakeCsv = path.join(fixtureRoot, "evil.csv");
     // Write ZIP magic bytes — file-type detects application/zip (not image, not CSV),

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -123,6 +123,7 @@ const HOST_READ_ALLOWED_DOCUMENT_MIMES = new Set([
   "application/vnd.openxmlformats-officedocument.presentationml.presentation",
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/zip",
   "text/csv",
   "text/markdown",
 ]);


### PR DESCRIPTION
## Summary

- **Problem:** ZIP file attachments are rejected via the message tool with error "Host-local media sends only allow buffer-verified images, audio, video, PDF, and Office documents (got application/zip)". This is a regression from v2026.4.23 to v2026.5.2.
- **What changed:** Added `application/zip` to `HOST_READ_ALLOWED_DOCUMENT_MIMES` set in `src/media/web-media.ts`, enabling ZIP files to pass the host-read media validator.
- **Why it matters:** Users frequently need to send ZIP archives (e.g., source code bundles) via Discord/other channels. Blocking ZIPs breaks common workflows.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security
- [ ] Chore

## Scope

- [ ] Gateway/orchestration
- [ ] Skills/tool execution
- [ ] Auth/tokens
- [ ] Memory/storage
- [x] Integrations (media handling for message tool)
- [ ] API/contracts
- [ ] UI/DX
- [ ] CI/CD

## Linked Issue

- Fixes #78057
- [x] This PR fixes a regression (ZIP attachments worked in v2026.4.23)

## Root Cause

- `HOST_READ_ALLOWED_DOCUMENT_MIMES` in `src/media/web-media.ts` lacked `application/zip`, causing ZIP files to fail validation.
- The host-read validator was introduced in commit 3bb02d333865, which omitted ZIP from the initial allowlist.

## Regression Test Plan

- [x] Unit test added
- Target test: `src/media/web-media.test.ts` - "allows host-read ZIP files"
- New test verifies ZIP magic bytes (PK\x03\x04) are accepted as `application/zip`.

## Security Impact

- [x] ZIP files are validated by `file-type` magic bytes detection
- No new permissions/capabilities
- Disguised files (e.g., CSV with ZIP magic bytes) still rejected via CSV/Markdown special handling

## User-visible Changes

- ZIP attachments now work via message tool (Discord and other channels)
- No config changes required

## Verification

- Code review of `assertHostReadMediaAllowed` logic
- Test added for ZIP acceptance
- Existing test "rejects binary data disguised as a CSV file" still valid (CSV special handling catches disguised files)

## Compatibility

- Backward compatible
- No migration needed
- Restores behavior from v2026.4.23