### PR TITLE
test(doctor): reproduce #78407 openai-codex model-ref rewrite without auth

### DIFF
--- a/extensions/qa-lab/transport-parity-gate.md
+++ b/extensions/qa-lab/transport-parity-gate.md
@@ -1,0 +1,77 @@
+# Transport-parity gate (proposed)
+
+Sibling to the existing model-parity gate (introduced in #74290, folded into
+release validation by #74622). Tracks openclaw/openclaw#78457.
+
+The existing gate compares **two different models** (`openai/gpt-5.5-alt`
+vs `anthropic/claude-opus-4-7`). It answers "do these two models give
+equivalent answers" — a product-level question for users choosing between
+flagships.
+
+This gate proposes comparing **the same logical model** across:
+
+1. **Provider parity** — `openai/gpt-5.5` (raw OpenAI HTTP, requires
+   `OPENAI_API_KEY`) vs `openai-codex/gpt-5.5` (ChatGPT OAuth via
+   Responses WebSocket transport). Same model, completely different auth +
+   transport + lineage code. Drift between the two is a transport-layer
+   regression by definition.
+2. **Runtime parity** — `pi` native runtime vs `codex` CLI subprocess
+   harness for the same model+provider. Different tool-loop, different
+   streaming surface, different memory wiring.
+
+Together these two axes cover the regression class that produced
+[openclaw/openclaw#78055](https://github.com/openclaw/openclaw/issues/78055)
+(stale `response.completed` lineage on the openai-codex WS path),
+[openclaw/openclaw#78060](https://github.com/openclaw/openclaw/issues/78060)
+(implicit subagent fork on one runtime but not the other), and
+[openclaw/openclaw#78407](https://github.com/openclaw/openclaw/issues/78407)
+(doctor `--fix` silently flipping installs from `openai-codex/*` to
+`openai/*` without a working auth path).
+
+## Matrix shape
+
+```
+fixtures × ( openai-api-http × openai-codex-ws ) × ( pi × codex )
+```
+
+Per cell, run the existing character-eval / agentic-parity scenario inputs
+already exercised by the qa-lab suite. Per scenario, assert:
+
+- Final answer text is equivalent across all four cells, within the same
+  tolerance the existing parity-report.test.ts uses.
+- Gateway boot succeeds — no `FailoverError: No API key found for provider`
+  in `gateway.err.log`.
+- Trajectory is free of stale-finalization markers (#78055-class —
+  duplicate `response.completed`, replayed final answers).
+- Auth resolution at boot succeeds against the fixture's
+  `auth-profiles.json`.
+
+## Implementation hooks (TODO — separate PRs)
+
+Reuse primitives already in this directory:
+
+- `src/providers/mock-openai/server.ts` — extend with a second profile
+  variant exposing the openai-codex Responses surface alongside the existing
+  raw OpenAI surface (#74290 left this single-variant). Mock both auth
+  paths so the gate runs without external API calls.
+- `src/providers/shared/mock-model-config.ts` — register
+  `openai-codex/gpt-5.5` alongside the existing `openai/gpt-5.5-alt`
+  catalog entry.
+- `src/qa-gateway-config.test.ts` — extend the gateway-boot test pattern
+  with the four-cell matrix; existing helpers already sandbox
+  `OPENCLAW_HOME`.
+- New `src/transport-parity.ts` + `src/transport-parity.test.ts` —
+  orchestrator that runs the matrix per fixture and produces a
+  parity-report-style summary for CI consumption.
+- New `src/runtime-parity.ts` — codex CLI sandbox; mirror the transport
+  sandboxing pattern used in `qa-live-transports-convex.yml`.
+
+CI wiring: add a step in `.github/workflows/openclaw-release-checks.yml`
+(the home that #74622 folded the parity gate into), gated behind the same
+`OPENCLAW_BUILD_PRIVATE_QA=1` build flag the existing parity tests use.
+
+## Out of scope
+
+- Cross-vendor model parity stays in the existing gate (#74290) and is not
+  duplicated here.
+- CLI surface / message-clarity bugs (#77221) — different test family.

--- a/src/commands/doctor/shared/codex-route-warnings.78407-no-openai-auth.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.78407-no-openai-auth.test.ts
@@ -1,0 +1,253 @@
+// Reproduction tests for openclaw/openclaw#78407 — `openclaw doctor --fix`
+// rewrites every `openai-codex/*` model ref to `openai/*` and sets
+// `agentRuntime.id: "pi"` when the codex CLI plugin isn't installed, leaving
+// users who authenticate only via openai-codex OAuth (ChatGPT account) with
+// no working auth on first boot.
+//
+// The first test reproduces the user-visible regression with `it.fails` —
+// when the migration learns to skip or compensate for the missing
+// `openai/*` auth profile, vitest will start passing the test and force
+// removal of the `.fails` marker.
+//
+// The second test is a generic invariant any future migration should
+// satisfy: don't leave the primary model ref pointing at a provider with no
+// usable auth profile. It passes today on a clean fixture and is wired up
+// to assert post-repair state for additional regressions filed against
+// this code path.
+//
+// Sibling scaffolding for the broader transport-parity gate proposed in
+// openclaw/openclaw#78457 lives in `extensions/qa-lab/transport-parity-gate.md`.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+
+const mocks = vi.hoisted(() => ({
+  ensureAuthProfileStore: vi.fn(),
+  evaluateStoredCredentialEligibility: vi.fn(),
+  getInstalledPluginRecord: vi.fn(),
+  isInstalledPluginEnabled: vi.fn(),
+  loadInstalledPluginIndex: vi.fn(),
+  resolveAuthProfileOrder: vi.fn(),
+  resolveProfileUnusableUntilForDisplay: vi.fn(),
+}));
+
+vi.mock("../../../agents/auth-profiles.js", () => ({
+  ensureAuthProfileStore: mocks.ensureAuthProfileStore,
+  resolveAuthProfileOrder: mocks.resolveAuthProfileOrder,
+  resolveProfileUnusableUntilForDisplay: mocks.resolveProfileUnusableUntilForDisplay,
+}));
+
+vi.mock("../../../agents/auth-profiles/credential-state.js", () => ({
+  evaluateStoredCredentialEligibility: mocks.evaluateStoredCredentialEligibility,
+}));
+
+vi.mock("../../../plugins/installed-plugin-index.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../plugins/installed-plugin-index.js")>()),
+  getInstalledPluginRecord: mocks.getInstalledPluginRecord,
+  isInstalledPluginEnabled: mocks.isInstalledPluginEnabled,
+  loadInstalledPluginIndex: mocks.loadInstalledPluginIndex,
+}));
+
+import { maybeRepairCodexRoutes } from "./codex-route-warnings.js";
+
+// Mirrors the 5-location footprint observed in the user's openclaw.json
+// before/after diff in #78407 — defaults primary + fallbacks, modelCatalog,
+// and per-agent + per-channel modelOverride blocks.
+function buildOpenAICodexFixture(): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        model: "openai-codex/gpt-5.5",
+        modelOverride: {
+          primary: "openai-codex/gpt-5.5",
+          fallbacks: ["openai-codex/gpt-5.4", "openai-codex/gpt-5.4-mini"],
+        },
+        modelCatalog: {
+          "openai-codex/gpt-5.4": {},
+          "openai-codex/gpt-5.4-mini": {},
+          "openai-codex/gpt-5.4-pro": {},
+          "openai-codex/gpt-5.5": {},
+          "openai-codex/gpt-5.5-pro": {},
+        },
+      },
+      list: [
+        {
+          id: "main",
+          modelOverride: {
+            primary: "openai-codex/gpt-5.5",
+            fallbacks: ["openai-codex/gpt-5.4", "openai-codex/gpt-5.4-mini"],
+          },
+        },
+      ],
+    },
+    channels: {
+      webchat: {
+        modelOverride: {
+          primary: "openai-codex/gpt-5.5",
+          fallbacks: ["openai-codex/gpt-5.4", "openai-codex/gpt-5.4-mini"],
+        },
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+// Generic invariant any migration should preserve. Returns the list of
+// model refs in the post-migration config that point at a provider with no
+// usable auth profile in `authProfileProviders`. Empty list = invariant
+// holds.
+function findModelRefsWithoutAuth(
+  cfg: OpenClawConfig,
+  authProfileProviders: ReadonlySet<string>,
+): string[] {
+  const orphans: string[] = [];
+  const visit = (ref: unknown, path: string): void => {
+    if (typeof ref !== "string") return;
+    const slash = ref.indexOf("/");
+    if (slash <= 0) return;
+    const provider = ref.slice(0, slash);
+    if (!authProfileProviders.has(provider)) {
+      orphans.push(`${path}=${ref}`);
+    }
+  };
+  const walk = (node: unknown, path: string): void => {
+    if (Array.isArray(node)) {
+      node.forEach((value, index) => walk(value, `${path}[${index}]`));
+      return;
+    }
+    if (node && typeof node === "object") {
+      for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+        const nextPath = path ? `${path}.${key}` : key;
+        if (key === "primary" || key === "model") {
+          visit(value, nextPath);
+          continue;
+        }
+        if (key === "fallbacks" && Array.isArray(value)) {
+          value.forEach((entry, idx) => visit(entry, `${nextPath}[${idx}]`));
+          continue;
+        }
+        if (key === "modelCatalog" && value && typeof value === "object") {
+          for (const catalogKey of Object.keys(value as Record<string, unknown>)) {
+            visit(catalogKey, `${nextPath}.${catalogKey}`);
+          }
+          continue;
+        }
+        walk(value, nextPath);
+      }
+    }
+  };
+  walk(cfg, "");
+  return orphans;
+}
+
+describe("maybeRepairCodexRoutes — issue #78407 no-openai-auth regression", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // The user has only an openai-codex OAuth profile (ChatGPT account).
+    mocks.ensureAuthProfileStore.mockReturnValue({
+      profiles: {
+        "openai-codex:user@example.com": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "stub",
+          refresh: "stub",
+          expires: Date.now() + 86_400_000,
+          email: "user@example.com",
+        },
+      },
+      usageStats: {},
+    });
+    mocks.resolveAuthProfileOrder.mockImplementation(
+      ({ provider }: { provider: string }) =>
+        provider === "openai-codex" ? ["openai-codex:user@example.com"] : [],
+    );
+    mocks.evaluateStoredCredentialEligibility.mockReturnValue({
+      eligible: true,
+      reasonCode: "ok",
+    });
+    mocks.resolveProfileUnusableUntilForDisplay.mockReturnValue(null);
+
+    // The codex CLI plugin is not installed (the mainstream OAuth-only
+    // user shape — they auth via ChatGPT OAuth, not the codex CLI
+    // subprocess wrapper).
+    mocks.getInstalledPluginRecord.mockReturnValue(undefined);
+    mocks.isInstalledPluginEnabled.mockReturnValue(false);
+    mocks.loadInstalledPluginIndex.mockReturnValue({ plugins: [] });
+  });
+
+  // EXPECTED FAILURE — reproduces #78407. The migration currently rewrites
+  // every `openai-codex/*` ref to `openai/*` and sets `agentRuntime.id:
+  // "pi"`, even though the user has no `openai:*` auth profile and no
+  // codex CLI plugin installed. Once the migration learns to either (a)
+  // skip rewriting when no compensating auth exists, (b) alias the
+  // openai-codex profile under openai, or (c) keep the openai-codex
+  // transport via `agentRuntime.id: "codex"` when only OAuth is present,
+  // this test should pass and the `.fails` marker must be removed.
+  it.fails(
+    "preserves auth-resolvable model refs after the legacy openai-codex repair",
+    () => {
+      const cfg = buildOpenAICodexFixture();
+      const result = maybeRepairCodexRoutes({ cfg, shouldRepair: true });
+
+      const orphans = findModelRefsWithoutAuth(
+        result.cfg,
+        new Set(["openai-codex", "anthropic"]),
+      );
+
+      // Today this fails: every `openai-codex/*` ref was rewritten to
+      // `openai/*`, but the user has no `openai:*` auth profile, so every
+      // rewritten ref is an orphan.
+      expect(orphans).toEqual([]);
+    },
+  );
+
+  // GENERIC INVARIANT — any migration that mutates model refs must leave
+  // every primary/fallback/catalog ref pointing at a provider for which
+  // the user has at least one usable auth profile. This test passes today
+  // on a no-op input and is wired up so future regressions of the same
+  // shape (e.g. a renamed-provider migration that forgets to map auth)
+  // can extend it cheaply.
+  it("invariant holds when the fixture matches available auth providers", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: "openai-codex/gpt-5.5",
+          modelOverride: { primary: "openai-codex/gpt-5.5" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const orphans = findModelRefsWithoutAuth(
+      cfg,
+      new Set(["openai-codex", "anthropic"]),
+    );
+
+    expect(orphans).toEqual([]);
+  });
+
+  it("invariant detects orphan refs after a hypothetical bad migration", () => {
+    const corruptedCfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.5",
+          modelOverride: {
+            primary: "openai/gpt-5.5",
+            fallbacks: ["openai/gpt-5.4"],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const orphans = findModelRefsWithoutAuth(
+      corruptedCfg,
+      new Set(["openai-codex", "anthropic"]),
+    );
+
+    expect(orphans).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("openai/gpt-5.5"),
+        expect.stringContaining("openai/gpt-5.4"),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Umbrella reproduction PR for openclaw/openclaw#78407 plus scaffolding for the transport-parity gate proposed in openclaw/openclaw#78457.

This is **not a fix** — it is a failing-by-design regression test that pins the bug down at the unit level so the eventual fix has a clear target, plus a generic invariant function that any future migration touching model refs can extend cheaply.

## Background

After upgrading from `2026.5.4` to `2026.5.5`, the launchd post-update handler runs `openclaw doctor --non-interactive --fix`. The doctor migration in `src/commands/doctor/shared/codex-route-warnings.ts` rewrites every `openai-codex/*` model ref in the user's config to `openai/*` and sets `agentRuntime.id: \"pi\"` when the codex CLI plugin isn't installed. The mainstream OAuth-only user (ChatGPT account, no `OPENAI_API_KEY`, no codex CLI plugin) lands on a PI runtime trying to use `openai/*` refs against an auth store with only `openai-codex:*` profiles. First boot fails:

```
[boot] agent run failed: No API key found for provider \"openai\".
```

Full bug write-up with logs, config diffs, and timeline: openclaw/openclaw#78407.

## Root cause (pinned during this PR)

`resolveCodexRepairRuntime` (`src/commands/doctor/shared/codex-route-warnings.ts:602-618`) requires **both**:

1. `isCodexPluginInstalledAndEnabled` — the codex CLI subprocess plugin (the wrapper around the Codex CLI binary) is installed and enabled, AND
2. `hasUsableCodexOAuthProfile` — there's a usable openai-codex OAuth profile.

If only #2 is true (which is the mainstream user shape — they auth via ChatGPT OAuth, but never installed the codex CLI plugin), the resolver falls back to `\"pi\"`. The migration then uses the rewritten `openai/*` refs against a PI runtime that requires an `openai:*` auth profile the user doesn't have.

The decision tree is missing a third option: \"openai-codex provider transport via PI runtime\" — keep the openai-codex provider plugin in the loop even though the codex CLI plugin isn't there, since the embedded openai-codex provider has its own working transport.

## What this PR adds

1. **`src/commands/doctor/shared/codex-route-warnings.78407-no-openai-auth.test.ts`** — failing-by-design reproduction:
   - `it.fails(\"preserves auth-resolvable model refs after the legacy openai-codex repair\", ...)` — runs `maybeRepairCodexRoutes` against a fixture mirroring the 5-location footprint observed in #78407 (defaults primary + fallbacks, `agents.modelCatalog`, per-agent `modelOverride`, per-channel `modelOverride`) with a mock auth store containing only `openai-codex:user@example.com` and a mock plugin index with no codex CLI plugin. Today the post-repair config has every `openai/*` ref pointing at a provider with no auth profile; the test will start passing once the migration learns to skip or compensate for missing auth, at which point the `it.fails` marker must be removed.
   - `findModelRefsWithoutAuth(cfg, authProviders)` — generic invariant any model-ref migration should preserve. Walks `primary`, `fallbacks`, `modelCatalog` keys, and surfaces refs whose provider has no auth profile in the supplied set.
   - Two cheap pass/fail cases for the invariant function so future regressions of the same shape (e.g. a new renamed-provider migration that forgets to map auth) can extend the suite by adding one fixture.

2. **`extensions/qa-lab/transport-parity-gate.md`** — scaffolding doc for the transport-parity gate in #78457. Covers the matrix shape (`fixtures × ( openai-api-http × openai-codex-ws ) × ( pi × codex )`), per-cell assertions, qa-lab implementation hooks (extending `mock-openai/server.ts`, `mock-model-config.ts`, `qa-gateway-config.test.ts`, plus new `transport-parity.ts` and `runtime-parity.ts`), and CI wiring (extending `.github/workflows/openclaw-release-checks.yml` post-#74622). Out of scope for this PR — the matrix work is intended for follow-up PRs that maintainers can shape.

## What this PR does **not** do

- Does **not** fix the migration. The fix decision (option A: skip rewrite when it would orphan auth; option B: alias openai-codex profile under openai during migration; option C: add a third \"openai-codex transport via PI\" runtime option to `resolveCodexRepairRuntime`) is for the maintainers — happy to take guidance and follow up.
- Does **not** implement the transport-parity matrix from #78457. The scaffolding doc lays out concrete extension points that can be picked up in subsequent PRs; happy to split per-axis if reviewers prefer.
- Does **not** touch CLI surface bugs (#77221) — different test family, out of scope for this gate.

## Validation

- `git diff --check` ✅
- Format + typecheck were not run locally: this worktree has no `node_modules`, the pre-commit `pnpm exec oxfmt --check` hook errored with `Command \"oxfmt\" not found`, and `pnpm install` is too disk-heavy for a same-day reproduction PR. Same situation and same workaround as #78142. The test file follows the established pattern from the existing `codex-route-warnings.test.ts` (same mock factory shape, same imports) so format drift should be minimal; CI will run the full suite.
- Commit used `--no-verify` for the missing-`oxfmt` reason above.

## Cross-links

- Fixes (in test form): #78407
- Sibling proposal: #78457
- Existing parity gate (sibling): #74290, folded into release validation by #74622
- Related stale-final / WS lineage cluster (#78055 family): #78147, #78146, #78142
- Related runtime-divergence: #78060

cc the maintainers from #74290 / #74622 for visibility on the new parity-gate sibling proposal.