### PR TITLE
fix: make conversation labels work with Codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/Codex: generate DM topic labels with Codex-compatible simple-completion requests so auto-created private topics can be renamed instead of staying `New Chat`.
 - Web fetch: bound guarded dispatcher cleanup after request timeouts so timed-out fetches return tool errors instead of leaving Gateway tool lanes active. (#78439) Thanks @obviyus.
 - Gate Slack startup user allowlist resolution [AI]. (#77898) Thanks @pgondhi987.
 - OpenAI/Codex: suppress stale `openai-codex` GPT-5.1/5.2/5.3 model refs that ChatGPT/Codex OAuth accounts now reject, keeping model lists, config validation, and forward-compat resolution on current 5.4/5.5 routes. Fixes #67158. Thanks @drpau.
@@ -174,6 +175,7 @@ Docs: https://docs.openclaw.ai
 - Hooks/session-memory: add collision suffixes to fallback memory filenames so repeated `/new` or `/reset` captures in the same minute do not overwrite the earlier session archive. Thanks @vincentkoc.
 - Agents/config: remove the ambiguous legacy `main` agent dir helper from runtime paths; model, auth, gateway, bundled plugin, and test helpers now resolve default/session agent dirs through `agents.list`/agent-scope helpers while plugin SDK keeps a deprecated compatibility export.
 - CLI/status: show the selected agent runtime/harness in `openclaw status` session rows so terminal status matches the `/status` runtime line. Thanks @vincentkoc.
+
 - CLI/sessions: prune old unreferenced transcript, compaction checkpoint, and trajectory artifacts during normal `sessions cleanup`, so gateway restart or crash orphans do not accumulate indefinitely outside `sessions.json`. Fixes #77608. Thanks @slideshow-dingo.
 - Doctor/Codex: repair legacy `openai-codex/*` routes in primary models, fallbacks, heartbeat/subagent/compaction overrides, hooks, channel overrides, and stale session pins to canonical `openai/*`, selecting `agentRuntime.id: "codex"` only when the Codex plugin is installed, enabled, contributes the `codex` harness, and has usable OAuth; otherwise select `agentRuntime.id: "pi"`. Thanks @vincentkoc.
 - Video generation: wait up to 20 minutes for slow fal/MiniMax queue-backed jobs, stop forwarding unsupported Google Veo generated-audio options, and normalize MiniMax `720P` requests to its supported `768P` resolution with the usual override warning/details instead of failing fallback.

--- a/src/auto-reply/reply/conversation-label-generator.test.ts
+++ b/src/auto-reply/reply/conversation-label-generator.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const completeSimple = vi.hoisted(() => vi.fn());
 const getRuntimeAuthForModel = vi.hoisted(() => vi.fn());
+const logVerbose = vi.hoisted(() => vi.fn());
 const requireApiKey = vi.hoisted(() => vi.fn());
 const resolveDefaultModelForAgent = vi.hoisted(() => vi.fn());
 const resolveModelAsync = vi.hoisted(() => vi.fn());
@@ -17,6 +18,8 @@ vi.mock("@mariozechner/pi-ai", async () => {
 });
 
 vi.mock("../../agents/model-auth.js", () => ({ requireApiKey }));
+
+vi.mock("../../globals.js", () => ({ logVerbose }));
 
 vi.mock("../../agents/model-selection.js", () => ({
   resolveDefaultModelForAgent,
@@ -40,6 +43,7 @@ describe("generateConversationLabel", () => {
   beforeEach(() => {
     completeSimple.mockReset();
     getRuntimeAuthForModel.mockReset();
+    logVerbose.mockReset();
     requireApiKey.mockReset();
     resolveDefaultModelForAgent.mockReset();
     resolveModelAsync.mockReset();
@@ -87,5 +91,71 @@ describe("generateConversationLabel", () => {
       model: { provider: "openai" },
       cfg: {},
     });
+  });
+
+  it("passes the label prompt as systemPrompt and the user text as message content", async () => {
+    await generateConversationLabel({
+      userMessage: "Need help with invoices",
+      prompt: "Generate a label",
+      cfg: {},
+    });
+
+    expect(completeSimple).toHaveBeenCalledWith(
+      { provider: "openai" },
+      {
+        systemPrompt: "Generate a label",
+        messages: [
+          {
+            role: "user",
+            content: "Need help with invoices",
+            timestamp: expect.any(Number),
+          },
+        ],
+      },
+      expect.objectContaining({
+        apiKey: "resolved-key",
+        maxTokens: 100,
+        temperature: 0.3,
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("omits temperature for Codex Responses simple completions", async () => {
+    resolveDefaultModelForAgent.mockReturnValue({ provider: "openai-codex", model: "gpt-5.5" });
+    resolveModelAsync.mockResolvedValue({
+      model: { provider: "openai-codex", api: "openai-codex-responses" },
+      authStorage: {},
+      modelRegistry: {},
+    });
+
+    await generateConversationLabel({
+      userMessage: "тест создания топика-треда",
+      prompt: "Generate a label",
+      cfg: {},
+    });
+
+    expect(completeSimple.mock.calls[0]?.[2]).toEqual(
+      expect.not.objectContaining({ temperature: expect.anything() }),
+    );
+  });
+
+  it("logs completion errors instead of treating them as empty labels", async () => {
+    completeSimple.mockResolvedValue({
+      content: [],
+      stopReason: "error",
+      errorMessage: "Codex error: Instructions are required",
+    });
+
+    const label = await generateConversationLabel({
+      userMessage: "Need help with invoices",
+      prompt: "Generate a label",
+      cfg: {},
+    });
+
+    expect(label).toBeNull();
+    expect(logVerbose).toHaveBeenCalledWith(
+      "conversation-label-generator: completion failed: Codex error: Instructions are required",
+    );
   });
 });

--- a/src/auto-reply/reply/conversation-label-generator.ts
+++ b/src/auto-reply/reply/conversation-label-generator.ts
@@ -23,6 +23,20 @@ function isTextContentBlock(block: { type: string }): block is TextContent {
   return block.type === "text";
 }
 
+function isCodexSimpleCompletionModel(model: { api?: string; provider?: string }): boolean {
+  return model.provider === "openai-codex" || model.api === "openai-codex-responses";
+}
+
+function extractSimpleCompletionError(result: {
+  stopReason?: string;
+  errorMessage?: string;
+}): string | null {
+  if (result.stopReason !== "error") {
+    return null;
+  }
+  return result.errorMessage?.trim() || "unknown error";
+}
+
 export async function generateConversationLabel(
   params: ConversationLabelParams,
 ): Promise<string | null> {
@@ -58,10 +72,11 @@ export async function generateConversationLabel(
     const result = await completeSimple(
       completionModel,
       {
+        systemPrompt: prompt,
         messages: [
           {
             role: "user",
-            content: `${prompt}\n\n${userMessage}`,
+            content: userMessage,
             timestamp: Date.now(),
           },
         ],
@@ -69,10 +84,15 @@ export async function generateConversationLabel(
       {
         apiKey,
         maxTokens: 100,
-        temperature: 0.3,
+        ...(isCodexSimpleCompletionModel(completionModel) ? {} : { temperature: 0.3 }),
         signal: controller.signal,
       },
     );
+    const errorMessage = extractSimpleCompletionError(result);
+    if (errorMessage) {
+      logVerbose(`conversation-label-generator: completion failed: ${errorMessage}`);
+      return null;
+    }
 
     const text = result.content
       .filter(isTextContentBlock)


### PR DESCRIPTION
## Problem
Telegram DM topic auto-labeling can silently leave new private topics named `New Chat` when the default model is `openai-codex/*`.

The conversation-label helper currently sends the label prompt inside the user message and always passes `temperature: 0.3`. Codex Responses simple completions require request instructions and reject unsupported `temperature`, so label generation returns empty content and the topic rename is skipped.

## Fix
- Pass the label prompt as `systemPrompt` and keep the first user message as user content.
- Omit `temperature` for `openai-codex` / `openai-codex-responses` simple completions.
- Log simple-completion `stopReason: "error"` with `errorMessage` instead of treating it as an empty label.

## Validation
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/conversation-label-generator.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src-auto-topic-label.tsbuildinfo`
- `./node_modules/.bin/oxfmt --check src/auto-reply/reply/conversation-label-generator.ts src/auto-reply/reply/conversation-label-generator.test.ts`

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Telegram DM private-topic auto-labeling with the default `openai-codex/gpt-5.5` model. Before this patch, Codex simple-completion label generation returned no label because the request lacked `systemPrompt` instructions and included unsupported `temperature`, so auto-created topics could stay named `New Chat`.
- Real environment tested: Local OpenClaw workspace on Linux, real configured `openai-codex/gpt-5.5` auth profile, real Telegram bot/account in a Telegram private chat with user `200512201`. Secrets/tokens are local and not included here.
- Exact steps or command run after this patch: Ran a live Node/tsx smoke from this PR branch that imports the patched `src/auto-reply/reply/conversation-label-generator.ts`, calls `generateConversationLabel(...)` with the same Telegram first-message text, creates a real Telegram private topic named `New Chat` via Bot API `createForumTopic`, then renames that topic via Bot API `editForumTopic` to the generated label.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
generated label: "Тест топика-треда"
createForumTopic result: {"chatId":"200512201","topicId":269805,"name":"New Chat"}
editForumTopic result: {"ok":true,"chatId":"200512201","messageThreadId":269805,"name":"Тест топика-треда"}
```

- Observed result after fix: The patched label generator produced a non-empty Codex label, a real Telegram private topic was created with `New Chat`, and `editForumTopic` successfully renamed that real topic to `Тест топика-треда`.
- What was not tested: Full inbound Telegram dispatcher end-to-end from a fresh user message through the async fire-and-forget rename path was not rerun after this patch; the proof covers the fixed label-generation request and the real Telegram create/rename API path used by the dispatcher.
- Before evidence (optional but encouraged): Before the patch, the same Codex simple-completion shape returned empty content with API errors such as `Instructions are required` and `Unsupported parameter: temperature`, which made `generateConversationLabel(...)` return `null` and skip the topic rename.
