### PR TITLE
[Fix] Preserve node reconnect state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -600,6 +600,7 @@ Docs: https://docs.openclaw.ai
 - Managed proxy/security: classify raw socket callsites and proxy runtime mutations in boundary checks so new direct egress or unmanaged proxy-state changes cannot land without explicit review. (#77126) Thanks @jesse-merhi.
 - Channels/iMessage: surface the silent group-allowlist drop at default log level by emitting a one-time `warn` per account at monitor startup when `channels.imessage.groupPolicy: "allowlist"` is set without a `channels.imessage.groups` block, plus a one-time `warn` per `chat_id` when the runtime gate drops a specific group, naming the exact `channels.imessage.groups[...]` key to add to allow it. Fixes #78749. (#79190) Thanks @omarshahine.
 - WhatsApp: stop Gateway-originated outbound echoes from advancing inbound activity in `openclaw channels status`, so outbound self-sends no longer look like handled inbound messages. Fixes #79056. (#79057) Thanks @ai-hpc and @bittoby.
+- Gateway/nodes: preserve the live node registry session and invoke ownership when an older same-node WebSocket closes after reconnecting. (#78351) Thanks @samzong.
 
 ## 2026.5.3-1
 

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { NodeRegistry } from "./node-registry.js";
+import type { GatewayWsClient } from "./server/ws-types.js";
+
+function makeClient(connId: string, nodeId: string, sent: string[] = []): GatewayWsClient {
+  return {
+    connId,
+    usesSharedGatewayAuth: false,
+    socket: {
+      send(frame: unknown) {
+        if (typeof frame === "string") {
+          sent.push(frame);
+        }
+      },
+    } as unknown as GatewayWsClient["socket"],
+    connect: {
+      client: { id: "openclaw-macos", version: "1.0.0", platform: "darwin", mode: "node" },
+      device: {
+        id: nodeId,
+        publicKey: "public-key",
+        signature: "signature",
+        signedAt: 1,
+        nonce: "nonce",
+      },
+    } as GatewayWsClient["connect"],
+  };
+}
+
+describe("gateway/node-registry", () => {
+  it("keeps a reconnected node when the old connection unregisters", async () => {
+    const registry = new NodeRegistry();
+    const oldFrames: string[] = [];
+    const newClient = makeClient("conn-new", "node-1");
+
+    registry.register(makeClient("conn-old", "node-1", oldFrames), {});
+    const oldInvoke = registry.invoke({
+      nodeId: "node-1",
+      command: "system.run",
+      timeoutMs: 1_000,
+    });
+    const oldDisconnected = oldInvoke.catch((err: unknown) => err);
+    const oldRequest = JSON.parse(oldFrames[0] ?? "{}") as { payload?: { id?: string } };
+    const newSession = registry.register(newClient, {});
+
+    expect(
+      registry.handleInvokeResult({
+        id: oldRequest.payload?.id ?? "",
+        nodeId: "node-1",
+        connId: "conn-new",
+        ok: true,
+      }),
+    ).toBe(false);
+    expect(registry.unregister("conn-old")).toBeNull();
+    expect(registry.get("node-1")).toBe(newSession);
+    await expect(oldDisconnected).resolves.toBeInstanceOf(Error);
+  });
+});

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -24,6 +24,7 @@ export type NodeSession = {
 
 type PendingInvoke = {
   nodeId: string;
+  connId: string;
   command: string;
   resolve: (value: NodeInvokeResult) => void;
   reject: (err: Error) => void;
@@ -88,16 +89,19 @@ export class NodeRegistry {
       return null;
     }
     this.nodesByConn.delete(connId);
-    this.nodesById.delete(nodeId);
+    const unregistersCurrentNode = this.nodesById.get(nodeId)?.connId === connId;
+    if (unregistersCurrentNode) {
+      this.nodesById.delete(nodeId);
+    }
     for (const [id, pending] of this.pendingInvokes.entries()) {
-      if (pending.nodeId !== nodeId) {
+      if (pending.connId !== connId) {
         continue;
       }
       clearTimeout(pending.timer);
       pending.reject(new Error(`node disconnected (${pending.command})`));
       this.pendingInvokes.delete(id);
     }
-    return nodeId;
+    return unregistersCurrentNode ? nodeId : null;
   }
 
   listConnected(): NodeSession[] {
@@ -150,6 +154,7 @@ export class NodeRegistry {
       }, timeoutMs);
       this.pendingInvokes.set(requestId, {
         nodeId: params.nodeId,
+        connId: node.connId,
         command: params.command,
         resolve,
         reject,
@@ -161,6 +166,7 @@ export class NodeRegistry {
   handleInvokeResult(params: {
     id: string;
     nodeId: string;
+    connId: string | undefined;
     ok: boolean;
     payload?: unknown;
     payloadJSON?: string | null;
@@ -170,7 +176,7 @@ export class NodeRegistry {
     if (!pending) {
       return false;
     }
-    if (pending.nodeId !== params.nodeId) {
+    if (pending.nodeId !== params.nodeId || pending.connId !== params.connId) {
       return false;
     }
     clearTimeout(pending.timer);

--- a/src/gateway/server-methods/nodes.handlers.invoke-result.ts
+++ b/src/gateway/server-methods/nodes.handlers.invoke-result.ts
@@ -54,6 +54,7 @@ export const handleNodeInvokeResult: GatewayRequestHandler = async ({
   const ok = context.nodeRegistry.handleInvokeResult({
     id: p.id,
     nodeId: p.nodeId,
+    connId: client?.connId,
     ok: p.ok,
     payload: p.payload,
     payloadJSON: p.payloadJSON ?? null,

--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -274,7 +274,6 @@ describe("attachGatewayWsConnectionHandler", () => {
       clients: new Set(),
       preauthConnectionBudget: { release: vi.fn() } as never,
       port: 19001,
-      canvasHostEnabled: false,
       resolvedAuth: createResolvedAuth("token"),
       gatewayMethods: [],
       events: [],

--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -3,12 +3,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { WebSocketServer } from "ws";
 import type { ResolvedGatewayAuth } from "../auth.js";
 
-const { attachGatewayWsMessageHandlerMock } = vi.hoisted(() => ({
-  attachGatewayWsMessageHandlerMock: vi.fn(),
-}));
+const { attachGatewayWsMessageHandlerMock, broadcastPresenceSnapshotMock, upsertPresenceMock } =
+  vi.hoisted(() => ({
+    attachGatewayWsMessageHandlerMock: vi.fn(),
+    broadcastPresenceSnapshotMock: vi.fn(),
+    upsertPresenceMock: vi.fn(),
+  }));
 
 vi.mock("./ws-connection/message-handler.js", () => ({
   attachGatewayWsMessageHandler: attachGatewayWsMessageHandlerMock,
+}));
+vi.mock("../../infra/system-presence.js", () => ({
+  upsertPresence: upsertPresenceMock,
+}));
+vi.mock("./presence-events.js", () => ({
+  broadcastPresenceSnapshot: broadcastPresenceSnapshotMock,
 }));
 
 import { attachGatewayWsConnectionHandler } from "./ws-connection.js";
@@ -122,6 +131,8 @@ async function connectTestWs(
 describe("attachGatewayWsConnectionHandler", () => {
   beforeEach(() => {
     attachGatewayWsMessageHandlerMock.mockReset();
+    broadcastPresenceSnapshotMock.mockReset();
+    upsertPresenceMock.mockReset();
   });
 
   afterEach(() => {
@@ -233,5 +244,80 @@ describe("attachGatewayWsConnectionHandler", () => {
     socket.emit("close", 1000, Buffer.from("done"));
     vi.advanceTimersByTime(25_000);
     expect(socket.ping).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips node presence disconnects for stale reconnected sockets", async () => {
+    const listeners = new Map<string, (...args: unknown[]) => void>();
+    const unregister = vi.fn(() => null);
+    const wss = {
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        listeners.set(event, handler);
+      }),
+    } as unknown as WebSocketServer;
+    const socket = Object.assign(new EventEmitter(), {
+      _socket: {
+        remoteAddress: "127.0.0.1",
+        remotePort: 1234,
+        localAddress: "127.0.0.1",
+        localPort: 5678,
+      },
+      send: vi.fn(),
+      close: vi.fn(),
+    });
+    const upgradeReq = {
+      headers: { host: "127.0.0.1:19001" },
+      socket: { localAddress: "127.0.0.1" },
+    };
+
+    attachGatewayWsConnectionHandler({
+      wss,
+      clients: new Set(),
+      preauthConnectionBudget: { release: vi.fn() } as never,
+      port: 19001,
+      canvasHostEnabled: false,
+      resolvedAuth: createResolvedAuth("token"),
+      gatewayMethods: [],
+      events: [],
+      refreshHealthSnapshot: vi.fn(),
+      logGateway: createLogger() as never,
+      logHealth: createLogger() as never,
+      logWsControl: createLogger() as never,
+      extraHandlers: {},
+      broadcast: vi.fn(),
+      buildRequestContext: () =>
+        ({
+          unsubscribeAllSessionEvents: vi.fn(),
+          nodeRegistry: { unregister },
+          nodeUnsubscribeAll: vi.fn(),
+        }) as never,
+    });
+
+    const onConnection = listeners.get("connection");
+    expect(onConnection).toBeTypeOf("function");
+    onConnection?.(socket, upgradeReq);
+    await waitForLazyMessageHandler();
+
+    const passed = attachGatewayWsMessageHandlerMock.mock.calls[0]?.[0] as {
+      setClient: (client: unknown) => boolean;
+    };
+    expect(
+      passed.setClient({
+        socket,
+        connect: {
+          role: "node",
+          client: { id: "openclaw-macos", mode: "node" },
+          device: { id: "node-1" },
+        },
+        connId: "conn-old",
+        presenceKey: "node-1",
+        usesSharedGatewayAuth: false,
+      }),
+    ).toBe(true);
+
+    socket.emit("close", 1000, Buffer.from("stale"));
+
+    expect(unregister).toHaveBeenCalledTimes(1);
+    expect(upsertPresenceMock).not.toHaveBeenCalled();
+    expect(broadcastPresenceSnapshotMock).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -387,19 +387,23 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
           `webchat disconnected code=${code} reason=${logReason || "n/a"} conn=${connId}`,
         );
       }
-      if (client?.presenceKey) {
+      const context = buildRequestContext();
+      context.unsubscribeAllSessionEvents(connId);
+      let currentDisconnectedNodeId: string | null = null;
+      if (client?.connect?.role === "node") {
+        currentDisconnectedNodeId = context.nodeRegistry.unregister(connId);
+      }
+      if (
+        client?.presenceKey &&
+        (client.connect.role !== "node" || currentDisconnectedNodeId !== null)
+      ) {
         upsertPresence(client.presenceKey, { reason: "disconnect" });
         broadcastPresenceSnapshot({ broadcast, incrementPresenceVersion, getHealthVersion });
       }
-      const context = buildRequestContext();
-      context.unsubscribeAllSessionEvents(connId);
-      if (client?.connect?.role === "node") {
-        const nodeId = context.nodeRegistry.unregister(connId);
-        if (nodeId) {
-          removeRemoteNodeInfo(nodeId);
-          context.nodeUnsubscribeAll(nodeId);
-          clearNodeWakeState(nodeId);
-        }
+      if (currentDisconnectedNodeId) {
+        removeRemoteNodeInfo(currentDisconnectedNodeId);
+        context.nodeUnsubscribeAll(currentDisconnectedNodeId);
+        clearNodeWakeState(currentDisconnectedNodeId);
       }
       logWs("out", "close", {
         connId,


### PR DESCRIPTION
## Summary

- Problem: a stale node WebSocket close could unregister or mark disconnected state for a node that had already reconnected with the same node id.
- Why it matters: gateway node presence, `node.list`, and node invokes can diverge during reconnect races, making a live node appear disconnected until another presence update arrives.
- What changed: `NodeRegistry` now scopes pending invokes and stale unregister cleanup by `connId`; `node.invoke.result` matches pending work by `nodeId + connId`; WebSocket close handling only writes node disconnect presence when the closing socket still owns the current node session.
- What did NOT change (scope boundary): no protocol schema changes, no node pairing changes, and no reconnect policy changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: stale node socket close after reconnect should not clear the new live node session, should not complete new-connection pending invokes from the old connection, and should not broadcast a node presence disconnect for the replacement session.
- Real environment tested: local macOS workspace with Node/pnpm test runner plus a real Gateway WebSocket reconnect harness using a paired node-role client.
- Exact steps or command run after this patch: `pnpm test src/gateway/node-registry.test.ts src/gateway/gateway-misc.test.ts src/gateway/server/ws-connection.test.ts -- --reporter=verbose`; `pnpm check:changed`; one-off `pnpm exec tsx` live Gateway harness that starts a loopback Gateway, pairs operator and node devices, connects the same node id twice, closes the old socket late, then verifies `node.list`, `node.invoke`, and `system-presence`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): targeted tests passed: 3 files, 40 tests; `pnpm check:changed` passed core/coreTests typecheck, lint, and guards; live Gateway reconnect harness passed with copied terminal output:

```text
LIVE_PROOF_PASS pr=78351 sha=5e74a09d24ba501c821b68390a1135cc4f0f70fc
gateway_url=ws://127.0.0.1:49817
node_id=c628f148a45664d0a21cf434846fed9e68b115e4c2eee4eb3a2b42d9d20931d9
before_reconnect.connected=true commands=["device.info"]
after_reconnect.connected=true commands=["device.info"]
after_old_close.connected=true commands=["device.info"]
invoke.payload.handledBy=new
presence.reason=connect presence.instanceId=c628f148a45664d0a21cf434846fed9e68b115e4c2eee4eb3a2b42d9d20931d9
invoke_requests.old=0 invoke_requests.new=1
```

- Observed result after fix: stale unregister returns `null`, keeps the reconnected session, rejects only the old connection's pending invokes, ignores mismatched invoke results, skips node presence disconnect broadcast for stale sockets, and the live replacement node still handles `node.invoke` after the old socket closes.
- What was not tested: physical mobile/desktop app binary reconnect. A live loopback Gateway WebSocket reconnect with a paired node-role client was tested.
- Before evidence (optional but encouraged): the added `node-registry` regression fails on the old implementation because `unregister(oldConnId)` deletes the current `nodesById` entry.

## Root Cause (if applicable)

- Root cause: `NodeRegistry.unregister(connId)` resolved the old connection to a `nodeId` and then cleaned `nodesById`, pending invokes, and close-side node state by `nodeId` without verifying that the closing connection still owned the current node session.
- Missing detection / guardrail: no regression test covered reconnecting the same node id before the old socket close event ran.
- Contributing context (if known): node sessions are keyed by `nodeId`, while WebSocket lifecycle events are keyed by `connId`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/node-registry.test.ts`; `src/gateway/server/ws-connection.test.ts`.
- Scenario the test should lock in: old/new connections with the same node id, stale old close, current session preserved, stale invoke result rejected, old pending invoke disconnected, and stale close presence disconnect skipped.
- Why this is the smallest reliable guardrail: it exercises the registry and close-handler seams directly without starting a full Gateway process.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

A reconnected node should no longer briefly appear disconnected or lose pending node invoke state because an older socket closed late.

## Diagram (if applicable)

```text
Before:
old socket close -> unregister(nodeId) -> deletes new session / broadcasts disconnect

After:
old socket close -> unregister(connId) -> stale close returns null -> new session remains live
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local development workspace
- Runtime/container: Node 22+ via repo pnpm scripts
- Model/provider: N/A
- Integration/channel (if any): Gateway node WebSocket lifecycle
- Relevant config (redacted): default local test configuration; live harness used an isolated temporary `OPENCLAW_STATE_DIR` and loopback token auth

### Steps

1. Register an old node connection for `node-1` and start a node invoke.
2. Register a new node connection for the same `node-1`.
3. Deliver a result from the wrong `connId`, then close the old connection.
4. Exercise the WebSocket close handler where `nodeRegistry.unregister(connId)` returns `null` for a stale node socket.
5. In the live harness, start a real loopback Gateway, pair operator and node devices, connect the same node id twice, close the old socket, then verify the replacement node remains connected and handles `node.invoke`.

### Expected

- The new session remains registered.
- The mismatched invoke result is ignored.
- The old pending invoke is rejected on old socket close.
- The stale close does not write or broadcast node presence disconnect.
- The replacement live node remains visible in `node.list`, keeps connected presence, and handles `node.invoke` after the old socket closes.

### Actual

- Matches expected in the new regression tests and in the live Gateway reconnect harness.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted registry reconnect race, stale invoke result rejection, old pending invoke disconnect cleanup, stale close presence disconnect skip, and live Gateway WebSocket reconnect where the replacement node remains connected and handles `node.invoke` after the stale old socket closes.
- Edge cases checked: `node.invoke.result` still treats unknown/late invoke ids as ignored success through `gateway-misc.test.ts`; current close cleanup remains gated on `unregister` returning the active node id.
- What you did **not** verify: reconnect with a physical mobile/desktop app binary.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: close-handler ordering changes could affect non-node clients.
  - Mitigation: disconnect presence still runs for non-node clients with a `presenceKey`; the new guard only suppresses node disconnect presence when `unregister(connId)` reports a stale close.

## Considered and deferred

- src/gateway/server/ws-connection.test.ts:321 [BOT-NIT]: New test repeats the local socket harness pattern already used in this file. Extracting a helper would be cleanup, not a correctness fix, and would broaden this commit.
