### PR TITLE
feat(plugins): add temporal context extension

### DIFF
--- a/extensions/temporal-context/README.md
+++ b/extensions/temporal-context/README.md
@@ -1,0 +1,68 @@
+# Temporal Context
+
+Temporal Context gives every OpenClaw agent turn a small, channel-agnostic sense of _now_.
+
+It injects a compact system-context block during `before_prompt_build` containing:
+
+- current local date and time
+- local ISO date
+- configured timezone
+- conversation surface when available
+- elapsed time since the previous user turn in the same session
+- previous user-turn local time
+
+This helps agents answer time-sensitive prompts, schedule naturally, avoid stale assumptions, and understand whether a reply is part of a rapid back-and-forth or a conversation resumed hours later.
+
+## Why this is useful
+
+LLM providers do not reliably know the operator's local date, timezone, channel, or interaction cadence. Temporal Context supplies those facts at the runtime boundary instead of relying on model memory or prompt boilerplate.
+
+Example injected block:
+
+```xml
+<temporal_context>
+Current local date: Wednesday, May 6, 2026
+Current local time: 8:13:25 a.m. EDT
+Local ISO date: 2026-05-06
+Timezone: America/Toronto
+Conversation surface: telegram
+Time since previous user turn in this session: 1 minute
+Previous user turn local time: Wednesday, May 6, 2026 at 8:12:16 a.m. EDT
+Use this for temporal grounding, recency, scheduling language, and stale-context checks. Do not mention it unless it helps the user.
+</temporal_context>
+```
+
+## Configuration
+
+```json
+{
+  "plugins": {
+    "allow": ["temporal-context"],
+    "entries": {
+      "temporal-context": {
+        "enabled": true,
+        "config": {
+          "timeZone": "America/Toronto",
+          "locale": "en-CA"
+        },
+        "hooks": {
+          "allowPromptInjection": true
+        }
+      }
+    }
+  }
+}
+```
+
+Options:
+
+- `enabled`: turn injection on or off. Defaults to `true`.
+- `timeZone`: IANA timezone. Defaults to `UTC`.
+- `locale`: `Intl.DateTimeFormat` locale. Defaults to `en-US`.
+- `statePath`: optional state file path. Supports `~` and `$OPENCLAW_HOME`. Defaults to `$OPENCLAW_HOME/state/temporal-context-state.json`.
+- `maxStateEntries`: maximum recent sessions retained. Defaults to `500`.
+- `debug`: log injection decisions. Defaults to `false`.
+
+## Privacy and storage
+
+The state file stores session keys, channel labels, timestamps, and turn counts only. It does not store message text.

--- a/extensions/temporal-context/index.test.ts
+++ b/extensions/temporal-context/index.test.ts
@@ -1,0 +1,104 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import plugin, { describeElapsed } from "./index.js";
+
+function createApi(statePath: string, extraConfig: Record<string, unknown> = {}) {
+  const hooks: Record<string, (...args: unknown[]) => unknown> = {};
+  const services: unknown[] = [];
+  const api = {
+    pluginConfig: {
+      timeZone: "America/Toronto",
+      locale: "en-CA",
+      statePath,
+      ...extraConfig,
+    },
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+    on: vi.fn((name: string, handler: (...args: unknown[]) => unknown) => {
+      hooks[name] = handler;
+    }),
+    registerService: vi.fn((service: unknown) => services.push(service)),
+  };
+  plugin.register(api as never);
+  return { api, hooks, services };
+}
+
+describe("temporal-context plugin", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("formats elapsed time compactly", () => {
+    expect(describeElapsed(3_000)).toBe("just now");
+    expect(describeElapsed(45_000)).toBe("45 seconds");
+    expect(describeElapsed(60_000)).toBe("1 minute");
+    expect(describeElapsed(2 * 60 * 60 * 1000)).toBe("2 hours");
+  });
+
+  test("injects current local time and records session state", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-temporal-context-"));
+    const statePath = join(dir, "state.json");
+    const { api, hooks } = createApi(statePath);
+
+    vi.setSystemTime(new Date("2026-05-06T12:13:25.000Z"));
+    const result = await hooks.before_prompt_build(
+      { prompt: "hello", messages: [] },
+      { sessionKey: "agent:main:telegram:123", messageProvider: "telegram" },
+    );
+
+    expect(api.on).toHaveBeenCalledWith("before_prompt_build", expect.any(Function), {
+      priority: 20,
+      timeoutMs: 750,
+    });
+    expect(result).toEqual({
+      prependSystemContext: expect.stringContaining("Current local date: Wednesday, May 6, 2026"),
+    });
+    const context = (result as { prependSystemContext: string }).prependSystemContext;
+    expect(context).toContain("Conversation surface: telegram");
+    expect(context).toContain(
+      "Time since previous user turn in this session: no previous turn recorded",
+    );
+
+    const state = JSON.parse(readFileSync(statePath, "utf8"));
+    expect(state.sessions["agent:main:telegram:123"].turnCount).toBe(1);
+  });
+
+  test("injects elapsed time since the previous user turn", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-temporal-context-"));
+    const statePath = join(dir, "state.json");
+    const { hooks } = createApi(statePath);
+
+    vi.setSystemTime(new Date("2026-05-06T12:00:00.000Z"));
+    await hooks.before_prompt_build({ prompt: "first", messages: [] }, { sessionKey: "session-1" });
+
+    vi.setSystemTime(new Date("2026-05-06T12:03:00.000Z"));
+    const result = await hooks.before_prompt_build(
+      { prompt: "second", messages: [] },
+      { sessionKey: "session-1" },
+    );
+
+    const context = (result as { prependSystemContext: string }).prependSystemContext;
+    expect(context).toContain("Time since previous user turn in this session: 3 minutes");
+  });
+
+  test("is inert when disabled", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-temporal-context-"));
+    const statePath = join(dir, "state.json");
+    const { hooks } = createApi(statePath, { enabled: false });
+
+    const result = await hooks.before_prompt_build(
+      { prompt: "hello", messages: [] },
+      { sessionKey: "session-1" },
+    );
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/extensions/temporal-context/index.ts
+++ b/extensions/temporal-context/index.ts
@@ -1,0 +1,326 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+
+type PluginHookAgentContext = {
+  runId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  messageProvider?: string;
+  trigger?: string;
+};
+
+type PluginHookBeforePromptBuildEvent = {
+  prompt: string;
+  messages: unknown[];
+};
+
+type TemporalContextConfig = {
+  enabled?: boolean;
+  timeZone?: string;
+  locale?: string;
+  statePath?: string;
+  maxStateEntries?: number;
+  debug?: boolean;
+};
+
+type TemporalSessionState = {
+  sessionKey: string;
+  channel: string;
+  lastUserTurnAt: string;
+  lastUserTurnAtMs: number;
+  previousUserTurnAt: string | null;
+  turnCount: number;
+};
+
+type TemporalState = {
+  schema: "openclaw.temporal-context.v1";
+  updatedAt?: string;
+  sessions?: Record<string, TemporalSessionState>;
+};
+
+type ResolvedTemporalContextConfig = Required<Omit<TemporalContextConfig, "statePath">> & {
+  statePath: string;
+};
+
+const DEFAULT_TIME_ZONE = "UTC";
+const DEFAULT_LOCALE = "en-US";
+const DEFAULT_MAX_STATE_ENTRIES = 500;
+const DEFAULT_STATE_FILE = "temporal-context-state.json";
+const MIN_STATE_ENTRIES = 1;
+const MAX_STATE_ENTRIES = 10_000;
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringOr(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function booleanOr(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function boundedIntegerOr(value: unknown, fallback: number, min: number, max: number): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, value));
+}
+
+function openClawHome(): string {
+  const configured = process.env.OPENCLAW_HOME?.trim();
+  return configured
+    ? resolve(configured.replace(/^~(?=$|[\\/])/, homedir()))
+    : resolve(homedir(), ".openclaw");
+}
+
+function resolveConfigPath(input: string | undefined): string {
+  const fallback = resolve(openClawHome(), "state", DEFAULT_STATE_FILE);
+  if (!input?.trim()) {
+    return fallback;
+  }
+  const expanded = input
+    .trim()
+    .replace(/^\$OPENCLAW_HOME(?=$|[\\/])/, openClawHome())
+    .replace(/^~(?=$|[\\/])/, homedir());
+  return resolve(expanded);
+}
+
+function resolveConfig(api: OpenClawPluginApi): ResolvedTemporalContextConfig {
+  const raw = asRecord(api.pluginConfig) ?? {};
+  return {
+    enabled: booleanOr(raw.enabled, true),
+    timeZone: stringOr(raw.timeZone, DEFAULT_TIME_ZONE),
+    locale: stringOr(raw.locale, DEFAULT_LOCALE),
+    statePath: resolveConfigPath(typeof raw.statePath === "string" ? raw.statePath : undefined),
+    maxStateEntries: boundedIntegerOr(
+      raw.maxStateEntries,
+      DEFAULT_MAX_STATE_ENTRIES,
+      MIN_STATE_ENTRIES,
+      MAX_STATE_ENTRIES,
+    ),
+    debug: booleanOr(raw.debug, false),
+  };
+}
+
+function readJson(path: string, fallback: TemporalState): TemporalState {
+  try {
+    if (!existsSync(path)) {
+      return fallback;
+    }
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    return asRecord(parsed) ? (parsed as TemporalState) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJsonAtomic(path: string, value: TemporalState): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(value, null, 2)}\n`);
+  renameSync(tmp, path);
+}
+
+function inferChannelFromSessionKey(sessionKey: string | undefined): string {
+  const key = sessionKey || "";
+  const match = /^agent:[^:]+:([^:]+)/.exec(key);
+  return match?.[1] || "";
+}
+
+function sessionKeyFrom(
+  _event: PluginHookBeforePromptBuildEvent,
+  ctx: PluginHookAgentContext,
+): string {
+  return ctx.sessionKey || ctx.sessionId || ctx.runId || "unknown-session";
+}
+
+function channelFrom(ctx: PluginHookAgentContext): string {
+  return (
+    ctx.messageProvider?.trim() ||
+    ctx.trigger?.trim() ||
+    inferChannelFromSessionKey(ctx.sessionKey) ||
+    "unknown"
+  );
+}
+
+function formatDateTimeParts(date: Date, timeZone: string, locale: string) {
+  const longDate = new Intl.DateTimeFormat(locale, {
+    timeZone,
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(date);
+  const time = new Intl.DateTimeFormat(locale, {
+    timeZone,
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZoneName: "short",
+  }).format(date);
+  const isoLocalDate = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+  return { longDate, time, isoLocalDate };
+}
+
+export function describeElapsed(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) {
+    return "unknown";
+  }
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 10) {
+    return "just now";
+  }
+  if (seconds < 60) {
+    return `${seconds} seconds`;
+  }
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) {
+    return `${hours} hour${hours === 1 ? "" : "s"}`;
+  }
+  const days = Math.round(hours / 24);
+  if (days < 45) {
+    return `${days} day${days === 1 ? "" : "s"}`;
+  }
+  const months = Math.round(days / 30);
+  if (months < 18) {
+    return `${months} month${months === 1 ? "" : "s"}`;
+  }
+  const years = Math.round(days / 365);
+  return `${years} year${years === 1 ? "" : "s"}`;
+}
+
+function compactState(state: TemporalState, nowMs: number, maxStateEntries: number): TemporalState {
+  const sessions = asRecord(state.sessions) ?? {};
+  const sorted = Object.entries(sessions)
+    .toSorted(
+      ([, a], [, b]) =>
+        Number(asRecord(b)?.lastUserTurnAtMs || 0) - Number(asRecord(a)?.lastUserTurnAtMs || 0),
+    )
+    .slice(0, maxStateEntries) as Array<[string, TemporalSessionState]>;
+  return {
+    schema: "openclaw.temporal-context.v1",
+    updatedAt: new Date(nowMs).toISOString(),
+    sessions: Object.fromEntries(sorted),
+  };
+}
+
+function buildContextBlock(params: {
+  now: Date;
+  previous: TemporalSessionState | null;
+  channel: string;
+  timeZone: string;
+  locale: string;
+}): string {
+  const parts = formatDateTimeParts(params.now, params.timeZone, params.locale);
+  const lines = [
+    "<temporal_context>",
+    `Current local date: ${parts.longDate}`,
+    `Current local time: ${parts.time}`,
+    `Local ISO date: ${parts.isoLocalDate}`,
+    `Timezone: ${params.timeZone}`,
+    `Conversation surface: ${params.channel}`,
+  ];
+
+  if (params.previous?.lastUserTurnAtMs) {
+    const elapsedMs = params.now.getTime() - params.previous.lastUserTurnAtMs;
+    const previousDate = new Date(params.previous.lastUserTurnAtMs);
+    const prevParts = formatDateTimeParts(previousDate, params.timeZone, params.locale);
+    lines.push(`Time since previous user turn in this session: ${describeElapsed(elapsedMs)}`);
+    lines.push(`Previous user turn local time: ${prevParts.longDate} at ${prevParts.time}`);
+  } else {
+    lines.push("Time since previous user turn in this session: no previous turn recorded");
+  }
+
+  lines.push(
+    "Use this for temporal grounding, recency, scheduling language, and stale-context checks. Do not mention it unless it helps the user.",
+  );
+  lines.push("</temporal_context>");
+  return lines.join("\n");
+}
+
+export default definePluginEntry({
+  id: "temporal-context",
+  name: "Temporal Context",
+  description: "Injects current local time and elapsed-time context into agent turns.",
+  register(api: OpenClawPluginApi) {
+    api.on(
+      "before_prompt_build",
+      async (event: PluginHookBeforePromptBuildEvent, ctx: PluginHookAgentContext) => {
+        const cfg = resolveConfig(api);
+        if (!cfg.enabled) {
+          return undefined;
+        }
+        try {
+          const now = new Date();
+          const nowMs = now.getTime();
+          const sessionKey = sessionKeyFrom(event, ctx);
+          const channel = channelFrom(ctx);
+          const state = readJson(cfg.statePath, {
+            schema: "openclaw.temporal-context.v1",
+            sessions: {},
+          });
+          const previous = state.sessions?.[sessionKey] ?? null;
+          const prependSystemContext = buildContextBlock({
+            now,
+            previous,
+            channel,
+            timeZone: cfg.timeZone,
+            locale: cfg.locale,
+          });
+
+          const nextSessions: Record<string, TemporalSessionState> = {
+            ...state.sessions,
+            [sessionKey]: {
+              sessionKey,
+              channel,
+              lastUserTurnAt: now.toISOString(),
+              lastUserTurnAtMs: nowMs,
+              previousUserTurnAt: previous?.lastUserTurnAt || null,
+              turnCount: (previous?.turnCount || 0) + 1,
+            },
+          };
+          writeJsonAtomic(
+            cfg.statePath,
+            compactState(
+              { schema: "openclaw.temporal-context.v1", sessions: nextSessions },
+              nowMs,
+              cfg.maxStateEntries,
+            ),
+          );
+
+          if (cfg.debug) {
+            api.logger.info(`temporal-context: injected for ${sessionKey} (${channel})`);
+          }
+          return { prependSystemContext };
+        } catch (error) {
+          api.logger.warn(
+            `temporal-context: injection failed: ${String((error as Error)?.stack || error)}`,
+          );
+          return undefined;
+        }
+      },
+      { priority: 20, timeoutMs: 750 },
+    );
+
+    api.registerService({
+      id: "temporal-context",
+      start: () => api.logger.info("temporal-context: ready"),
+      stop: () => {},
+    });
+  },
+});

--- a/extensions/temporal-context/openclaw.plugin.json
+++ b/extensions/temporal-context/openclaw.plugin.json
@@ -1,0 +1,44 @@
+{
+  "id": "temporal-context",
+  "name": "Temporal Context",
+  "description": "Injects current local date/time and elapsed-time grounding into agent turns.",
+  "kind": "runtime",
+  "activation": {
+    "onStartup": true
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "description": "Enable temporal context injection."
+      },
+      "timeZone": {
+        "type": "string",
+        "description": "IANA timezone used for local date/time formatting, e.g. America/Toronto."
+      },
+      "locale": {
+        "type": "string",
+        "description": "Intl locale used for human-readable date/time formatting."
+      },
+      "statePath": {
+        "type": "string",
+        "description": "Optional path for per-session temporal state. Supports ~ and $OPENCLAW_HOME."
+      },
+      "maxStateEntries": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 10000,
+        "description": "Maximum number of recent sessions to retain in the state file."
+      },
+      "debug": {
+        "type": "boolean",
+        "description": "Log temporal injection decisions."
+      }
+    }
+  },
+  "hooks": {
+    "allowPromptInjection": true
+  }
+}

--- a/extensions/temporal-context/package.json
+++ b/extensions/temporal-context/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/temporal-context-plugin",
+  "version": "2026.5.6",
+  "private": true,
+  "description": "OpenClaw temporal grounding plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/temporal-context/tsconfig.json
+++ b/extensions/temporal-context/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts"],
+  "exclude": ["./**/*.test.ts", "./dist/**", "./node_modules/**"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1371,6 +1371,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/temporal-context:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/telegram:
     dependencies:
       '@grammyjs/runner':

--- a/src/plugins/contracts/boundary-invariants.test.ts
+++ b/src/plugins/contracts/boundary-invariants.test.ts
@@ -19,6 +19,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_FILES = [
   "extensions/memory-core/src/dreaming.ts",
   "extensions/memory-lancedb/index.ts",
   "extensions/skill-workshop/index.ts",
+  "extensions/temporal-context/index.ts",
   "extensions/thread-ownership/index.ts",
 ] as const;
 const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
@@ -44,6 +45,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   "extensions/memory-core/src/dreaming.ts": ["before_agent_reply", "gateway_start", "gateway_stop"],
   "extensions/memory-lancedb/index.ts": ["agent_end", "before_prompt_build", "session_end"],
   "extensions/skill-workshop/index.ts": ["agent_end", "before_prompt_build"],
+  "extensions/temporal-context/index.ts": ["before_prompt_build"],
   "extensions/thread-ownership/index.ts": ["message_received", "message_sending"],
 } as const satisfies Record<
   (typeof BUNDLED_TYPED_HOOK_REGISTRATION_FILES)[number],


### PR DESCRIPTION
## Summary

Adds a bundled `temporal-context` runtime extension that gives OpenClaw agent turns a compact, channel-agnostic sense of *now*.

The plugin injects a small `before_prompt_build` system-context block with:

- current local date/time
- local ISO date
- configured timezone and locale
- conversation surface when available
- elapsed time since the previous user turn in the same session
- previous user-turn local time

This makes agents better at time-sensitive replies, scheduling language, stale-context checks, and distinguishing a rapid back-and-forth from a conversation resumed much later.

## Design notes

- Uses `prependSystemContext` so the temporal facts live in system-prompt space.
- Stores only lightweight state: session key, channel label, timestamps, and turn count. No message text is persisted.
- Defaults to `$OPENCLAW_HOME/state/temporal-context-state.json` and caps retained sessions to 500 by default.
- Supports `enabled`, `timeZone`, `locale`, `statePath`, `maxStateEntries`, and `debug` config.
- Ships with a README and extension package metadata so it is easy to enable and review.

## Real behavior proof

Behavior or issue addressed: `before_prompt_build` temporal context injection adds current local date/time, timezone, conversation surface, elapsed time since the previous user turn, and previous user-turn local time to agent system context.

Real environment tested: Real local OpenClaw Gateway on macOS/Darwin, loopback Gateway on port 18789, Telegram channel enabled in polling mode, timezone `America/Toronto`.

Exact steps or command run after this patch:

1. Enabled the workspace temporal-context plugin in `~/.openclaw/openclaw.json` with `timeZone: America/Toronto`, `locale: en-CA`, and prompt injection allowed.
2. Let the Gateway hot-reload/restart after config changes.
3. Verified Gateway and channel health with `openclaw gateway status` and `openclaw health --json`.
4. Sent real Telegram turns through the Gateway and inspected the resulting injected runtime context visible to the agent.

Evidence after fix:

Runtime status from the live Gateway:

```text
$ openclaw gateway status
Runtime: running (pid 31592, state active)
Connectivity probe: ok
Gateway: bind=loopback (127.0.0.1), port=18789 (service args)
Listening: 127.0.0.1:18789
```

Health output showed the temporal plugin loaded alongside production channels:

```json
{
  "ok": true,
  "plugins": {
    "loaded": [
      "browser",
      "imessage",
      "lumen-temporal-context",
      "openclaw-mem0",
      "telegram"
    ],
    "errors": []
  },
  "channels": {
    "telegram": {
      "enabled": true,
      "running": true,
      "connected": true,
      "mode": "polling"
    }
  }
}
```

The live Telegram conversation received injected temporal system context like:

```xml
<temporal_context>
Current local date: Wednesday, May 6, 2026
Current local time: 8:40:39 a.m. EDT
Local ISO date: 2026-05-06
Timezone: America/Toronto
Conversation surface: telegram
Time since previous user turn in this session: 5 minutes
Previous user turn local time: Wednesday, May 6, 2026 at 8:35:32 a.m. EDT
Use this for temporal grounding, recency, scheduling language, and stale-context checks. Do not mention it unless it helps the user.
</temporal_context>
```

Observed result after fix: The Gateway stayed healthy, Telegram remained connected, the temporal plugin loaded without errors, and real agent turns included the expected local time and elapsed-time context. A follow-up live turn confirmed the agent could use the injected elapsed-time context without the user restating it.

What was not tested: I did not install this exact bundled `extensions/temporal-context` package from the PR into a clean production Gateway yet; the real setup used the same hook behavior from the workspace plugin before it was upstream-shaped and renamed for bundling.

## Validation

- `pnpm exec vitest run extensions/temporal-context/index.test.ts --config test/vitest/vitest.extensions.config.ts`
- `pnpm exec vitest run src/plugins/contracts/boundary-invariants.test.ts --config test/vitest/vitest.contracts-plugin.config.ts`
- `pnpm run lint:extensions:bundled`
- `pnpm exec oxlint extensions/temporal-context src/plugins/contracts/boundary-invariants.test.ts`
- `pnpm exec tsc -p extensions/temporal-context/tsconfig.json --noEmit`
- `pnpm build:plugin-sdk:strict-smoke`
- `pnpm dlx --config.resolution-mode=highest markdownlint-cli2 --config config/markdownlint-cli2.jsonc extensions/temporal-context/README.md`
