### PR TITLE
Fix Telegram embedded final transcript gap-fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ Docs: https://docs.openclaw.ai
 - Memory Wiki: skip empty and whitespace-only source pages when refreshing generated Related blocks, preventing blank pages from being rewritten into Related-only stubs. Fixes #78121. Thanks @amknight.
 - LINE: reject `dmPolicy: "open"` configs without wildcard `allowFrom` so webhook DMs fail validation instead of being acknowledged and silently blocked before inbound processing. Fixes #78316.
 - Telegram/Codex: keep message-tool-only progress drafts visible and render native Codex tool progress once per tool instead of duplicating item/tool draft lines. Fixes #75641. (#77949) Thanks @keshavbotagent.
+- Telegram/sessions: gap-fill delivered embedded final replies into the session JSONL even when the runner trace is missing, so Telegram answers after tool calls do not vanish from the durable transcript. Fixes #77814. Thanks @ChushulSuri and @DougButdorf.
 - Providers/xAI: stop sending OpenAI-style reasoning effort controls to native Grok Responses models, so `xai/grok-4.3` no longer fails live Docker/Gateway runs with `Invalid reasoning effort`.
 - Providers/xAI: clamp the bundled xAI thinking profile to `off` so live Gateway runs cannot send unsupported reasoning levels to native Grok Responses models.
 - Matrix/approvals: retry approval delivery up to 3 times with a short backoff so transient Matrix send failures do not strand pending approval prompts. (#78179) Thanks @Patrick-Erichsen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,7 +126,7 @@ Docs: https://docs.openclaw.ai
 - Memory Wiki: skip empty and whitespace-only source pages when refreshing generated Related blocks, preventing blank pages from being rewritten into Related-only stubs. Fixes #78121. Thanks @amknight.
 - LINE: reject `dmPolicy: "open"` configs without wildcard `allowFrom` so webhook DMs fail validation instead of being acknowledged and silently blocked before inbound processing. Fixes #78316.
 - Telegram/Codex: keep message-tool-only progress drafts visible and render native Codex tool progress once per tool instead of duplicating item/tool draft lines. Fixes #75641. (#77949) Thanks @keshavbotagent.
-- Telegram/sessions: gap-fill delivered embedded final replies into the session JSONL even when the runner trace is missing, so Telegram answers after tool calls do not vanish from the durable transcript. Fixes #77814. Thanks @ChushulSuri and @DougButdorf.
+- Telegram/sessions: gap-fill delivered embedded final replies into the session JSONL even when the runner trace is missing, so Telegram answers after tool calls do not vanish from the durable transcript. Fixes #77814. (#78426) Thanks @obviyus, @ChushulSuri, and @DougButdorf.
 - Providers/xAI: stop sending OpenAI-style reasoning effort controls to native Grok Responses models, so `xai/grok-4.3` no longer fails live Docker/Gateway runs with `Invalid reasoning effort`.
 - Providers/xAI: clamp the bundled xAI thinking profile to `off` so live Gateway runs cannot send unsupported reasoning levels to native Grok Responses models.
 - Matrix/approvals: retry approval delivery up to 3 times with a short backoff so transient Matrix send failures do not strand pending approval prompts. (#78179) Thanks @Patrick-Erichsen.

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1197,7 +1197,11 @@ async function agentCommandInternal(
     }
 
     const transcriptPersistenceRunner = result.meta.executionTrace?.runner;
-    if (transcriptPersistenceRunner === "cli" || transcriptPersistenceRunner === "embedded") {
+    const embeddedAssistantGapFill =
+      transcriptPersistenceRunner === "embedded" ||
+      (transcriptPersistenceRunner === undefined &&
+        Boolean(result.meta.finalAssistantVisibleText?.trim()));
+    if (transcriptPersistenceRunner === "cli" || embeddedAssistantGapFill) {
       try {
         sessionEntry = await attemptExecutionRuntime.persistCliTurnTranscript({
           body,
@@ -1212,7 +1216,7 @@ async function agentCommandInternal(
           threadId: opts.threadId,
           sessionCwd: workspaceDir,
           config: cfg,
-          embeddedAssistantGapFill: transcriptPersistenceRunner === "embedded",
+          embeddedAssistantGapFill,
         });
         sessionEntry = await (
           await loadCliCompactionRuntime()

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -417,6 +417,48 @@ describe("agentCommand", () => {
     });
   });
 
+  it("gap-fills Telegram-visible embedded replies without a runner trace", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store);
+      const sendMessageTelegram = vi.fn(async () => undefined);
+      const base = createDefaultAgentResult({ payloads: [{ text: "assistant-visible" }] });
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValueOnce({
+        ...base,
+        meta: {
+          ...base.meta,
+          finalAssistantVisibleText: "assistant-visible",
+        },
+      });
+
+      await agentCommandFromIngress(
+        {
+          message: "call a tool then answer",
+          agentId: "main",
+          to: "+1222",
+          channel: "telegram",
+          messageChannel: "telegram",
+          deliver: true,
+          senderIsOwner: false,
+          allowModelOverride: false,
+        },
+        runtime,
+        { sendMessageTelegram },
+      );
+
+      expect(sendMessageTelegram).toHaveBeenCalledWith(
+        "+1222",
+        "assistant-visible",
+        expect.objectContaining({ verbose: false }),
+      );
+      expect(vi.mocked(attemptExecutionRuntime.persistCliTurnTranscript)).toHaveBeenCalledTimes(1);
+      const persistArgs = vi.mocked(attemptExecutionRuntime.persistCliTurnTranscript).mock
+        .calls[0]?.[0];
+      expect(persistArgs?.embeddedAssistantGapFill).toBe(true);
+      expect(persistArgs?.body).toBe("call a tool then answer");
+    });
+  });
+
   it("passes configured fast mode to embedded runs", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");


### PR DESCRIPTION
Summary:
- Persist visible embedded final replies through the existing assistant gap-fill path when the runner trace is missing.
- Add a Telegram ingress regression that proves delivery can succeed while transcript persistence would otherwise be skipped.
- Add the unreleased changelog entry for #77814.

Verification:
- Red test on clean origin/main: `pnpm test src/commands/agent.test.ts -- --reporter=verbose -t 'gap-fills Telegram-visible embedded replies without a runner trace'` failed with `persistCliTurnTranscript` called 0 times.
- `pnpm test src/commands/agent.test.ts -- --reporter=verbose -t 'gap-fills Telegram-visible embedded replies without a runner trace'`
- `pnpm test src/commands/agent.test.ts src/agents/command/attempt-execution.cli.test.ts -- --reporter=verbose -t 'embedded-runner turns|gap-fills Telegram-visible|embedded assistant gap-fill'`
- `pnpm test src/auto-reply/reply/dispatch-from-config.test.ts -- --reporter=verbose -t 'sendPolicy deny'`
- `pnpm exec oxfmt --check --threads=1 src/agents/agent-command.ts src/commands/agent.test.ts`
- `git diff --check`
- Testbox `pnpm check:changed` passed after syncing 3 changed files.

## Real behavior proof

- Behavior addressed: Telegram-visible final assistant replies can exist even when the embedded runner trace is missing; the branch now routes visible final text through the durable assistant gap-fill path instead of skipping transcript persistence.
- Real setup tested: Local OpenClaw install on this machine, branch-built CLI from `fix/telegram-session-jsonl-gapfill`, real Claude CLI runtime, existing local OpenClaw state redacted.
- Exact steps or command run after the patch: `pnpm openclaw agent --local --agent main --message 'Reply exactly: PROOF-77814-PERSISTED' --json --timeout 180`
- Evidence after fix: redacted terminal output from the real local OpenClaw run:

```text
OpenClaw 2026.5.6 (b770766)
[agent/cli-backend] cli exec: provider=claude-cli model=opus promptChars=36 trigger=user useResume=false session=none resumeSession=none reuse=none historyPrompt=none
[agent/cli-backend] claude live session start: provider=claude-cli model=claude-opus-4-7 activeSessions=1
[agent/cli-backend] claude live session turn: provider=claude-cli model=claude-opus-4-7 durationMs=3221 rawLines=13
{
  "payloads": [
    {
      "text": "PROOF-77814-PERSISTED",
      "mediaUrl": null
    }
  ],
  "meta": {
    "finalAssistantVisibleText": "PROOF-77814-PERSISTED",
    "finalAssistantRawText": "PROOF-77814-PERSISTED",
    "executionTrace": {
      "winnerProvider": "claude-cli",
      "winnerModel": "claude-opus-4-7",
      "attempts": [{ "provider": "claude-cli", "model": "claude-opus-4-7", "result": "success" }],
      "fallbackUsed": false,
      "runner": "cli"
    }
  }
}
```

- Observed result after fix: The real local OpenClaw run produced the visible final assistant payload `PROOF-77814-PERSISTED`; the regression test covers the exact missing-runner Telegram persistence branch red/green.
- What was not tested: No live outbound Telegram message was sent; delivery is covered by the Telegram ingress regression without sending to a real chat.

Fixes #77814.
