### PR TITLE
fix(control-ui): read exec policy from tools.exec.security instead of agents.defaults.exec.security

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -592,6 +592,14 @@ function extractQuickSettingsSecurity(state: AppViewState): {
       }
     }
   }
+  const tools = cfg.tools;
+  if (tools && typeof tools === "object") {
+    const t = tools as Record<string, unknown>;
+    const exec = t.exec && typeof t.exec === "object" ? (t.exec as Record<string, unknown>) : null;
+    if (exec && typeof exec.security === "string") {
+      execPolicy = exec.security;
+    }
+  }
   let deviceAuth = true;
   if (gateway) {
     const controlUi =


### PR DESCRIPTION
## Summary

The Control UI Settings page was reading exec policy from `agents.defaults.exec.security`, but the actual config key that controls exec security policy is `tools.exec.security`. This caused the UI to always show "allowlist" even when the user had set `tools.exec.security` to "full".

## Root Cause

The `extractQuickSettingsSecurity` function in `ui/src/ui/app-render.ts` was reading from the wrong config path. The real exec security policy lives at `tools.exec.security`, not `agents.defaults.exec.security`.

## Fix

Check `tools.exec.security` after `agents.defaults.exec.security`, so the actual active policy takes precedence.

Fixes #78311