### PR TITLE
fix(msteams): respect thread context in proactive send path

### DIFF
--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -574,6 +574,100 @@ describe("msteams messenger", () => {
       expect(reference.conversation?.id).toBe("19:abc@thread.tacv2;messageid=legacy-activity-id");
     });
 
+    it("falls back to proactive send with thread targeting when no context is provided", async () => {
+      const proactiveSent: string[] = [];
+      let capturedReference: unknown;
+
+      const channelRef: StoredConversationReference = {
+        activityId: "thread-root-msg",
+        threadId: "thread-root-msg",
+        user: { id: "user123", name: "User" },
+        agent: { id: "bot123", name: "Bot" },
+        conversation: {
+          id: "19:abc@thread.tacv2",
+          conversationType: "channel",
+        },
+        channelId: "msteams",
+        serviceUrl: "https://service.example.com",
+      };
+
+      const adapter: MSTeamsAdapter = {
+        continueConversation: async (_appId, reference, logic) => {
+          capturedReference = reference;
+          await logic({
+            sendActivity: createRecordedSendActivity(proactiveSent),
+            updateActivity: noopUpdateActivity,
+            deleteActivity: noopDeleteActivity,
+          });
+        },
+        process: async () => {},
+        updateActivity: noopUpdateActivity,
+        deleteActivity: noopDeleteActivity,
+      };
+
+      // No context provided — simulates the proactive send path
+      const ids = await sendMSTeamsMessages({
+        replyStyle: "thread",
+        adapter,
+        appId: "app123",
+        conversationRef: channelRef,
+        messages: [{ text: "proactive thread reply" }],
+      });
+
+      // Message was delivered via proactive path
+      expect(proactiveSent).toEqual(["proactive thread reply"]);
+      expect(ids).toEqual(["id:proactive thread reply"]);
+
+      // The conversation reference includes the thread suffix
+      const ref = capturedReference as { conversation?: { id?: string } };
+      expect(ref.conversation?.id).toBe("19:abc@thread.tacv2;messageid=thread-root-msg");
+    });
+
+    it("falls back to proactive send using activityId when threadId is absent and no context", async () => {
+      const proactiveSent: string[] = [];
+      let capturedReference: unknown;
+
+      const channelRef: StoredConversationReference = {
+        activityId: "legacy-activity-id",
+        // No threadId — uses activityId fallback
+        user: { id: "user123", name: "User" },
+        agent: { id: "bot123", name: "Bot" },
+        conversation: {
+          id: "19:abc@thread.tacv2",
+          conversationType: "channel",
+        },
+        channelId: "msteams",
+        serviceUrl: "https://service.example.com",
+      };
+
+      const adapter: MSTeamsAdapter = {
+        continueConversation: async (_appId, reference, logic) => {
+          capturedReference = reference;
+          await logic({
+            sendActivity: createRecordedSendActivity(proactiveSent),
+            updateActivity: noopUpdateActivity,
+            deleteActivity: noopDeleteActivity,
+          });
+        },
+        process: async () => {},
+        updateActivity: noopUpdateActivity,
+        deleteActivity: noopDeleteActivity,
+      };
+
+      const ids = await sendMSTeamsMessages({
+        replyStyle: "thread",
+        adapter,
+        appId: "app123",
+        conversationRef: channelRef,
+        messages: [{ text: "fallback reply" }],
+      });
+
+      expect(proactiveSent).toEqual(["fallback reply"]);
+      expect(ids).toEqual(["id:fallback reply"]);
+      const ref = capturedReference as { conversation?: { id?: string } };
+      expect(ref.conversation?.id).toBe("19:abc@thread.tacv2;messageid=legacy-activity-id");
+    });
+
     it("does not add thread suffix for top-level replyStyle even with threadId set", async () => {
       let capturedReference: unknown;
       const sent: string[] = [];

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -572,7 +572,11 @@ export async function sendMSTeamsMessages(params: {
   if (params.replyStyle === "thread") {
     const ctx = params.context;
     if (!ctx) {
-      throw new Error("Missing context for replyStyle=thread");
+      // When no turn context is available (proactive send path / CLI sends),
+      // fall back to sendProactively with thread targeting instead of throwing.
+      // The proactive path reconstructs the threaded conversation ID
+      // (;messageid=<threadRootId>) so the message lands in the correct thread.
+      return await sendProactively(messages, 0, resolvedThreadId);
     }
     const messageIds: string[] = [];
     for (const [idx, message] of messages.entries()) {

--- a/extensions/msteams/src/send.test.ts
+++ b/extensions/msteams/src/send.test.ts
@@ -302,6 +302,106 @@ describe("sendMessageMSTeams", () => {
     );
   });
 
+  it("passes replyStyle thread for channel conversations with threadId", async () => {
+    mockState.resolveMSTeamsSendContext.mockResolvedValue({
+      adapter: {},
+      appId: "app-id",
+      conversationId: "19:channel@thread.tacv2",
+      ref: {
+        threadId: "thread-root-123",
+        user: { id: "user-1" },
+        agent: { id: "agent-1" },
+        conversation: { id: "19:channel@thread.tacv2", conversationType: "channel" },
+        channelId: "msteams",
+      },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      conversationType: "channel",
+      tokenProvider: { getAccessToken: vi.fn(async () => "token") },
+      mediaMaxBytes: 8 * 1024,
+    });
+
+    await sendMessageMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: "conversation:19:channel@thread.tacv2",
+      text: "threaded reply",
+    });
+
+    expect(mockState.sendMSTeamsMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ replyStyle: "thread" }),
+    );
+  });
+
+  it("passes replyStyle thread for channel conversations with activityId fallback", async () => {
+    mockState.resolveMSTeamsSendContext.mockResolvedValue({
+      adapter: {},
+      appId: "app-id",
+      conversationId: "19:channel@thread.tacv2",
+      ref: {
+        activityId: "activity-root-456",
+        user: { id: "user-1" },
+        agent: { id: "agent-1" },
+        conversation: { id: "19:channel@thread.tacv2", conversationType: "channel" },
+        channelId: "msteams",
+      },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      conversationType: "channel",
+      tokenProvider: { getAccessToken: vi.fn(async () => "token") },
+      mediaMaxBytes: 8 * 1024,
+    });
+
+    await sendMessageMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: "conversation:19:channel@thread.tacv2",
+      text: "threaded via activityId",
+    });
+
+    expect(mockState.sendMSTeamsMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ replyStyle: "thread" }),
+    );
+  });
+
+  it("passes replyStyle top-level for personal conversations", async () => {
+    // Default mock is personal — verify it stays top-level
+    await sendMessageMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: "conversation:19:conversation@thread.tacv2",
+      text: "dm message",
+    });
+
+    expect(mockState.sendMSTeamsMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ replyStyle: "top-level" }),
+    );
+  });
+
+  it("passes replyStyle top-level for channel conversations without thread root", async () => {
+    mockState.resolveMSTeamsSendContext.mockResolvedValue({
+      adapter: {},
+      appId: "app-id",
+      conversationId: "19:channel@thread.tacv2",
+      ref: {
+        // No threadId, no activityId
+        user: { id: "user-1" },
+        agent: { id: "agent-1" },
+        conversation: { id: "19:channel@thread.tacv2", conversationType: "channel" },
+        channelId: "msteams",
+      },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      conversationType: "channel",
+      tokenProvider: { getAccessToken: vi.fn(async () => "token") },
+      mediaMaxBytes: 8 * 1024,
+    });
+
+    await sendMessageMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: "conversation:19:channel@thread.tacv2",
+      text: "no thread root",
+    });
+
+    expect(mockState.sendMSTeamsMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ replyStyle: "top-level" }),
+    );
+  });
+
   it("falls back to conversationId when graphChatId is not available", async () => {
     const botFrameworkConversationId = "19:fallback-id@thread.tacv2";
 

--- a/extensions/msteams/src/send.ts
+++ b/extensions/msteams/src/send.ts
@@ -393,10 +393,17 @@ async function sendTextWithMedia(
     mediaMaxBytes,
   } = ctx;
 
+  // Resolve replyStyle from conversation context instead of hardcoding "top-level".
+  // For channel conversations with a known thread root, use "thread" so the
+  // proactive message lands in the correct thread. For DMs and group chats,
+  // continue using "top-level".
+  const isChannelThread = ctx.conversationType === "channel" && (ref.threadId || ref.activityId);
+  const resolvedReplyStyle = isChannelThread ? "thread" : "top-level";
+
   let platformMessageIds: string[];
   try {
     platformMessageIds = await sendMSTeamsMessages({
-      replyStyle: "top-level",
+      replyStyle: resolvedReplyStyle,
       adapter,
       appId,
       conversationRef: ref,


### PR DESCRIPTION
## Summary

- Problem: The proactive send path in `send.ts` hardcodes `replyStyle: "top-level"`, causing all proactive/CLI messages to land as new top-level channel posts regardless of thread context.
- Why it matters: Channel thread replies never thread correctly when sent via the message tool or CLI, breaking conversational continuity for users.
- What changed: `send.ts` resolves `replyStyle` dynamically from conversation context; `messenger.ts` falls back to proactive send with thread targeting instead of throwing.
- What did NOT change (scope boundary): DM and group chat behavior unchanged. The inbound reply-dispatcher path (which already threads correctly) is untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78298
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Proactive sends to channel conversations always create top-level posts instead of threading into the existing conversation thread.
- Real environment tested: Local test suite exercising the real `sendTextWithMedia` → `sendMSTeamsMessages` → `sendProactively` chain with mocked Bot Framework adapter.
- Exact steps or command run after this patch: `pnpm test extensions/msteams/src/send.test.ts` and `pnpm test extensions/msteams/src/messenger.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): 13/13 send tests pass (4 new), 31/31 messenger tests pass (2 new). New tests assert `replyStyle: "thread"` is passed for channel+threadId conversations and that the proactive fallback constructs `;messageid=<threadRootId>` conversation IDs.
- Observed result after fix: Channel conversations with thread context route to `sendProactively(messages, 0, resolvedThreadId)` which builds `19:abc@thread.tacv2;messageid=thread-root-msg` — proven by captured adapter reference in test.
- What was not tested: Live Teams environment (requires bot registration + tenant). The adapter mock faithfully replicates the continueConversation contract.
- Before evidence (optional but encouraged): Before this fix, `sendMSTeamsMessages` was always called with `replyStyle: "top-level"` (hardcoded at old line 399 of send.ts).

## Root Cause (if applicable)

- Root cause: `sendTextWithMedia()` hardcoded `replyStyle: "top-level"` instead of resolving from conversation context. Additionally, `sendMSTeamsMessages()` threw when `replyStyle === "thread"` with no turn context, blocking the proactive path from threading.
- Missing detection / guardrail: No test asserted the `replyStyle` value passed to `sendMSTeamsMessages` from the proactive send path.
- Contributing context (if known): The proactive send path was written before channel thread support was added; the hardcode was never updated.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/msteams/src/send.test.ts`, `extensions/msteams/src/messenger.test.ts`
- Scenario the test should lock in: Channel conversations with thread root resolve to `replyStyle: "thread"`; no-context thread sends fall back to proactive with thread targeting.
- Why this is the smallest reliable guardrail: Tests exercise the routing decision and the fallback path at the seam boundary (mocked adapter), covering all 4 conversation scenarios.
- Existing test that already covers this (if any): None existed before this PR.

## User-visible / Behavior Changes

- Proactive messages (message tool, CLI sends) to Teams channels now thread into the correct conversation thread instead of creating new top-level posts.

## Diagram (if applicable)

```text
Before:
[proactive send to channel] -> replyStyle: "top-level" (hardcoded) -> new top-level post

After:
[proactive send to channel] -> isChannelThread? -> replyStyle: "thread" -> sendProactively(msgs, 0, resolvedThreadId) -> ;messageid=<threadRoot> -> threaded reply
[proactive send to DM]      -> !isChannelThread -> replyStyle: "top-level" -> top-level (unchanged)
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22
- Integration/channel (if any): MS Teams

### Steps

1. Configure msteams plugin with a channel conversation that has a stored `threadId`
2. Send a proactive message via the message tool to that conversation
3. Observe the message lands in the thread (after fix) vs. top-level post (before fix)

### Expected

- Message threads into the existing channel thread

### Actual

- Before: Message creates a new top-level post
- After: Message threads correctly

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Channel+threadId → thread, channel+activityId → thread, personal → top-level, channel without thread root → top-level, no-context fallback → proactive with thread suffix
- Edge cases checked: activityId fallback when threadId absent; channel with neither threadId nor activityId stays top-level
- What you did **not** verify: Live Teams tenant delivery (requires bot registration)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Stored conversation references without `threadId` or `activityId` could miss the thread routing.
  - Mitigation: Falls back to `"top-level"` when neither field is present — same behavior as before this fix.