### PR TITLE
feat(agents): add subagent model router shadow telemetry

### DIFF
--- a/src/agents/subagent-model-router.test.ts
+++ b/src/agents/subagent-model-router.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { classifySubagentModelRouterTask } from "./subagent-model-router.js";
+
+describe("classifySubagentModelRouterTask", () => {
+  it("classifies Hebrew operational tasks with the shared model-router task taxonomy", () => {
+    expect(classifySubagentModelRouterTask("קאבינט נפל עם שגיאה בלוגים")).toBe("coding");
+    expect(classifySubagentModelRouterTask("מה דעתך, כדאי לפתוח rollout הדרגתי?")).toBe(
+      "reasoning",
+    );
+    expect(classifySubagentModelRouterTask("תסכם לי את הדוח הזה לבן")).toBe("writing");
+    expect(classifySubagentModelRouterTask("כן")).toBe("trivial");
+  });
+
+  it("keeps visual and research routes distinct", () => {
+    expect(classifySubagentModelRouterTask("analyze this screenshot and UI state")).toBe("visual");
+    expect(classifySubagentModelRouterTask("research and compare model routing options")).toBe(
+      "research",
+    );
+  });
+});

--- a/src/agents/subagent-model-router.ts
+++ b/src/agents/subagent-model-router.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { promises as fs } from "node:fs";
+import nodePath from "node:path";
 import { promisify } from "node:util";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
@@ -24,6 +25,7 @@ export type SubagentModelRouterRecommendation = {
   source: "heuristic" | "shared-model-router-cli";
   reason: string;
   routeEffectApplied: false;
+  resolvedConfig: SubagentModelRouterConfig;
 };
 
 export type SubagentModelRouterTelemetryEvent = {
@@ -113,6 +115,12 @@ export async function resolveSubagentModelRouterRecommendation(params: {
   const config = resolveSubagentModelRouterConfig(params.cfg);
   const mode = config.mode ?? "off";
   if (mode === "off") return undefined;
+  if (mode === "pilot" || mode === "live") {
+    // pilot/live not yet implemented — behaves as shadow and emits a warning
+    console.warn(
+      `[subagent-model-router] mode "${mode}" is not yet implemented; falling back to shadow-only behavior`,
+    );
+  }
   const taskType = classifySubagentModelRouterTask(params.task);
 
   let source: SubagentModelRouterRecommendation["source"] = "heuristic";
@@ -143,6 +151,7 @@ export async function resolveSubagentModelRouterRecommendation(params: {
     source,
     reason,
     routeEffectApplied: false,
+    resolvedConfig: config,
   };
 }
 
@@ -152,6 +161,6 @@ export async function appendSubagentModelRouterTelemetry(params: {
 }): Promise<void> {
   const telemetryPath = params.config.telemetryPath;
   if (!telemetryPath) return;
-  await fs.mkdir(telemetryPath.replace(/[/\\][^/\\]*$/, "") || ".", { recursive: true });
+  await fs.mkdir(nodePath.dirname(telemetryPath) || ".", { recursive: true });
   await fs.appendFile(telemetryPath, `${JSON.stringify(params.event)}\n`, "utf8");
 }

--- a/src/agents/subagent-model-router.ts
+++ b/src/agents/subagent-model-router.ts
@@ -1,0 +1,157 @@
+import { execFile } from "node:child_process";
+import { promises as fs } from "node:fs";
+import { promisify } from "node:util";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+const execFileAsync = promisify(execFile);
+
+export type SubagentModelRouterMode = "off" | "shadow" | "pilot" | "live";
+export type SubagentModelRouterTaskType = "coding" | "research" | "vision" | "general";
+
+export type SubagentModelRouterConfig = {
+  mode?: SubagentModelRouterMode;
+  telemetryPath?: string;
+  command?: string;
+  args?: string[];
+  policyPath?: string;
+};
+
+export type SubagentModelRouterRecommendation = {
+  enabled: boolean;
+  mode: SubagentModelRouterMode;
+  taskType: SubagentModelRouterTaskType;
+  recommendedModel?: string;
+  source: "heuristic" | "shared-model-router-cli";
+  reason: string;
+  routeEffectApplied: false;
+};
+
+export type SubagentModelRouterTelemetryEvent = {
+  component: "openclaw.subagent_spawn";
+  requestId: string;
+  timestamp: string;
+  mode: SubagentModelRouterMode;
+  taskType: SubagentModelRouterTaskType;
+  recommendedModel?: string;
+  actualModel?: string;
+  routeEffectApplied: false;
+  status: "accepted" | "error";
+  source: SubagentModelRouterRecommendation["source"];
+  reason: string;
+};
+
+function readEnvString(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+function readEnvMode(): SubagentModelRouterMode | undefined {
+  const value = readEnvString("OPENCLAW_SUBAGENT_MODEL_ROUTER_MODE");
+  return value === "off" || value === "shadow" || value === "pilot" || value === "live"
+    ? value
+    : undefined;
+}
+
+export function resolveSubagentModelRouterConfig(cfg: OpenClawConfig): SubagentModelRouterConfig {
+  const configured = cfg.agents?.defaults?.subagents?.modelRouter ?? {};
+  return {
+    ...configured,
+    mode: readEnvMode() ?? configured.mode ?? "off",
+    telemetryPath:
+      readEnvString("OPENCLAW_SUBAGENT_MODEL_ROUTER_TELEMETRY") ?? configured.telemetryPath,
+    command: readEnvString("OPENCLAW_SUBAGENT_MODEL_ROUTER_COMMAND") ?? configured.command,
+    policyPath: readEnvString("OPENCLAW_SUBAGENT_MODEL_ROUTER_POLICY") ?? configured.policyPath,
+  };
+}
+
+export function classifySubagentModelRouterTask(task: string): SubagentModelRouterTaskType {
+  if (/\b(code|coding|bug|debug|fix|test|repo|typescript|javascript|python)\b/i.test(task)) {
+    return "coding";
+  }
+  if (/\b(research|analyze|analysis|compare|investigate)\b/i.test(task)) {
+    return "research";
+  }
+  if (/\b(image|vision|screenshot|design|ui|ux)\b/i.test(task)) {
+    return "vision";
+  }
+  return "general";
+}
+
+function fallbackModelForTaskType(taskType: SubagentModelRouterTaskType): string | undefined {
+  if (taskType === "coding") return "openai-codex/gpt-5.5";
+  if (taskType === "research") return "google/gemini-3-flash";
+  return undefined;
+}
+
+async function routeWithSharedModelRouterCli(params: {
+  config: SubagentModelRouterConfig;
+  taskType: SubagentModelRouterTaskType;
+}): Promise<string | undefined> {
+  const command = params.config.command;
+  if (!command) return undefined;
+  const args = [
+    ...(params.config.args ?? []),
+    ...(params.config.policyPath ? ["--config", params.config.policyPath] : []),
+    "--task-type",
+    params.taskType,
+    "--mode",
+    "execute",
+    "--priority",
+    "normal",
+    "--primary-only",
+  ];
+  const { stdout } = await execFileAsync(command, args, { timeout: 5_000 });
+  const model = stdout.trim().split(/\r?\n/).at(-1)?.trim();
+  return model || undefined;
+}
+
+export async function resolveSubagentModelRouterRecommendation(params: {
+  cfg: OpenClawConfig;
+  task: string;
+  modelOverride?: string;
+}): Promise<SubagentModelRouterRecommendation | undefined> {
+  const config = resolveSubagentModelRouterConfig(params.cfg);
+  const mode = config.mode ?? "off";
+  if (mode === "off") return undefined;
+  const taskType = classifySubagentModelRouterTask(params.task);
+
+  let source: SubagentModelRouterRecommendation["source"] = "heuristic";
+  let reason = "shadow-only recommendation; no live override applied";
+  let recommendedModel: string | undefined;
+  if (!params.modelOverride) {
+    try {
+      recommendedModel = await routeWithSharedModelRouterCli({ config, taskType });
+      if (recommendedModel) {
+        source = "shared-model-router-cli";
+        reason = "shared model-router CLI recommendation; no live override applied";
+      }
+    } catch (err) {
+      reason = `shared model-router CLI failed; using heuristic fallback; no live override applied: ${
+        err instanceof Error ? err.message : String(err)
+      }`;
+    }
+    recommendedModel ??= fallbackModelForTaskType(taskType);
+  } else {
+    reason = "explicit model override present; router kept recommendation shadow-only";
+  }
+
+  return {
+    enabled: true,
+    mode,
+    taskType,
+    recommendedModel,
+    source,
+    reason,
+    routeEffectApplied: false,
+  };
+}
+
+export async function appendSubagentModelRouterTelemetry(params: {
+  config: SubagentModelRouterConfig;
+  event: SubagentModelRouterTelemetryEvent;
+}): Promise<void> {
+  const telemetryPath = params.config.telemetryPath;
+  if (!telemetryPath) return;
+  await fs.mkdir(telemetryPath.replace(/[/\\][^/\\]*$/, "") || ".", { recursive: true });
+  await fs.appendFile(telemetryPath, `${JSON.stringify(params.event)}\n`, "utf8");
+}

--- a/src/agents/subagent-model-router.ts
+++ b/src/agents/subagent-model-router.ts
@@ -7,7 +7,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 const execFileAsync = promisify(execFile);
 
 export type SubagentModelRouterMode = "off" | "shadow" | "pilot" | "live";
-export type SubagentModelRouterTaskType = "coding" | "research" | "vision" | "general";
+export type SubagentModelRouterTaskType = "chat" | "coding" | "research" | "visual";
 
 export type SubagentModelRouterConfig = {
   mode?: SubagentModelRouterMode;
@@ -74,14 +74,14 @@ export function classifySubagentModelRouterTask(task: string): SubagentModelRout
     return "research";
   }
   if (/\b(image|vision|screenshot|design|ui|ux)\b/i.test(task)) {
-    return "vision";
+    return "visual";
   }
-  return "general";
+  return "chat";
 }
 
 function fallbackModelForTaskType(taskType: SubagentModelRouterTaskType): string | undefined {
-  if (taskType === "coding") return "openai-codex/gpt-5.5";
-  if (taskType === "research") return "google/gemini-3-flash";
+  if (taskType === "coding") return "openai-codex/gpt-5.4";
+  if (taskType === "research") return "openrouter/qwen/qwen3-next-80b-a3b-instruct:free";
   return undefined;
 }
 
@@ -99,7 +99,7 @@ async function routeWithSharedModelRouterCli(params: {
     "--mode",
     "execute",
     "--priority",
-    "normal",
+    "medium",
     "--primary-only",
   ];
   const { stdout } = await execFileAsync(command, args, { timeout: 5_000 });

--- a/src/agents/subagent-model-router.ts
+++ b/src/agents/subagent-model-router.ts
@@ -7,7 +7,15 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 const execFileAsync = promisify(execFile);
 
 export type SubagentModelRouterMode = "off" | "shadow" | "pilot" | "live";
-export type SubagentModelRouterTaskType = "chat" | "coding" | "research" | "visual";
+export type SubagentModelRouterTaskType =
+  | "chat"
+  | "coding"
+  | "writing"
+  | "research"
+  | "batch"
+  | "trivial"
+  | "visual"
+  | "reasoning";
 
 export type SubagentModelRouterConfig = {
   mode?: SubagentModelRouterMode;
@@ -67,21 +75,50 @@ export function resolveSubagentModelRouterConfig(cfg: OpenClawConfig): SubagentM
 }
 
 export function classifySubagentModelRouterTask(task: string): SubagentModelRouterTaskType {
-  if (/\b(code|coding|bug|debug|fix|test|repo|typescript|javascript|python)\b/i.test(task)) {
+  const text = task || "";
+  if (
+    /\b(code|coding|bug|debug|fix|test|repo|typescript|javascript|python)\b/i.test(text) ||
+    /(באג|שגיאה|לוג|לוגים|נפל|נופל|לא עובד|תתקן|תקן|דיבאג|ריפו|בדיקות?)/i.test(text)
+  ) {
     return "coding";
   }
-  if (/\b(research|analyze|analysis|compare|investigate)\b/i.test(task)) {
-    return "research";
-  }
-  if (/\b(image|vision|screenshot|design|ui|ux)\b/i.test(task)) {
+  if (
+    /\b(image|vision|screenshot|design|ui|ux)\b/i.test(text) ||
+    /(תמונה|צילום מסך|עיצוב|ויזואל|ממשק)/i.test(text)
+  ) {
     return "visual";
   }
+  if (
+    /\b(write|draft|copy|post|email|summarize|summary|report)\b/i.test(text) ||
+    /(כתוב|טיוטה|פוסט|מייל|תסכם|סכם|דוח|סקירה)/i.test(text)
+  ) {
+    return "writing";
+  }
+  if (
+    /\b(research|analyze|analysis|compare|investigate|search)\b/i.test(text) ||
+    /(בדוק|חפש|מקורות|השווה|תחקור|נתח)/i.test(text)
+  ) {
+    return "research";
+  }
+  if (
+    /\b(reason|plan|strategy|recommend|decide|should)\b/i.test(text) ||
+    /(מה דעתך|כדאי|המלצות|אסטרטג|תכנון|לתכנן|להחליט)/i.test(text)
+  ) {
+    return "reasoning";
+  }
+  if (text.trim().length < 80) return "trivial";
   return "chat";
 }
 
 function fallbackModelForTaskType(taskType: SubagentModelRouterTaskType): string | undefined {
-  if (taskType === "coding") return "openai-codex/gpt-5.4";
-  if (taskType === "research") return "openrouter/qwen/qwen3-next-80b-a3b-instruct:free";
+  if (taskType === "coding") return "openai-codex/gpt-5.3-codex";
+  if (taskType === "visual") return "xai/grok-3-vision";
+  if (taskType === "chat" || taskType === "writing" || taskType === "reasoning") {
+    return "openai-codex/gpt-5.5";
+  }
+  if (taskType === "research" || taskType === "batch" || taskType === "trivial") {
+    return "openai-codex/gpt-5.1-codex-mini";
+  }
   return undefined;
 }
 

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -1,4 +1,6 @@
+import { promises as fs } from "node:fs";
 import os from "node:os";
+import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createSubagentSpawnTestConfig,
@@ -184,7 +186,7 @@ describe("spawnSubagentDirect seam flow", () => {
     const result = await spawnSubagentDirect(
       {
         task: "inspect the spawn seam",
-        model: "openai-codex/gpt-5.4",
+        model: "openai/gpt-5.5",
       },
       {
         agentSessionKey: "agent:main:main",
@@ -221,7 +223,7 @@ describe("spawnSubagentDirect seam flow", () => {
         },
         task: "inspect the spawn seam",
         cleanup: "keep",
-        model: "openai-codex/gpt-5.4",
+        model: "openai/gpt-5.5",
         workspaceDir: "/tmp/requester-workspace",
         expectsCompletionMessage: true,
         spawnMode: "run",
@@ -271,7 +273,7 @@ describe("spawnSubagentDirect seam flow", () => {
     const result = await spawnSubagentDirect(
       {
         task: "inspect unthreaded spawn",
-        model: "openai-codex/gpt-5.4",
+        model: "openai/gpt-5.5",
       },
       {
         agentSessionKey: "agent:main:main",
@@ -311,7 +313,7 @@ describe("spawnSubagentDirect seam flow", () => {
     const result = await spawnSubagentDirect(
       {
         task: "verify per-method scope routing",
-        model: "openai-codex/gpt-5.4",
+        model: "openai/gpt-5.5",
       },
       {
         agentSessionKey: "agent:main:main",
@@ -371,6 +373,95 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(agentCall?.params).toMatchObject({
       thinking: "high",
     });
+  });
+
+  it("returns a shadow-only model-router recommendation without changing the applied model", async () => {
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+          subagents: {
+            modelRouter: {
+              mode: "shadow",
+            },
+          },
+        },
+        list: [{ id: "main", workspace: "/tmp/workspace-main" }],
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "fix this TypeScript test failure in the repo",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: "accepted",
+      modelApplied: true,
+      routerRecommendation: {
+        enabled: true,
+        mode: "shadow",
+        taskType: "coding",
+        recommendedModel: "openai-codex/gpt-5.3-codex",
+        routeEffectApplied: false,
+      },
+    });
+    expect(hoisted.registerSubagentRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "openai/gpt-5.5",
+      }),
+    );
+  });
+
+  it("appends shadow model-router telemetry when configured", async () => {
+    const telemetryPath = path.join(
+      os.tmpdir(),
+      `openclaw-subagent-router-${Date.now()}-${Math.random()}.jsonl`,
+    );
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+          subagents: {
+            modelRouter: {
+              mode: "shadow",
+              telemetryPath,
+            },
+          },
+        },
+        list: [{ id: "main", workspace: "/tmp/workspace-main" }],
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "research and compare model routing options",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const raw = await fs.readFile(telemetryPath, "utf8");
+    const event = JSON.parse(raw.trim());
+    expect(event).toMatchObject({
+      component: "openclaw.subagent_spawn",
+      mode: "shadow",
+      taskType: "research",
+      recommendedModel: "openai-codex/gpt-5.1-codex-mini",
+      actualModel: "openai/gpt-5.5",
+      routeEffectApplied: false,
+      status: "accepted",
+    });
+    expect(typeof event.requestId).toBe("string");
+    await fs.rm(telemetryPath, { force: true });
   });
 
   it("does not duplicate long subagent task text in the initial user message (#72019)", async () => {

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -407,7 +407,7 @@ describe("spawnSubagentDirect seam flow", () => {
         enabled: true,
         mode: "shadow",
         taskType: "coding",
-        recommendedModel: "openai-codex/gpt-5.4",
+        recommendedModel: "openai-codex/gpt-5.3-codex",
         routeEffectApplied: false,
       },
     });
@@ -455,7 +455,7 @@ describe("spawnSubagentDirect seam flow", () => {
       component: "openclaw.subagent_spawn",
       mode: "shadow",
       taskType: "research",
-      recommendedModel: "openrouter/qwen/qwen3-next-80b-a3b-instruct:free",
+      recommendedModel: "openai-codex/gpt-5.1-codex-mini",
       actualModel: "openai/gpt-5.5",
       routeEffectApplied: false,
       status: "accepted",

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -407,7 +407,7 @@ describe("spawnSubagentDirect seam flow", () => {
         enabled: true,
         mode: "shadow",
         taskType: "coding",
-        recommendedModel: "openai-codex/gpt-5.3-codex",
+        recommendedModel: "openai-codex/gpt-5.4",
         routeEffectApplied: false,
       },
     });
@@ -455,7 +455,7 @@ describe("spawnSubagentDirect seam flow", () => {
       component: "openclaw.subagent_spawn",
       mode: "shadow",
       taskType: "research",
-      recommendedModel: "openai-codex/gpt-5.1-codex-mini",
+      recommendedModel: "openrouter/qwen/qwen3-next-80b-a3b-instruct:free",
       actualModel: "openai/gpt-5.5",
       routeEffectApplied: false,
       status: "accepted",

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1317,7 +1317,7 @@ export async function spawnSubagentDirect(
   if (routerRecommendation) {
     try {
       await appendSubagentModelRouterTelemetry({
-        config: resolveSubagentModelRouterConfig(cfg),
+        config: routerRecommendation.resolvedConfig ?? resolveSubagentModelRouterConfig(cfg),
         event: {
           component: "openclaw.subagent_spawn",
           requestId: childRunId,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -27,6 +27,12 @@ import {
 import { resolveSubagentCapabilities } from "./subagent-capabilities.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { buildSubagentInitialUserMessage } from "./subagent-initial-user-message.js";
+import {
+  appendSubagentModelRouterTelemetry,
+  resolveSubagentModelRouterConfig,
+  resolveSubagentModelRouterRecommendation,
+  type SubagentModelRouterRecommendation,
+} from "./subagent-model-router.js";
 import { countActiveRunsForSession, registerSubagentRun } from "./subagent-registry.js";
 import { resolveSubagentSpawnAcceptedNote } from "./subagent-spawn-accepted-note.js";
 import { resolveSubagentTargetPolicy } from "./subagent-target-policy.js";
@@ -161,6 +167,7 @@ export type SpawnSubagentResult = {
   mode?: SpawnSubagentMode;
   note?: string;
   modelApplied?: boolean;
+  routerRecommendation?: SubagentModelRouterRecommendation;
   error?: string;
   attachments?: {
     count: number;
@@ -863,6 +870,11 @@ export async function spawnSubagentDirect(
     };
   }
   const { resolvedModel, thinkingOverride } = plan;
+  const routerRecommendation = await resolveSubagentModelRouterRecommendation({
+    cfg,
+    task,
+    modelOverride,
+  });
   const patchChildSession = async (patch: Record<string, unknown>): Promise<string | undefined> => {
     try {
       const target = resolveGatewaySessionStoreTarget({
@@ -1301,6 +1313,30 @@ export async function spawnSubagentDirect(
     spawnMode,
     agentSessionKey: ctx.agentSessionKey,
   });
+
+  if (routerRecommendation) {
+    try {
+      await appendSubagentModelRouterTelemetry({
+        config: resolveSubagentModelRouterConfig(cfg),
+        event: {
+          component: "openclaw.subagent_spawn",
+          requestId: childRunId,
+          timestamp: new Date().toISOString(),
+          mode: routerRecommendation.mode,
+          taskType: routerRecommendation.taskType,
+          recommendedModel: routerRecommendation.recommendedModel,
+          actualModel: resolvedModel,
+          routeEffectApplied: false,
+          status: "accepted",
+          source: routerRecommendation.source,
+          reason: routerRecommendation.reason,
+        },
+      });
+    } catch {
+      // Telemetry is best-effort; subagent spawn must not fail because shadow logging failed.
+    }
+  }
+
   return {
     status: "accepted",
     childSessionKey,
@@ -1310,6 +1346,7 @@ export async function spawnSubagentDirect(
       ? `${acceptedNote} ${preparedSpawnContext.forkFallbackNote}`
       : acceptedNote,
     modelApplied: resolvedModel ? modelApplied : undefined,
+    routerRecommendation,
     attachments: attachmentsReceipt,
   };
 }

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -434,6 +434,19 @@ export type AgentDefaultsConfig = {
     thinking?: string;
     /** Default run timeout in seconds for spawned sub-agents (0 = no timeout). */
     runTimeoutSeconds?: number;
+    /** Shadow/pilot/live model-router recommendation hook for spawned sub-agents. */
+    modelRouter?: {
+      /** Feature flag: off disables the hook; shadow logs recommendations without changing the run model. */
+      mode?: "off" | "shadow" | "pilot" | "live";
+      /** Optional JSONL path for model-router recommendation telemetry. */
+      telemetryPath?: string;
+      /** Optional external route-model compatible CLI command. Falls back to local heuristic if unset or failing. */
+      command?: string;
+      /** Base args passed before generated route-model args. */
+      args?: string[];
+      /** Optional policy YAML path passed as --config to the command. */
+      policyPath?: string;
+    };
     /** Gateway timeout in ms for sub-agent announce delivery calls (default: 90000). */
     announceTimeoutMs?: number;
     /** Require explicit agentId in sessions_spawn (no default same-as-caller). Default: false. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -282,6 +282,18 @@ export const AgentDefaultsSchema = z
         model: AgentModelSchema.optional(),
         thinking: z.string().optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),
+        modelRouter: z
+          .object({
+            mode: z
+              .union([z.literal("off"), z.literal("shadow"), z.literal("pilot"), z.literal("live")])
+              .optional(),
+            telemetryPath: z.string().optional(),
+            command: z.string().optional(),
+            args: z.array(z.string()).optional(),
+            policyPath: z.string().optional(),
+          })
+          .strict()
+          .optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
         requireAgentId: z.boolean().optional(),
       })


### PR DESCRIPTION
## Summary

Adds a shadow-only subagent model-router seam that can recommend subagent models and emit telemetry without changing the applied runtime model.

This PR includes:

- `agents.defaults.subagents.modelRouter` config schema/types
- subagent task classification + recommendation helper
- shadow telemetry JSONL append path
- `sessions_spawn` response metadata for router recommendation
- tests for shadow-only behavior, telemetry, and Oz/shared-policy task taxonomy

## Safety

- Default mode is `off`
- `shadow` mode does not change the applied model
- `pilot/live` currently warn and remain shadow-only
- Telemetry is best-effort and must not fail subagent spawn

## Real behavior proof

After the rebase, I exercised the new shadow router helper in a real local OpenClaw source checkout with Node 22 against the shared model-router CLI and the current shared policy. This was not a mock/unit assertion; it imported `src/agents/subagent-model-router.ts`, called the resolver, and appended the same JSONL event shape used by subagent spawn telemetry.

Command context:

```text
checkout: /home/gidon/shared-agents/openclaw-source
node: v22.22.2
route_model_cli: /home/gidon/.hermes/hermes-agent/venv/bin/route-model
policyPath: /home/gidon/shared-agents/model-router/policies/default.yaml
mode: shadow
task: תתקן באג TypeScript בסאב-אייג׳נט ותציג לוגים
```

Observed output:

```json
{
  "mode": "shadow",
  "taskType": "coding",
  "source": "shared-model-router-cli",
  "actualModel": "runtime-default-model-not-overridden-by-shadow-router",
  "recommendedModel": "openai-codex/gpt-5.3-codex",
  "routeEffectApplied": false
}
```

Telemetry line written by `appendSubagentModelRouterTelemetry`:

```json
{"component":"openclaw.subagent_spawn","requestId":"real-proof-local-openclaw-shadow-cli","timestamp":"2026-05-06T17:47:28.763Z","mode":"shadow","taskType":"coding","recommendedModel":"openai-codex/gpt-5.3-codex","actualModel":"runtime-default-model-not-overridden-by-shadow-router","routeEffectApplied":false,"status":"accepted","source":"shared-model-router-cli","reason":"shared model-router CLI recommendation; no live override applied"}
```

This proves the new seam can classify a real subagent task, consume the shared router CLI, emit telemetry, and keep `routeEffectApplied=false` so the runtime model is not overridden in shadow mode.

## Local verification

Before rebasing onto current upstream, focused tests passed in this checkout:

```text
src/agents/subagent-model-router.test.ts: 2 passed
src/agents/subagent-spawn.test.ts: 7 passed
Total: 9 passed
```

After rebasing onto current `openclaw/main`, the small taxonomy test still passed, but this checkout could not run the broader gate because dependency installation currently fails while preparing the git-hosted package `@openclaw/fs-safe`:

```text
ERR_PNPM_PREPARE_PACKAGE Failed to prepare git-hosted package fetched from
https://codeload.github.com/openclaw/fs-safe/tar.gz/3c508734af0b
@openclaw/fs-safe@0.1.2 pnpm-install: `pnpm install`
ERROR packages field missing or empty
```

Typecheck also fails on missing `@openclaw/fs-safe/*` modules in this local checkout for the same dependency state, before reaching this PR's files.

## Notes

The route effect remains deliberately disabled. This is intended as a safe integration surface for observing routing decisions before any future enforcement mode.

