### PR TITLE
fix: skip module loading for disabled plugins in loadOpenClawPlugins

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2494,6 +2494,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         record.status = "disabled";
         record.error = enableState.reason;
         markPluginActivationDisabled(record, enableState.reason);
+        registry.plugins.push(record);
+        seenIds.set(pluginId, candidate.origin);
+        continue;
       }
 
       if (


### PR DESCRIPTION
When a plugin's enableState.enabled is false, the loader previously set the record
  status to "disabled" but continued to execute the module loading code path below.
  This caused bundled plugins with missing runtime dependencies (e.g. feishu's
  @larksuiteoapi/node-sdk) to crash with MODULE_NOT_FOUND during config-reload and
  gateway request handling.

  Now the disabled branch properly pushes the record, marks the seen ID, and continues
   to the next plugin — matching the pattern used by other early-exit conditions in
  the same loop.

  Closes #78321

  ## Summary

  - Problem: Disabled bundled plugins (e.g. feishu) still had their modules loaded via
   `getJiti()`, crashing with `MODULE_NOT_FOUND` when runtime deps like
  `@larksuiteoapi/node-sdk` are missing
  - Why it matters: Recurring crashes in config-reload and gateway request paths on
  vanilla installs; `openclaw plugins disable` CLI also crashes with the same error
  it's meant to silence
  - What changed: Added `registry.plugins.push(record)`, `seenIds.set(pluginId,
  candidate.origin)`, and `continue` to the `!enableState.enabled` branch in
  `loadOpenClawPlugins`, so disabled plugins skip module loading entirely
  - What did NOT change (scope boundary): No changes to the enable-state resolution
  logic, bundled plugin packaging, or the `plugins disable` CLI command itself — the
  CLI fix is a side effect of the loader now correctly short-circuiting

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [x] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #78321
  - Related #
  - [x] This PR fixes a bug or regression

  ## Real behavior proof (required for external PRs)

  - Behavior or issue addressed: `MODULE_NOT_FOUND` crash for
  `@larksuiteoapi/node-sdk` during config-reload and gateway request handling
  - Real environment tested: macOS 26.2, node v25.6.1, openclaw installed from source
  (commit b3d9948c4c)
  - Exact steps or command run after this patch: `openclaw daemon restart && sleep 5
  && tail gateway.err.log` — zero `MODULE_NOT_FOUND` occurrences; `openclaw plugins
  inspect feishu` shows `Status: disabled in config`
  - Evidence after fix: No `[reload] config restart failed` or `[gateway] request
  handler failed` entries referencing `@larksuiteoapi/node-sdk` after 30s observation
  - Observed result after fix: feishu plugin record exists in registry with `status:
  "disabled"`, no module evaluation attempted
  - What was not tested: feishu plugin with SDK actually installed and enabled (don't
  have Feishu credentials)
  - Before evidence: See issue #78321 production log evidence (7 occurrences over 13
  days)

  ## Root Cause (if applicable)

  - Root cause: The `!enableState.enabled` branch at line 2493 in `loader.ts` set
  status and called `markPluginActivationDisabled()` but did not `continue` —
  execution fell through to the module loading block at line 2725 which calls
  `getJiti(safeSource)(safeImportSource)`, triggering the full import chain
  - Missing detection / guardrail: No test asserts that disabled plugins skip module
  evaluation; the loop has 6 other early-exit patterns that all use `continue`, this
  one was the exception
  - Contributing context: The `shouldInstallBundledRuntimeDeps` guard at line 2499
  checks `enableState.enabled` but only gates dependency installation, not the later
  unconditional module load

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [x] Unit test
    - [ ] Seam / integration test
    - [ ] End-to-end test
    - [ ] Existing coverage already sufficient
  - Target test or file: `src/plugins/loader.test.ts`
  - Scenario the test should lock in: A bundled plugin with `enabledByDefault: false`
  and a missing runtime dep should produce a `status: "disabled"` record without
  triggering module evaluation
  - Why this is the smallest reliable guardrail: Unit-level mock of `getJiti` can
  assert it was never called for disabled plugins
  - Existing test that already covers this (if any): None found
  - If no new test is added, why not: Maintainers have better context on the test
  harness setup for plugin loading; happy to add one if guided

  ## User-visible / Behavior Changes

  - Disabled bundled plugins no longer produce `MODULE_NOT_FOUND` errors in logs
  - `openclaw plugins disable <id>` no longer crashes when the target plugin has
  missing deps
  - `openclaw plugins inspect <id>` for disabled bundled plugins shows `disabled in
  config` instead of `Error: Cannot find module`

  ## Diagram (if applicable)

  ```text
  Before:
  [config-reload] -> loadOpenClawPlugins -> enableState.enabled=false -> set status
  "disabled" -> CONTINUE TO MODULE LOAD -> getJiti() -> MODULE_NOT_FOUND crash

  After:
  [config-reload] -> loadOpenClawPlugins -> enableState.enabled=false -> set status
  "disabled" -> push record + continue -> SKIP MODULE LOAD -> no crash

  Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  Repro + Verification

  Environment

  - OS: macOS 26.2 (Darwin 25.2.0)
  - Runtime/container: node v25.6.1
  - Model/provider: N/A
  - Integration/channel: feishu (bundled, never configured)
  - Relevant config: default openclaw.json, no plugins.entries.feishu key

  Steps

  1. Fresh install of openclaw (brew or npm)
  2. Trigger config reload (openclaw doctor or edit openclaw.json)
  3. Observe gateway.err.log

  Expected

  - No MODULE_NOT_FOUND errors for disabled plugins

  Actual (before fix)

  - [reload] config restart failed: Error: Cannot find module
  '@larksuiteoapi/node-sdk'

  Evidence

  - Failing test/log before + passing after
  - Trace/log snippets
  - Screenshot/recording
  - Perf numbers (if relevant)

  Human Verification (required)

  - Verified scenarios: config-reload path no longer crashes for disabled feishu
  plugin; plugin record correctly shows disabled status in registry
  - Edge cases checked: other early-exit branches in the same loop still work
  (duplicate-id, validation failure); enabled plugins still load normally
  - What you did not verify: feishu plugin with SDK installed and Feishu credentials
  configured

  Review Conversations

  - I replied to or resolved every bot review conversation I addressed in this PR.
  - I left unresolved only the conversations that still need reviewer or maintainer
  judgment.

  Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No

  Risks and Mitigations

  - Risk: A plugin that was previously disabled but still had its module loaded (for
  side-effect registration) would now skip that load
    - Mitigation: Disabled plugins should never execute — this matches the documented
  behavior and the pattern of every other early-exit in the loop. The
  shouldInstallBundledRuntimeDeps block already gates on enableState.enabled,
  confirming intent.