### PR TITLE
fix(telegram): deduplicate MEDIA attachments in non-streaming mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -316,6 +316,7 @@ Docs: https://docs.openclaw.ai
 - Agents/memory flush: persist the pre-increment compaction counter after flush-triggered compaction so consecutive eligible compaction cycles run memoryFlush instead of alternating. Fixes #12590. Refs #12760, #26145, and #46513. Thanks @Kaspre, @lailoo, @drvoss, @Br1an67, and @dial481.
 - Status: treat CLI runtime aliases such as `claude-cli/<model>` as the canonical selected provider route in `/status`, avoiding spurious fallback/unknown-auth display and preserving fresh context usage from CLI usage snapshots. Fixes #79015. Thanks @ItsThierry.
 - Compute plugin callback authorization dynamically [AI]. (#78866) Thanks @pgondhi987.
+- Telegram: deduplicate media attachments in non-streaming mode so block-delivered images are not resent in the final reply, and clear legacy `mediaUrl` fallback when all media URLs are filtered. Fixes #78372.
 - Gateway/auth: allow `gateway.auth.mode: "none"` loopback backend RPC clients to skip device identity only for local non-browser backend connections, restoring subagent spawns and gateway tools without opening remote or browser-origin bypasses. Fixes #75780. Thanks @yozakura-ava.
 - Canvas plugin: keep legacy root `canvasHost` configs valid until `openclaw doctor --fix` migrates them into `plugins.entries.canvas.config.host`, move Canvas/A2UI clients to gateway protocol v4 plugin surfaces, and refresh the generated A2UI bundle hash so normal builds stay clean.
 - feishu: honor config write policy for dynamic agents [AI]. (#78520) Thanks @pgondhi987.

--- a/extensions/telegram/src/bot-message-dispatch.media-dedup.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.media-dedup.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { deduplicateBlockSentMedia } from "./bot-message-dispatch.media-dedup.js";
+
+describe("deduplicateBlockSentMedia", () => {
+  it("returns payload unchanged when no media URLs", () => {
+    const payload = { text: "hello", mediaUrls: [] };
+    const sent = new Set(["/tmp/a.jpg"]);
+    expect(deduplicateBlockSentMedia(payload, sent)).toBe(payload);
+  });
+
+  it("returns payload unchanged when sent set is empty", () => {
+    const payload = { text: "hello", mediaUrls: ["/tmp/a.jpg"] };
+    const sent = new Set<string>();
+    expect(deduplicateBlockSentMedia(payload, sent)).toBe(payload);
+  });
+
+  it("returns payload unchanged when no overlap", () => {
+    const payload = { text: "hello", mediaUrls: ["/tmp/a.jpg"] };
+    const sent = new Set(["/tmp/other.jpg"]);
+    expect(deduplicateBlockSentMedia(payload, sent)).toBe(payload);
+  });
+
+  it("filters out already-sent media URLs from final payload", () => {
+    const payload = { text: "hello", mediaUrls: ["/tmp/a.jpg", "/tmp/b.jpg"] };
+    const sent = new Set(["/tmp/a.jpg"]);
+    const result = deduplicateBlockSentMedia(payload, sent);
+    expect(result).toEqual({ text: "hello", mediaUrls: ["/tmp/b.jpg"] });
+  });
+
+  it("returns undefined when all media already sent and no text", () => {
+    const payload = { text: undefined, mediaUrls: ["/tmp/a.jpg"] };
+    const sent = new Set(["/tmp/a.jpg"]);
+    expect(deduplicateBlockSentMedia(payload, sent)).toBeUndefined();
+  });
+
+  it("returns payload with empty mediaUrls when all media already sent but text remains", () => {
+    const payload = { text: "some text", mediaUrls: ["/tmp/a.jpg"] };
+    const sent = new Set(["/tmp/a.jpg"]);
+    const result = deduplicateBlockSentMedia(payload, sent);
+    expect(result).toEqual({ text: "some text", mediaUrls: [] });
+  });
+
+  it("handles partial overlap with multiple URLs", () => {
+    const payload = { text: "see attached", mediaUrls: ["/tmp/a.jpg", "/tmp/b.jpg", "/tmp/c.jpg"] };
+    const sent = new Set(["/tmp/a.jpg", "/tmp/c.jpg"]);
+    const result = deduplicateBlockSentMedia(payload, sent);
+    expect(result).toEqual({ text: "see attached", mediaUrls: ["/tmp/b.jpg"] });
+  });
+});

--- a/extensions/telegram/src/bot-message-dispatch.media-dedup.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.media-dedup.test.ts
@@ -46,4 +46,22 @@ describe("deduplicateBlockSentMedia", () => {
     const result = deduplicateBlockSentMedia(payload, sent);
     expect(result).toEqual({ text: "see attached", mediaUrls: ["/tmp/b.jpg"] });
   });
+
+  it("clears legacy mediaUrl when all mediaUrls removed but text remains", () => {
+    const payload = { text: "captioned", mediaUrl: "/tmp/a.jpg", mediaUrls: ["/tmp/a.jpg"] };
+    const sent = new Set(["/tmp/a.jpg"]);
+    const result = deduplicateBlockSentMedia(payload, sent);
+    expect(result).toEqual({ text: "captioned", mediaUrl: undefined, mediaUrls: [] });
+  });
+
+  it("preserves legacy mediaUrl when some mediaUrls remain", () => {
+    const payload = {
+      text: "hey",
+      mediaUrl: "/tmp/a.jpg",
+      mediaUrls: ["/tmp/a.jpg", "/tmp/b.jpg"],
+    };
+    const sent = new Set(["/tmp/a.jpg"]);
+    const result = deduplicateBlockSentMedia(payload, sent);
+    expect(result).toEqual({ text: "hey", mediaUrl: "/tmp/a.jpg", mediaUrls: ["/tmp/b.jpg"] });
+  });
 });

--- a/extensions/telegram/src/bot-message-dispatch.media-dedup.ts
+++ b/extensions/telegram/src/bot-message-dispatch.media-dedup.ts
@@ -1,0 +1,22 @@
+/**
+ * Deduplicate media URLs in a final-reply payload against media already
+ * delivered via block replies. Returns the deduplicated payload, or
+ * undefined if the payload should be skipped entirely (all media already
+ * sent and no text remains).
+ */
+export function deduplicateBlockSentMedia(
+  payload: { mediaUrls?: string[]; text?: string; [key: string]: unknown },
+  sentBlockMediaUrls: ReadonlySet<string>,
+): typeof payload | undefined {
+  if (!payload.mediaUrls?.length || sentBlockMediaUrls.size === 0) {
+    return payload;
+  }
+  const remainingMedia = payload.mediaUrls.filter((url) => !sentBlockMediaUrls.has(url));
+  if (remainingMedia.length === payload.mediaUrls.length) {
+    return payload;
+  }
+  if (remainingMedia.length === 0 && !payload.text) {
+    return undefined;
+  }
+  return { ...payload, mediaUrls: remainingMedia };
+}

--- a/extensions/telegram/src/bot-message-dispatch.media-dedup.ts
+++ b/extensions/telegram/src/bot-message-dispatch.media-dedup.ts
@@ -4,10 +4,10 @@
  * undefined if the payload should be skipped entirely (all media already
  * sent and no text remains).
  */
-export function deduplicateBlockSentMedia(
-  payload: { mediaUrls?: string[]; text?: string; [key: string]: unknown },
+export function deduplicateBlockSentMedia<T extends { mediaUrls?: string[]; text?: string }>(
+  payload: T,
   sentBlockMediaUrls: ReadonlySet<string>,
-): typeof payload | undefined {
+): T | undefined {
   if (!payload.mediaUrls?.length || sentBlockMediaUrls.size === 0) {
     return payload;
   }

--- a/extensions/telegram/src/bot-message-dispatch.media-dedup.ts
+++ b/extensions/telegram/src/bot-message-dispatch.media-dedup.ts
@@ -1,9 +1,3 @@
-/**
- * Deduplicate media URLs in a final-reply payload against media already
- * delivered via block replies. Returns the deduplicated payload, or
- * undefined if the payload should be skipped entirely (all media already
- * sent and no text remains).
- */
 export function deduplicateBlockSentMedia<
   T extends { mediaUrl?: string; mediaUrls?: string[]; text?: string },
 >(payload: T, sentBlockMediaUrls: ReadonlySet<string>): T | undefined {

--- a/extensions/telegram/src/bot-message-dispatch.media-dedup.ts
+++ b/extensions/telegram/src/bot-message-dispatch.media-dedup.ts
@@ -4,10 +4,9 @@
  * undefined if the payload should be skipped entirely (all media already
  * sent and no text remains).
  */
-export function deduplicateBlockSentMedia<T extends { mediaUrls?: string[]; text?: string }>(
-  payload: T,
-  sentBlockMediaUrls: ReadonlySet<string>,
-): T | undefined {
+export function deduplicateBlockSentMedia<
+  T extends { mediaUrl?: string; mediaUrls?: string[]; text?: string },
+>(payload: T, sentBlockMediaUrls: ReadonlySet<string>): T | undefined {
   if (!payload.mediaUrls?.length || sentBlockMediaUrls.size === 0) {
     return payload;
   }
@@ -18,5 +17,9 @@ export function deduplicateBlockSentMedia<T extends { mediaUrls?: string[]; text
   if (remainingMedia.length === 0 && !payload.text) {
     return undefined;
   }
-  return { ...payload, mediaUrls: remainingMedia };
+  return {
+    ...payload,
+    mediaUrls: remainingMedia,
+    mediaUrl: remainingMedia.length === 0 ? undefined : payload.mediaUrl,
+  };
 }

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1791,4 +1791,91 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(replies?.[0]?.text?.trim()).toBeTruthy();
     expect(replies?.[0]?.text).not.toBe("NO_REPLY");
   });
+
+  describe("non-streaming media dedup", () => {
+    const finalDeliveryPayload = () => {
+      for (const [params] of deliverInboundReplyWithMessageSendContext.mock.calls) {
+        if (params.info.kind === "final") {
+          return params.payload;
+        }
+      }
+      throw new Error("missing final delivery");
+    };
+
+    it("deduplicates block-sent media from final reply", async () => {
+      deliverReplies.mockResolvedValue({ delivered: true });
+      deliverInboundReplyWithMessageSendContext.mockResolvedValue({
+        status: "handled_visible",
+        delivery: { messageIds: ["101"], visibleReplySent: true },
+      });
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ mediaUrls: ["/tmp/cat.jpg"] }, { kind: "block" });
+        await dispatcherOptions.deliver(
+          { text: "Here is the image", mediaUrls: ["/tmp/cat.jpg"] },
+          { kind: "final" },
+        );
+        return { queuedFinal: true };
+      });
+
+      await dispatchWithContext({
+        context: createContext(),
+        streamMode: "off",
+        telegramDeps: telegramDepsForTest,
+      });
+
+      expect(finalDeliveryPayload().mediaUrls).toEqual([]);
+    });
+
+    it("preserves final media when block delivery reports no visible send", async () => {
+      deliverReplies.mockResolvedValueOnce({ delivered: false });
+      deliverReplies.mockResolvedValue({ delivered: true });
+      deliverInboundReplyWithMessageSendContext.mockResolvedValue({
+        status: "handled_visible",
+        delivery: { messageIds: ["101"], visibleReplySent: true },
+      });
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ mediaUrls: ["/tmp/cat.jpg"] }, { kind: "block" });
+        await dispatcherOptions.deliver(
+          { text: "Here is the image", mediaUrls: ["/tmp/cat.jpg"] },
+          { kind: "final" },
+        );
+        return { queuedFinal: true };
+      });
+
+      await dispatchWithContext({
+        context: createContext(),
+        streamMode: "off",
+        telegramDeps: telegramDepsForTest,
+      });
+
+      expect(finalDeliveryPayload().mediaUrls).toEqual(["/tmp/cat.jpg"]);
+    });
+
+    it("preserves final media when block delivery fails", async () => {
+      deliverReplies.mockRejectedValueOnce(new Error("Telegram API error"));
+      deliverReplies.mockResolvedValue({ delivered: true });
+      deliverInboundReplyWithMessageSendContext.mockResolvedValue({
+        status: "handled_visible",
+        delivery: { messageIds: ["101"], visibleReplySent: true },
+      });
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+        try {
+          await dispatcherOptions.deliver({ mediaUrls: ["/tmp/cat.jpg"] }, { kind: "block" });
+        } catch {}
+        await dispatcherOptions.deliver(
+          { text: "Here is the image", mediaUrls: ["/tmp/cat.jpg"] },
+          { kind: "final" },
+        );
+        return { queuedFinal: true };
+      });
+
+      await dispatchWithContext({
+        context: createContext(),
+        streamMode: "off",
+        telegramDeps: telegramDepsForTest,
+      });
+
+      expect(finalDeliveryPayload().mediaUrls).toEqual(["/tmp/cat.jpg"]);
+    });
+  });
 });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -57,6 +57,7 @@ import {
   resolveAgentDir,
   resolveDefaultModelForAgent,
 } from "./bot-message-dispatch.agent.runtime.js";
+import { deduplicateBlockSentMedia } from "./bot-message-dispatch.media-dedup.js";
 import { pruneStickerMediaFromContext } from "./bot-message-dispatch.media.js";
 import {
   generateTopicLabel,
@@ -1164,8 +1165,14 @@ export const dispatchTelegramMessage = async ({
             ctxPayload,
             recordInboundSession: context.turn.recordInboundSession,
             record: context.turn.record,
-            runDispatch: () =>
-              telegramDeps.dispatchReplyWithBufferedBlockDispatcher({
+            runDispatch: () => {
+              // Track media URLs delivered via block replies so final replies
+              // can skip duplicates. Without this, non-streaming Telegram
+              // delivers each MEDIA: attachment twice — once from the
+              // media-only block reply and once from the final reply.
+              const sentBlockMediaUrls = new Set<string>();
+
+              return telegramDeps.dispatchReplyWithBufferedBlockDispatcher({
                 ctx: ctxPayload,
                 cfg,
                 dispatcherOptions: {
@@ -1178,6 +1185,25 @@ export const dispatchTelegramMessage = async ({
                     if (payload.isError === true) {
                       hadErrorReplyFailureOrSkip = true;
                     }
+
+                    // Track media URLs from block replies so final replies
+                    // can skip duplicates (non-streaming MEDIA: dedup).
+                    if (info.kind === "block" && payload.mediaUrls?.length) {
+                      for (const url of payload.mediaUrls) {
+                        sentBlockMediaUrls.add(url);
+                      }
+                    }
+
+                    // Filter out media already sent via block reply.
+                    const deduped =
+                      info.kind === "final"
+                        ? deduplicateBlockSentMedia(payload, sentBlockMediaUrls)
+                        : payload;
+                    if (deduped === undefined) {
+                      return;
+                    }
+                    const effectivePayload = deduped;
+
                     if (info.kind === "final") {
                       await enqueueDraftLaneEvent(async () => {});
                     }
@@ -1192,16 +1218,16 @@ export const dispatchTelegramMessage = async ({
                       return;
                     }
                     const telegramButtons = (
-                      payload.channelData?.telegram as
+                      effectivePayload.channelData?.telegram as
                         | { buttons?: TelegramInlineButtons }
                         | undefined
                     )?.buttons;
                     const split = splitTextIntoLaneSegments(
-                      { text: payload.text },
+                      { text: effectivePayload.text },
                       payload.isReasoning,
                     );
                     const segments = split.segments;
-                    const reply = resolveSendableOutboundReplyParts(payload);
+                    const reply = resolveSendableOutboundReplyParts(effectivePayload);
                     const _hasMedia = reply.hasMedia;
 
                     const flushBufferedFinalAnswer = async () => {
@@ -1232,7 +1258,7 @@ export const dispatchTelegramMessage = async ({
                         reasoningStepState.shouldBufferFinalAnswer()
                       ) {
                         reasoningStepState.bufferFinalAnswer({
-                          payload,
+                          payload: effectivePayload,
                           text: segment.update.text,
                           bufferedGeneration: replyFenceGeneration,
                         });
@@ -1245,11 +1271,14 @@ export const dispatchTelegramMessage = async ({
                         streamMode === "progress" &&
                         segment.lane === "answer" &&
                         info.kind === "final"
-                          ? await deliverProgressModeFinalAnswer(payload, segment.update.text)
+                          ? await deliverProgressModeFinalAnswer(
+                              effectivePayload,
+                              segment.update.text,
+                            )
                           : await deliverLaneText({
                               laneName: segment.lane,
                               text: segment.update.text,
-                              payload,
+                              payload: effectivePayload,
                               infoKind: info.kind,
                               buttons: telegramButtons,
                             });
@@ -1273,7 +1302,9 @@ export const dispatchTelegramMessage = async ({
                     if (split.suppressedReasoningOnly) {
                       if (reply.hasMedia) {
                         const payloadWithoutSuppressedReasoning =
-                          typeof payload.text === "string" ? { ...payload, text: "" } : payload;
+                          typeof effectivePayload.text === "string"
+                            ? { ...effectivePayload, text: "" }
+                            : effectivePayload;
                         await sendPayload(payloadWithoutSuppressedReasoning, {
                           durable: info.kind === "final",
                         });
@@ -1296,7 +1327,7 @@ export const dispatchTelegramMessage = async ({
                       }
                       return;
                     }
-                    await sendPayload(payload, { durable: info.kind === "final" });
+                    await sendPayload(effectivePayload, { durable: info.kind === "final" });
                     if (info.kind === "final") {
                       await flushBufferedFinalAnswer();
                     }
@@ -1488,7 +1519,8 @@ export const dispatchTelegramMessage = async ({
                     : undefined,
                   onModelSelected,
                 },
-              }),
+              });
+            },
           }),
         },
       });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1166,10 +1166,6 @@ export const dispatchTelegramMessage = async ({
             recordInboundSession: context.turn.recordInboundSession,
             record: context.turn.record,
             runDispatch: () => {
-              // Track media URLs delivered via block replies so final replies
-              // can skip duplicates. Without this, non-streaming Telegram
-              // delivers each MEDIA: attachment twice — once from the
-              // media-only block reply and once from the final reply.
               const sentBlockMediaUrls = new Set<string>();
 
               return telegramDeps.dispatchReplyWithBufferedBlockDispatcher({

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1186,15 +1186,6 @@ export const dispatchTelegramMessage = async ({
                       hadErrorReplyFailureOrSkip = true;
                     }
 
-                    // Track media URLs from block replies so final replies
-                    // can skip duplicates (non-streaming MEDIA: dedup).
-                    if (info.kind === "block" && payload.mediaUrls?.length) {
-                      for (const url of payload.mediaUrls) {
-                        sentBlockMediaUrls.add(url);
-                      }
-                    }
-
-                    // Filter out media already sent via block reply.
                     const deduped =
                       info.kind === "final"
                         ? deduplicateBlockSentMedia(payload, sentBlockMediaUrls)
@@ -1251,6 +1242,7 @@ export const dispatchTelegramMessage = async ({
                       reasoningStepState.resetForNextStep();
                     };
 
+                    let blockDelivered = false;
                     for (const segment of segments) {
                       if (
                         segment.lane === "answer" &&
@@ -1285,6 +1277,7 @@ export const dispatchTelegramMessage = async ({
                       if (info.kind === "final") {
                         emitPreviewFinalizedHook(result);
                       }
+                      blockDelivered = blockDelivered || result.kind !== "skipped";
                       if (segment.lane === "reasoning") {
                         if (result.kind !== "skipped") {
                           reasoningStepState.noteReasoningDelivered();
@@ -1296,22 +1289,33 @@ export const dispatchTelegramMessage = async ({
                         reasoningStepState.resetForNextStep();
                       }
                     }
+                    const trackBlockMedia = (delivered: boolean) => {
+                      if (delivered && info.kind === "block" && payload.mediaUrls?.length) {
+                        for (const url of payload.mediaUrls) {
+                          sentBlockMediaUrls.add(url);
+                        }
+                      }
+                    };
+
                     if (segments.length > 0) {
+                      trackBlockMedia(blockDelivered);
                       return;
                     }
                     if (split.suppressedReasoningOnly) {
+                      let delivered = false;
                       if (reply.hasMedia) {
                         const payloadWithoutSuppressedReasoning =
                           typeof effectivePayload.text === "string"
                             ? { ...effectivePayload, text: "" }
                             : effectivePayload;
-                        await sendPayload(payloadWithoutSuppressedReasoning, {
+                        delivered = await sendPayload(payloadWithoutSuppressedReasoning, {
                           durable: info.kind === "final",
                         });
                       }
                       if (info.kind === "final") {
                         await flushBufferedFinalAnswer();
                       }
+                      trackBlockMedia(delivered);
                       return;
                     }
 
@@ -1327,10 +1331,13 @@ export const dispatchTelegramMessage = async ({
                       }
                       return;
                     }
-                    await sendPayload(effectivePayload, { durable: info.kind === "final" });
+                    const delivered = await sendPayload(effectivePayload, {
+                      durable: info.kind === "final",
+                    });
                     if (info.kind === "final") {
                       await flushBufferedFinalAnswer();
                     }
+                    trackBlockMedia(delivered);
                   },
                   onSkip: (payload, info) => {
                     if (payload.isError === true) {


### PR DESCRIPTION
## Summary

- Non-streaming Telegram delivers each `MEDIA:` attachment twice — once from the media-only block reply and once from the final reply
- Track media URLs sent via block replies in a `Set`, then filter duplicates from final reply payloads
- Extract `deduplicateBlockSentMedia` into a standalone pure function for testability
- Clear legacy `mediaUrl` fallback when all `mediaUrls` are deduped, preventing `resolvePayloadMediaUrls` from resending via the single-URL path

Closes #78372

## Root cause

When `streaming: "off"`, the `deliver` callback in `bot-message-dispatch.ts` receives both:
1. A **block reply** with `mediaUrls` populated (sent directly via `sendDirectBlockReply` in `reply-delivery.ts:160`, which sends media-only blocks even when streaming is off)
2. A **final reply** with the same `mediaUrls` (the `MEDIA:` directive text persists in the agent's complete output)

Unlike WebChat (which has `appendedWebchatAgentMedia` guard at `chat.ts:2512`) or the streaming path (which deduplicates via `blockReplyPipeline`), Telegram's non-streaming `deliver` callback had no mechanism to detect that the same media was already delivered.

## Changes

- **`bot-message-dispatch.ts`**: Add `sentBlockMediaUrls` tracking set inside `runDispatch`. In the `deliver` callback, record block-reply media URLs and call `deduplicateBlockSentMedia` for final replies. All downstream usage switches from `payload` to `effectivePayload`.
- **`bot-message-dispatch.media-dedup.ts`** (new): Pure function `deduplicateBlockSentMedia` — returns deduplicated payload, or `undefined` to skip entirely. Also clears legacy `mediaUrl` when all `mediaUrls` entries are removed.
- **`bot-message-dispatch.media-dedup.test.ts`** (new): 9 test cases covering no-media, no-overlap, partial overlap, full overlap with/without text, and legacy `mediaUrl` clearing.

## Real behavior proof

**Behavior or issue addressed:** Non-streaming Telegram bot delivers each MEDIA attachment twice — once via block reply, once in final reply. Fixes #78372.

**Real environment tested:** OpenClaw 2026.5.6, macOS 15.5, Node 22, gateway restarted after build, real Telegram bot in non-streaming mode.

**Exact steps or command run after fix:**
1. `pnpm build`
2. `openclaw gateway restart`
3. Sent message to Telegram bot asking it to search for a cat image and send it

**Evidence after fix:**

<img width="1266" height="804" alt="telegram_dedup_proof" src="https://github.com/user-attachments/assets/16407afa-867d-4f76-9d01-f3e9a13ee75a" />

**Observed result after fix:** Image delivered exactly once via block reply. Final reply contained only text — no duplicate media. No errors in gateway logs.

**What was not tested:** Streaming mode (uses separate `blockReplyPipeline` dedup path, not affected by this change). Multi-image payloads in live environment (covered by unit tests).

## Test plan

- [x] Unit tests pass: `pnpm test extensions/telegram/src/bot-message-dispatch.media-dedup.test.ts` — 9/9
- [x] Broader telegram dispatch tests: `pnpm test extensions/telegram/src/bot-message-dispatch.test.ts` — 45/45
- [x] Format check passes: `pnpm exec oxfmt --check` on all changed files
- [x] Real behavior proof: Telegram non-streaming media dedup verified (see above)
- [ ] Full extension suite: `pnpm test extensions/telegram`
