### PR TITLE
Process: add attach recovery for interactive sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Plugin skills/Windows: publish plugin-provided skill directories as junctions on Windows so standard users without Developer Mode can register plugin skills without symlink EPERM failures. Fixes #77958. (#77971) Thanks @hclsys and @jarro.
+- Process tool: add `attach` plus input-wait hints for idle interactive background sessions so operators can inspect stuck CLIs and resume them with existing input actions. Fixes #33957. Thanks @vincentkoc.
 - MS Teams: surface blocked Bot Framework egress by logging JWKS fetch network failures and adding a Bot Connector send hint for transport-level reply failures. Fixes #77674. (#78081) Thanks @Beandon13.
 - PR triage: mark external pull requests with `proof: supplied` when Barnacle finds structured real behavior proof, keep stale negative proof labels in sync across CRLF-edited PR bodies, and let ClawSweeper own the stronger `proof: sufficient` judgement.
 - Sessions CLI: show the selected agent runtime in the `openclaw sessions` table so terminal output matches the runtime visibility already present in JSON/status surfaces. Thanks @vincentkoc.

--- a/docs/gateway/background-process.md
+++ b/docs/gateway/background-process.md
@@ -46,6 +46,7 @@ Environment overrides:
 - `PI_BASH_MAX_OUTPUT_CHARS`: in-memory output cap (chars)
 - `OPENCLAW_BASH_PENDING_MAX_OUTPUT_CHARS`: pending stdout/stderr cap per stream (chars)
 - `PI_BASH_JOB_TTL_MS`: TTL for finished sessions (ms, bounded to 1m–3h)
+- `OPENCLAW_PROCESS_INPUT_WAIT_IDLE_MS`: idle-output threshold before writable background sessions are marked as likely waiting for input (default 15000 ms)
 
 Config (preferred):
 
@@ -60,6 +61,7 @@ Config (preferred):
 Actions:
 
 - `list`: running + finished sessions
+- `attach`: read the aggregated output and show input recovery hints
 - `poll`: drain new output for a session (also reports exit status)
 - `log`: read the aggregated output (supports `offset` + `limit`)
 - `write`: send stdin (`data`, optional `eof`)
@@ -74,13 +76,18 @@ Notes:
 
 - Only backgrounded sessions are listed/persisted in memory.
 - Sessions are lost on process restart (no disk persistence).
-- Session logs are only saved to chat history if you run `process poll/log` and the tool result is recorded.
+- Session logs are only saved to chat history if you run `process attach/poll/log` and the tool result is recorded.
 - `process` is scoped per agent; it only sees sessions started by that agent.
 - Use `poll` / `log` for status, logs, quiet-success confirmation, or
   completion confirmation when automatic completion wake is unavailable.
+- Use `attach` before recovering an interactive CLI so the current transcript,
+  stdin state, and input-wait hint are visible together.
 - Use `write` / `send-keys` / `submit` / `paste` / `kill` when you need input
   or intervention.
 - `process list` includes a derived `name` (command verb + target) for quick scans.
+- `process list`, `attach`, `poll`, and `log` report `waitingForInput` only
+  when the session still has writable stdin and has been idle longer than the
+  input-wait threshold.
 - `process log` uses line-based `offset`/`limit`.
 - When both `offset` and `limit` are omitted, it returns the last 200 lines and includes a paging hint.
 - When `offset` is provided and `limit` is omitted, it returns from `offset` to the end (not capped to 200).
@@ -97,6 +104,12 @@ Run a long task and poll later:
 
 ```json
 { "tool": "process", "action": "poll", "sessionId": "<id>" }
+```
+
+Attach to an interactive session before sending input:
+
+```json
+{ "tool": "process", "action": "attach", "sessionId": "<id>" }
 ```
 
 Start immediately in background:

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -25,6 +25,9 @@ export type SessionStdin = {
   // When backed by a real Node stream (child.stdin), this exists; for PTY wrappers it may not.
   destroy?: () => void;
   destroyed?: boolean;
+  writable?: boolean;
+  writableEnded?: boolean;
+  writableFinished?: boolean;
 };
 
 export interface ProcessSession {

--- a/src/agents/bash-tools.descriptions.ts
+++ b/src/agents/bash-tools.descriptions.ts
@@ -65,8 +65,8 @@ export function describeExecTool(params?: { agentId?: string; hasCronTool?: bool
 
 export function describeProcessTool(params?: { hasCronTool?: boolean }): string {
   return [
-    "Manage running exec sessions for commands already started: list, poll, log, write, send-keys, submit, paste, kill.",
-    "Use poll/log when you need status, logs, quiet-success confirmation, or completion confirmation when automatic completion wake is unavailable. Use write/send-keys/submit/paste/kill for input or intervention.",
+    "Manage running exec sessions for commands already started: list, attach, poll, log, write, send-keys, submit, paste, kill.",
+    "Use attach/poll/log when you need status, logs, quiet-success confirmation, or completion confirmation when automatic completion wake is unavailable. Use write/send-keys/submit/paste/kill for input or intervention.",
     params?.hasCronTool
       ? "Do not use process polling to emulate timers or reminders; use cron for scheduled follow-ups."
       : undefined,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1612,7 +1612,7 @@ export function createExecTool(
                 type: "text",
                 text: `${getWarningText()}Command still running (session ${run.session.id}, pid ${
                   run.session.pid ?? "n/a"
-                }). Use process (list/poll/log/write/kill/clear/remove) for follow-up.`,
+                }). Use process (list/attach/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.`,
               },
             ],
             details: {

--- a/src/agents/bash-tools.process-send-keys.ts
+++ b/src/agents/bash-tools.process-send-keys.ts
@@ -7,6 +7,9 @@ export type WritableStdin = {
   write: (data: string, cb?: (err?: Error | null) => void) => void;
   end: () => void;
   destroyed?: boolean;
+  writable?: boolean;
+  writableEnded?: boolean;
+  writableFinished?: boolean;
 };
 
 function failText(text: string): AgentToolResult<unknown> {

--- a/src/agents/bash-tools.process.attach.test.ts
+++ b/src/agents/bash-tools.process.attach.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  addSession,
+  appendOutput,
+  markExited,
+  resetProcessRegistryForTests,
+} from "./bash-process-registry.js";
+import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
+import { createProcessTool } from "./bash-tools.process.js";
+
+type ProcessTool = ReturnType<typeof createProcessTool>;
+type ProcessToolResult = Awaited<ReturnType<ProcessTool["execute"]>>;
+
+afterEach(() => {
+  resetProcessRegistryForTests();
+  vi.useRealTimers();
+});
+
+async function runProcessAction(
+  processTool: ProcessTool,
+  args: Record<string, unknown>,
+): Promise<ProcessToolResult> {
+  return processTool.execute("toolcall", args as Parameters<ProcessTool["execute"]>[1], undefined);
+}
+
+function textOf(result: ProcessToolResult): string {
+  const item = result.content[0];
+  return item?.type === "text" ? item.text : "";
+}
+
+function attachWritableStdin(
+  session: ReturnType<typeof createProcessSessionFixture>,
+  state?: { writableEnded?: boolean; writableFinished?: boolean; destroyed?: boolean },
+) {
+  session.stdin = {
+    write: vi.fn((_data: string, cb?: (err?: Error | null) => void) => cb?.(null)),
+    end: vi.fn(),
+    destroyed: state?.destroyed ?? false,
+    writableEnded: state?.writableEnded,
+    writableFinished: state?.writableFinished,
+  } as NonNullable<typeof session.stdin> & {
+    writableEnded?: boolean;
+    writableFinished?: boolean;
+  };
+}
+
+describe("process attach", () => {
+  it("returns output and input-wait metadata for an idle writable session", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:20.000Z"));
+    const processTool = createProcessTool();
+    const session = createProcessSessionFixture({
+      id: "sess-attach",
+      command: "node cli.js",
+      backgrounded: true,
+      startedAt: Date.now() - 20_000,
+    });
+    attachWritableStdin(session);
+    appendOutput(session, "stdout", "Name? ");
+    addSession(session);
+
+    const result = await runProcessAction(processTool, {
+      action: "attach",
+      sessionId: "sess-attach",
+    });
+
+    const text = textOf(result);
+    expect(text).toContain("Name? ");
+    expect(text).toContain("No new output for 20s");
+    expect(text).toContain("Use process write, send-keys, submit, or paste to provide input.");
+    expect(text).not.toContain("Use process attach");
+    expect(result.details).toMatchObject({
+      status: "running",
+      sessionId: "sess-attach",
+      stdinWritable: true,
+      waitingForInput: true,
+      idleMs: 20_000,
+      lastOutputAt: Date.now() - 20_000,
+    });
+  });
+
+  it("adds input-wait hints to poll when no new output arrives", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:16.000Z"));
+    const processTool = createProcessTool();
+    const session = createProcessSessionFixture({
+      id: "sess-poll",
+      command: "python prompt.py",
+      backgrounded: true,
+      startedAt: Date.now() - 16_000,
+    });
+    attachWritableStdin(session);
+    addSession(session);
+
+    const result = await runProcessAction(processTool, {
+      action: "poll",
+      sessionId: "sess-poll",
+    });
+
+    expect(textOf(result)).toContain("(no new output)");
+    expect(textOf(result)).toContain("may be waiting for input");
+    expect(result.details).toMatchObject({
+      status: "running",
+      sessionId: "sess-poll",
+      stdinWritable: true,
+      waitingForInput: true,
+      idleMs: 16_000,
+      lastOutputAt: Date.now() - 16_000,
+    });
+  });
+
+  it("marks idle writable sessions in process list", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:30.000Z"));
+    const processTool = createProcessTool();
+    const session = createProcessSessionFixture({
+      id: "sess-list",
+      command: "npm run interactive",
+      backgrounded: true,
+      startedAt: Date.now() - 30_000,
+    });
+    attachWritableStdin(session);
+    addSession(session);
+
+    const result = await runProcessAction(processTool, { action: "list" });
+
+    expect(textOf(result)).toContain("sess-list");
+    expect(textOf(result)).toContain("[input-wait]");
+    const sessions = (result.details as { sessions?: Array<Record<string, unknown>> }).sessions;
+    expect(sessions?.[0]).toMatchObject({
+      sessionId: "sess-list",
+      stdinWritable: true,
+      waitingForInput: true,
+      idleMs: 30_000,
+    });
+  });
+
+  it("adds input-wait metadata to log without changing log text", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:25.000Z"));
+    const processTool = createProcessTool();
+    const session = createProcessSessionFixture({
+      id: "sess-log",
+      command: "node prompt.js",
+      backgrounded: true,
+      startedAt: Date.now() - 25_000,
+    });
+    attachWritableStdin(session);
+    appendOutput(session, "stdout", "Password: ");
+    addSession(session);
+
+    const result = await runProcessAction(processTool, {
+      action: "log",
+      sessionId: "sess-log",
+    });
+
+    expect(textOf(result)).toBe("Password: ");
+    expect(result.details).toMatchObject({
+      status: "running",
+      sessionId: "sess-log",
+      stdinWritable: true,
+      waitingForInput: true,
+      idleMs: 25_000,
+    });
+  });
+
+  it("does not treat ended stdin as writable input-wait state", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:01:00.000Z"));
+    const processTool = createProcessTool();
+    const session = createProcessSessionFixture({
+      id: "sess-ended",
+      command: "node closed-stdin.js",
+      backgrounded: true,
+      startedAt: Date.now() - 60_000,
+    });
+    attachWritableStdin(session, { writableEnded: true });
+    addSession(session);
+
+    const attach = await runProcessAction(processTool, {
+      action: "attach",
+      sessionId: "sess-ended",
+    });
+    expect(textOf(attach)).not.toContain("provide input");
+    expect(attach.details).toMatchObject({
+      status: "running",
+      stdinWritable: false,
+      waitingForInput: false,
+    });
+
+    const write = await runProcessAction(processTool, {
+      action: "write",
+      sessionId: "sess-ended",
+      data: "answer\n",
+    });
+    expect(textOf(write)).toContain("stdin is not writable");
+    expect(write.details).toMatchObject({ status: "failed" });
+  });
+
+  it("can attach to finished sessions without exposing input controls", async () => {
+    const processTool = createProcessTool();
+    const session = createProcessSessionFixture({
+      id: "sess-finished",
+      command: "echo done",
+      backgrounded: true,
+    });
+    appendOutput(session, "stdout", "done\n");
+    addSession(session);
+    markExited(session, 0, null, "completed");
+
+    const result = await runProcessAction(processTool, {
+      action: "attach",
+      sessionId: "sess-finished",
+    });
+
+    expect(textOf(result)).toContain("done");
+    expect(textOf(result)).toContain("Session already exited.");
+    expect(textOf(result)).not.toContain("provide input");
+    expect(result.details).toMatchObject({
+      status: "completed",
+      sessionId: "sess-finished",
+      exitCode: 0,
+    });
+  });
+});

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -17,7 +17,14 @@ import {
 import { describeProcessTool } from "./bash-tools.descriptions.js";
 import { handleProcessSendKeys, type WritableStdin } from "./bash-tools.process-send-keys.js";
 import { processSchema } from "./bash-tools.schemas.js";
-import { deriveSessionName, pad, sliceLogLines, truncateMiddle } from "./bash-tools.shared.js";
+import {
+  clampWithDefault,
+  deriveSessionName,
+  pad,
+  readEnvInt,
+  sliceLogLines,
+  truncateMiddle,
+} from "./bash-tools.shared.js";
 import { recordCommandPoll, resetCommandPollCount } from "./command-poll-backoff.js";
 import { encodePaste } from "./pty-keys.js";
 import { PROCESS_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
@@ -26,10 +33,14 @@ import type { AgentToolWithMeta } from "./tools/common.js";
 export type ProcessToolDefaults = {
   cleanupMs?: number;
   hasCronTool?: boolean;
+  inputWaitIdleMs?: number;
   scopeKey?: string;
 };
 
 const DEFAULT_LOG_TAIL_LINES = 200;
+const DEFAULT_INPUT_WAIT_IDLE_MS = 15_000;
+const MIN_INPUT_WAIT_IDLE_MS = 1_000;
+const MAX_INPUT_WAIT_IDLE_MS = 10 * 60 * 1000;
 
 function resolveLogSliceWindow(offset?: number, limit?: number) {
   const usingDefaultTail = offset === undefined && limit === undefined;
@@ -50,6 +61,36 @@ function defaultTailNote(totalLines: number, usingDefaultTail: boolean) {
 }
 
 const MAX_POLL_WAIT_MS = 30_000;
+
+type RunningSessionRuntime = {
+  stdinWritable: boolean;
+  waitingForInput: boolean;
+  idleMs: number;
+  lastOutputAt: number;
+};
+
+function resolveSessionStdin(session: ProcessSession): WritableStdin | undefined {
+  return (session.stdin ?? session.child?.stdin) as WritableStdin | undefined;
+}
+
+function isWritableStdin(stdin: WritableStdin | undefined): stdin is WritableStdin {
+  if (!stdin || stdin.destroyed) {
+    return false;
+  }
+  if (stdin.writable === false || stdin.writableEnded === true || stdin.writableFinished === true) {
+    return false;
+  }
+  return true;
+}
+
+function runningSessionInputDetails(runtime: RunningSessionRuntime) {
+  return {
+    stdinWritable: runtime.stdinWritable,
+    waitingForInput: runtime.waitingForInput,
+    idleMs: runtime.idleMs,
+    lastOutputAt: runtime.lastOutputAt,
+  };
+}
 
 function resolvePollWaitMs(value: unknown) {
   if (typeof value === "number" && Number.isFinite(value)) {
@@ -140,8 +181,41 @@ export function createProcessTool(
   }
   const scopeKey = defaults?.scopeKey;
   const supervisor = getProcessSupervisor();
+  const inputWaitIdleMs = clampWithDefault(
+    defaults?.inputWaitIdleMs ?? readEnvInt("OPENCLAW_PROCESS_INPUT_WAIT_IDLE_MS"),
+    DEFAULT_INPUT_WAIT_IDLE_MS,
+    MIN_INPUT_WAIT_IDLE_MS,
+    MAX_INPUT_WAIT_IDLE_MS,
+  );
   const isInScope = (session?: { scopeKey?: string } | null) =>
     !scopeKey || session?.scopeKey === scopeKey;
+
+  const describeRunningSession = (session: ProcessSession): RunningSessionRuntime => {
+    const record = supervisor.getRecord(session.id);
+    const lastOutputAt = record?.lastOutputAtMs ?? session.startedAt;
+    const idleMs = Math.max(0, Date.now() - lastOutputAt);
+    const stdinWritable = isWritableStdin(resolveSessionStdin(session));
+    return {
+      stdinWritable,
+      waitingForInput: stdinWritable && idleMs >= inputWaitIdleMs,
+      idleMs,
+      lastOutputAt,
+    };
+  };
+
+  const buildInputWaitHint = (
+    runtime: RunningSessionRuntime | undefined,
+    options?: { attachContext?: boolean },
+  ) => {
+    if (!runtime?.waitingForInput) {
+      return "";
+    }
+    const idle = formatDurationCompact(runtime.idleMs) ?? `${runtime.idleMs}ms`;
+    const inputHint = options?.attachContext
+      ? "Use process write, send-keys, submit, or paste to provide input."
+      : "Use process attach, then process write, send-keys, submit, or paste to provide input.";
+    return `\n\nNo new output for ${idle}; this session may be waiting for input. ${inputHint}`;
+  };
 
   const cancelManagedSession = (sessionId: string) => {
     const record = supervisor.getRecord(sessionId);
@@ -171,6 +245,7 @@ export function createProcessTool(
       const params = args as {
         action:
           | "list"
+          | "attach"
           | "poll"
           | "log"
           | "write"
@@ -196,18 +271,25 @@ export function createProcessTool(
       if (params.action === "list") {
         const running = listRunningSessions()
           .filter((s) => isInScope(s))
-          .map((s) => ({
-            sessionId: s.id,
-            status: "running",
-            pid: s.pid ?? undefined,
-            startedAt: s.startedAt,
-            runtimeMs: Date.now() - s.startedAt,
-            cwd: s.cwd,
-            command: s.command,
-            name: deriveSessionName(s.command),
-            tail: s.tail,
-            truncated: s.truncated,
-          }));
+          .map((s) => {
+            const runtime = describeRunningSession(s);
+            return {
+              sessionId: s.id,
+              status: "running",
+              pid: s.pid ?? undefined,
+              startedAt: s.startedAt,
+              runtimeMs: Date.now() - s.startedAt,
+              cwd: s.cwd,
+              command: s.command,
+              name: deriveSessionName(s.command),
+              tail: s.tail,
+              truncated: s.truncated,
+              stdinWritable: runtime.stdinWritable,
+              waitingForInput: runtime.waitingForInput,
+              idleMs: runtime.idleMs,
+              lastOutputAt: runtime.lastOutputAt,
+            };
+          });
         const finished = listFinishedSessions()
           .filter((s) => isInScope(s))
           .map((s) => ({
@@ -228,7 +310,10 @@ export function createProcessTool(
           .toSorted((a, b) => b.startedAt - a.startedAt)
           .map((s) => {
             const label = s.name ? truncateMiddle(s.name, 80) : truncateMiddle(s.command, 120);
-            return `${s.sessionId} ${pad(s.status, 9)} ${formatDurationCompact(s.runtimeMs) ?? "n/a"} :: ${label}`;
+            const marker = "waitingForInput" in s && s.waitingForInput ? " [input-wait]" : "";
+            return `${s.sessionId} ${pad(s.status, 9)} ${
+              formatDurationCompact(s.runtimeMs) ?? "n/a"
+            }${marker} :: ${label}`;
           });
         return {
           content: [
@@ -271,14 +356,14 @@ export function createProcessTool(
             result: failedResult(`Session ${params.sessionId} is not backgrounded.`),
           };
         }
-        const stdin = scopedSession.stdin ?? scopedSession.child?.stdin;
-        if (!stdin || stdin.destroyed) {
+        const stdin = resolveSessionStdin(scopedSession);
+        if (!isWritableStdin(stdin)) {
           return {
             ok: false as const,
             result: failedResult(`Session ${params.sessionId} stdin is not writable.`),
           };
         }
-        return { ok: true as const, session: scopedSession, stdin: stdin as WritableStdin };
+        return { ok: true as const, session: scopedSession, stdin };
       };
 
       const writeToStdin = async (stdin: WritableStdin, data: string) => {
@@ -306,6 +391,82 @@ export function createProcessTool(
       });
 
       switch (params.action) {
+        case "attach": {
+          if (scopedSession) {
+            if (!scopedSession.backgrounded) {
+              return failText(`Session ${params.sessionId} is not backgrounded.`);
+            }
+            const window = resolveLogSliceWindow(params.offset, params.limit);
+            const { slice, totalLines, totalChars } = sliceLogLines(
+              scopedSession.aggregated,
+              window.effectiveOffset,
+              window.effectiveLimit,
+            );
+            const runtime = describeRunningSession(scopedSession);
+            const attachDefaultTailNote = defaultTailNote(totalLines, window.usingDefaultTail);
+            const inputWaitHint = buildInputWaitHint(runtime, { attachContext: true });
+            const inputControlHint =
+              runtime.stdinWritable && !runtime.waitingForInput
+                ? "\n\nUse process write, send-keys, submit, or paste to provide input."
+                : "";
+            return {
+              content: [
+                {
+                  type: "text",
+                  text:
+                    (slice || "(no output yet)") +
+                    attachDefaultTailNote +
+                    inputWaitHint +
+                    inputControlHint,
+                },
+              ],
+              details: {
+                status: "running",
+                sessionId: params.sessionId,
+                total: totalLines,
+                totalLines,
+                totalChars,
+                truncated: scopedSession.truncated,
+                name: deriveSessionName(scopedSession.command),
+                ...runningSessionInputDetails(runtime),
+              },
+            };
+          }
+          if (scopedFinished) {
+            const window = resolveLogSliceWindow(params.offset, params.limit);
+            const { slice, totalLines, totalChars } = sliceLogLines(
+              scopedFinished.aggregated,
+              window.effectiveOffset,
+              window.effectiveLimit,
+            );
+            const status = scopedFinished.status === "completed" ? "completed" : "failed";
+            const attachDefaultTailNote = defaultTailNote(totalLines, window.usingDefaultTail);
+            return {
+              content: [
+                {
+                  type: "text",
+                  text:
+                    (slice || "(no output recorded)") +
+                    attachDefaultTailNote +
+                    "\n\nSession already exited.",
+                },
+              ],
+              details: {
+                status,
+                sessionId: params.sessionId,
+                total: totalLines,
+                totalLines,
+                totalChars,
+                truncated: scopedFinished.truncated,
+                exitCode: scopedFinished.exitCode ?? undefined,
+                exitSignal: scopedFinished.exitSignal ?? undefined,
+                name: deriveSessionName(scopedFinished.command),
+              },
+            };
+          }
+          return failText(`No session found for ${params.sessionId}`);
+        }
+
         case "poll": {
           if (!scopedSession) {
             if (scopedFinished) {
@@ -374,6 +535,7 @@ export function createProcessTool(
           if (exited) {
             resetPollRetrySuggestion(params.sessionId);
           }
+          const runtime = exited ? undefined : describeRunningSession(scopedSession);
           return {
             content: [
               {
@@ -384,7 +546,7 @@ export function createProcessTool(
                     ? `\n\nProcess exited with ${
                         exitSignal ? `signal ${exitSignal}` : `code ${exitCode}`
                       }.`
-                    : "\n\nProcess still running."),
+                    : buildInputWaitHint(runtime) || "\n\nProcess still running."),
               },
             ],
             details: {
@@ -393,6 +555,7 @@ export function createProcessTool(
               exitCode: exited ? exitCode : undefined,
               aggregated: scopedSession.aggregated,
               name: deriveSessionName(scopedSession.command),
+              ...(runtime ? runningSessionInputDetails(runtime) : {}),
               ...(typeof retryInMs === "number" ? { retryInMs } : {}),
             },
           };
@@ -417,6 +580,7 @@ export function createProcessTool(
               window.effectiveOffset,
               window.effectiveLimit,
             );
+            const runtime = describeRunningSession(scopedSession);
             const logDefaultTailNote = defaultTailNote(totalLines, window.usingDefaultTail);
             return {
               content: [{ type: "text", text: (slice || "(no output yet)") + logDefaultTailNote }],
@@ -428,6 +592,7 @@ export function createProcessTool(
                 totalChars,
                 truncated: scopedSession.truncated,
                 name: deriveSessionName(scopedSession.command),
+                ...runningSessionInputDetails(runtime),
               },
             };
           }

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -50,7 +50,10 @@ export const execSchema = Type.Object({
 });
 
 export const processSchema = Type.Object({
-  action: Type.String({ description: "Process action" }),
+  action: Type.String({
+    description:
+      "Process action (list|attach|poll|log|write|send-keys|submit|paste|kill|clear|remove)",
+  }),
   sessionId: Type.Optional(Type.String({ description: "Session id for actions other than list" })),
   data: Type.Optional(Type.String({ description: "Data to write for write" })),
   keys: Type.Optional(

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -186,6 +186,37 @@ describe("createChildAdapter", () => {
     expect(killMock).toHaveBeenCalledWith("SIGTERM");
   });
 
+  it("reports stdin as non-writable after end or destroy", async () => {
+    const { adapter } = await createAdapterHarness({ pid: 6767 });
+
+    expect(adapter.stdin?.writable).toBe(true);
+    expect(adapter.stdin?.writableEnded).toBe(false);
+
+    adapter.stdin?.end();
+    expect(adapter.stdin?.writable).toBe(false);
+    expect(adapter.stdin?.writableEnded).toBe(true);
+
+    adapter.stdin?.destroy?.();
+    expect(adapter.stdin?.destroyed).toBe(true);
+    expect(adapter.stdin?.writable).toBe(false);
+  });
+
+  it("reports pipe-closed stdin as ended", async () => {
+    const { child } = createStubChild(3434);
+    spawnWithFallbackMock.mockResolvedValue({
+      child,
+      usedFallback: false,
+    });
+
+    const adapter = await createChildAdapter({
+      argv: ["node", "-e", "process.exit(0)"],
+      stdinMode: "pipe-closed",
+    });
+
+    expect(adapter.stdin?.writable).toBe(false);
+    expect(adapter.stdin?.writableEnded).toBe(true);
+  });
+
   it("wait does not settle immediately on SIGKILL", async () => {
     vi.useFakeTimers();
     const { adapter } = await createAdapterHarness({ pid: 4567 });

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -73,18 +73,43 @@ export async function createChildAdapter(params: {
   });
 
   const child = spawned.child as ChildProcessWithoutNullStreams;
+  let stdinDestroyed = child.stdin.destroyed;
+  let stdinEnded = child.stdin.writableEnded || child.stdin.writableFinished;
   if (child.stdin) {
+    child.stdin.once("finish", () => {
+      stdinEnded = true;
+    });
+    child.stdin.once("close", () => {
+      stdinEnded = true;
+      stdinDestroyed = true;
+    });
+    child.stdin.once("error", () => {
+      stdinDestroyed = true;
+    });
     if (params.input !== undefined) {
       child.stdin.write(params.input);
+      stdinEnded = true;
       child.stdin.end();
     } else if (stdinMode === "pipe-closed") {
+      stdinEnded = true;
       child.stdin.end();
     }
   }
 
   const stdin: ManagedRunStdin | undefined = child.stdin
     ? {
-        destroyed: false,
+        get destroyed() {
+          return stdinDestroyed || child.stdin.destroyed;
+        },
+        get writable() {
+          return !stdinDestroyed && !stdinEnded && child.stdin.writable;
+        },
+        get writableEnded() {
+          return stdinEnded || child.stdin.writableEnded;
+        },
+        get writableFinished() {
+          return child.stdin.writableFinished;
+        },
         write: (data: string, cb?: (err?: Error | null) => void) => {
           try {
             child.stdin.write(data, cb);
@@ -94,6 +119,7 @@ export async function createChildAdapter(params: {
         },
         end: () => {
           try {
+            stdinEnded = true;
             child.stdin.end();
           } catch {
             // ignore close errors
@@ -101,6 +127,8 @@ export async function createChildAdapter(params: {
         },
         destroy: () => {
           try {
+            stdinDestroyed = true;
+            stdinEnded = true;
             child.stdin.destroy();
           } catch {
             // ignore destroy errors

--- a/src/process/supervisor/adapters/pty.test.ts
+++ b/src/process/supervisor/adapters/pty.test.ts
@@ -153,6 +153,29 @@ describe("createPtyAdapter", () => {
     expect(stub.onExit).toHaveBeenCalledTimes(1);
     stub.emitExit({ exitCode: 3, signal: 0 });
     await expect(adapter.wait()).resolves.toEqual({ code: 3, signal: null });
+    expect(adapter.stdin?.destroyed).toBe(true);
+    expect(adapter.stdin?.writable).toBe(false);
+  });
+
+  it("reports stdin as non-writable after EOF or dispose", async () => {
+    const stub = createStubPty();
+    spawnMock.mockReturnValue(stub);
+
+    const adapter = await createPtyAdapter({
+      shell: "bash",
+      args: ["-lc", "cat"],
+    });
+
+    expect(adapter.stdin?.writable).toBe(true);
+    expect(adapter.stdin?.writableEnded).toBe(false);
+
+    adapter.stdin?.end();
+    expect(stub.write).toHaveBeenCalledWith(process.platform === "win32" ? "\x1a" : "\x04");
+    expect(adapter.stdin?.writable).toBe(false);
+    expect(adapter.stdin?.writableEnded).toBe(true);
+
+    adapter.dispose();
+    expect(adapter.stdin?.destroyed).toBe(true);
   });
 
   it("disposes PTY listeners", async () => {

--- a/src/process/supervisor/adapters/pty.ts
+++ b/src/process/supervisor/adapters/pty.ts
@@ -75,6 +75,8 @@ export async function createPtyAdapter(params: {
   let waitPromise: Promise<{ code: number | null; signal: NodeJS.Signals | number | null }> | null =
     null;
   let forceKillWaitFallbackTimer: NodeJS.Timeout | null = null;
+  let stdinDestroyed = false;
+  let stdinEnded = false;
 
   const clearForceKillWaitFallback = () => {
     if (!forceKillWaitFallbackTimer) {
@@ -89,6 +91,8 @@ export async function createPtyAdapter(params: {
       return;
     }
     clearForceKillWaitFallback();
+    stdinDestroyed = true;
+    stdinEnded = true;
     waitResult = value;
     if (resolveWait) {
       const resolve = resolveWait;
@@ -114,7 +118,18 @@ export async function createPtyAdapter(params: {
     }) ?? null;
 
   const stdin: ManagedRunStdin = {
-    destroyed: false,
+    get destroyed() {
+      return stdinDestroyed;
+    },
+    get writable() {
+      return !stdinDestroyed && !stdinEnded;
+    },
+    get writableEnded() {
+      return stdinEnded;
+    },
+    get writableFinished() {
+      return stdinEnded;
+    },
     write: (data, cb) => {
       try {
         pty.write(data);
@@ -125,11 +140,16 @@ export async function createPtyAdapter(params: {
     },
     end: () => {
       try {
+        stdinEnded = true;
         const eof = process.platform === "win32" ? "\x1a" : "\x04";
         pty.write(eof);
       } catch {
         // ignore EOF errors
       }
+    },
+    destroy: () => {
+      stdinDestroyed = true;
+      stdinEnded = true;
     },
   };
 
@@ -182,6 +202,8 @@ export async function createPtyAdapter(params: {
   };
 
   const dispose = () => {
+    stdinDestroyed = true;
+    stdinEnded = true;
     try {
       dataListener?.dispose();
     } catch {

--- a/src/process/supervisor/types.ts
+++ b/src/process/supervisor/types.ts
@@ -52,6 +52,9 @@ export type ManagedRunStdin = {
   end: () => void;
   destroy?: () => void;
   destroyed?: boolean;
+  writable?: boolean;
+  writableEnded?: boolean;
+  writableFinished?: boolean;
 };
 
 export type SpawnProcessAdapter<WaitSignal = NodeJS.Signals | number | null> = {


### PR DESCRIPTION
## Summary

* **Problem:** Background interactive CLI sessions appear stuck when waiting on stdin because there is no attach mechanism or reliable input-wait detection.
* **Why it matters:** Operators cannot safely recover visibility or provide input (e.g., login/2FA) without guessing, losing observability and debugging context.
* **What changed:** Added `process attach`, input-wait metadata (`stdinWritable`, `waitingForInput`, `idleMs`, `lastOutputAt`), input-wait hints in `attach`/`poll`/`list`, and accurate stdin state tracking for child and PTY adapters.
* **What did NOT change (scope boundary):** No persistent sessions, no tmux/psmux integration, no new network calls or permissions, and no changes to existing process input actions.

---

## Change Type (select all)

* [x] Bug fix
* [x] Feature
* [ ] Refactor required for the fix
* [x] Docs
* [ ] Security hardening
* [ ] Chore/infra

---

## Scope (select all touched areas)

* [x] Gateway / orchestration
* [x] Skills / tool execution
* [ ] Auth / tokens
* [ ] Memory / storage
* [ ] Integrations
* [x] API / contracts
* [x] UI / DX
* [ ] CI/CD / infra

---

## Linked Issue/PR

* Closes #33957
* Related #34501
* [x] This PR fixes a bug or regression

---

## Real behavior proof (required for external PRs)

* **Behavior or issue addressed:** Recovering and interacting with idle background sessions waiting for stdin.
* **Real environment tested:** Local OpenClaw setup, Linux container, Node v24.13.0, gateway `exec` and `process` tools.
* **Exact steps or command run after this patch:**

  1. Start PTY background process that prints `READY` / `Code:` and waits on stdin.
  2. Wait past input-wait threshold.
  3. Run `process attach`.
  4. Run `process write` with `123456\n`.
  5. Run `process poll`.
* **Evidence after fix:**

```json
{
  "sessionId": "rapid-sage",
  "execStatus": "running",
  "attachText": "READY\nCode: \n\nNo new output for 1s; this session may be waiting for input. Use process write, send-keys, submit, or paste to provide input.",
  "attachDetails": {
    "status": "running",
    "sessionId": "rapid-sage",
    "stdinWritable": true,
    "waitingForInput": true
  },
  "pollText": "READY\r\nCode: 123456\r\nGOT:123456\r\n\n\nProcess exited with code 0."
}
```

* **Observed result after fix:** Attach shows prompt + `waitingForInput: true`; input is accepted; process completes successfully.
* **What was not tested:** Live Expo login/2FA, tmux/psmux, full UI flows.
* **Before evidence (optional but encouraged):** Previously failed with `Unknown action attach`, no input-wait hints, and incorrect stdin writability.

---

## Root Cause (if applicable)

* **Root cause:** No attach capability and no runtime contract for detecting idle stdin-waiting sessions.
* **Missing detection / guardrail:** Tests did not cover idle writable sessions or ended stdin states.
* **Contributing context (if known):** Child and PTY stdin wrappers exposed only `destroyed`, causing ended streams to appear writable.

---

## Regression Test Plan (if applicable)

* **Coverage level that should have caught this:**

  * [x] Unit test
  * [x] Seam / integration test
  * [ ] End-to-end test
  * [ ] Existing coverage already sufficient
* **Target test or file:**

  * `bash-tools.process.attach.test.ts`
  * `child.test.ts`
  * `pty.test.ts`
* **Scenario the test should lock in:**
  Attach returns transcript + input hints; metadata exposed in `list`/`poll`; ended stdin is not writable; completed sessions remain attachable read-only.
* **Why this is the smallest reliable guardrail:**
  Validates process-tool contract and adapter behavior without requiring external CLI dependencies.
* **Existing test that already covers this (if any):**
  Existing `poll`, `send-keys`, and supervisor tests cover compatibility with existing actions.
* **If no new test is added, why not:** N/A

---

## User-visible / Behavior Changes

* New `process attach` command
* Input-wait indicators in `attach`, `poll`, and `list` (`[input-wait]`)
* New metadata fields: `stdinWritable`, `waitingForInput`, `idleMs`, `lastOutputAt`
* Optional env config: `OPENCLAW_PROCESS_INPUT_WAIT_IDLE_MS` (default 15s)

---

## Diagram (if applicable)

```text
Before:
exec background session -> waits for stdin -> poll/log show no progress

After:
exec background session -> attach/list/poll show input-wait -> user sends input -> process resumes
```

---

## Security Impact (required)

* New permissions/capabilities? No

* Secrets/tokens handling changed? No

* New/changed network calls? No

* Command/tool execution surface changed? Yes

* Data access scope changed? No

* If any `Yes`, explain risk + mitigation:
  Adds a scoped process-management action (`attach`) that reads existing in-memory output and uses existing input actions. No new execution or cross-session access is introduced.

---

## Repro + Verification

### Environment

* OS: Linux container
* Runtime/container: Local OpenClaw, Node v24.13.0
* Model/provider: N/A
* Integration/channel (if any): N/A
* Relevant config (redacted):
  `createExecTool({ backgroundMs: 10 })`,
  `createProcessTool({ inputWaitIdleMs: 1000 })`

### Steps

1. Start background PTY process waiting for stdin
2. Wait past idle threshold
3. Run `process attach`, then `process write`, then `process poll`

### Expected

* Attach shows transcript + input-wait state
* Input is accepted
* Process completes successfully

### Actual

* Matches expected behavior

---

## Evidence

* [x] Failing test/log before + passing after
* [x] Trace/log snippets
* [ ] Screenshot/recording
* [ ] Perf numbers (if relevant)

---

## Human Verification (required)

* **Verified scenarios:** Attach flow, input-wait detection, stdin write, process completion, regression tests passing.
* **Edge cases checked:** Ended stdin, PTY EOF, completed sessions, compatibility with existing actions.
* **What you did not verify:** External CLIs (Expo login/2FA), tmux/psmux, full UI workflows.

---

## Review Conversations

* [x] I replied to or resolved every bot review conversation I addressed in this PR.
* [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

---

## Compatibility / Migration

* Backward compatible? Yes
* Config/env changes? Yes
* Migration needed? No
* If yes, exact upgrade steps: N/A

---

## Risks and Mitigations

* **Risk:** False positive input-wait hints on quiet processes

  * **Mitigation:** Requires writable stdin + configurable idle threshold

* **Risk:** Incorrect stdin writability detection

  * **Mitigation:** Improved checks (`destroyed`, `writableEnded`, etc.) + adapter tests
