### PR TITLE
fix(mattermost): collect setup URL in wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Docs: https://docs.openclaw.ai
 
 - Telegram/Codex: generate DM topic labels with Codex-compatible simple-completion requests so auto-created private topics can be renamed instead of staying `New Chat`.
 - Web fetch: bound guarded dispatcher cleanup after request timeouts so timed-out fetches return tool errors instead of leaving Gateway tool lanes active. (#78439) Thanks @obviyus.
+- Mattermost/setup: prompt for and persist the server base URL after the bot token in `openclaw setup --wizard`, instead of failing validation before `--http-url` is collected. Fixes #76670. Thanks @gordan-bobic.
 - Gate Slack startup user allowlist resolution [AI]. (#77898) Thanks @pgondhi987.
 - OpenAI/Codex: suppress stale `openai-codex` GPT-5.1/5.2/5.3 model refs that ChatGPT/Codex OAuth accounts now reject, keeping model lists, config validation, and forward-compat resolution on current 5.4/5.5 routes. Fixes #67158. Thanks @drpau.
 - CLI/update: keep pnpm package updates on the running custom global install root and pass pnpm's `--global-dir` so `openclaw update` does not create a second default-prefix install when `OPENCLAW_HOME` or the shell points at a custom OpenClaw directory. Fixes #78377. Thanks @amknight.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,7 @@ Docs: https://docs.openclaw.ai
 
 - Telegram/Codex: generate DM topic labels with Codex-compatible simple-completion requests so auto-created private topics can be renamed instead of staying `New Chat`.
 - Web fetch: bound guarded dispatcher cleanup after request timeouts so timed-out fetches return tool errors instead of leaving Gateway tool lanes active. (#78439) Thanks @obviyus.
-- Mattermost/setup: prompt for and persist the server base URL after the bot token in `openclaw setup --wizard`, instead of failing validation before `--http-url` is collected. Fixes #76670. Thanks @gordan-bobic.
+- Mattermost/setup: prompt for and persist the server base URL after the bot token in `openclaw setup --wizard`, instead of failing validation before `--http-url` is collected. Fixes #76670. Thanks @jacobtomlinson.
 - Gate Slack startup user allowlist resolution [AI]. (#77898) Thanks @pgondhi987.
 - OpenAI/Codex: suppress stale `openai-codex` GPT-5.1/5.2/5.3 model refs that ChatGPT/Codex OAuth accounts now reject, keeping model lists, config validation, and forward-compat resolution on current 5.4/5.5 routes. Fixes #67158. Thanks @drpau.
 - CLI/update: keep pnpm package updates on the running custom global install root and pass pnpm's `--global-dir` so `openclaw update` does not create a second default-prefix install when `OPENCLAW_HOME` or the shell points at a custom OpenClaw directory. Fixes #78377. Thanks @amknight.

--- a/extensions/mattermost/src/setup-core.ts
+++ b/extensions/mattermost/src/setup-core.ts
@@ -30,6 +30,33 @@ export function resolveMattermostAccountWithSecrets(cfg: OpenClawConfig, account
   });
 }
 
+export function applyMattermostSetupConfigPatch(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  name?: string;
+  patch: Record<string, unknown>;
+}): OpenClawConfig {
+  const namedConfig = applyAccountNameToChannelSection({
+    cfg: params.cfg,
+    channelKey: channel,
+    accountId: params.accountId,
+    name: params.name,
+  });
+  const next =
+    params.accountId !== DEFAULT_ACCOUNT_ID
+      ? migrateBaseNameToDefaultAccount({
+          cfg: namedConfig,
+          channelKey: channel,
+        })
+      : namedConfig;
+  return applySetupAccountConfigPatch({
+    cfg: next,
+    channelKey: channel,
+    accountId: params.accountId,
+    patch: params.patch,
+  });
+}
+
 export const mattermostSetupAdapter: ChannelSetupAdapter = {
   resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
   applyAccountName: ({ cfg, accountId, name }) =>
@@ -66,23 +93,10 @@ export const mattermostSetupAdapter: ChannelSetupAdapter = {
   applyAccountConfig: ({ cfg, accountId, input }) => {
     const token = input.botToken ?? input.token;
     const baseUrl = normalizeMattermostBaseUrl(input.httpUrl);
-    const namedConfig = applyAccountNameToChannelSection({
+    return applyMattermostSetupConfigPatch({
       cfg,
-      channelKey: channel,
       accountId,
       name: input.name,
-    });
-    const next =
-      accountId !== DEFAULT_ACCOUNT_ID
-        ? migrateBaseNameToDefaultAccount({
-            cfg: namedConfig,
-            channelKey: channel,
-          })
-        : namedConfig;
-    return applySetupAccountConfigPatch({
-      cfg: next,
-      channelKey: channel,
-      accountId,
       patch: input.useEnv
         ? {}
         : {

--- a/extensions/mattermost/src/setup-surface.ts
+++ b/extensions/mattermost/src/setup-surface.ts
@@ -6,7 +6,11 @@ import {
   formatDocsLink,
   type ChannelSetupWizard,
 } from "openclaw/plugin-sdk/setup";
-import { isMattermostConfigured, resolveMattermostAccountWithSecrets } from "./setup-core.js";
+import {
+  applyMattermostSetupConfigPatch,
+  isMattermostConfigured,
+  resolveMattermostAccountWithSecrets,
+} from "./setup-core.js";
 import { normalizeMattermostBaseUrl } from "./setup.client.runtime.js";
 import { hasConfiguredSecretInput } from "./setup.secret-input.runtime.js";
 
@@ -81,6 +85,12 @@ export const mattermostSetupWizard: ChannelSetupWizard = {
           hasConfiguredValue: hasConfiguredSecretInput(resolvedAccount.config.botToken),
         };
       },
+      applySet: async ({ cfg, accountId, value }) =>
+        applyMattermostSetupConfigPatch({
+          cfg,
+          accountId,
+          patch: { botToken: value },
+        }),
     },
   ],
   textInputs: [
@@ -106,6 +116,12 @@ export const mattermostSetupWizard: ChannelSetupWizard = {
           ? undefined
           : "Mattermost base URL must include a valid base URL.",
       normalizeValue: ({ value }) => normalizeMattermostBaseUrl(value) ?? value.trim(),
+      applySet: async ({ cfg, accountId, value }) =>
+        applyMattermostSetupConfigPatch({
+          cfg,
+          accountId,
+          patch: { baseUrl: value },
+        }),
     },
   ],
   disable: (cfg: OpenClawConfig) => ({

--- a/extensions/mattermost/src/setup.test.ts
+++ b/extensions/mattermost/src/setup.test.ts
@@ -1,4 +1,9 @@
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import {
+  createSetupWizardAdapter,
+  createQueuedWizardPrompter,
+  runSetupWizardConfigure,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/setup";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, OpenClawPluginApi } from "../runtime-api.js";
@@ -351,6 +356,41 @@ describe("mattermost setup", () => {
         },
       },
     });
+  });
+
+  it("prompts for bot token and server URL before validating wizard setup", async () => {
+    normalizeMattermostBaseUrl.mockImplementation((value: string | undefined) =>
+      value?.startsWith("http") ? value : undefined,
+    );
+    const queued = createQueuedWizardPrompter({
+      textValues: ["bot-token", "https://chat.example.com"],
+    });
+    const adapter = createSetupWizardAdapter({
+      plugin: {
+        id: "mattermost",
+        meta: { label: "Mattermost" },
+        config: {
+          listAccountIds: () => [DEFAULT_ACCOUNT_ID],
+        },
+        setup: mattermostSetupAdapter,
+      } as never,
+      wizard: mattermostSetupWizard,
+    });
+
+    const result = await runSetupWizardConfigure({
+      configure: adapter.configure,
+      cfg: { channels: { mattermost: {} } } as OpenClawConfig,
+      prompter: queued.prompter,
+      options: { secretInputMode: "plaintext" as const },
+    });
+
+    const textMessages = queued.text.mock.calls.map(
+      ([params]) => (params as { message: string }).message,
+    );
+    expect(textMessages).toEqual(["Enter Mattermost bot token", "Enter Mattermost base URL"]);
+    expect(result.cfg.channels?.mattermost?.botToken).toBe("bot-token");
+    expect(result.cfg.channels?.mattermost?.baseUrl).toBe("https://chat.example.com");
+    expect(result.accountId).toBe(DEFAULT_ACCOUNT_ID);
   });
 });
 


### PR DESCRIPTION
## Summary

- Problem: Mattermost setup had a base URL prompt in the declarative wizard, but the bot token step applied through the combined setup adapter before `httpUrl` was collected.
- Why it matters: `openclaw setup --wizard` failed immediately after entering the Mattermost bot token with `Mattermost requires --bot-token and --http-url (or --use-env).`
- What changed: Mattermost wizard token and URL answers now patch `botToken` and `baseUrl` independently, while the non-interactive adapter still validates `--bot-token` + `--http-url` together.
- What did NOT change: Mattermost runtime config shape, env-var setup, and non-interactive setup validation are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #76670
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: Mattermost wizard URL prompt was unreachable after entering the bot token.
- Real environment tested: Local OpenClaw setup using the Mattermost wizard path against a real Mattermost server.
- Exact steps or command run after this patch: `pnpm openclaw setup --wizard`, choose Mattermost, enter a real Mattermost bot token, then enter a real Mattermost server/base URL.
- Evidence after fix: Copied live terminal output from the reporter's local OpenClaw wizard run against a real Mattermost server, with private Mattermost URL, bot token, and local home path redacted:

```text
◇  Enter Mattermost bot token
│  <redacted>
│
◇  Enter Mattermost base URL
│  http://<redacted>
│
◇  Selected channels
│
│  Mattermost — self-hosted Slack-style chat; install the plugin to enable. Docs:
│  mattermost
│
Config overwrite: ~/.openclaw/openclaw.json (backup=~/.openclaw/openclaw.json.bak)
Updated ~/.openclaw/openclaw.json
Workspace OK: ~/.openclaw/workspace
Sessions OK: ~/.openclaw/agents/main/sessions
│
◇
Mattermost: configured
Agents: main (default)
Heartbeat interval: 30m (main)
```

  The reporter also supplied screenshot evidence showing the wizard successfully continued after Mattermost configuration.
- Observed result after fix: Wizard reaches the Mattermost URL prompt, persists both token and base URL, continues setup after Mattermost configuration, and connects to the real Mattermost server with the entered credentials.
- What was not tested: Full Mattermost message send/receive workflow beyond confirming setup continuation and live server connection.

## Root Cause

- Root cause: The generic declarative channel setup wizard applies credential answers immediately. Mattermost's default credential application used `mattermostSetupAdapter.applyAccountConfig`, whose validation requires both token and `httpUrl`, so validation ran after the token answer and before the URL text input prompt.
- Missing detection / guardrail: Existing tests covered the non-interactive adapter writing `baseUrl`, but not the interactive wizard ordering where token and URL are collected in separate steps.
- Contributing context: #76670 was closed as already implemented because source inspection saw `textInputs[*].inputKey = "httpUrl"`; the prompt existed, but the flow failed before reaching it.

## Regression Test Plan

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/mattermost/src/setup.test.ts`
- Scenario the test should lock in: Mattermost wizard prompts for bot token then base URL and persists both without hitting combined adapter validation between prompts.
- Why this is the smallest reliable guardrail: It exercises the declarative wizard adapter with the real Mattermost setup surface and adapter, without needing a live Mattermost server.
- Existing test that already covers this: None before this PR.

## User-visible / Behavior Changes

`openclaw setup --wizard` now reaches the Mattermost server/base URL prompt after the bot token prompt, writes `channels.mattermost.baseUrl`, and can complete setup against a real Mattermost server.

## Diagram

```text
Before:
[token prompt] -> adapter validation requires httpUrl -> setup error

After:
[token prompt] -> token patch -> URL prompt -> baseUrl patch -> setup continues
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No new secret storage mode; the wizard still writes the same `botToken` value/ref, but no longer validates the URL before it is collected.
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux local checkout
- Runtime/container: Node/pnpm local repo
- Model/provider: N/A
- Integration/channel: Mattermost
- Relevant config: real Mattermost server URL and bot token used by the reporter, redacted from PR evidence

### Steps

1. Run `pnpm openclaw setup --wizard`.
2. Choose Mattermost as the channel.
3. Enter a Mattermost bot token.
4. Enter a Mattermost server/base URL.

### Expected

- Wizard asks for the Mattermost URL, persists `channels.mattermost.baseUrl`, continues after Mattermost configuration, and the configured channel connects to the real Mattermost server.

### Actual before fix

- Wizard failed immediately after the bot token with `Mattermost requires --bot-token and --http-url (or --use-env).`

## Evidence

- [x] Failing behavior reported in #76670 and reproduced locally before the patch
- [x] Passing regression test after the patch
- [x] Reporter confirmed the patched local setup works against a real Mattermost server
- [x] Reporter supplied copied terminal output and screenshot evidence showing the wizard continued after Mattermost configuration

## Human Verification (required)

- Verified scenarios:
  - `pnpm test extensions/mattermost`
  - `pnpm tsgo:extensions`
  - `pnpm tsgo:extensions:test`
  - `pnpm exec oxfmt --check --threads=1 extensions/mattermost/src/setup-core.ts extensions/mattermost/src/setup-surface.ts extensions/mattermost/src/setup.test.ts`
  - `git diff --check upstream/main...HEAD`
- Edge cases checked: non-interactive adapter validation remains in place for explicit `--bot-token` + `--http-url` setup inputs.
- Manual live verification: reporter ran the patched wizard locally with a real Mattermost server URL and bot token, confirmed the wizard continued after Mattermost configuration, and confirmed the configured channel connected to that server.
- What I did not verify: Full Mattermost message send/receive workflow beyond setup continuation and live server connection.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Splitting wizard persistence could drift from non-interactive setup behavior.
  - Mitigation: The shared helper keeps the same account/name promotion behavior, and existing adapter validation tests continue to cover non-interactive setup.
