### PR TITLE
fix(feishu): pass card_msg_content_type=user_card_content when fetching messages

### DIFF
--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -167,6 +167,11 @@ describe("getMessageFeishu", () => {
         content: "hello markdown\nhello div",
       }),
     );
+    expect(mockClientGet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { card_msg_content_type: "user_card_content" },
+      }),
+    );
   });
 
   it("falls through empty interactive card element arrays and locale variants", async () => {
@@ -417,6 +422,11 @@ describe("getMessageFeishu", () => {
         content: "hello from card 2.0",
       }),
     ]);
+    expect(mockClientList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({ card_msg_content_type: "user_card_content" }),
+      }),
+    );
   });
 });
 

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -404,6 +404,7 @@ export async function getMessageFeishu(params: {
   try {
     const response = (await client.im.message.get({
       path: { message_id: messageId },
+      params: { card_msg_content_type: "user_card_content" },
     })) as FeishuGetMessageResponse;
 
     if (response.code !== 0) {
@@ -466,6 +467,7 @@ export async function listFeishuThreadMessages(params: {
       // Results are reversed below to restore chronological order.
       sort_type: "ByCreateTimeDesc",
       page_size: Math.min(limit + 1, 50),
+      card_msg_content_type: "user_card_content",
     },
   })) as {
     code?: number;


### PR DESCRIPTION
## Root cause

The Feishu GET message API returns a degraded stub (`[Interactive Card]`) by default. Passing `card_msg_content_type=user_card_content` makes it return the full card JSON (Card 1.0/2.0 format).

Both `getMessageFeishu` and `listFeishuThreadMessages` were missing this param, so `parseInteractiveCardContent` — which already handles Card 2.0 `body.elements` — never had real data to work with.

## Change

- `getMessageFeishu`: add `params: { card_msg_content_type: 'user_card_content' }` to `client.im.message.get()`
- `listFeishuThreadMessages`: add `card_msg_content_type: 'user_card_content'` to the existing `params` object in `client.im.message.list()`
- Tests: assert both API calls include the param; existing card content extraction tests also validate the parse layer still works correctly

## Fixes

Fixes #78289