### PR TITLE
fix(gateway): allow tweakcn.com in Control UI CSP connect-src

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - OpenAI: support `openai/chat-latest` as an explicit direct API-key model override for trying the moving ChatGPT Instant API alias without changing the stable default model.
 - Plugins/install: add `npm-pack:<path.tgz>` installs so local npm pack artifacts run through the same managed npm-root install, lockfile verification, dependency scan, and install-record path as registry npm plugins.
 - Codex app-server: disarm the short post-tool completion watchdog after current-turn activity, expose `appServer.turnCompletionIdleTimeoutMs`, and include raw assistant item context in idle-timeout diagnostics so status-only post-tool stalls stop failing as idle. Fixes #77984. Thanks @roseware-dev and @rubencu.
+- Control UI/CSP: allow `https://tweakcn.com` in `connect-src` so the documented tweakcn custom-theme import feature works from the browser. Fixes #78504.
 - Plugin skills/Windows: publish plugin-provided skill directories as junctions on Windows so standard users without Developer Mode can register plugin skills without symlink EPERM failures. Fixes #77958. (#77971) Thanks @hclsys and @jarro.
 - MS Teams: surface blocked Bot Framework egress by logging JWKS fetch network failures and adding a Bot Connector send hint for transport-level reply failures. Fixes #77674. (#78081) Thanks @Beandon13.
 - Gateway/sessions: fast-path already-qualified model refs while building session-list rows so `openclaw sessions` and Control UI session lists avoid heavyweight model resolution on large stores. (#77902) Thanks @ragesaq.

--- a/src/gateway/control-ui-csp.test.ts
+++ b/src/gateway/control-ui-csp.test.ts
@@ -26,6 +26,7 @@ describe("buildControlUiCspHeader", () => {
       "ws:",
       "wss:",
       "https://api.openai.com",
+      "https://tweakcn.com",
     ]);
   });
 

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -47,6 +47,6 @@ export function buildControlUiCspHeader(opts?: { inlineScriptHashes?: string[] }
     "img-src 'self' data: blob:",
     "font-src 'self' https://fonts.gstatic.com",
     "worker-src 'self'",
-    "connect-src 'self' ws: wss: https://api.openai.com",
+    "connect-src 'self' ws: wss: https://api.openai.com https://tweakcn.com",
   ].join("; ");
 }


### PR DESCRIPTION
## Summary

The Control UI fetches `https://tweakcn.com/r/themes/<id>` directly from the browser when importing custom themes, but the served CSP did not include that origin in `connect-src`. This aligns the CSP with the approved direct-fetch design documented in the tweakcn custom-theme import spec.

## Changes

- Added `https://tweakcn.com` to the `connect-src` directive in `buildControlUiCspHeader()`
- Updated `control-ui-csp.test.ts` to expect the new origin in the CSP allowlist
- Added changelog entry under Unreleased

## Testing

- `pnpm test src/gateway/control-ui-csp.test.ts` — CSP unit test updated to assert the new origin is present
- `pnpm test src/gateway/control-ui.http.test.ts` — HTTP handler test passes (no CSP assertion changes needed)

## Real behavior proof

Screen recording demonstrating the fix:

The video shows a local Control UI session where a tweakcn share link is imported via **Appearance → Custom Theme → Import from tweakcn**. Before the fix, this triggers a CSP `connect-src` violation in the browser console. With the patched CSP (adding `https://tweakcn.com` to `connect-src`), the fetch succeeds and the theme is applied without any CSP errors.

https://github.com/user-attachments/assets/d3443157-71b7-4955-ae10-cade0bb0e89c

Key frames in the recording:
- Control UI loads with the patched Gateway CSP
- `importCustomThemeFromUrl()` resolves the tweakcn link to `https://tweakcn.com/r/themes/{id}`
- The browser fetch completes (no `violates the following Content Security Policy directive` error)
- Custom theme tokens are applied to the UI

Fixes openclaw/openclaw#78504

---

**AI-assisted:** Yes. This fix was identified, implemented, and tested with assistance from OpenClaw.

- [x] Mark as AI-assisted in the PR title or description
- [x] Include human-run real behavior proof from your own setup
- [x] Confirm I understand what the code does: the CSP `connect-src` directive is a browser security policy that restricts which origins the Control UI can fetch from. The tweakcn theme import feature was documented but broken in practice because the CSP allowlist did not include the origin the UI actually fetches from. This is a narrowly scoped allowlist addition.