### PR TITLE
fix(agent): preserve fast mode in fast reply runtime

### DIFF
--- a/src/auto-reply/reply.test-harness.ts
+++ b/src/auto-reply/reply.test-harness.ts
@@ -74,6 +74,7 @@ vi.mock("./reply/agent-runner.runtime.js", () => ({
         agentId: string;
         config: unknown;
         execOverrides?: unknown;
+        fastMode?: unknown;
         inputProvenance?: unknown;
         messageProvider?: string;
         model: string;
@@ -99,6 +100,7 @@ vi.mock("./reply/agent-runner.runtime.js", () => ({
       agentId: params.followupRun.run.agentId,
       config: params.followupRun.run.config,
       execOverrides: params.followupRun.run.execOverrides,
+      fastMode: params.followupRun.run.fastMode,
       inputProvenance: params.followupRun.run.inputProvenance,
       messageProvider: params.followupRun.run.messageProvider,
       model: params.followupRun.run.model,

--- a/src/auto-reply/reply/agent-runner-run-params.ts
+++ b/src/auto-reply/reply/agent-runner-run-params.ts
@@ -85,6 +85,7 @@ export function buildEmbeddedRunBaseParams(params: {
     modelFallbacksOverride,
     ...params.authProfile,
     thinkLevel: params.run.thinkLevel,
+    fastMode: params.run.fastMode,
     verboseLevel: params.run.verboseLevel,
     reasoningLevel: params.run.reasoningLevel,
     execOverrides: params.run.execOverrides,

--- a/src/auto-reply/reply/agent-runner-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-runtime-config.test.ts
@@ -23,6 +23,7 @@ function makeRun(config: OpenClawConfig): FollowupRun["run"] {
     enforceFinalTag: false,
     skipProviderRuntimeHints: true,
     thinkLevel: "medium",
+    fastMode: true,
     verboseLevel: "off",
     reasoningLevel: "none",
     execOverrides: {},
@@ -74,5 +75,17 @@ describe("buildEmbeddedRunBaseParams runtime config", () => {
     });
 
     expect(resolved.config).toBe(resolvedRunConfig);
+  });
+
+  it("forwards fast mode to embedded runner params", () => {
+    const resolved = buildEmbeddedRunBaseParams({
+      run: makeRun({}),
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      runId: "run-1",
+      authProfile: {},
+    });
+
+    expect(resolved.fastMode).toBe(true);
   });
 });

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -994,15 +994,13 @@ export async function runPreparedReply(
       authProfileId,
       authProfileIdSource,
       thinkLevel: resolvedThinkLevel,
-      fastMode: useFastReplyRuntime
-        ? false
-        : resolveFastModeState({
-            cfg,
-            provider,
-            model,
-            agentId,
-            sessionEntry: preparedSessionState.sessionEntry,
-          }).enabled,
+      fastMode: resolveFastModeState({
+        cfg,
+        provider,
+        model,
+        agentId,
+        sessionEntry: preparedSessionState.sessionEntry,
+      }).enabled,
       verboseLevel: resolvedVerboseLevel,
       reasoningLevel: resolvedReasoningLevel,
       elevatedLevel: resolvedElevatedLevel,

--- a/src/auto-reply/reply/get-reply.fast-path.runtime.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.runtime.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
@@ -59,6 +61,57 @@ describe("getReplyFromConfig fast-path runtime", () => {
       expect(text).toBe("ok");
       expect(seenPrompt).toContain("[media attached: 2 files]");
       expect(seenPrompt).toContain("hello");
+    });
+  });
+
+  it("preserves session fast mode in the fast-path runtime", async () => {
+    await withTempHome(async (home) => {
+      const sessionKey = "agent:main:whatsapp:+2000";
+      const sessionFile = path.join(
+        home,
+        ".openclaw",
+        "agents",
+        "main",
+        "sessions",
+        "session-fast-mode.jsonl",
+      );
+      await fs.writeFile(
+        path.join(home, "sessions.json"),
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "session-fast-mode",
+            sessionFile,
+            fastMode: true,
+            updatedAt: Date.now(),
+          },
+        }),
+        "utf8",
+      );
+
+      let seenFastMode: unknown;
+      agentMocks.runEmbeddedPiAgent.mockImplementation(async (params) => {
+        seenFastMode = params.fastMode;
+        return makeEmbeddedTextResult("ok");
+      });
+
+      await getReplyFromConfig(
+        {
+          Body: "hello",
+          BodyForAgent: "hello",
+          RawBody: "hello",
+          CommandBody: "hello",
+          From: "+1001",
+          To: "+2000",
+          SessionKey: sessionKey,
+          Provider: "whatsapp",
+          Surface: "whatsapp",
+          ChatType: "direct",
+        },
+        {},
+        makeReplyConfig(home) as OpenClawConfig,
+      );
+
+      expect(seenFastMode).toBe(true);
     });
   });
 });

--- a/src/auto-reply/reply/get-reply.fast-path.runtime.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.runtime.test.ts
@@ -64,54 +64,57 @@ describe("getReplyFromConfig fast-path runtime", () => {
     });
   });
 
-  it("preserves session fast mode in the fast-path runtime", async () => {
-    await withTempHome(async (home) => {
-      const sessionKey = "agent:main:whatsapp:+2000";
-      const sessionFile = path.join(
-        home,
-        ".openclaw",
-        "agents",
-        "main",
-        "sessions",
-        "session-fast-mode.jsonl",
-      );
-      await fs.writeFile(
-        path.join(home, "sessions.json"),
-        JSON.stringify({
-          [sessionKey]: {
-            sessionId: "session-fast-mode",
-            sessionFile,
-            fastMode: true,
-            updatedAt: Date.now(),
+  it.each([true, false])(
+    "preserves session fast mode=%s in the fast-path runtime",
+    async (fastMode) => {
+      await withTempHome(async (home) => {
+        const sessionKey = "agent:main:whatsapp:+2000";
+        const sessionFile = path.join(
+          home,
+          ".openclaw",
+          "agents",
+          "main",
+          "sessions",
+          "session-fast-mode.jsonl",
+        );
+        await fs.writeFile(
+          path.join(home, "sessions.json"),
+          JSON.stringify({
+            [sessionKey]: {
+              sessionId: "session-fast-mode",
+              sessionFile,
+              fastMode,
+              updatedAt: Date.now(),
+            },
+          }),
+          "utf8",
+        );
+
+        let seenFastMode: unknown;
+        agentMocks.runEmbeddedPiAgent.mockImplementation(async (params) => {
+          seenFastMode = params.fastMode;
+          return makeEmbeddedTextResult("ok");
+        });
+
+        await getReplyFromConfig(
+          {
+            Body: "hello",
+            BodyForAgent: "hello",
+            RawBody: "hello",
+            CommandBody: "hello",
+            From: "+1001",
+            To: "+2000",
+            SessionKey: sessionKey,
+            Provider: "whatsapp",
+            Surface: "whatsapp",
+            ChatType: "direct",
           },
-        }),
-        "utf8",
-      );
+          {},
+          makeReplyConfig(home) as OpenClawConfig,
+        );
 
-      let seenFastMode: unknown;
-      agentMocks.runEmbeddedPiAgent.mockImplementation(async (params) => {
-        seenFastMode = params.fastMode;
-        return makeEmbeddedTextResult("ok");
+        expect(seenFastMode).toBe(fastMode);
       });
-
-      await getReplyFromConfig(
-        {
-          Body: "hello",
-          BodyForAgent: "hello",
-          RawBody: "hello",
-          CommandBody: "hello",
-          From: "+1001",
-          To: "+2000",
-          SessionKey: sessionKey,
-          Provider: "whatsapp",
-          Surface: "whatsapp",
-          ChatType: "direct",
-        },
-        {},
-        makeReplyConfig(home) as OpenClawConfig,
-      );
-
-      expect(seenFastMode).toBe(true);
-    });
-  });
+    },
+  );
 });

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -80,6 +80,7 @@ export type FollowupRun = {
     authProfileId?: string;
     authProfileIdSource?: "auto" | "user";
     thinkLevel?: ThinkLevel;
+    fastMode?: boolean;
     verboseLevel?: VerboseLevel;
     reasoningLevel?: ReasoningLevel;
     elevatedLevel?: ElevatedLevel;


### PR DESCRIPTION
## Summary
- Preserve resolved session/default fast mode when auto-reply uses the fast reply runtime.
- Forward `fastMode` through the real `FollowupRun.run` / `buildEmbeddedRunBaseParams()` path so embedded runs receive it outside the test harness.
- Add regression coverage for `/fast on` and `/fast off` session state plus the embedded runner base-param forwarding seam.

## Root cause
The fast reply runtime path hard-coded `fastMode: false`, so `/fast on` was persisted in session state but never reached the downstream agent run metadata. The first patch fixed the high-level fast-path runtime test seam, but the real typed follow-up runner still dropped `fastMode` before calling the embedded runner.

## Real behavior proof
Verified on a patched Kubernetes OpenClaw bot using an OpenAI-compatible Responses proxy after enabling `/fast on` in the session. The session store and status reported the main session as fast-enabled, and the final OpenAI Responses SDK request for the main model included `service_tier: "priority"`:

```json
{
  "sessionKey": "agent:main:main",
  "model": "gpt-5.4",
  "fastMode": true,
  "flags": ["fast"]
}
```

```json
{
  "url": "https://<redacted>/v1/responses",
  "model": "gpt-5.4",
  "hasServiceTier": true,
  "service_tier": "priority",
  "inputType": "array",
  "keys": [
    "input",
    "max_output_tokens",
    "model",
    "parallel_tool_calls",
    "service_tier",
    "store",
    "stream",
    "text",
    "tools"
  ]
}
```

The same runtime proof also distinguished the background active-memory request from the main reply request: active-memory used `gpt-5.4-mini`, while the main reply used `gpt-5.4` and carried `service_tier: "priority"`.

## Tests
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/queue/types.ts src/auto-reply/reply/agent-runner-run-params.ts src/auto-reply/reply/agent-runner-runtime-config.test.ts src/auto-reply/reply/get-reply.fast-path.runtime.test.ts src/auto-reply/reply.test-harness.ts src/auto-reply/reply/get-reply-run.ts`
- `git diff --check`
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/auto-reply/reply/get-reply.fast-path.runtime.test.ts src/auto-reply/reply/agent-runner-runtime-config.test.ts`
