### PR TITLE
fix(ui): read exec security from tools.exec.security (#78311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ Docs: https://docs.openclaw.ai
 - Web fetch: bound guarded dispatcher cleanup after request timeouts so timed-out fetches return tool errors instead of leaving Gateway tool lanes active. (#78439) Thanks @obviyus.
 - Mattermost/setup: prompt for and persist the server base URL after the bot token in `openclaw setup --wizard`, instead of failing validation before `--http-url` is collected. Fixes #76670. Thanks @jacobtomlinson.
 - Gate Slack startup user allowlist resolution [AI]. (#77898) Thanks @pgondhi987.
+- Control UI: read the Quick Settings exec policy from the canonical `tools.exec.security` config path instead of the non-existent `agents.defaults.exec.security` path, so the Settings card reflects the user's actual exec security setting (`full`/`deny`/`allowlist`) instead of always rendering the literal default. Fixes #78311. Thanks @markvivv.
 - OpenAI/Codex: suppress stale `openai-codex` GPT-5.1/5.2/5.3 model refs that ChatGPT/Codex OAuth accounts now reject, keeping model lists, config validation, and forward-compat resolution on current 5.4/5.5 routes. Fixes #67158. Thanks @drpau.
 - CLI/update: keep pnpm package updates on the running custom global install root and pass pnpm's `--global-dir` so `openclaw update` does not create a second default-prefix install when `OPENCLAW_HOME` or the shell points at a custom OpenClaw directory. Fixes #78377. Thanks @amknight.
 - Google Meet/Voice Call: wait longer before playing PIN-derived Twilio DTMF for Meet dial-in prompts and retire stale delegated phone sessions instead of reusing completed calls.

--- a/ui/src/ui/app-render.exec-policy.test.ts
+++ b/ui/src/ui/app-render.exec-policy.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment node
+// @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 import { extractQuickSettingsSecurity } from "./app-render.ts";
 import type { AppViewState } from "./app-view-state.ts";

--- a/ui/src/ui/app-render.exec-policy.test.ts
+++ b/ui/src/ui/app-render.exec-policy.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { extractQuickSettingsSecurity } from "./app-render.ts";
+import type { AppViewState } from "./app-view-state.ts";
+
+function makeState(config: Record<string, unknown>): AppViewState {
+  // Only configForm is read by extractQuickSettingsSecurity, so this minimal
+  // cast is enough — the test deliberately exercises the config-shape
+  // contract that the Quick Settings card relies on.
+  return { configForm: config } as unknown as AppViewState;
+}
+
+describe("extractQuickSettingsSecurity", () => {
+  it("reads execPolicy from the canonical tools.exec.security path", () => {
+    const result = extractQuickSettingsSecurity(
+      makeState({ tools: { exec: { security: "full" } } }),
+    );
+    expect(result.execPolicy).toBe("full");
+  });
+
+  it("reads execPolicy from tools.exec.security when set to deny", () => {
+    const result = extractQuickSettingsSecurity(
+      makeState({ tools: { exec: { security: "deny" } } }),
+    );
+    expect(result.execPolicy).toBe("deny");
+  });
+
+  it("falls back to the literal allowlist default when tools.exec.security is missing", () => {
+    expect(extractQuickSettingsSecurity(makeState({})).execPolicy).toBe("allowlist");
+    expect(extractQuickSettingsSecurity(makeState({ tools: { exec: {} } })).execPolicy).toBe(
+      "allowlist",
+    );
+  });
+
+  it("ignores the legacy non-existent agents.defaults.exec.security path", () => {
+    // Regression for https://github.com/openclaw/openclaw/issues/78311 where
+    // the Control UI Quick Settings card read from a config path that does
+    // not exist in the schema, so it always rendered "allowlist" regardless
+    // of the user's actual tools.exec.security setting.
+    const result = extractQuickSettingsSecurity(
+      makeState({
+        tools: { exec: { security: "full" } },
+        agents: { defaults: { exec: { security: "deny" } } },
+      }),
+    );
+    expect(result.execPolicy).toBe("full");
+  });
+
+  it("trims whitespace and ignores empty strings", () => {
+    expect(
+      extractQuickSettingsSecurity(makeState({ tools: { exec: { security: "  full  " } } }))
+        .execPolicy,
+    ).toBe("full");
+    expect(
+      extractQuickSettingsSecurity(makeState({ tools: { exec: { security: "   " } } })).execPolicy,
+    ).toBe("allowlist");
+  });
+
+  it("returns the unknown sentinel when configForm is absent", () => {
+    const result = extractQuickSettingsSecurity({} as AppViewState);
+    expect(result).toEqual({
+      gatewayAuth: "unknown",
+      execPolicy: "unknown",
+      deviceAuth: false,
+    });
+  });
+});

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -545,7 +545,7 @@ function extractMcpServerCount(state: AppViewState): number {
   return Object.keys(servers).length;
 }
 
-function extractQuickSettingsSecurity(state: AppViewState): {
+export function extractQuickSettingsSecurity(state: AppViewState): {
   gatewayAuth: string;
   execPolicy: string;
   deviceAuth: boolean;
@@ -578,17 +578,21 @@ function extractQuickSettingsSecurity(state: AppViewState): {
       gatewayAuth = "none";
     }
   }
-  const agents = cfg.agents;
+  // The canonical exec security key is `tools.exec.security` (see
+  // `src/node-host/invoke-system-run.ts` which reads
+  // `cfg.tools?.exec?.security` as the global default and per-agent
+  // `agents.list[i].tools.exec.security` as the override). The previously
+  // read `agents.defaults.exec.security` path does not exist in the schema,
+  // so this card always fell back to the literal "allowlist" default even
+  // when the user had set `tools.exec.security` to "full" or "deny".
   let execPolicy = "allowlist";
-  if (agents && typeof agents === "object") {
-    const defaults = (agents as Record<string, unknown>).defaults;
-    if (defaults && typeof defaults === "object") {
-      const exec = (defaults as Record<string, unknown>).exec;
-      if (exec && typeof exec === "object") {
-        const security = (exec as Record<string, unknown>).security;
-        if (typeof security === "string") {
-          execPolicy = security;
-        }
+  const tools = cfg.tools;
+  if (tools && typeof tools === "object") {
+    const exec = (tools as Record<string, unknown>).exec;
+    if (exec && typeof exec === "object") {
+      const security = (exec as Record<string, unknown>).security;
+      if (typeof security === "string" && security.trim()) {
+        execPolicy = security.trim();
       }
     }
   }


### PR DESCRIPTION
## Summary

The Control UI Settings/Exec section displays Exec Policy: allowlist even after the user has set tools.exec.security to full in openclaw.json. The frontend reads from the wrong config path.

Fixes #78311

## Root Cause

extractQuickSettingsSecurity() reads exec security from cfg.agents.defaults.exec.security, but the actual config key is cfg.tools.exec.security.

## Fix

Read from cfg.tools.exec.security with trim/empty-guard. Export helper for testing.

## Changes

- ui/src/ui/app-render.ts: Read tools.exec.security with trim/empty-guard
- ui/src/ui/app-render.exec-policy.test.ts: 6 regression tests
- CHANGELOG.md: Unreleased Fixes entry

## Attribution

Cherry-picked from @BSG2000 PR #78448. Original author preserved via git cherry-pick.

## Real behavior proof

- **Behavior or issue addressed**: Control UI reads exec security from wrong config path
- **Real environment tested**: macOS ARM64, OpenClaw main branch, Node v25.9.0
- **Exact steps or command run after this patch**: rg 'exec.*security' src/config/schema.labels.ts && rg 'agents.defaults.exec' src/config/schema.labels.ts && pnpm test ui/src/ui/app-render.exec-policy.test.ts && git diff -- ui/src/ui/app-render.ts
- **Evidence after fix**:
```
$ rg 'exec.*security' src/config/schema.labels.ts
229:  "tools.exec.security": "Exec Security",

$ rg 'agents.defaults.exec' src/config/schema.labels.ts
(no results)

$ pnpm test ui/src/ui/app-render.exec-policy.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)

$ git diff -- ui/src/ui/app-render.ts
-  const agents = cfg.agents;
+  const tools = cfg.tools;
+  if (tools && typeof tools === "object") {
+    const exec = (tools as Record<string, unknown>).exec;
```
- **Observed result after fix**: extractQuickSettingsSecurity now reads cfg.tools.exec.security correctly. With tools.exec.security: full configured, the UI displays full instead of the hardcoded fallback allowlist.
- **What was not tested**: Live runtime UI rendering with gateway session (requires running gateway). The fix is a read-only config path correction verified by schema path alignment and unit regression test.
