### PR TITLE
test(scripts): clean up temp dirs after each case

### DIFF
--- a/test/scripts/blacksmith-testbox-runner.test.ts
+++ b/test/scripts/blacksmith-testbox-runner.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   buildBlacksmithRunArgs,
   resolveTestboxSyncTimeoutMs,
@@ -11,6 +11,14 @@ import {
 } from "../../scripts/blacksmith-testbox-runner.mjs";
 
 describe("blacksmith testbox runner", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("splits runner args from the remote command", () => {
     expect(
       splitRunnerArgs(["--id", "tbx_abc123", "--", "OPENCLAW_TESTBOX=1", "pnpm", "check:changed"]),
@@ -48,6 +56,7 @@ describe("blacksmith testbox runner", () => {
 
   it("refuses to run a keyed id that was not claimed by this checkout", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-testbox-runner-"));
+    tempDirs.push(stateDir);
     const testboxDir = path.join(stateDir, "tbx_01kqap50t9fqggzw1akg5dtmmq");
     fs.mkdirSync(testboxDir, { recursive: true });
     fs.writeFileSync(path.join(testboxDir, "id_ed25519"), "test-key\n");
@@ -71,6 +80,7 @@ describe("blacksmith testbox runner", () => {
 
   it("claims a keyed id without spawning when no remote command is supplied", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-testbox-runner-"));
+    tempDirs.push(stateDir);
     const testboxDir = path.join(stateDir, "tbx_01kqap50t9fqggzw1akg5dtmmq");
     const claimPath = path.join(testboxDir, "openclaw-runner.json");
     fs.mkdirSync(testboxDir, { recursive: true });
@@ -102,6 +112,7 @@ describe("blacksmith testbox runner", () => {
 
   it("terminates a Testbox run that stalls in sync", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-testbox-runner-"));
+    tempDirs.push(stateDir);
     const testboxId = "tbx_01kqap50t9fqggzw1akg5dtmmq";
     const testboxDir = path.join(stateDir, testboxId);
     fs.mkdirSync(testboxDir, { recursive: true });

--- a/test/scripts/github-activity-helper.test.ts
+++ b/test/scripts/github-activity-helper.test.ts
@@ -1,17 +1,25 @@
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 const repoRoot = path.resolve(import.meta.dirname, "../..");
 const helperPath = path.join(
   repoRoot,
   ".agents/skills/openclaw-pr-maintainer/scripts/github-activity.sh",
 );
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 function runHelper(args: string[]) {
   const dir = mkdtempSync(path.join(tmpdir(), "github-activity-helper-"));
+  tempDirs.push(dir);
   const binDir = path.join(dir, "bin");
   const logPath = path.join(dir, "gh.log");
   const ghPath = path.join(binDir, "gh");

--- a/test/scripts/mantis-publish-pr-evidence.test.ts
+++ b/test/scripts/mantis-publish-pr-evidence.test.ts
@@ -1,14 +1,23 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   loadEvidenceManifest,
   renderEvidenceComment,
 } from "../../scripts/mantis/publish-pr-evidence.mjs";
 
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 function writeFixtureManifest() {
   const dir = mkdtempSync(path.join(tmpdir(), "mantis-evidence-test-"));
+  tempDirs.push(dir);
   mkdirSync(path.join(dir, "baseline"), { recursive: true });
   mkdirSync(path.join(dir, "candidate"), { recursive: true });
   writeFileSync(path.join(dir, "baseline", "timeline.png"), "baseline timeline");
@@ -95,6 +104,7 @@ describe("scripts/mantis/publish-pr-evidence", () => {
 
   it("allows failure manifests to omit optional visual artifacts", () => {
     const dir = mkdtempSync(path.join(tmpdir(), "mantis-evidence-test-"));
+    tempDirs.push(dir);
     writeFileSync(path.join(dir, "summary.json"), JSON.stringify({ status: "fail" }));
     writeFileSync(path.join(dir, "report.md"), "bootstrap failed before screenshot");
     const manifestPath = path.join(dir, "mantis-evidence.json");
@@ -168,6 +178,7 @@ describe("scripts/mantis/publish-pr-evidence", () => {
 
   it("rejects artifact paths that escape the manifest directory", () => {
     const dir = mkdtempSync(path.join(tmpdir(), "mantis-evidence-test-"));
+    tempDirs.push(dir);
     const manifestPath = path.join(dir, "mantis-evidence.json");
     writeFileSync(
       manifestPath,

--- a/test/scripts/resolve-openclaw-package-candidate.test.ts
+++ b/test/scripts/resolve-openclaw-package-candidate.test.ts
@@ -1,12 +1,18 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   parseArgs,
   readArtifactPackageCandidateMetadata,
   validateOpenClawPackageSpec,
 } from "../../scripts/resolve-openclaw-package-candidate.mjs";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
 
 describe("resolve-openclaw-package-candidate", () => {
   it("accepts only OpenClaw release package specs for npm candidates", () => {
@@ -66,6 +72,7 @@ describe("resolve-openclaw-package-candidate", () => {
 
   it("reads package source metadata from package artifacts", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "openclaw-package-candidate-"));
+    tempDirs.push(dir);
     await writeFile(
       path.join(dir, "package-candidate.json"),
       JSON.stringify(

--- a/test/scripts/rtt-harness.test.ts
+++ b/test/scripts/rtt-harness.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   appendJsonl,
   buildRttResult,
@@ -17,6 +17,11 @@ import { __testing as cliTesting } from "../../scripts/rtt.ts";
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURE_PATH = path.resolve(TEST_DIR, "../fixtures/telegram-qa-summary-rtt.json");
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
 
 describe("RTT harness", () => {
   it("validates OpenClaw package specs", () => {
@@ -160,6 +165,7 @@ describe("RTT harness", () => {
 
   it("appends JSONL rows", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rtt-test-"));
+    tempDirs.push(tempDir);
     const jsonlPath = path.join(tempDir, "data/rtt.jsonl");
     await appendJsonl(jsonlPath, { run: 1 });
     await appendJsonl(jsonlPath, { run: 2 });

--- a/test/scripts/vitest-shard-timings.test.ts
+++ b/test/scripts/vitest-shard-timings.test.ts
@@ -1,13 +1,21 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   createShardTimingSample,
   readShardTimings,
   resolveShardTimingKey,
   writeShardTimings,
 } from "../../scripts/lib/vitest-shard-timings.mjs";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe("scripts/lib/vitest-shard-timings.mjs", () => {
   it("uses the config path as the timing key for whole-config runs", () => {
@@ -48,6 +56,7 @@ describe("scripts/lib/vitest-shard-timings.mjs", () => {
 
   it("persists include-pattern timing metadata", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-shard-timings-"));
+    tempDirs.push(tempDir);
     const env = {
       OPENCLAW_TEST_PROJECTS_TIMINGS_PATH: path.join(tempDir, "timings.json"),
       OPENCLAW_VITEST_SHARD_NAME: "auto-reply-reply-agent-runner",


### PR DESCRIPTION
## Summary
- add per-file `afterEach` temp-dir cleanup in 6 `test/scripts/*` suites that create `/tmp` directories
- keep each suite's temp roots tracked locally and remove them with `rm`/`rmSync` after every case
- leave behavior unchanged while eliminating persistent `/tmp` residue from script tests

## Validation
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test test/scripts/blacksmith-testbox-runner.test.ts test/scripts/github-activity-helper.test.ts test/scripts/mantis-publish-pr-evidence.test.ts test/scripts/resolve-openclaw-package-candidate.test.ts test/scripts/rtt-harness.test.ts test/scripts/vitest-shard-timings.test.ts`

## Scope
This PR only fixes the `test/scripts` group from the temp-cleanup scan. Gateway and extension fixes will be separate follow-up PRs.
