### PR TITLE
fix(net): bound guarded fetch dispatcher cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Web fetch: bound guarded dispatcher cleanup after request timeouts so timed-out fetches return tool errors instead of leaving Gateway tool lanes active. (#78439) Thanks @obviyus.
 - Gate Slack startup user allowlist resolution [AI]. (#77898) Thanks @pgondhi987.
 - OpenAI/Codex: suppress stale `openai-codex` GPT-5.1/5.2/5.3 model refs that ChatGPT/Codex OAuth accounts now reject, keeping model lists, config validation, and forward-compat resolution on current 5.4/5.5 routes. Fixes #67158. Thanks @drpau.
 - Google Meet/Voice Call: wait longer before playing PIN-derived Twilio DTMF for Meet dial-in prompts and retire stale delegated phone sessions instead of reusing completed calls.

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -1138,6 +1138,43 @@ describe("fetchWithSsrFGuard hardening", () => {
     await result.release();
   });
 
+  it("rejects timed-out fetches even when dispatcher close stalls", async () => {
+    agentCtor.mockImplementationOnce(function MockAgent(this: { close: () => Promise<void> }) {
+      this.close = () => new Promise(() => {});
+    });
+    (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: agentCtor,
+      EnvHttpProxyAgent: envHttpProxyAgentCtor,
+      ProxyAgent: proxyAgentCtor,
+      fetch: vi.fn(async () => okResponse()),
+    };
+    const fetchImpl = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(init.signal?.reason ?? new Error("aborted"));
+          });
+        }),
+    );
+
+    const fetchPromise = fetchWithSsrFGuard({
+      url: "https://public.example/resource",
+      fetchImpl,
+      lookupFn: createPublicLookup(),
+      timeoutMs: 1,
+    });
+
+    const outcome = await Promise.race([
+      fetchPromise.then(
+        () => "resolved",
+        (error: unknown) => (error instanceof Error ? error.name : "rejected"),
+      ),
+      new Promise<string>((resolve) => setTimeout(() => resolve("hung"), 250)),
+    ]);
+
+    expect(outcome).toBe("TimeoutError");
+  });
+
   it("inherits the configured global stream timeout for guarded direct dispatchers", async () => {
     try {
       ensureGlobalUndiciStreamTimeouts({ timeoutMs: 1_900_000 });

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -27,6 +27,7 @@ type LookupCallback = (
 ) => void;
 
 type LookupResult = LookupAddress | LookupAddress[];
+const DISPATCHER_CLOSE_TIMEOUT_MS = 100;
 
 export class SsrFBlockedError extends Error {
   constructor(message: string) {
@@ -551,19 +552,55 @@ export function createPinnedDispatcher(
   );
 }
 
+type ClosableDispatcher = {
+  close?: () => Promise<void> | void;
+  destroy?: () => void;
+};
+
+function destroyDispatcher(candidate: ClosableDispatcher): void {
+  try {
+    candidate.destroy?.();
+  } catch {
+    // ignore dispatcher cleanup errors
+  }
+}
+
+async function waitForDispatcherClose(candidate: ClosableDispatcher): Promise<void> {
+  const close = candidate.close;
+  if (typeof close !== "function") {
+    destroyDispatcher(candidate);
+    return;
+  }
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      Promise.resolve(close.call(candidate)),
+      new Promise<void>((resolve) => {
+        timeout = setTimeout(() => {
+          timeout = undefined;
+          destroyDispatcher(candidate);
+          resolve();
+        }, DISPATCHER_CLOSE_TIMEOUT_MS);
+        timeout.unref?.();
+      }),
+    ]);
+  } catch (err) {
+    destroyDispatcher(candidate);
+    throw err;
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
 export async function closeDispatcher(dispatcher?: Dispatcher | null): Promise<void> {
   if (!dispatcher) {
     return;
   }
-  const candidate = dispatcher as { close?: () => Promise<void> | void; destroy?: () => void };
+  const candidate = dispatcher as ClosableDispatcher;
   try {
-    if (typeof candidate.close === "function") {
-      await candidate.close();
-      return;
-    }
-    if (typeof candidate.destroy === "function") {
-      candidate.destroy();
-    }
+    await waitForDispatcherClose(candidate);
   } catch {
     // ignore dispatcher cleanup errors
   }


### PR DESCRIPTION
## Summary
- Bound guarded-fetch dispatcher cleanup so timeout/error paths cannot hang behind a stalled undici close.
- Add regression coverage for a timed-out fetch whose dispatcher close never resolves.

## Real behavior proof
- **Behavior or issue addressed:** A timed-out guarded `web_fetch` must finish with a tool error instead of leaving the Gateway/tool lane stuck behind dispatcher cleanup.
- **Real environment tested:** Local OpenClaw candidate gateway from this PR head (`9bb72ae`) on macOS, profile `web-fetch-proof`, port `19089`, token auth, real Gateway HTTP `POST /tools/invoke` surface.
- **Exact steps or command run after this patch:** Started `pnpm openclaw --profile web-fetch-proof gateway run --port 19089 --auth token --token <redacted> --allow-unconfigured --dev --compact`, then called `POST /tools/invoke` for `web_fetch` against `https://1.1.1.1:81/`; while that request was pending and again after it completed, checked `/health` and called `web_fetch` against `https://example.com/`.
- **Evidence after fix:** Redacted runtime log excerpt: `16:56:39 [fetch-timeout] fetch timeout after 30000ms (elapsed 30002ms) operation=fetchWithSsrFGuard url=https://1.1.1.1:81/`; `16:56:39 [tools-invoke] tool execution failed: TimeoutError: request timed out`. Live output during/after: `/health` returned `{"ok":true,"status":"live"}`; `web_fetch` for `https://example.com/` returned `{"ok":true,..."status":200...}`.
- **Observed result after fix:** The timed-out fetch returned a tool error after about 30s, the gateway stayed live during the pending request, and a later `web_fetch` still succeeded with HTTP 200.
- **What was not tested:** Full Telegram group roundtrip was not rerun; this proof exercises the shared Gateway `tools.invoke` and `web_fetch` timeout path directly.

## Verification
- pnpm test src/infra/net/fetch-guard.ssrf.test.ts -- --reporter=verbose
- OPENCLAW_LOCAL_CHECK_MODE=throttled OPENCLAW_TESTBOX=0 pnpm check:changed
- OPENCLAW_LOCAL_CHECK_MODE=throttled OPENCLAW_TESTBOX=0 pnpm test:changed
- pnpm exec oxfmt --check --threads=1 src/infra/net/ssrf.ts src/infra/net/fetch-guard.ssrf.test.ts
- git diff --check
