### PR TITLE
fix: clear current type-aware lint failures

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -4,7 +4,6 @@ import path from "node:path";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import {
   abortAgentHarnessRun,
-  buildAgentRuntimePlan,
   embeddedAgentLog,
   nativeHookRelayTesting,
   onAgentEvent,
@@ -53,32 +52,6 @@ function createParams(sessionFile: string, workspaceDir: string): EmbeddedRunAtt
     authProfileStore: { version: 1, profiles: {} },
     modelRegistry: {} as never,
   } as EmbeddedRunAttemptParams;
-}
-
-function createParamsWithRuntimePlan(
-  sessionFile: string,
-  workspaceDir: string,
-): EmbeddedRunAttemptParams {
-  const params = createParams(sessionFile, workspaceDir);
-  return {
-    ...params,
-    runtimePlan: buildCodexRuntimePlan(params, workspaceDir),
-  };
-}
-
-function buildCodexRuntimePlan(params: EmbeddedRunAttemptParams, workspaceDir: string) {
-  return buildAgentRuntimePlan({
-    provider: params.provider,
-    modelId: params.modelId,
-    model: params.model,
-    modelApi: params.model.api,
-    harnessId: "codex",
-    harnessRuntime: "codex",
-    config: params.config,
-    workspaceDir,
-    agentDir: tempDir,
-    thinkingLevel: params.thinkLevel,
-  });
 }
 
 function createCodexRuntimePlanFixture(): NonNullable<EmbeddedRunAttemptParams["runtimePlan"]> {

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -735,7 +735,7 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
           const includeDisabled = Boolean(params.includeDisabled);
           let offset = 0;
           let result: unknown;
-          do {
+          for (;;) {
             result = await callGateway("cron.list", gatewayOpts, {
               includeDisabled,
               agentId: listAgentId,
@@ -749,7 +749,7 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
               break;
             }
             offset = nextOffset;
-          } while (true);
+          }
           return jsonResult(
             selfRemoveOnlyJobId ? filterCronListResultToJobId(result, selfRemoveOnlyJobId) : result,
           );


### PR DESCRIPTION
## Summary
- Remove an unused Codex app-server test helper and its stale `buildAgentRuntimePlan` import.
- Rewrite an intentional cron pagination loop from `do { ... } while (true)` to `for (;;) { ... }` to satisfy `no-constant-condition` without changing behavior.
- Fixes the current type-aware lint failures on the latest `origin/main`.

## Real behavior proof
- **Behavior or issue addressed:** In a real local OpenClaw checkout, type-aware lint failed on the latest upstream base because `extensions/codex/src/app-server/run-attempt.test.ts` retained an unused helper/import and `src/agents/tools/cron-tool.ts` used a constant-condition loop. This patch removes the dead Codex helper/import and rewrites the cron loop form while preserving the same internal break behavior.
- **Real environment tested:** Local OpenClaw checkout at `/Volumes/PRO-G40/X CPA/openclaw`, macOS, Node `v24.13.1` via Volta, pnpm `10.33.2`, branch `fix/codex-run-attempt-unused-helper` rebased on upstream `b70a2451f8`.
- **Exact steps or command run after this patch:** Ran real terminal verification against the patched checkout, then ran the repo lint gate and targeted Codex/cron tests.
- **Evidence after fix:** Terminal capture from the patched checkout:

```text
$ OPENCLAW_OXLINT_SHARDS_SERIAL=1 volta run --node 24.13.1 pnpm lint
Found 0 warnings and 0 errors.
[oxlint:core] finished
Found 0 warnings and 0 errors.
[oxlint:extensions] finished
Found 0 warnings and 0 errors.
[oxlint:scripts] finished

$ volta run --node 24.13.1 node scripts/run-vitest.mjs run extensions/codex/src/app-server/run-attempt.test.ts src/agents/tools/cron-tool.test.ts src/agents/tools/cron-tool.flat-params.test.ts src/agents/tools/cron-tool.schema.test.ts
Test Files  6 passed (6)
Tests  224 passed (224)
```

- **Observed result after fix:** The real checkout passes the type-aware lint gate with zero warnings/errors, the affected Codex app-server test file still passes, and the cron tool test coverage still passes after the loop-form rewrite.
- **What was not tested:** No live Codex app-server or cron gateway runtime session was launched; these are lint-only/test-only source cleanups with behavior-preserving changes.

## Validation
- `OPENCLAW_OXLINT_SHARDS_SERIAL=1 volta run --node 24.13.1 pnpm lint`
- `volta run --node 24.13.1 node scripts/run-vitest.mjs run extensions/codex/src/app-server/run-attempt.test.ts src/agents/tools/cron-tool.test.ts src/agents/tools/cron-tool.flat-params.test.ts src/agents/tools/cron-tool.schema.test.ts`
