### PR TITLE
Fix Memory Wiki blank page related stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ Docs: https://docs.openclaw.ai
 - CLI/infer: pass minimal instructions to local `openai-codex/*` model probes and surface provider error details when `infer model run` returns no text. Fixes #76464. Thanks @lilesjtu.
 - Dependencies: override transitive `ip-address` to `10.2.0` so the runtime lockfile no longer includes the vulnerable `10.1.0` build flagged by Dependabot alert 109. Thanks @vincentkoc.
 - Feishu: hydrate missing native topic starter thread IDs before session routing so first turns and follow-ups stay in the same topic session. Fixes #78262. Thanks @joeyzenghuan.
+- Memory Wiki: skip empty and whitespace-only source pages when refreshing generated Related blocks, preventing blank pages from being rewritten into Related-only stubs. Fixes #78121. Thanks @amknight.
 - LINE: reject `dmPolicy: "open"` configs without wildcard `allowFrom` so webhook DMs fail validation instead of being acknowledged and silently blocked before inbound processing. Fixes #78316.
 - Telegram/Codex: keep message-tool-only progress drafts visible and render native Codex tool progress once per tool instead of duplicating item/tool draft lines. Fixes #75641. (#77949) Thanks @keshavbotagent.
 - Providers/xAI: stop sending OpenAI-style reasoning effort controls to native Grok Responses models, so `xai/grok-4.3` no longer fails live Docker/Gateway runs with `Invalid reasoning effort`.

--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -170,6 +170,24 @@ describe("compileMemoryWikiVault", () => {
     );
   });
 
+  it("does not rewrite empty source pages into related-only stubs", async () => {
+    const { rootDir, config } = await createVault({
+      rootDir: nextCaseRoot(),
+      initialize: true,
+    });
+    const emptySourcePath = path.join(rootDir, "sources", "empty.md");
+    const whitespaceSourcePath = path.join(rootDir, "sources", "whitespace.md");
+    await fs.writeFile(emptySourcePath, "", "utf8");
+    await fs.writeFile(whitespaceSourcePath, " \n\t", "utf8");
+
+    const result = await compileMemoryWikiVault(config);
+
+    await expect(fs.readFile(emptySourcePath, "utf8")).resolves.toBe("");
+    await expect(fs.readFile(whitespaceSourcePath, "utf8")).resolves.toBe(" \n\t");
+    expect(result.updatedFiles).not.toContain(emptySourcePath);
+    expect(result.updatedFiles).not.toContain(whitespaceSourcePath);
+  });
+
   it("does not relate every page through a broad shared source", async () => {
     const { rootDir, config } = await createVault({
       rootDir: nextCaseRoot(),

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -776,6 +776,9 @@ async function refreshPageRelatedBlocks(params: {
       continue;
     }
     const original = await root.readText(page.relativePath);
+    if (original.trim().length === 0) {
+      continue;
+    }
     const updated = withTrailingNewline(
       replaceManagedMarkdownBlock({
         original,


### PR DESCRIPTION
## Summary

- Skip empty and whitespace-only Memory Wiki source pages while refreshing generated Related blocks.
- Add regression coverage for zero-byte and whitespace-only Markdown pages.
- Add the unreleased changelog entry for the user-facing fix.

Fixes #78121.

## Root Cause

`refreshPageRelatedBlocks` treated every non-report Markdown page as eligible for a managed Related section. For empty pages, `replaceManagedMarkdownBlock` had no surrounding content to preserve, so compile rewrote blank files into Related-only stubs.

## Verification

- Pre-fix local repro: the new regression test failed because an empty source page was rewritten to a `## Related` stub.
- Pre-fix Hetzner Crabbox focused repro: reset only `extensions/memory-wiki/src/compile.ts` on the remote while keeping the test, then `pnpm test extensions/memory-wiki/src/compile.test.ts -- --reporter=verbose` failed with the same assertion.
- Hetzner Crabbox CLI repro on `cbx_ef7555bdcdb1`: enabled `memory-wiki` with `openclaw plugins enable memory-wiki`, configured an isolated vault with `openclaw config set plugins.entries.memory-wiki.config.vault.path`, ran `openclaw wiki init --json`, wrote blank `sources/empty.md` and whitespace-only `sources/whitespace.md`, then ran `openclaw wiki compile --json` with parent `compile.ts`; both source files were rewritten to 107-byte Related stubs with `openclaw:wiki:related:start` markers.
- Hetzner Crabbox CLI validation on `cbx_ef7555bdcdb1`: restored the PR `compile.ts`, repeated the same `openclaw` CLI flow, and `sources/empty.md` stayed 0 bytes while `sources/whitespace.md` stayed 3 bytes with no Related markers. Lease stopped.
- `pnpm test extensions/memory-wiki/src/compile.test.ts -- --reporter=verbose`
- Hetzner Crabbox `cbx_ddaee5569df3`: checksum-synced final diff, installed dependencies, and ran `pnpm test extensions/memory-wiki/src/compile.test.ts -- --reporter=verbose` successfully.
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md extensions/memory-wiki/src/compile.ts extensions/memory-wiki/src/compile.test.ts`
- `git diff --check`
- `pnpm check:changed`