### PR TITLE
fix(ui): update exec policy config path in quick settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Control UI: Correct configuration path from `agents.defaults.exec.security` to `tools.exec.security` in Quick Settings security card. Fixes #78311. (#78350)
 - Plugin skills/Windows: publish plugin-provided skill directories as junctions on Windows so standard users without Developer Mode can register plugin skills without symlink EPERM failures. Fixes #77958. (#77971) Thanks @hclsys and @jarro.
 - MS Teams: surface blocked Bot Framework egress by logging JWKS fetch network failures and adding a Bot Connector send hint for transport-level reply failures. Fixes #77674. (#78081) Thanks @Beandon13.
 - Gateway/sessions: fast-path already-qualified model refs while building session-list rows so `openclaw sessions` and Control UI session lists avoid heavyweight model resolution on large stores. (#77902) Thanks @ragesaq.

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -578,17 +578,14 @@ function extractQuickSettingsSecurity(state: AppViewState): {
       gatewayAuth = "none";
     }
   }
-  const agents = cfg.agents;
+  const tools = cfg.tools;
   let execPolicy = "allowlist";
-  if (agents && typeof agents === "object") {
-    const defaults = (agents as Record<string, unknown>).defaults;
-    if (defaults && typeof defaults === "object") {
-      const exec = (defaults as Record<string, unknown>).exec;
-      if (exec && typeof exec === "object") {
-        const security = (exec as Record<string, unknown>).security;
-        if (typeof security === "string") {
-          execPolicy = security;
-        }
+  if (tools && typeof tools === "object") {
+    const exec = (tools as Record<string, unknown>).exec;
+    if (exec && typeof exec === "object") {
+      const security = (exec as Record<string, unknown>).security;
+      if (typeof security === "string") {
+        execPolicy = security;
       }
     }
   }


### PR DESCRIPTION
## Summary
- **Problem**: The Control UI Settings/Exec section incorrectly displays "Exec Policy: allowlist" even when `tools.exec.security` is set to "full" in `openclaw.json`. This is because the frontend incorrectly reads from the non-existent path `agents.defaults.exec.security`.
- **What changed**: Updated `extractQuickSettingsSecurity` in `ui/src/ui/app-render.ts` to read from the correct configuration path: `tools.exec.security`.
- **Why it matters**: Users need accurate feedback in the UI to confirm their security policies are active.

## Change Type
- Bug fix

## Scope
- UI / DX

## Linked Issue/PR
- Fixes #78311

## User-visible / Behavior Changes
- The Settings card in the Control UI now correctly reflects the active Exec security policy configured in `openclaw.json`.

## Security Impact (required)
- **New permissions/capabilities?** No
- **Secrets/tokens handling changed?** No
- **New/changed network calls?** No
- **Command/tool execution surface changed?** No
- **Data access scope changed?** No

## Repro + Verification

### Environment
- **OS**: Linux (Ubuntu 6.8)
- **Model**: Gemini 3 Flash Preview
- **Relevant config**: `"tools": { "exec": { "security": "full" } }`

### Steps
1. Set `tools.exec.security` to `"full"` in `~/.openclaw/openclaw.json`.
2. Restart the gateway.
3. Navigate to the Control UI Settings page.

### Expected
- Exec Policy shows `full`.

### Actual (before fix)
- Exec Policy shows `allowlist`.

## Evidence
- Local manual verification of the state extraction logic shows it now correctly pulls from `cfg.tools.exec.security`.
- Verified by Alex (AI agent) on behalf of chouzz.

## AI-assisted PR
- [x] AI-assisted (Claude Code + Alex)
- [x] Human-run real behavior proof 
- [x] Confirmed understanding of code changes
