### PR TITLE
fix(gateway): quiet startup-pending websocket closes

### DIFF
--- a/src/gateway/server/ws-connection.startup.test.ts
+++ b/src/gateway/server/ws-connection.startup.test.ts
@@ -51,6 +51,7 @@ describe("attachGatewayWsConnectionHandler startup readiness", () => {
       headers: { host: "127.0.0.1:19001" },
       socket: { localAddress: "127.0.0.1" },
     };
+    const logWsControl = createLogger();
 
     attachGatewayWsConnectionHandler({
       wss,
@@ -65,7 +66,7 @@ describe("attachGatewayWsConnectionHandler startup readiness", () => {
       refreshHealthSnapshot: vi.fn(async () => ({}) as never),
       logGateway: createLogger() as never,
       logHealth: createLogger() as never,
-      logWsControl: createLogger() as never,
+      logWsControl: logWsControl as never,
       extraHandlers: {},
       broadcast: vi.fn(),
       buildRequestContext: () => createRequestContext() as never,
@@ -124,5 +125,16 @@ describe("attachGatewayWsConnectionHandler startup readiness", () => {
     await vi.waitFor(() => {
       expect(socket.close).toHaveBeenCalledWith(1013, "gateway starting");
     });
+    expect(logWsControl.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("closed before connect"),
+      expect.objectContaining({ cause: "startup-sidecars-pending" }),
+    );
+    expect(logWsControl.debug).toHaveBeenCalledWith(
+      expect.stringContaining("closed before connect"),
+      expect.objectContaining({
+        cause: "startup-sidecars-pending",
+        handshake: "failed",
+      }),
+    );
   });
 });

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -374,10 +374,13 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         endpoint,
         ...closeMeta,
       };
+      const isExpectedStartupPendingClose =
+        closeCause === "startup-sidecars-pending" && code === 1013;
       if (!client) {
-        const logFn = isNoisySwiftPmHelperClose(requestUserAgent, remoteAddr)
-          ? logWsControl.debug
-          : logWsControl.warn;
+        const logFn =
+          isNoisySwiftPmHelperClose(requestUserAgent, remoteAddr) || isExpectedStartupPendingClose
+            ? logWsControl.debug
+            : logWsControl.warn;
         logFn(
           `closed before connect conn=${connId} peer=${endpoint ?? "n/a"} remote=${remoteAddr ?? "?"} fwd=${logForwardedFor || "n/a"} origin=${logOrigin || "n/a"} host=${logHost || "n/a"} ua=${logUserAgent || "n/a"} code=${code ?? "n/a"} reason=${logReason || "n/a"}`,
           closeContext,


### PR DESCRIPTION
## Summary

- Problem: expected retryable native-approval websocket connects during gateway startup were logged as `WARN` `closed before connect` events.
- Why it matters: Ruben's live log sweep found 1,173 `startup-sidecars-pending` warnings from `2026-05-06T10:29:44.624Z` through `2026-05-06T10:37:25.024Z`, which made normal startup retry behavior look like an incident.
- What changed: downgrade only `startup-sidecars-pending` pre-auth closes with code `1013` to debug while preserving warnings for other pre-connect close failures.
- What did NOT change (scope boundary): no gateway protocol change, no client retry change, no new config surface.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: retryable gateway-starting native approval websocket closes no longer emit warning-level log spam.
- Real environment tested: macOS local OpenClaw source checkout from `origin/main`, Node/pnpm workspace.
- Exact steps or command run after this patch: `pnpm test src/gateway/server/ws-connection.startup.test.ts`
- Evidence after fix: targeted regression output showed `1 passed`, and the added assertion verifies the startup-pending `1013` close is logged through `logWsControl.debug` with no matching `logWsControl.warn` call.
- Observed result after fix: expected startup-pending close remains retryable to the client and is no longer warning-level telemetry.
- What was not tested: owner performs final live-channel manual verification outside this agent run.
- Before evidence: live operator scan found 1,173 `startup-sidecars-pending` warning log lines over `2026-05-06T10:29:44.624Z` to `2026-05-06T10:37:25.024Z` while the gateway correctly returned code `1013` / `gateway starting`.

## Root Cause (if applicable)

- Root cause: the pre-connect close logger treated protocol-correct startup-pending `1013` closes the same as unexpected websocket closes.
- Missing detection / guardrail: the startup readiness regression test asserted the retryable close contract but not the log level.
- Contributing context (if known): native approval clients can reconnect repeatedly while sidecars are still pending during startup, creating large warning bursts for normal retry behavior.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server/ws-connection.startup.test.ts`
- Scenario the test should lock in: `startup-sidecars-pending` websocket close keeps returning retryable `UNAVAILABLE`/`1013` while logging at debug instead of warn.
- Why this is the smallest reliable guardrail: the existing startup readiness test already drives the exact pre-auth websocket path.
- Existing test that already covers this (if any): the same test covered the client close contract before this PR.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Normal gateway startup retry closes produce less warning-level log noise. No config or protocol changes.

## Diagram (if applicable)

```text
Before:
[native approval WS during sidecar startup] -> [1013 retry close] -> [WARN log burst]

After:
[native approval WS during sidecar startup] -> [1013 retry close] -> [debug log]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Gateway websocket path used by native approval clients
- Relevant config (redacted): default source checkout; no new config

### Steps

1. Start or observe gateway while startup sidecars are still pending.
2. Let a native approval websocket client connect before gateway readiness.
3. Inspect gateway websocket control logs for the pre-connect close.

### Expected

- Client receives retryable `1013 gateway starting`; expected startup-pending close is not warning-level telemetry.

### Actual

- Before this patch, expected startup-pending retry closes emitted repeated `WARN` `closed before connect` lines.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted startup websocket regression test and local Codex review.
- Edge cases checked: warnings remain available for other pre-connect close failures; the demotion is limited to `startup-sidecars-pending` with code `1013`.
- What you did **not** verify: owner performs final live-channel manual verification outside this agent run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a real startup-pending regression could become less visible at warning level.
  - Mitigation: the close remains logged at debug and only the exact expected `startup-sidecars-pending`/`1013` case is demoted; other pre-connect failures still warn.

## Local Validation

- `pnpm exec oxfmt --check --threads=1 src/gateway/server/ws-connection.ts src/gateway/server/ws-connection.startup.test.ts`
- `git diff --check`
- `pnpm test src/gateway/server/ws-connection.startup.test.ts`
- `CODEX_HOME=/Users/rubencu/.codex codex review --base origin/main` returned no actionable findings.
- Broad validation: GitHub PR CI.