### PR TITLE
fix(onboard): recover externalized channel plugin from stale config

### DIFF
--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -85,6 +85,9 @@ const resolveDefaultAgentId = vi.hoisted(() => vi.fn((_cfg?: unknown) => "defaul
 const listTrustedChannelPluginCatalogEntries = vi.hoisted(() =>
   vi.fn((_params?: unknown): unknown[] => []),
 );
+const getTrustedChannelPluginCatalogEntry = vi.hoisted(() =>
+  vi.fn((_channelId: string, _params?: unknown): unknown => undefined),
+);
 const getChannelSetupPlugin = vi.hoisted(() => vi.fn((_channel?: unknown) => undefined));
 const listChannelSetupPlugins = vi.hoisted(() => vi.fn((): unknown[] => []));
 const listActiveChannelSetupPlugins = vi.hoisted(() => vi.fn((): unknown[] => []));
@@ -162,6 +165,8 @@ vi.mock("../commands/channel-setup/registry.js", () => ({
 vi.mock("../commands/channel-setup/trusted-catalog.js", () => ({
   listTrustedChannelPluginCatalogEntries: (params?: unknown) =>
     listTrustedChannelPluginCatalogEntries(params),
+  getTrustedChannelPluginCatalogEntry: (channelId: string, params?: unknown) =>
+    getTrustedChannelPluginCatalogEntry(channelId, params),
 }));
 
 vi.mock("../config/channel-configured.js", () => ({
@@ -661,4 +666,461 @@ describe("setupChannels workspace shadow exclusion", () => {
       "Channel setup",
     );
   });
+
+  it(
+    "reinstalls the external plugin via catalog when a stale channel config " +
+      "declares an already-installed plugin whose runtime cannot be loaded",
+    async () => {
+      // Regression: users who uninstalled an externalized channel plugin
+      // (qqbot / bluebubbles / discord / ...) while a non-empty
+      // `channels.<id>` entry remained in their config got dead-ended with
+      // "<channel> plugin not available" because the installed-catalog
+      // branch did not fall back to the catalog install flow.
+      const configure = vi.fn(async ({ cfg }: { cfg: Record<string, unknown> }) => ({
+        cfg: { ...cfg, channels: { "external-chat": { token: "secret" } } },
+      }));
+      const externalChatPlugin = makeSetupPlugin({
+        id: "external-chat",
+        label: "External Chat",
+        setupWizard: {
+          channel: "external-chat",
+          getStatus: vi.fn(async () => ({
+            channel: "external-chat",
+            configured: false,
+            statusLines: [],
+          })),
+          configure,
+        } as ChannelSetupPlugin["setupWizard"],
+      });
+      const installedCatalogEntry = makeCatalogEntry("external-chat", "External Chat", {
+        pluginId: "@vendor/external-chat-plugin",
+        install: { npmSpec: "@vendor/external-chat-plugin" },
+      });
+      resolveChannelSetupEntries.mockReturnValue(
+        externalChatSetupEntries({
+          installedCatalogEntries: [installedCatalogEntry],
+          installedCatalogById: new Map([["external-chat", installedCatalogEntry]]),
+        }),
+      );
+      // First snapshot (pre-install) is empty — plugin runtime is gone.
+      // After `ensureChannelSetupPluginInstalled` runs, subsequent snapshots
+      // resolve the plugin as expected.
+      loadChannelSetupPluginRegistrySnapshotForChannel
+        .mockReturnValueOnce(makePluginRegistry())
+        .mockReturnValue(
+          makePluginRegistry({
+            channels: [
+              {
+                pluginId: "@vendor/external-chat-plugin",
+                source: "global",
+                plugin: externalChatPlugin,
+              },
+            ],
+          }),
+        );
+      ensureChannelSetupPluginInstalled.mockResolvedValueOnce({
+        cfg: {},
+        installed: true,
+        pluginId: "@vendor/external-chat-plugin",
+        status: "installed",
+      });
+      isChannelConfigured.mockReturnValue(false);
+      const note = vi.fn(async () => undefined);
+      const select = vi
+        .fn()
+        .mockResolvedValueOnce("external-chat")
+        .mockResolvedValueOnce("__done__");
+
+      await setupChannels(
+        {} as never,
+        {} as never,
+        {
+          confirm: vi.fn(async () => true),
+          note,
+          select,
+        } as never,
+        {
+          deferStatusUntilSelection: true,
+          skipConfirm: true,
+          skipDmPolicyPrompt: true,
+        },
+      );
+
+      expect(ensureChannelSetupPluginInstalled).toHaveBeenCalledTimes(1);
+      expect(ensureChannelSetupPluginInstalled).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entry: expect.objectContaining({
+            id: "external-chat",
+            install: expect.objectContaining({ npmSpec: "@vendor/external-chat-plugin" }),
+          }),
+          autoConfirmSingleSource: true,
+        }),
+      );
+      expect(note).not.toHaveBeenCalledWith("external-chat plugin not available.", "Channel setup");
+      expect(configure).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it(
+    "returns to channel selection when catalog-fallback install is declined " +
+      "from the installed-catalog branch",
+    async () => {
+      const installedCatalogEntry = makeCatalogEntry("external-chat", "External Chat", {
+        pluginId: "@vendor/external-chat-plugin",
+        install: { npmSpec: "@vendor/external-chat-plugin" },
+      });
+      resolveChannelSetupEntries.mockReturnValue(
+        externalChatSetupEntries({
+          installedCatalogEntries: [installedCatalogEntry],
+          installedCatalogById: new Map([["external-chat", installedCatalogEntry]]),
+        }),
+      );
+      loadChannelSetupPluginRegistrySnapshotForChannel.mockReturnValue(makePluginRegistry());
+      ensureChannelSetupPluginInstalled.mockResolvedValueOnce({
+        cfg: {},
+        installed: false,
+        pluginId: "@vendor/external-chat-plugin",
+        status: "skipped",
+      });
+      isChannelConfigured.mockReturnValue(false);
+      let quickstartSelectionCount = 0;
+      const select = vi.fn(async ({ message }: { message: string }) => {
+        if (message === "Select channel (QuickStart)") {
+          quickstartSelectionCount += 1;
+          if (quickstartSelectionCount === 1) {
+            return "external-chat";
+          }
+        }
+        return "__skip__";
+      });
+      const note = vi.fn(async () => undefined);
+
+      await setupChannels(
+        {} as never,
+        {} as never,
+        {
+          confirm: vi.fn(async () => true),
+          note,
+          select,
+        } as never,
+        {
+          quickstartDefaults: true,
+          skipConfirm: true,
+          skipDmPolicyPrompt: true,
+        },
+      );
+
+      // Install prompt ran once, was declined; user returned to channel
+      // selection (quickstartSelectionCount === 2) rather than being
+      // dead-ended with a "plugin not available" note.
+      expect(ensureChannelSetupPluginInstalled).toHaveBeenCalledTimes(1);
+      expect(quickstartSelectionCount).toBe(2);
+      expect(note).not.toHaveBeenCalledWith("external-chat plugin not available.", "Channel setup");
+    },
+  );
+
+  it(
+    "auto-installs external plugin from catalog when both discovery buckets " +
+      "are empty due to a stale `channels.<id>` config entry",
+    async () => {
+      // Regression test for the real-world repro: `channels.qqbot` has stale
+      // fields (appId/secret) from an earlier install, so
+      // `isStaticallyChannelConfigured` drops qqbot from
+      // `installableCatalogEntries`; qqbot isn't on disk either, so
+      // `manifestInstalledIds` doesn't include it. Both discovery buckets
+      // come back empty, but the channel is still selectable (entries list
+      // does not apply the static-config filter). Before the fix, onboard
+      // fell through to `enableBundledPluginForSetup` which just printed
+      // "qqbot plugin not available." and exited the flow. The fix consults
+      // the catalog directly and drives `ensureChannelSetupPluginInstalled`.
+      const configure = vi.fn(async ({ cfg }: { cfg: Record<string, unknown> }) => ({
+        cfg: { ...cfg, channels: { "external-chat": { token: "secret" } } },
+      }));
+      const externalChatPlugin = makeSetupPlugin({
+        id: "external-chat",
+        label: "External Chat",
+        setupWizard: {
+          channel: "external-chat",
+          getStatus: vi.fn(async () => ({
+            channel: "external-chat",
+            configured: false,
+            statusLines: [],
+          })),
+          configure,
+        } as ChannelSetupPlugin["setupWizard"],
+      });
+      // Entries list exposes the channel in the menu, but BOTH discovery
+      // buckets are empty — faithfully reproducing the observed bug.
+      resolveChannelSetupEntries.mockReturnValue(
+        makeChannelSetupEntries({
+          entries: [
+            {
+              id: "external-chat",
+              meta: makeMeta("external-chat", "External Chat"),
+            },
+          ],
+          installedCatalogEntries: [],
+          installableCatalogEntries: [],
+          installedCatalogById: new Map(),
+          installableCatalogById: new Map(),
+        }),
+      );
+      const fallbackCatalogEntry = makeCatalogEntry("external-chat", "External Chat", {
+        pluginId: "@vendor/external-chat-plugin",
+        install: { npmSpec: "@vendor/external-chat-plugin" },
+      });
+      getTrustedChannelPluginCatalogEntry.mockReturnValue(fallbackCatalogEntry);
+      ensureChannelSetupPluginInstalled.mockResolvedValueOnce({
+        cfg: {},
+        installed: true,
+        pluginId: "@vendor/external-chat-plugin",
+        status: "installed",
+      });
+      loadChannelSetupPluginRegistrySnapshotForChannel.mockReturnValue(
+        makePluginRegistry({
+          channels: [
+            {
+              pluginId: "@vendor/external-chat-plugin",
+              source: "global",
+              plugin: externalChatPlugin,
+            },
+          ],
+        }),
+      );
+      isChannelConfigured.mockReturnValue(false);
+      const note = vi.fn(async () => undefined);
+      const select = vi
+        .fn()
+        .mockResolvedValueOnce("external-chat")
+        .mockResolvedValueOnce("__done__");
+
+      await setupChannels(
+        {} as never,
+        {} as never,
+        {
+          confirm: vi.fn(async () => true),
+          note,
+          select,
+        } as never,
+        {
+          deferStatusUntilSelection: true,
+          skipConfirm: true,
+          skipDmPolicyPrompt: true,
+        },
+      );
+
+      expect(getTrustedChannelPluginCatalogEntry).toHaveBeenCalledWith(
+        "external-chat",
+        expect.objectContaining({ workspaceDir: "/tmp/openclaw-workspace" }),
+      );
+      expect(ensureChannelSetupPluginInstalled).toHaveBeenCalledTimes(1);
+      expect(ensureChannelSetupPluginInstalled).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entry: expect.objectContaining({
+            id: "external-chat",
+            install: expect.objectContaining({ npmSpec: "@vendor/external-chat-plugin" }),
+          }),
+          autoConfirmSingleSource: true,
+        }),
+      );
+      expect(note).not.toHaveBeenCalledWith("external-chat plugin not available.", "Channel setup");
+      expect(configure).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it(
+    "returns to channel selection when the catalog-fallback install is " +
+      "declined from the bundled-enable branch",
+    async () => {
+      resolveChannelSetupEntries.mockReturnValue(
+        makeChannelSetupEntries({
+          entries: [
+            {
+              id: "external-chat",
+              meta: makeMeta("external-chat", "External Chat"),
+            },
+          ],
+        }),
+      );
+      const fallbackCatalogEntry = makeCatalogEntry("external-chat", "External Chat", {
+        pluginId: "@vendor/external-chat-plugin",
+        install: { npmSpec: "@vendor/external-chat-plugin" },
+      });
+      getTrustedChannelPluginCatalogEntry.mockReturnValue(fallbackCatalogEntry);
+      ensureChannelSetupPluginInstalled.mockResolvedValueOnce({
+        cfg: {},
+        installed: false,
+        pluginId: "@vendor/external-chat-plugin",
+        status: "skipped",
+      });
+      isChannelConfigured.mockReturnValue(false);
+      let quickstartSelectionCount = 0;
+      const select = vi.fn(async ({ message }: { message: string }) => {
+        if (message === "Select channel (QuickStart)") {
+          quickstartSelectionCount += 1;
+          if (quickstartSelectionCount === 1) {
+            return "external-chat";
+          }
+        }
+        return "__skip__";
+      });
+      const note = vi.fn(async () => undefined);
+
+      await setupChannels(
+        {} as never,
+        {} as never,
+        {
+          confirm: vi.fn(async () => true),
+          note,
+          select,
+        } as never,
+        {
+          quickstartDefaults: true,
+          skipConfirm: true,
+          skipDmPolicyPrompt: true,
+        },
+      );
+
+      expect(ensureChannelSetupPluginInstalled).toHaveBeenCalledTimes(1);
+      expect(quickstartSelectionCount).toBe(2);
+      expect(note).not.toHaveBeenCalledWith("external-chat plugin not available.", "Channel setup");
+    },
+  );
+
+  it(
+    "refuses catalog-fallback install from empty discovery buckets when the " +
+      "channel is explicitly disabled in config",
+    async () => {
+      // Review-note regression: the bundled-enable `else` branch used to rely
+      // on `enableBundledPluginForSetup`'s own disabled-config guard. The
+      // new catalog fallback runs BEFORE that helper, so it must re-apply
+      // the same `resolveConfigDisabledHint` check — otherwise an operator-
+      // disabled channel with a stale `channels.<id>` entry could be
+      // reinstalled/re-enabled silently.
+      //
+      // We intentionally do NOT pass `deferStatusUntilSelection` here so the
+      // top-level `deferredDisabledHint` guard in `handleChannelChoice` is
+      // bypassed. That isolates the guard newly added inside the catalog
+      // fallback; without it, the test would pass against an unguarded
+      // fallback because the QuickStart path's early guard would catch the
+      // disabled state first.
+      resolveChannelSetupEntries.mockReturnValue(
+        makeChannelSetupEntries({
+          entries: [
+            {
+              id: "external-chat",
+              meta: makeMeta("external-chat", "External Chat"),
+            },
+          ],
+        }),
+      );
+      const fallbackCatalogEntry = makeCatalogEntry("external-chat", "External Chat", {
+        pluginId: "@vendor/external-chat-plugin",
+        install: { npmSpec: "@vendor/external-chat-plugin" },
+      });
+      getTrustedChannelPluginCatalogEntry.mockReturnValue(fallbackCatalogEntry);
+      const select = vi
+        .fn()
+        .mockResolvedValueOnce("external-chat")
+        .mockResolvedValueOnce("__done__");
+      const note = vi.fn(async () => undefined);
+      // Operator has explicitly disabled the plugin while a stale
+      // `channels.<id>` entry lingers in config.
+      const cfg = {
+        plugins: { entries: { "external-chat": { enabled: false } } },
+        channels: {
+          "external-chat": {
+            enabled: true,
+            appId: "999999",
+            clientSecret: "stale",
+          },
+        },
+      };
+
+      await setupChannels(
+        cfg as never,
+        {} as never,
+        {
+          confirm: vi.fn(async () => true),
+          note,
+          select,
+        } as never,
+        {
+          skipConfirm: true,
+          skipDmPolicyPrompt: true,
+        },
+      );
+
+      // The new catalog fallback must NOT drive an install.
+      expect(ensureChannelSetupPluginInstalled).not.toHaveBeenCalled();
+      // Instead, the same "Enable it before setup." note used by
+      // `enableBundledPluginForSetup` should be shown.
+      expect(note).toHaveBeenCalledWith(
+        "external-chat cannot be configured while plugin disabled. Enable it before setup.",
+        "Channel setup",
+      );
+    },
+  );
+
+  it(
+    "refuses the installed-catalog install fallback when the channel is " +
+      "explicitly disabled in config",
+    async () => {
+      // Symmetric guard for the `installedCatalogEntry` fallback path. When
+      // `loadScopedChannelPlugin` returns null and the catalog entry carries
+      // `install.npmSpec`, the fix reaches for the catalog install flow —
+      // but must first respect an operator-level disable, matching the
+      // guard inside `enableBundledPluginForSetup`.
+      //
+      // As in the sibling test, we omit `deferStatusUntilSelection` to skip
+      // the top-level guard and isolate the new inline guard.
+      const installedCatalogEntry = makeCatalogEntry("external-chat", "External Chat", {
+        pluginId: "@vendor/external-chat-plugin",
+        install: { npmSpec: "@vendor/external-chat-plugin" },
+      });
+      resolveChannelSetupEntries.mockReturnValue(
+        externalChatSetupEntries({
+          installedCatalogEntries: [installedCatalogEntry],
+          installedCatalogById: new Map([["external-chat", installedCatalogEntry]]),
+        }),
+      );
+      loadChannelSetupPluginRegistrySnapshotForChannel.mockReturnValue(makePluginRegistry());
+      isChannelConfigured.mockReturnValue(false);
+      const select = vi
+        .fn()
+        .mockResolvedValueOnce("external-chat")
+        .mockResolvedValueOnce("__done__");
+      const note = vi.fn(async () => undefined);
+      const cfg = {
+        plugins: { entries: { "external-chat": { enabled: false } } },
+        channels: {
+          "external-chat": {
+            enabled: true,
+            appId: "999999",
+            clientSecret: "stale",
+          },
+        },
+      };
+
+      await setupChannels(
+        cfg as never,
+        {} as never,
+        {
+          confirm: vi.fn(async () => true),
+          note,
+          select,
+        } as never,
+        {
+          skipConfirm: true,
+          skipDmPolicyPrompt: true,
+        },
+      );
+
+      expect(ensureChannelSetupPluginInstalled).not.toHaveBeenCalled();
+      expect(note).toHaveBeenCalledWith(
+        "external-chat cannot be configured while plugin disabled. Enable it before setup.",
+        "Channel setup",
+      );
+    },
+  );
 });

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -16,7 +16,10 @@ import {
   loadChannelSetupPluginRegistrySnapshotForChannel,
 } from "../commands/channel-setup/plugin-install.js";
 import { resolveChannelSetupWizardAdapterForPlugin } from "../commands/channel-setup/registry.js";
-import { listTrustedChannelPluginCatalogEntries } from "../commands/channel-setup/trusted-catalog.js";
+import {
+  getTrustedChannelPluginCatalogEntry,
+  listTrustedChannelPluginCatalogEntries,
+} from "../commands/channel-setup/trusted-catalog.js";
 import type {
   ChannelSetupConfiguredResult,
   ChannelSetupResult,
@@ -584,16 +587,99 @@ export async function setupChannels(
       await loadScopedChannelPlugin(channel, result.pluginId ?? catalogEntry.pluginId);
       await refreshStatus(channel);
     } else if (installedCatalogEntry) {
-      const plugin = await loadScopedChannelPlugin(channel, installedCatalogEntry.pluginId);
+      let plugin = await loadScopedChannelPlugin(channel, installedCatalogEntry.pluginId);
+      if (!plugin && installedCatalogEntry.install?.npmSpec) {
+        // The channel is recorded in the user's config (e.g. a stale
+        // `channels.<id>` entry left over from a previous install) but the
+        // plugin runtime cannot be loaded from disk — typically because the
+        // externalized npm package was uninstalled or pruned during an
+        // upgrade. Rather than dead-ending with "plugin not available", fall
+        // back to the catalog-driven install flow so onboard can recover by
+        // reinstalling the official external plugin.
+        //
+        // Preserve the same disabled-config guard used by
+        // `enableBundledPluginForSetup` so an operator-disabled channel
+        // cannot be silently reinstalled/re-enabled through this path.
+        const disabledHint = resolveConfigDisabledHint(channel);
+        if (disabledHint) {
+          await prompter.note(
+            `${channel} cannot be configured while ${disabledHint}. Enable it before setup.`,
+            "Channel setup",
+          );
+          return "done";
+        }
+        const workspaceDir = resolveWorkspaceDir();
+        const result = await ensureChannelSetupPluginInstalled({
+          cfg: next,
+          entry: installedCatalogEntry,
+          prompter,
+          runtime,
+          workspaceDir,
+          autoConfirmSingleSource: true,
+        });
+        next = result.cfg;
+        if (!result.installed) {
+          return "retry_selection";
+        }
+        plugin = await loadScopedChannelPlugin(
+          channel,
+          result.pluginId ?? installedCatalogEntry.pluginId,
+        );
+      }
       if (!plugin) {
         await prompter.note(`${channel} plugin not available.`, "Channel setup");
         return "done";
       }
       await refreshStatus(channel);
     } else {
-      const enabled = await enableBundledPluginForSetup(channel);
-      if (!enabled) {
-        return "done";
+      // Neither discovery bucket yielded an entry for this channel. This can
+      // happen when `channels.<id>` in user config carries stale fields (e.g.
+      // `appId`, tokens) left over from a previous install: `isStatically-
+      // ChannelConfigured` returns true, which removes the channel from the
+      // `installableCatalogEntries` bucket, while a missing/pruned plugin on
+      // disk keeps it out of `installedCatalogEntries`. Before falling back
+      // to the bundled-plugin enable path, consult the catalog directly so
+      // users with a stale config entry for an externalized channel (qqbot,
+      // bluebubbles, discord, whatsapp, ...) still get auto-install instead
+      // of a dead-end "plugin not available" note.
+      const fallbackCatalogEntry = getTrustedChannelPluginCatalogEntry(channel, {
+        cfg: next,
+        workspaceDir: resolveWorkspaceDir(),
+      });
+      if (fallbackCatalogEntry?.install?.npmSpec) {
+        // Preserve the same disabled-config guard used by
+        // `enableBundledPluginForSetup` so an operator-disabled channel
+        // cannot be silently reinstalled/re-enabled through this path. This
+        // mirrors the guard that was previously enforced inside the
+        // bundled-enable fallback.
+        const disabledHint = resolveConfigDisabledHint(channel);
+        if (disabledHint) {
+          await prompter.note(
+            `${channel} cannot be configured while ${disabledHint}. Enable it before setup.`,
+            "Channel setup",
+          );
+          return "done";
+        }
+        const workspaceDir = resolveWorkspaceDir();
+        const result = await ensureChannelSetupPluginInstalled({
+          cfg: next,
+          entry: fallbackCatalogEntry,
+          prompter,
+          runtime,
+          workspaceDir,
+          autoConfirmSingleSource: true,
+        });
+        next = result.cfg;
+        if (!result.installed) {
+          return "retry_selection";
+        }
+        await loadScopedChannelPlugin(channel, result.pluginId ?? fallbackCatalogEntry.pluginId);
+        await refreshStatus(channel);
+      } else {
+        const enabled = await enableBundledPluginForSetup(channel);
+        if (!enabled) {
+          return "done";
+        }
       }
     }
 


### PR DESCRIPTION
When a user's config has a stale `channels.<id>` entry (e.g. `appId` or tokens left over from an earlier install) and the plugin is no longer on disk -- for instance because the externalized npm package was uninstalled or pruned during an upgrade -- `handleChannelChoice` used to dead-end with `<channel> plugin not available.` and leave onboard stuck until the user manually deleted the config entry and re-ran the CLI.

Two discovery paths are affected:

1. The `installedCatalogEntry` branch: when `loadScopedChannelPlugin` returns null but the catalog entry still carries `install.npmSpec`, fall back to `ensureChannelSetupPluginInstalled` with the same entry so onboard can reinstall the plugin from the official catalog.

2. The bundled-enable `else` branch: with a non-empty `channels.<id>` record, `isStaticallyChannelConfigured` drops the channel from `installableCatalogEntries`; if the plugin is also missing on disk (so it never enters `manifestInstalledIds`), both discovery buckets come back empty and the channel falls through to `enableBundledPluginForSetup`. Before delegating to that bundled path, consult the trusted catalog via `getTrustedChannelPluginCatalogEntry` and, if an `install.npmSpec` is available, drive the same catalog install flow used by a fresh pick of the channel.

Both branches keep their previous behavior when no catalog npm spec is available (e.g. purely bundled channels), so this change is a superset of the old flow rather than a replacement.

Affects all externalized channel plugins listed in the core package's `files` exclusion (qqbot, bluebubbles, discord, whatsapp, line, msteams, feishu, googlechat, nostr, zalo, zalouser, synology-chat, tlon, twitch, and similar).

## Summary

- **Problem**: After an externalized channel plugin is uninstalled (or pruned during a core package upgrade) while a non-empty `channels.<id>` entry remains in `openclaw.json`, running `openclaw onboard` and selecting that channel dead-ends with `<channel> plugin not available.` and no recovery path — even though the channel is listed in the official catalog with a valid `install.npmSpec`.
- **Why it matters**: This is a silent regression trap for existing users. Any upgrade that externalizes a previously-bundled channel plugin, or any user-driven uninstall, leaves the config pointing at a plugin that is no longer loadable. The only workaround before this change is to hand-edit `~/.openclaw/openclaw.json` to delete `channels.<id>` — a step that is not discoverable from the CLI output.
- **What changed**: `handleChannelChoice` now treats "channel listed in the trusted catalog with an `install.npmSpec`" as an install opportunity in both the `installedCatalogEntry` branch (after `loadScopedChannelPlugin` fails) and the bundled-enable `else` branch (when both discovery buckets are empty), driving the same `ensureChannelSetupPluginInstalled` flow a fresh install uses.
- **What did NOT change**: Channels without an external catalog `npmSpec` (purely bundled channels, unknown channels) still fall through to `enableBundledPluginForSetup` / `plugin not available.` exactly like before. The discovery bucketing (`resolveChannelSetupEntries`, `isStaticallyChannelConfigured`) is untouched. No config-migration or config-rewrite behavior is introduced; the existing plugin install flow already handles `plugins.entries` writes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed**: `openclaw onboard` dead-ending on `<channel> plugin not available.` for any externalized channel plugin (qqbot, bluebubbles, discord, whatsapp, etc.) when the config still references it but the plugin is not installed on disk.
- **Real environment tested**: Linux (bash 5.2), Node v24.14.0, `openclaw` monorepo at `fix/onboard-stale-channel-config-fallback`, built locally (`pnpm build`), config at `~/.openclaw/openclaw.json`.
- **Exact steps or command run after this patch**:
  1. `pnpm openclaw plugins uninstall qqbot` and `rm -rf ~/.openclaw/plugins/@openclaw/qqbot` to guarantee the npm package is not on disk.
  2. Inject a stale `channels.qqbot` entry via `jq`:
     ```
     jq '.channels.qqbot = { "enabled": true, "appId": "999999999", "clientSecret": "stale-secret-placeholder" } | del(.plugins.entries.qqbot)' \
        ~/.openclaw/openclaw.json > /tmp/o.json && mv /tmp/o.json ~/.openclaw/openclaw.json
     ```
  3. Run `pnpm openclaw onboard` and pick `QQ Bot (Official API)` from the QuickStart menu.
- **Evidence after fix (terminal capture)**:
  ```
  ◇  Select channel (QuickStart)
  │  QQ Bot (Official API)
  │
  ◇  Installed QQ Bot plugin
  │
  ◆  选择 QQ 绑定方式
  │  ● 扫码绑定（推荐） (使用 QQ 扫描二维码自动完成绑定)
  │  ○ 手动输入 QQ Bot AppID 和 AppSecret
  │  ○ 稍后配置
  └
  ```
- **Observed result after fix**: The channel is auto-installed from npm (`@openclaw/qqbot`), the plugin's setup wizard is entered, and the user never sees `qqbot plugin not available.` again.
- **What was not tested**: ClawHub-only install path (the catalog entries I exercised were npm-only), Windows and macOS runtimes (verified only on Linux), and channels other than `qqbot` for the exact trigger (scanned all externalized channels statically by reading the `files` exclusion list in `package.json`).
- **Before evidence (reproduced against the same HEAD before this fix)**:
  ```
  ◇  Select channel (QuickStart)
  │  QQ Bot (Official API)
  │
  ◇  Channel setup ───────────────╮
  │                               │
  │  qqbot plugin not available.  │
  │                               │
  ├───────────────────────────────╯
  Config warnings:
  - plugins.entries.qqbot: plugin not installed: qqbot — install the
    official external plugin with: openclaw plugins install @openclaw/qqbot
  ```

## Root Cause (if applicable)

- **Root cause**: The channel-setup flow in `src/flows/channel-setup.ts` has three entry paths (`catalogEntry`, `installedCatalogEntry`, `else -> enableBundledPluginForSetup`). Discovery bucketing in `src/commands/channel-setup/discovery.ts` removes a channel from `installableCatalogEntries` as soon as `isStaticallyChannelConfigured(cfg, channel)` returns true — which is triggered by **any** non-`enabled` key under `channels.<id>` (`appId`, tokens, etc., see `src/config/channel-configured-shared.ts:14-19`). If the plugin is not installed on disk, it never enters `manifestInstalledIds`, so `installedCatalogEntries` is also empty. The channel then falls through to `enableBundledPluginForSetup`, which prints `<channel> plugin not available.` and returns without consulting the catalog.
- **Missing detection / guardrail**: No existing unit test exercised "stale `channels.<id>` + missing externalized plugin on disk". The assumption that a configured channel must have an accompanying installed plugin only held while the majority of channels were bundled into the core package; externalizing plugins broke that invariant without an onboard-side recovery path.
- **Contributing context (if known)**: The core `package.json` `files` list explicitly excludes `dist/extensions/<id>/**` for a growing set of channels (qqbot, bluebubbles, discord, whatsapp, line, msteams, feishu, googlechat, nostr, zalo, zalouser, synology-chat, tlon, twitch, ...). Every minor upgrade of `openclaw` that prunes these via `postinstall-bundled-plugins.mjs`'s `pruneInstalledPackageDist` leaves existing configs pointing at now-missing plugins, so this bug is reachable for any existing user of those channels.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file**: `src/flows/channel-setup.test.ts`
- **Scenario the test should lock in**: Two discovery-layout scenarios that were previously uncovered — (a) channel is in `installedCatalogById` but its runtime cannot be loaded, and (b) channel is in neither `catalogById` nor `installedCatalogById` while a catalog entry with `install.npmSpec` exists. In both cases the setup flow must drive `ensureChannelSetupPluginInstalled`, not emit `plugin not available.` and exit.
- **Why this is the smallest reliable guardrail**: `handleChannelChoice` is the single decision point that routes between auto-install, installed-plugin load, and bundled-enable. Asserting its branching via the existing mock seam (`resolveChannelSetupEntries`, `getTrustedChannelPluginCatalogEntry`, `ensureChannelSetupPluginInstalled`) catches regressions without requiring a real npm install or filesystem plugin layout.
- **Existing test that already covers this (if any)**: None. The pre-existing `workspace shadow exclusion` suite covers `installedCatalogEntry` with a successful load; neither a failed `loadScopedChannelPlugin` in that branch nor the empty-buckets + catalog-fallback path were exercised.
- **If no new test is added, why not**: N/A — four new test cases are added: two for the `installedCatalogEntry` fallback (success and user-declined) and two for the `else` catalog-fallback (success and user-declined).

## User-visible / Behavior Changes

- Onboard no longer dead-ends on `<channel> plugin not available.` when `channels.<id>` has stale fields and the externalized plugin is missing. Users now see the standard `Installed <Channel> plugin` prompt followed by the plugin's setup wizard, matching the flow a fresh user gets when selecting the channel for the first time.
- If the user declines the install prompt (where applicable), onboard returns to the channel selection menu (`retry_selection`) instead of exiting.
- No changes to defaults, config schema, or non-channel flows.

## Diagram (if applicable)

```text
Before:
  stale channels.<id>        plugin not on disk
           \                       /
            \                     /
             v                   v
    isStaticallyChannelConfigured = true
             |
             v
    installableCatalogEntries: ∅   installedCatalogEntries: ∅
             \                           /
              \                         /
               v                       v
              handleChannelChoice → else → enableBundledPluginForSetup
                                              |
                                              v
                                    "<channel> plugin not available." (dead end)

After:
  (same inputs)
             |
             v
    installableCatalogEntries: ∅   installedCatalogEntries: ∅
             \                           /
              \                         /
               v                       v
              handleChannelChoice → else
                                    |
                                    v
                      getTrustedChannelPluginCatalogEntry(channel)
                                    |
                             has install.npmSpec?
                          /                      \
                       yes                        no
                        |                          |
                        v                          v
         ensureChannelSetupPluginInstalled   enableBundledPluginForSetup
                        |                          |
                        v                          v
         loadScopedChannelPlugin        (original legacy path)
                        |
                        v
                  enters setup wizard

  (the installedCatalogEntry branch gains the symmetric fallback
   when loadScopedChannelPlugin returns null and install.npmSpec is set)
```

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No** — the npm install is already issued by the pre-existing `ensureChannelSetupPluginInstalled` flow (same one used for a fresh channel pick); this PR only widens the set of states that can reach it.
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A.

Note: the fallback is gated on `getTrustedChannelPluginCatalogEntry`, which filters out untrusted workspace shadows via `isTrustedWorkspaceChannelCatalogEntry` in `src/commands/channel-setup/trusted-catalog.ts` — the same trust model used for the existing auto-install path, so this does not introduce a new trust boundary.

## Repro + Verification

### Environment

- **OS**: Linux (bash 5.2)
- **Runtime/container**: Node v24.14.0 via nvm, monorepo at `/data/workspace/Maintainer/openclaw`, pnpm 10.33.2
- **Model/provider**: N/A (onboard flow, no model call)
- **Integration/channel (if any)**: `qqbot` (externalized channel plugin, `@openclaw/qqbot`)
- **Relevant config (redacted)**:
  ```json
  {
    "channels": {
      "qqbot": {
        "enabled": true,
        "appId": "<redacted>",
        "clientSecret": "<redacted>"
      }
    },
    "plugins": { "entries": { /* qqbot deliberately absent */ } }
  }
  ```

### Steps

1. Start from a clean `fix/onboard-stale-channel-config-fallback` checkout; run `pnpm install && pnpm build`.
2. `pnpm openclaw plugins uninstall qqbot 2>/dev/null; rm -rf ~/.openclaw/plugins/@openclaw/qqbot` to guarantee the plugin is absent.
3. Inject the stale entry:
   ```
   jq '.channels.qqbot = { "enabled": true, "appId": "999999999", "clientSecret": "stale" } | del(.plugins.entries.qqbot)' \
      ~/.openclaw/openclaw.json > /tmp/o.json && mv /tmp/o.json ~/.openclaw/openclaw.json
   ```
4. `pnpm openclaw onboard` → select `QQ Bot (Official API)` from the QuickStart menu.

### Expected

- Onboard prints `Installed QQ Bot plugin` and enters the QQ-bot setup wizard (scan-code / manual / later). `qqbot plugin not available.` is never printed.

### Actual

- Matches expected output. See captured terminal transcript under "Evidence after fix" above.

## Evidence

- [x] Failing test/log before + passing after: before-fix terminal capture and after-fix terminal capture both included in "Real behavior proof".
- [x] Trace/log snippets: `Config warnings: - plugins.entries.qqbot: plugin not installed ...` disappears after the fix.
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Test suite:
```
$ node_modules/.bin/vitest run --config test/vitest/vitest.unit-fast.config.ts src/flows/channel-setup.test.ts
 RUN  v4.1.5 /data/workspace/Maintainer/openclaw
 ✓ unit-fast src/flows/channel-setup.test.ts (13 tests) 242ms
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

(9 pre-existing + 4 newly added cases, all green.)

## Human Verification (required)

- **Verified scenarios**:
  - Stale `channels.qqbot` + missing `@openclaw/qqbot` on disk → onboard auto-installs and enters setup wizard. ✅
  - Clean config (no `channels.qqbot`, no installed plugin) → unchanged happy path via `catalogEntry`. ✅
  - `pnpm openclaw plugins uninstall qqbot` from an already-configured state → subsequent onboard reinstalls correctly. ✅
- **Edge cases checked**:
  - `channels.qqbot = { "enabled": true }` only (no non-`enabled` fields) → `isStaticallyChannelConfigured` stays false, channel stays in `installableCatalogEntries`, original auto-install path is used (no behavior change). ✅
  - `vi.clearAllMocks()` resets `getTrustedChannelPluginCatalogEntry` to returning `undefined` between tests, so pre-existing tests still exercise the legacy `else → enableBundledPluginForSetup` branch unchanged. ✅
  - Catalog entry without `install.npmSpec` (purely bundled channel, unknown channel) → still falls through to `enableBundledPluginForSetup` (no regression). Verified by the new test's guard `fallbackCatalogEntry?.install?.npmSpec` branch plus the existing bundled-path tests. ✅
- **What I did not verify**:
  - End-to-end npm install failure path (network error, registry outage) — relies on `ensureChannelSetupPluginInstalled`'s existing error handling which is unchanged.
  - Non-qqbot externalized channels manually; their behavior is covered only by the shared code path and unit tests.
  - Windows / macOS runtimes.
  - ClawHub-only catalog entries (all my manual runs hit the npm-spec branch).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes** — a strict superset of the previous flow; only channels with a catalog `install.npmSpec` reach the new code path, and behavior for channels without one is unchanged.
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A.
