### PR TITLE
fix(agents): strip historical Qwen reasoning_content on OpenAI-compat replay (#46637)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/transcript: extend the OpenAI-compatible reasoning-replay strip to Qwen 3.x and QwQ model ids so self-hosted oMLX/vLLM/llama.cpp deployments no longer 422 on follow-up turns when Qwen returns `reasoning_content` blocks containing unescaped control characters. Fixes #46637. Thanks @lexhoefsloot.
 - Web fetch: bound guarded dispatcher cleanup after request timeouts so timed-out fetches return tool errors instead of leaving Gateway tool lanes active. (#78439) Thanks @obviyus.
 - Gate Slack startup user allowlist resolution [AI]. (#77898) Thanks @pgondhi987.
 - OpenAI/Codex: suppress stale `openai-codex` GPT-5.1/5.2/5.3 model refs that ChatGPT/Codex OAuth accounts now reject, keeping model lists, config validation, and forward-compat resolution on current 5.4/5.5 routes. Fixes #67158. Thanks @drpau.

--- a/src/agents/pi-embedded-helpers/google.ts
+++ b/src/agents/pi-embedded-helpers/google.ts
@@ -1,4 +1,5 @@
 import { isGemma4ModelId } from "../../shared/google-models.js";
+import { isQwenModelRequiringReasoningStrip } from "../../shared/qwen-models.js";
 import { sanitizeGoogleTurnOrdering } from "./bootstrap.js";
 
 export function isGoogleModelApi(api?: string | null): boolean {
@@ -7,6 +8,17 @@ export function isGoogleModelApi(api?: string | null): boolean {
 
 export function isGemma4ModelRequiringReasoningStrip(modelId?: string | null): boolean {
   return isGemma4ModelId(modelId);
+}
+
+// Returns true for any model id that emits provider-side reasoning_content blocks
+// over OpenAI-compatible APIs, where replaying that historical reasoning into
+// follow-up requests breaks strict JSON parsers (oMLX/vLLM/Pydantic). Covers the
+// existing Gemma 4 case plus Qwen-family models that surface the same regression
+// (#46637).
+export function isOpenAiCompatibleReasoningStripModelId(
+  modelId?: string | null,
+): boolean {
+  return isGemma4ModelId(modelId) || isQwenModelRequiringReasoningStrip(modelId);
 }
 
 export { sanitizeGoogleTurnOrdering };

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -362,6 +362,36 @@ describe("resolveTranscriptPolicy", () => {
     expect(gemma3Policy.dropReasoningFromHistory).toBe(false);
   });
 
+  it("strips historical reasoning for Qwen 3.x on OpenAI-compatible providers (#46637)", () => {
+    // Self-hosted oMLX/vLLM/llama.cpp users typically register Qwen 3.x models
+    // via a custom OpenAI-compatible base url; Qwen returns provider-side
+    // `reasoning_content` blocks that, when replayed verbatim into the next
+    // request body, contain unescaped control characters that strict server-
+    // side JSON parsers (Pydantic/FastAPI in oMLX) reject as 422 parse errors.
+    for (const modelId of [
+      "omlx/Qwen3.5-122B-A10B-8bit",
+      "qwen3.6-plus",
+      "qwen3-coder-plus",
+      "vllm/qwen3-thinking-70b",
+      "qwq-32b",
+    ]) {
+      const policy = resolveTranscriptPolicy({
+        provider: "custom-openai-proxy",
+        modelId,
+        modelApi: "openai-completions",
+      });
+      expect(policy.dropReasoningFromHistory).toBe(true);
+    }
+
+    // Non-Qwen models on the same OpenAI-compatible fallback are unaffected.
+    const llamaPolicy = resolveTranscriptPolicy({
+      provider: "custom-openai-proxy",
+      modelId: "meta-llama/llama-3.3-70b-instruct",
+      modelApi: "openai-completions",
+    });
+    expect(llamaPolicy.dropReasoningFromHistory).toBe(false);
+  });
+
   it("falls back to unowned transport defaults when no owning plugin exists", () => {
     expectStrictOpenAiCompatibleReplayDefaults("custom-openai-proxy");
   });

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -7,8 +7,8 @@ import type { ProviderReplayPolicy } from "../plugins/types.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { normalizeProviderId } from "./model-selection.js";
 import {
-  isGemma4ModelRequiringReasoningStrip,
   isGoogleModelApi,
+  isOpenAiCompatibleReasoningStripModelId,
 } from "./pi-embedded-helpers/google.js";
 import type { ToolCallIdMode } from "./tool-call-id.js";
 
@@ -120,7 +120,7 @@ function buildUnownedProviderTransportReplayFallback(params: {
     ...(isAnthropic && modelId.includes("claude")
       ? { dropThinkingBlocks: !shouldPreserveThinkingBlocks(modelId) }
       : {}),
-    ...(isStrictOpenAiCompatible && isGemma4ModelRequiringReasoningStrip(modelId)
+    ...(isStrictOpenAiCompatible && isOpenAiCompatibleReasoningStripModelId(modelId)
       ? { dropReasoningFromHistory: true }
       : {}),
     ...(isGoogle || isStrictOpenAiCompatible ? { applyAssistantFirstOrderingFix: true } : {}),

--- a/src/plugins/provider-replay-helpers.ts
+++ b/src/plugins/provider-replay-helpers.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { isGemma4ModelId } from "../shared/google-models.js";
 import { sanitizeGoogleAssistantFirstOrdering } from "../shared/google-turn-ordering.js";
+import { isQwenModelRequiringReasoningStrip } from "../shared/qwen-models.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import type {
   ProviderReasoningOutputMode,
@@ -40,7 +41,8 @@ export function buildOpenAICompatibleReplayPolicy(
           validateGeminiTurns: false,
           validateAnthropicTurns: false,
         }),
-    ...(modelApi === "openai-completions" && isGemma4ModelId(options.modelId)
+    ...(modelApi === "openai-completions" &&
+    (isGemma4ModelId(options.modelId) || isQwenModelRequiringReasoningStrip(options.modelId))
       ? { dropReasoningFromHistory: true }
       : {}),
   };

--- a/src/shared/qwen-models.ts
+++ b/src/shared/qwen-models.ts
@@ -1,0 +1,24 @@
+import { normalizeLowercaseStringOrEmpty } from "./string-coerce.js";
+
+// Matches Qwen-family model ids that emit `reasoning_content` blocks over
+// OpenAI-compatible APIs (oMLX/vLLM/llama.cpp). Replaying those historical
+// reasoning blocks into follow-up requests trips strict server-side JSON
+// parsers (Pydantic/FastAPI in oMLX) on unescaped control characters, causing
+// 422 parse errors and empty assistant turns from turn 2 onward. (#46637)
+//
+// Covers the documented Qwen 3.x series plus QwQ/Qwen3-thinking variants. The
+// pattern intentionally also matches `qwen3.5`, `qwen3.6`, `qwen-3`, `qwen_3`,
+// and `qwq`/`qwen3-thinking` ids that appear in self-hosted deployments.
+export function isQwenModelRequiringReasoningStrip(modelId?: string | null): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(modelId);
+  if (!normalized) return false;
+  // `qwen3`, `qwen-3`, `qwen_3`, `qwen3.5`, `qwen3.6`, `qwen3-coder`, `qwen3-max`, ...
+  if (/(?:^|[/_:-])qwen[-_]?3(?:[._-]?\d)?(?:$|[/_.:-])/.test(normalized)) {
+    return true;
+  }
+  // `qwq` (Qwen reasoning-specialized series).
+  if (/(?:^|[/_:-])qwq(?:$|[/_.:-])/.test(normalized)) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

Self-hosted Qwen 3.x and QwQ deployments on oMLX/vLLM/llama.cpp surface a turn-2-onward 422 JSON parse error: Qwen models emit provider-side `reasoning_content` blocks that, when replayed verbatim into the next OpenAI-compatible request body, contain unescaped control characters that strict server-side parsers (Pydantic/FastAPI in oMLX) reject. The agent then produces empty `\n\n` assistant turns with `usage: { input: 0, output: 0 }`. OpenClaw already has a generic OpenAI-compatible reasoning-replay strip path, but it currently only matches Gemma 4 ids; this PR widens the same path to also match Qwen-family ids.

## Root Cause

- `src/agents/transcript-policy.ts:122` — `dropReasoningFromHistory: true` was gated on `isStrictOpenAiCompatible && isGemma4ModelRequiringReasoningStrip(modelId)`. Qwen ids like `omlx/Qwen3.5-122B-A10B-8bit`, `qwen3.6-plus`, `qwen3-coder-plus`, `qwq-32b` did not match `isGemma4ModelId`, so historical `reasoning_content` blocks captured at `src/agents/openai-transport-stream.ts:1542` continued through replay into follow-up requests.
- `src/plugins/provider-replay-helpers.ts:43` — same Gemma-only branch in the shared OpenAI-compatible replay helper used by provider plugins that don't define their own `buildReplayPolicy`.
- Execution path: `openai-transport-stream(reasoning_content delta)` → captured as assistant thinking block → `sanitizeSessionHistory()` skips `dropReasoningFromHistory` for Qwen → strict server (oMLX/vLLM Pydantic) rejects unescaped control chars in the next request body → 422 → empty assistant turn.
- This follows clawsweeper's review direction: *"Add a targeted replay-history policy for affected local/self-hosted Qwen-style OpenAI-compatible backends that removes or downgrades historical provider reasoning thinking blocks before follow-up requests, while preserving contracts that require replayed reasoning and current same-turn tool-call continuations."*

## Changes

- `src/shared/qwen-models.ts` (new): `isQwenModelRequiringReasoningStrip()` matches Qwen 3.x family (`qwen3`, `qwen-3`, `qwen3.5`, `qwen3.6`, `qwen3-coder`, `qwen3-max`, …) and the QwQ reasoning-specialized series. Pattern mirrors the shape of `isGemma4ModelId`.
- `src/agents/pi-embedded-helpers/google.ts`: add `isOpenAiCompatibleReasoningStripModelId()` that ORs Gemma 4 + Qwen, so the OpenAI-compatible fallback has one unified reasoning-strip predicate.
- `src/agents/transcript-policy.ts`: switch the line-122 fallback to use the unified predicate. Same Gemma 4 behavior; now also matches Qwen.
- `src/plugins/provider-replay-helpers.ts`: same OR-extend in the shared OpenAI-compatible replay helper so unowned Qwen-on-OpenAI-compat providers also get the strip.
- `src/agents/transcript-policy.test.ts`: regression test pinning the new behavior across `omlx/Qwen3.5-122B-A10B-8bit`, `qwen3.6-plus`, `qwen3-coder-plus`, `vllm/qwen3-thinking-70b`, `qwq-32b`, plus a non-Qwen `llama-3.3-70b-instruct` negative case.
- `CHANGELOG.md`: single-line entry under Unreleased / Fixes.

## Real behavior proof

- **Behavior or issue addressed**: After the first turn against a self-hosted Qwen 3.x model exposed via the OpenAI-compatible API (oMLX/vLLM/llama.cpp), follow-up turns return empty assistant content because the strict server-side parser rejects the next request body with 422 due to unescaped control characters in the replayed historical `reasoning_content` block. Reproduced and re-confirmed in the issue thread on 2026.5.4 with vLLM + Qwen 3.6 27B (commenter `@lexhoefsloot`) and originally on oMLX + Qwen 3.5 122B (`@yhyatt`). Issue: https://github.com/openclaw/openclaw/issues/46637
- **Real environment tested**: Local OpenClaw checkout on Windows 11 + Node 24, with the patched `src/agents/transcript-policy.ts` resolution exercised through the actual production `resolveTranscriptPolicy` entry point (no stubbed seam) for the failing model id strings the issue thread reported (`omlx/Qwen3.5-122B-A10B-8bit`, `qwen3.6-plus`, `qwen3-coder-plus`, `vllm/qwen3-thinking-70b`, `qwq-32b`).
- **Exact steps or command run after this patch**:
  ```
  git checkout fix/qwen-reasoning-replay-strip
  pnpm install
  pnpm test src/agents/transcript-policy.test.ts src/plugins/provider-replay-helpers.test.ts src/plugin-sdk/provider-model-shared.test.ts --no-coverage
  ```
- **Evidence after fix** (terminal output captured locally on PR head `2428496521`):
  ```
  [test] starting test/vitest/vitest.agents.config.ts

   RUN  v4.1.5 C:/Users/pss/OneDrive/Documents/github/openclaw-46637

   Test Files  1 passed (1)
        Tests  33 passed (33)
     Start at  20:59:01
     Duration  5.04s

  [test] passed 1 Vitest shard in 8.97s
  ```
  Plus 12/12 in `provider-replay-helpers.test.ts` and 18/18 in `provider-model-shared.test.ts`.
- **Observed result after fix**: For each of the Qwen model id strings the issue thread named, `resolveTranscriptPolicy({ provider: "custom-openai-proxy", modelId, modelApi: "openai-completions" })` now returns `dropReasoningFromHistory: true` (instead of `false`), so `sanitizeSessionHistory` removes historical `reasoning_content` thinking blocks before the next request body is built; non-Qwen `meta-llama/llama-3.3-70b-instruct` on the same fallback path stays at `false`, preserving the existing Gemma 4 behavior verbatim. `pnpm tsgo` against the touched modules is clean.
- **What was not tested**: Live oMLX or vLLM server with a real Qwen 3 weight is not available on the contributor machine, so this is unit-level proof against the production resolution function, not a live HTTP roundtrip against the strict server. Maintainers may apply `proof: override` if a fuller live recording is required; the issue thread already contains live failure logs from `@yhyatt` and `@lexhoefsloot` against the same code path.

## Test

- `pnpm test src/agents/transcript-policy.test.ts` — 33/33 passed (was 32; +1 Qwen regression).
- `pnpm test src/plugins/provider-replay-helpers.test.ts` — 12/12 passed.
- `pnpm test src/plugin-sdk/provider-model-shared.test.ts` — 18/18 passed.

Total: 63/63 across the three transcript-policy / replay-policy test surfaces.

## Notes

- Scope: smallest complete fix. No changes to provider plugins (extensions/qwen, etc.) — Qwen-via-OpenAI-compat self-hosted users typically don't go through the qwen plugin runtime, so the fix lives at the OpenAI-compatible fallback layer where it matches the existing Gemma 4 shape.
- Compatibility: Qwen models on providers that already supply their own `buildReplayPolicy` (with explicit `dropReasoningFromHistory` setting) are unaffected — the merge order in `mergeTranscriptPolicy` lets explicit policy override the fallback.
- Prior PRs #46668, #46758, #52505 attempted JSON-escaping or content-stripping at the serialization layer; all closed for branch hygiene (3000-file dirty diffs), not because the fix shape was wrong. This PR uses the architecturally correct seam (replay-policy fallback) that clawsweeper identified.

Closes #46637
