### PR TITLE
fix(msteams): preserve proactive thread replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Docs: https://docs.openclaw.ai
 - PDF/Codex: include extraction-fallback instructions for `openai-codex/*` PDF tool requests so Codex Responses receives its required system prompt. Fixes #77872. Thanks @anyech.
 - Onboard/channels: recover externalized channel plugins from stale `channels.<id>` config by falling back to `ensureChannelSetupPluginInstalled` via the trusted catalog when the plugin is missing on disk, so leftover `appId`/token entries no longer dead-end onboard with "<channel> plugin not available." (#78328) Thanks @sliverp.
 - Codex/app-server: forward the OpenClaw workspace bootstrap block through Codex `developerInstructions` instead of `config.instructions`, so persona/style guidance reaches the behavior-shaping app-server lane. Fixes #77363. Thanks @lonexreb.
+- MS Teams: route proactive channel sends with stored thread roots through the configured threaded reply path instead of forcing every CLI/message-tool send into a new top-level post. Fixes #78298. Thanks @amknight.
 - CLI/infer: pass minimal instructions to local `openai-codex/*` model probes and surface provider error details when `infer model run` returns no text. Fixes #76464. Thanks @lilesjtu.
 - Dependencies: override transitive `ip-address` to `10.2.0` so the runtime lockfile no longer includes the vulnerable `10.1.0` build flagged by Dependabot alert 109. Thanks @vincentkoc.
 - Feishu: hydrate missing native topic starter thread IDs before session routing so first turns and follow-ups stay in the same topic session. Fixes #78262. Thanks @joeyzenghuan.

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -574,6 +574,94 @@ describe("msteams messenger", () => {
       expect(reference.conversation?.id).toBe("19:abc@thread.tacv2;messageid=legacy-activity-id");
     });
 
+    it("sends no-context thread replies proactively with the channel thread root", async () => {
+      let capturedReference: unknown;
+      const sent: string[] = [];
+      const channelRef: StoredConversationReference = {
+        activityId: "current-msg",
+        user: { id: "user123", name: "User" },
+        agent: { id: "bot123", name: "Bot" },
+        conversation: {
+          id: "19:abc@thread.tacv2",
+          conversationType: "channel",
+        },
+        channelId: "msteams",
+        serviceUrl: "https://service.example.com",
+        threadId: "thread-root-msg-id",
+      };
+
+      const adapter: MSTeamsAdapter = {
+        continueConversation: async (_appId, reference, logic) => {
+          capturedReference = reference;
+          await logic({
+            sendActivity: createRecordedSendActivity(sent),
+            updateActivity: noopUpdateActivity,
+            deleteActivity: noopDeleteActivity,
+          });
+        },
+        process: async () => {},
+        updateActivity: noopUpdateActivity,
+        deleteActivity: noopDeleteActivity,
+      };
+
+      const ids = await sendMSTeamsMessages({
+        replyStyle: "thread",
+        adapter,
+        appId: "app123",
+        conversationRef: channelRef,
+        messages: [{ text: "hello" }],
+      });
+
+      expect(sent).toEqual(["hello"]);
+      expect(ids).toEqual(["id:hello"]);
+      const ref = capturedReference as { conversation?: { id?: string }; activityId?: string };
+      expect(ref.conversation?.id).toBe("19:abc@thread.tacv2;messageid=thread-root-msg-id");
+      expect(ref.activityId).toBeUndefined();
+    });
+
+    it("uses activityId for no-context thread replies when threadId is absent", async () => {
+      let capturedReference: unknown;
+      const sent: string[] = [];
+      const channelRef: StoredConversationReference = {
+        activityId: "legacy-activity-id",
+        user: { id: "user123", name: "User" },
+        agent: { id: "bot123", name: "Bot" },
+        conversation: {
+          id: "19:abc@thread.tacv2",
+          conversationType: "channel",
+        },
+        channelId: "msteams",
+        serviceUrl: "https://service.example.com",
+      };
+
+      const adapter: MSTeamsAdapter = {
+        continueConversation: async (_appId, reference, logic) => {
+          capturedReference = reference;
+          await logic({
+            sendActivity: createRecordedSendActivity(sent),
+            updateActivity: noopUpdateActivity,
+            deleteActivity: noopDeleteActivity,
+          });
+        },
+        process: async () => {},
+        updateActivity: noopUpdateActivity,
+        deleteActivity: noopDeleteActivity,
+      };
+
+      await sendMSTeamsMessages({
+        replyStyle: "thread",
+        adapter,
+        appId: "app123",
+        conversationRef: channelRef,
+        messages: [{ text: "hello" }],
+      });
+
+      const ref = capturedReference as { conversation?: { id?: string }; activityId?: string };
+      expect(sent).toEqual(["hello"]);
+      expect(ref.conversation?.id).toBe("19:abc@thread.tacv2;messageid=legacy-activity-id");
+      expect(ref.activityId).toBeUndefined();
+    });
+
     it("does not add thread suffix for top-level replyStyle even with threadId set", async () => {
       let capturedReference: unknown;
       const sent: string[] = [];

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -572,7 +572,7 @@ export async function sendMSTeamsMessages(params: {
   if (params.replyStyle === "thread") {
     const ctx = params.context;
     if (!ctx) {
-      throw new Error("Missing context for replyStyle=thread");
+      return await sendProactively(messages, 0, resolvedThreadId);
     }
     const messageIds: string[] = [];
     for (const [idx, message] of messages.entries()) {

--- a/extensions/msteams/src/send-context.test.ts
+++ b/extensions/msteams/src/send-context.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import type { MSTeamsConfig } from "../runtime-api.js";
+import type { StoredConversationReference } from "./conversation-store.js";
+import { resolveMSTeamsProactiveReplyStyle } from "./send-context.js";
+
+function channelRef(params?: Partial<StoredConversationReference>): StoredConversationReference {
+  return {
+    user: { id: "user-1" },
+    agent: { id: "agent-1" },
+    conversation: { id: "19:channel@thread.tacv2", conversationType: "channel" },
+    channelId: "msteams",
+    teamId: "team-1",
+    ...params,
+  };
+}
+
+describe("resolveMSTeamsProactiveReplyStyle", () => {
+  it("uses thread for channel conversations with a stored thread root", () => {
+    expect(
+      resolveMSTeamsProactiveReplyStyle({
+        cfg: {},
+        conversationId: "19:channel@thread.tacv2",
+        ref: channelRef({ threadId: "thread-root-1" }),
+        conversationType: "channel",
+      }),
+    ).toBe("thread");
+  });
+
+  it("falls back to activityId for legacy channel references", () => {
+    expect(
+      resolveMSTeamsProactiveReplyStyle({
+        cfg: {},
+        conversationId: "19:channel@thread.tacv2",
+        ref: channelRef({ activityId: "legacy-root-1" }),
+        conversationType: "channel",
+      }),
+    ).toBe("thread");
+  });
+
+  it("keeps configured top-level channel routing", () => {
+    const cfg: MSTeamsConfig = {
+      replyStyle: "thread",
+      teams: {
+        "team-1": {
+          channels: {
+            "19:channel@thread.tacv2": { replyStyle: "top-level" },
+          },
+        },
+      },
+    };
+
+    expect(
+      resolveMSTeamsProactiveReplyStyle({
+        cfg,
+        conversationId: "19:channel@thread.tacv2",
+        ref: channelRef({ threadId: "thread-root-1" }),
+        conversationType: "channel",
+      }),
+    ).toBe("top-level");
+  });
+
+  it("uses top-level when a channel has no stored thread root", () => {
+    expect(
+      resolveMSTeamsProactiveReplyStyle({
+        cfg: { replyStyle: "thread" },
+        conversationId: "19:channel@thread.tacv2",
+        ref: channelRef(),
+        conversationType: "channel",
+      }),
+    ).toBe("top-level");
+  });
+
+  it("uses top-level for non-channel conversations", () => {
+    const ref = channelRef({ activityId: "activity-1" });
+
+    expect(
+      resolveMSTeamsProactiveReplyStyle({
+        cfg: { replyStyle: "thread" },
+        conversationId: "19:group@thread.v2",
+        ref,
+        conversationType: "groupChat",
+      }),
+    ).toBe("top-level");
+    expect(
+      resolveMSTeamsProactiveReplyStyle({
+        cfg: { replyStyle: "thread" },
+        conversationId: "a:personal",
+        ref,
+        conversationType: "personal",
+      }),
+    ).toBe("top-level");
+  });
+});

--- a/extensions/msteams/src/send-context.ts
+++ b/extensions/msteams/src/send-context.ts
@@ -1,6 +1,8 @@
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import {
   resolveChannelMediaMaxBytes,
+  type MSTeamsConfig,
+  type MSTeamsReplyStyle,
   type OpenClawConfig,
   type PluginRuntime,
 } from "../runtime-api.js";
@@ -13,6 +15,7 @@ import type {
 import { formatUnknownError } from "./errors.js";
 import { resolveGraphChatId } from "./graph-upload.js";
 import type { MSTeamsAdapter } from "./messenger.js";
+import { resolveMSTeamsReplyPolicy, resolveMSTeamsRouteConfig } from "./policy.js";
 import { getMSTeamsRuntime } from "./runtime.js";
 import { createMSTeamsAdapter, createMSTeamsTokenProvider, loadMSTeamsSdkWithAuth } from "./sdk.js";
 import { resolveMSTeamsCredentials } from "./token.js";
@@ -27,6 +30,8 @@ export type MSTeamsProactiveContext = {
   log: ReturnType<PluginRuntime["logging"]["getChildLogger"]>;
   /** The type of conversation: personal (1:1), groupChat, or channel */
   conversationType: MSTeamsConversationType;
+  /** Reply style resolved for proactive text/media sends. */
+  replyStyle: MSTeamsReplyStyle;
   /** Token provider for Graph API / OneDrive operations */
   tokenProvider: MSTeamsAccessTokenProvider;
   /** SharePoint site ID for file uploads in group chats/channels */
@@ -41,6 +46,32 @@ export type MSTeamsProactiveContext = {
    */
   graphChatId?: string | null;
 };
+
+export function resolveMSTeamsProactiveReplyStyle(params: {
+  cfg?: MSTeamsConfig;
+  conversationId: string;
+  ref: StoredConversationReference;
+  conversationType: MSTeamsConversationType;
+}): MSTeamsReplyStyle {
+  const threadRootId = params.ref.threadId ?? params.ref.activityId;
+  if (params.conversationType !== "channel" || !threadRootId) {
+    return "top-level";
+  }
+
+  const routeConfig = resolveMSTeamsRouteConfig({
+    cfg: params.cfg,
+    teamId: params.ref.teamId,
+    conversationId: params.conversationId,
+    allowNameMatching: false,
+  });
+  const { replyStyle } = resolveMSTeamsReplyPolicy({
+    isDirectMessage: false,
+    globalConfig: params.cfg,
+    teamConfig: routeConfig.teamConfig,
+    channelConfig: routeConfig.channelConfig,
+  });
+  return replyStyle;
+}
 
 /**
  * Parse the target value into a conversation reference lookup key.
@@ -167,6 +198,12 @@ export async function resolveMSTeamsSendContext(params: {
     // groupChat, or unknown defaults to groupChat behavior
     conversationType = "groupChat";
   }
+  const replyStyle = resolveMSTeamsProactiveReplyStyle({
+    cfg: msteamsCfg,
+    conversationId,
+    ref,
+    conversationType,
+  });
 
   // Get SharePoint site ID from config (required for file uploads in group chats/channels)
   const sharePointSiteId = msteamsCfg.sharePointSiteId;
@@ -223,6 +260,7 @@ export async function resolveMSTeamsSendContext(params: {
     adapter: adapter as unknown as MSTeamsAdapter,
     log,
     conversationType,
+    replyStyle,
     tokenProvider,
     sharePointSiteId,
     mediaMaxBytes,

--- a/extensions/msteams/src/send.test.ts
+++ b/extensions/msteams/src/send.test.ts
@@ -116,6 +116,7 @@ function createSharePointSendContext(params: {
     ref: {},
     log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     conversationType: "groupChat" as const,
+    replyStyle: "top-level" as const,
     tokenProvider: { getAccessToken: vi.fn(async () => "token") },
     mediaMaxBytes: 8 * 1024 * 1024,
     sharePointSiteId: params.siteId,
@@ -184,6 +185,7 @@ describe("sendMessageMSTeams", () => {
       ref: {},
       log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
       conversationType: "personal",
+      replyStyle: "top-level",
       tokenProvider: { getAccessToken: vi.fn(async () => "token") },
       mediaMaxBytes: 8 * 1024,
       sharePointSiteId: undefined,
@@ -264,6 +266,62 @@ describe("sendMessageMSTeams", () => {
       channel: "msteams",
     });
     expect(mockState.convertMarkdownTables).toHaveBeenCalledWith("hello", "off");
+  });
+
+  it("passes the resolved proactive replyStyle to text sends", async () => {
+    mockState.resolveMSTeamsSendContext.mockResolvedValue({
+      adapter: {},
+      appId: "app-id",
+      conversationId: "19:channel@thread.tacv2",
+      ref: {
+        threadId: "thread-root-1",
+        conversation: { id: "19:channel@thread.tacv2", conversationType: "channel" },
+      },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      conversationType: "channel",
+      replyStyle: "thread",
+      tokenProvider: { getAccessToken: vi.fn(async () => "token") },
+      mediaMaxBytes: 8 * 1024,
+      sharePointSiteId: undefined,
+    });
+
+    await sendMessageMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: "conversation:19:channel@thread.tacv2",
+      text: "threaded reply",
+    });
+
+    expect(mockState.sendMSTeamsMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ replyStyle: "thread" }),
+    );
+  });
+
+  it("keeps top-level proactive replyStyle when resolved for a channel", async () => {
+    mockState.resolveMSTeamsSendContext.mockResolvedValue({
+      adapter: {},
+      appId: "app-id",
+      conversationId: "19:channel@thread.tacv2",
+      ref: {
+        threadId: "thread-root-1",
+        conversation: { id: "19:channel@thread.tacv2", conversationType: "channel" },
+      },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      conversationType: "channel",
+      replyStyle: "top-level",
+      tokenProvider: { getAccessToken: vi.fn(async () => "token") },
+      mediaMaxBytes: 8 * 1024,
+      sharePointSiteId: undefined,
+    });
+
+    await sendMessageMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: "conversation:19:channel@thread.tacv2",
+      text: "top-level reply",
+    });
+
+    expect(mockState.sendMSTeamsMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ replyStyle: "top-level" }),
+    );
   });
 
   it("uses graphChatId instead of conversationId when uploading to SharePoint", async () => {

--- a/extensions/msteams/src/send.ts
+++ b/extensions/msteams/src/send.ts
@@ -391,12 +391,13 @@ async function sendTextWithMedia(
     tokenProvider,
     sharePointSiteId,
     mediaMaxBytes,
+    replyStyle,
   } = ctx;
 
   let platformMessageIds: string[];
   try {
     platformMessageIds = await sendMSTeamsMessages({
-      replyStyle: "top-level",
+      replyStyle,
       adapter,
       appId,
       conversationRef: ref,


### PR DESCRIPTION
## Summary

- Resolve the Microsoft Teams proactive send `replyStyle` from stored conversation context and the existing Teams channel/team/global policy instead of hardcoding `top-level`.
- Allow no-context threaded proactive sends to use the existing proactive thread-targeting path, so channel sends with `threadId` or legacy `activityId` build the `;messageid=<threadRoot>` conversation id.
- Add focused regression coverage for proactive reply-style resolution, send-path forwarding, no-context thread fallback, and configured `top-level` channel overrides.
- Add an unreleased changelog entry.

Closes #78298.

## Root Cause

The proactive text/media send path always passed `replyStyle: "top-level"` into `sendMSTeamsMessages()`, so CLI/message-tool sends ignored stored Teams channel thread roots. Switching that path to `thread` was previously blocked because `sendMSTeamsMessages()` threw when no live turn context was present.

## Manual CLI Repro Proof

I exercised the actual CLI command path with a temp OpenClaw config/state directory and a network shim that only replaced AAD token acquisition and the Bot Framework service URL. The command under test was:

```sh
openclaw message send --channel msteams --target conversation:19:abc@thread.tacv2 --message "CLI proactive reply" --json
```

- Local before/after CLI proof: `origin/main` sent to `https://service.example.com/v3/conversations/19:abc@thread.tacv2/activities`; this branch sent to `https://service.example.com/v3/conversations/19:abc@thread.tacv2;messageid=thread-root-msg-id/activities`.
- Hetzner Crabbox `cbx_2a5cfab75860` (`coral-crab`): same CLI command passed before/after proof with `HETZNER_CLI_SUMMARY beforeStatus=0 beforeId=19:abc@thread.tacv2 afterStatus=0 afterId=19:abc@thread.tacv2;messageid=thread-root-msg-id afterRef=93b8a7c9848e3eadaf2f3e03ddcc22f72e5446d2`.
- Lease was released after the Hetzner run.

No live Teams tenant send was run; no Teams/Microsoft/Azure credentials were present in env or `~/.profile`.

## Additional Manual Adapter Proof

A throwaway harness also exercised the Bot Framework proactive adapter boundary directly with a stored channel reference containing `threadId: "thread-root-msg-id"` and no live turn context.

- Hetzner Crabbox `cbx_2c7ac22b6281` (`crimson-krill`): before patch on `origin/main` failed with `{"ok":false,"name":"Error","message":"Missing context for replyStyle=thread"}`.
- Same Hetzner Crabbox run after patch on `93b8a7c9848e3eadaf2f3e03ddcc22f72e5446d2` succeeded with `{"ok":true,"ids":["id:manual proactive reply"],"sent":["manual proactive reply"],"proactiveConversationId":"19:abc@thread.tacv2;messageid=thread-root-msg-id","proactiveActivityId":null}`.
- Lease was released after the run.

## Verification

- Manual local CLI before/after proof: passed as described above.
- Manual Hetzner Crabbox CLI before/after proof on `cbx_2a5cfab75860`: passed as described above.
- Manual local adapter before/after harness: before `origin/main` failed with `Missing context for replyStyle=thread`; after branch succeeded with threaded proactive conversation id.
- Manual Hetzner Crabbox adapter before/after harness on `cbx_2c7ac22b6281`: passed as described above.
- `pnpm test extensions/msteams/src/send-context.test.ts extensions/msteams/src/send.test.ts extensions/msteams/src/messenger.test.ts` locally: 3 files, 47 tests passed.
- `pnpm exec oxfmt --check --threads=1 extensions/msteams/src/send-context.ts extensions/msteams/src/send.ts extensions/msteams/src/messenger.ts extensions/msteams/src/send-context.test.ts extensions/msteams/src/send.test.ts extensions/msteams/src/messenger.test.ts CHANGELOG.md`
- `git diff --check`
- Crabbox/Testbox focused test on `tbx_01kqy8brzxk1e58fhcdggmkdfs`: 3 files, 47 tests passed; lease stopped.
- Crabbox/Testbox `pnpm check:changed` on `tbx_01kqy8k9cb8300643vamz6d3ss`: passed; lease stopped.
