### PR TITLE
fix(feishu): keep topic sessions stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu: hydrate missing native topic starter thread IDs before session routing so first turns and follow-ups stay in the same topic session. Fixes #78262. Thanks @joeyzenghuan.
 - Providers/xAI: stop sending OpenAI-style reasoning effort controls to native Grok Responses models, so `xai/grok-4.3` no longer fails live Docker/Gateway runs with `Invalid reasoning effort`.
 - Providers/xAI: clamp the bundled xAI thinking profile to `off` so live Gateway runs cannot send unsupported reasoning levels to native Grok Responses models.
 - Discord/gateway: measure heartbeat ACK timeouts from the actual heartbeat send, preventing late initial heartbeats from triggering false reconnect loops while the channel is still awaiting readiness. Fixes #77668. (#78087) Thanks @bryce-d-greybeard and @NikolaFC.

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -479,9 +479,10 @@ conversion fails, OpenClaw falls back to a file attachment and logs the reason.
 
 For `groupSessionScope: "group_topic"` and `"group_topic_sender"`, native
 Feishu/Lark topic groups use the event `thread_id` (`omt_*`) as the canonical
-topic session key. Normal group replies that OpenClaw turns into threads keep
-using the reply root message ID (`om_*`) so the first turn and follow-up turn
-stay in the same session.
+topic session key. If a native topic starter event omits `thread_id`, OpenClaw
+hydrates it from Feishu before routing the turn. Normal group replies that
+OpenClaw turns into threads keep using the reply root message ID (`om_*`) so the
+first turn and follow-up turn stay in the same session.
 
 ---
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2514,6 +2514,75 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("hydrates missing native topic thread_id before routing starter events", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockGetMessageFeishu.mockResolvedValueOnce({
+      messageId: "msg-native-topic-first",
+      chatId: "oc-group",
+      chatType: "topic_group",
+      content: "topic starter",
+      contentType: "text",
+      threadId: "omt_native_topic",
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group_topic",
+              replyInThread: "enabled",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const firstTurn: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-topic-init" } },
+      message: {
+        message_id: "msg-native-topic-first",
+        chat_id: "oc-group",
+        chat_type: "topic_group",
+        message_type: "text",
+        content: JSON.stringify({ text: "create native topic" }),
+      },
+    };
+    const secondTurn: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-topic-init" } },
+      message: {
+        message_id: "msg-native-topic-second",
+        chat_id: "oc-group",
+        chat_type: "topic_group",
+        thread_id: "omt_native_topic",
+        message_type: "text",
+        content: JSON.stringify({ text: "follow up in same native topic" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event: firstTurn });
+    await dispatchMessage({ cfg, event: secondTurn });
+
+    expect(mockGetMessageFeishu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "msg-native-topic-first",
+      }),
+    );
+    expect(mockResolveAgentRoute).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        peer: { kind: "group", id: "oc-group:topic:omt_native_topic" },
+      }),
+    );
+    expect(mockResolveAgentRoute).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        peer: { kind: "group", id: "oc-group:topic:omt_native_topic" },
+      }),
+    );
+  });
+
   it("replies to the topic root when handling a message inside an existing topic", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -78,6 +78,31 @@ const groupNameCache = new Map<string, { name: string; expiresAt: number }>();
 const GROUP_NAME_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const GROUP_NAME_CACHE_MAX_SIZE = 500; // hard cap
 
+type FeishuGroupSessionScope = "group" | "group_sender" | "group_topic" | "group_topic_sender";
+
+function resolveConfiguredFeishuGroupSessionScope(params: {
+  groupConfig?: {
+    groupSessionScope?: FeishuGroupSessionScope;
+    topicSessionMode?: "enabled" | "disabled";
+  };
+  feishuCfg?: {
+    groupSessionScope?: FeishuGroupSessionScope;
+    topicSessionMode?: "enabled" | "disabled";
+  };
+}): FeishuGroupSessionScope {
+  const legacyTopicSessionMode =
+    params.groupConfig?.topicSessionMode ?? params.feishuCfg?.topicSessionMode ?? "disabled";
+  return (
+    params.groupConfig?.groupSessionScope ??
+    params.feishuCfg?.groupSessionScope ??
+    (legacyTopicSessionMode === "enabled" ? "group_topic" : "group")
+  );
+}
+
+function isFeishuTopicSessionScope(scope: FeishuGroupSessionScope): boolean {
+  return scope === "group_topic" || scope === "group_topic_sender";
+}
+
 function evictGroupNameCache(): void {
   const now = Date.now();
   for (const [key, val] of groupNameCache) {
@@ -503,6 +528,36 @@ export async function handleFeishuMessage(params: {
   const groupConfig = isGroup
     ? resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: ctx.chatId })
     : undefined;
+  const groupSessionScope = isGroup
+    ? resolveConfiguredFeishuGroupSessionScope({ groupConfig, feishuCfg })
+    : null;
+  let effectiveThreadId = ctx.threadId;
+  if (
+    isGroup &&
+    ctx.chatType === "topic_group" &&
+    !effectiveThreadId &&
+    isFeishuTopicSessionScope(groupSessionScope ?? "group")
+  ) {
+    try {
+      const messageInfo = await getMessageFeishu({
+        cfg,
+        accountId: account.accountId,
+        messageId: ctx.messageId,
+      });
+      const hydratedThreadId = messageInfo?.threadId?.trim();
+      if (hydratedThreadId) {
+        ctx = { ...ctx, threadId: hydratedThreadId };
+        effectiveThreadId = hydratedThreadId;
+        log(
+          `feishu[${account.accountId}]: hydrated topic thread_id=${hydratedThreadId} for message=${ctx.messageId}`,
+        );
+      }
+    } catch (err) {
+      log(
+        `feishu[${account.accountId}]: failed to hydrate topic thread_id for message=${ctx.messageId}: ${String(err)}`,
+      );
+    }
+  }
   const effectiveGroupSenderAllowFrom = isGroup
     ? (groupConfig?.allowFrom?.length ?? 0) > 0
       ? (groupConfig?.allowFrom ?? [])
@@ -514,7 +569,7 @@ export async function handleFeishuMessage(params: {
         senderOpenId: ctx.senderOpenId,
         messageId: ctx.messageId,
         rootId: ctx.rootId,
-        threadId: ctx.threadId,
+        threadId: effectiveThreadId,
         chatType: ctx.chatType,
         groupConfig,
         feishuCfg,


### PR DESCRIPTION
## Summary

- Problem: Feishu native topic starter events can arrive without `thread_id`, while later topic replies include the canonical `omt_*` thread id.
- Why it matters: with `groupSessionScope: "group_topic"` / `"group_topic_sender"`, the first turn can route by `message_id` and follow-ups by `thread_id`, splitting one Feishu topic into multiple OpenClaw sessions.
- What changed: Feishu hydrates a missing native topic starter `thread_id` with `getMessageFeishu` before resolving the group session route.
- What did NOT change: group visible-reply defaults/message-tool behavior. PR #78310 was narrowed to topic hydration only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78262
- Related #78230
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Feishu native topic starter and follow-up messages resolve to the same topic session key.
- Real environment tested: Blacksmith Testbox via Crabbox, Linux CI-equivalent checkout.
- Exact steps or command run after this patch:
  - `pnpm test extensions/feishu/src/bot.test.ts -- -t "hydrates missing native topic thread_id|keeps topic session key stable"`
  - `pnpm check:changed`
- Evidence after fix:
  - Local focused test: 2 passed, 59 skipped.
  - Crabbox `check:changed`: `tbx_01kqxytxdcy4hky5j0sses6237`, exit 0.
- Observed result after fix: the new regression test hydrates `omt_native_topic` before routing the starter event, and both starter/follow-up route to `oc-group:topic:omt_native_topic`.
- What was not tested: live Feishu tenant message round-trip.
- Before evidence: existing test coverage showed first-turn topic sessions could fall back to the starter `message_id` when no `thread_id` was available.

## Root Cause (if applicable)

- Root cause: Feishu route/session resolution happened before any API hydration that could recover a missing native topic `thread_id`.
- Missing detection / guardrail: tests covered normal group reply-root stability but not native `topic_group` starter events missing `thread_id`.
- Contributing context (if known): #78230 mixed this with visible-reply behavior; this PR deliberately keeps only the proven topic-session fix.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/feishu/src/bot.test.ts`
- Scenario the test should lock in: a native Feishu topic starter missing `thread_id` is hydrated before route resolution, and its follow-up with `thread_id` resolves to the same `group_topic` peer.
- Why this is the smallest reliable guardrail: it exercises Feishu inbound routing directly with mocked Feishu message hydration.
- Existing test that already covers this (if any): adjacent topic-session stability tests cover normal group reply roots.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Feishu topic-mode group sessions are more stable when native topic starter events omit `thread_id`.

## Diagram (if applicable)

```text
Before:
Feishu topic starter without thread_id -> route by message_id
Feishu topic follow-up with thread_id -> route by omt_* -> split session

After:
Feishu topic starter without thread_id -> hydrate omt_* -> route by omt_*
Feishu topic follow-up with thread_id -> route by same omt_* -> same session
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: Feishu topic-scoped starter events may call existing Feishu message lookup to hydrate `thread_id`; this uses the already configured Feishu account and only runs for native `topic_group` topic-scoped routing when the event omitted `thread_id`.

## Repro + Verification

### Environment

- OS: macOS local targeted test; Linux Blacksmith Testbox via Crabbox.
- Runtime/container: Node/pnpm repo test runtime.
- Model/provider: mocked test runtime.
- Integration/channel (if any): Feishu plugin.
- Relevant config (redacted): `channels.feishu.groups.oc-group.groupSessionScope: "group_topic"`, `replyInThread: "enabled"`.

### Steps

1. Dispatch a native Feishu `topic_group` starter event with no `thread_id`.
2. Mock `getMessageFeishu` to return `threadId: "omt_native_topic"`.
3. Dispatch a follow-up event carrying `thread_id: "omt_native_topic"`.

### Expected

Both turns route to `oc-group:topic:omt_native_topic`.

### Actual

Matches expected in focused test and Crabbox changed gate.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Feishu native topic starter hydration and follow-up route stability.
- Edge cases checked: existing first-turn/follow-up topic stability test still passes.
- What you did **not** verify: live Feishu tenant round-trip.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: extra Feishu message lookup on native topic starters with missing `thread_id`.
  - Mitigation: narrow condition; failures are logged and existing fallback behavior remains.
