### PR TITLE
test(auth): add oauth refresh race gateway proof

### DIFF
--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -329,6 +329,12 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     const authPath = resolveAuthStorePath(ownerAgentDir);
     ensureAuthStoreFile(authPath);
     const globalRefreshLockPath = resolveOAuthRefreshLockPath(params.provider, params.profileId);
+    const logContext = {
+      profileId: params.profileId,
+      provider: params.provider,
+      agentDir: params.agentDir,
+      ownerAgentDir,
+    };
 
     try {
       return await withFileLock(globalRefreshLockPath, OAUTH_REFRESH_LOCK_OPTIONS, async () =>
@@ -341,6 +347,15 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           let credentialToRefresh = cred;
 
           if (hasUsableOAuthCredential(cred)) {
+            log.debug(
+              "oauth refresh skipped after coordination because credential is already fresh",
+              {
+                ...logContext,
+                credentialExpires: Number.isFinite(cred.expires)
+                  ? new Date(cred.expires).toISOString()
+                  : undefined,
+              },
+            );
             return {
               apiKey: await adapter.buildApiKey(cred.provider, cred, {
                 cfg: params.cfg,
@@ -435,7 +450,21 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
             `refreshOAuthCredential(${cred.provider})`,
             OAUTH_REFRESH_CALL_TIMEOUT_MS,
             async () => {
+              log.debug("oauth refresh attempt starting", {
+                ...logContext,
+                credentialExpires: Number.isFinite(credentialToRefresh.expires)
+                  ? new Date(credentialToRefresh.expires).toISOString()
+                  : undefined,
+              });
               const refreshed = await adapter.refreshCredential(credentialToRefresh);
+              log.debug("oauth refresh attempt completed", {
+                ...logContext,
+                refreshed: Boolean(refreshed),
+                refreshedExpires:
+                  refreshed && Number.isFinite(refreshed.expires)
+                    ? new Date(refreshed.expires).toISOString()
+                    : undefined,
+              });
               return refreshed
                 ? ({
                     ...credentialToRefresh,
@@ -488,6 +517,13 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
   }): Promise<ResolvedOAuthAccess | null> {
     const key = refreshQueueKey(params.provider, params.profileId);
     const prev = refreshQueues.get(key) ?? Promise.resolve();
+    const queueHadPrevious = refreshQueues.has(key);
+    log.debug("oauth refresh requested", {
+      profileId: params.profileId,
+      provider: params.provider,
+      agentDir: params.agentDir,
+      queuedBehindInProcessRefresh: queueHadPrevious,
+    });
     let release!: () => void;
     const gate = new Promise<void>((resolve) => {
       release = resolve;
@@ -495,6 +531,12 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     refreshQueues.set(key, gate);
     try {
       await prev;
+      log.debug("oauth refresh queue entered", {
+        profileId: params.profileId,
+        provider: params.provider,
+        agentDir: params.agentDir,
+        queuedBehindInProcessRefresh: queueHadPrevious,
+      });
       return await doRefreshOAuthTokenWithLock(params);
     } finally {
       release();

--- a/src/agents/auth-profiles/oauth.concurrent-agents.test.ts
+++ b/src/agents/auth-profiles/oauth.concurrent-agents.test.ts
@@ -122,4 +122,70 @@ describe("resolveApiKeyForProfile cross-agent refresh coordination (#26322)", ()
       expect(result?.provider).toBe(provider);
     }
   }, 10_000);
+
+  it("does not reuse a stale refresh token when a second agent enters after rotation", async () => {
+    const profileId = "openai-codex:default";
+    const provider = "openai-codex";
+    const accountId = "acct-shared-refresh-reuse";
+    const freshExpiry = Date.now() + 60 * 60 * 1000;
+
+    const subAgents = await Promise.all(
+      ["race-a", "race-b"].map(async (agentId) => {
+        const dir = path.join(tempRoot, "agents", agentId, "agent");
+        await fs.mkdir(dir, { recursive: true });
+        saveAuthProfileStore(createExpiredOauthStore({ profileId, provider, accountId }), dir);
+        return dir;
+      }),
+    );
+    saveAuthProfileStore(createExpiredOauthStore({ profileId, provider, accountId }), mainAgentDir);
+
+    let callCount = 0;
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementation(async (params?: unknown) => {
+      callCount += 1;
+      if (callCount > 1) {
+        throw new Error(
+          '401 {"error":{"message":"Your refresh token has already been used to generate a new access token.","code":"refresh_token_reused"}}',
+        );
+      }
+      const context = (params as { context?: { refresh?: string; accountId?: string } } | undefined)
+        ?.context;
+      expect(context?.refresh).toBe("refresh-token");
+      expect(context?.accountId).toBe(accountId);
+      await new Promise((resolve) => setImmediate(resolve));
+      return {
+        type: "oauth",
+        provider,
+        access: "first-rotated-access",
+        refresh: "first-rotated-refresh",
+        expires: freshExpiry,
+        accountId,
+      } as never;
+    });
+
+    const results = await Promise.all(
+      subAgents.map((agentDir) =>
+        resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+          store: ensureAuthProfileStore(agentDir),
+          profileId,
+          agentDir,
+        }),
+      ),
+    );
+
+    expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
+    expect(callCount).toBe(1);
+    expect(results.map((result) => result?.apiKey)).toEqual([
+      "first-rotated-access",
+      "first-rotated-access",
+    ]);
+
+    const mainRaw = JSON.parse(
+      await fs.readFile(path.join(mainAgentDir, "auth-profiles.json"), "utf8"),
+    ) as { profiles: Record<string, { access?: string; refresh?: string; accountId?: string }> };
+    expect(mainRaw.profiles[profileId]).toMatchObject({
+      access: "first-rotated-access",
+      refresh: "first-rotated-refresh",
+      accountId,
+    });
+  }, 10_000);
 });


### PR DESCRIPTION
## Summary

- Problem: OAuth refresh races are hard to prove from the live gateway path, even though the manager has cross-agent coordination for shared profiles.
- Why it matters: rotating refresh-token providers can reject concurrent refreshes with `refresh_token_reused` / "Your refresh token has already been used".
- What changed: added debug-level refresh coordination logs and a dev-gateway proof harness that generates an isolated local OpenAI provider plugin, seeds two agents with the same expired OAuth profile, fires concurrent agent calls, and verifies one refresh plus one coordinated skip.
- What did NOT change (scope boundary): no production synthetic refresh hook, no Computer Use changes, no real OAuth credential refresh, no marketplace/plugin support changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: two agents sharing one expired OAuth profile concurrently reach refresh coordination through the dev gateway.
- Real environment tested: local macOS source checkout, isolated OpenClaw state/config under `.mem/main/proofs/oauth-refresh-race/run`, loopback dev gateway.
- Exact steps or command run after this patch: `node scripts/oauth-refresh-race-dev-gateway.mjs`
- Evidence after fix:

```json
{
  "agentCalls": [
    { "accepted": true, "code": 0 },
    { "accepted": true, "code": 0 }
  ],
  "evidence": {
    "refreshRequestedLogCount": 2,
    "refreshQueueEnteredLogCount": 2,
    "refreshSkippedFreshAfterCoordinationCount": 1,
    "refreshAttemptStartingLogCount": 1,
    "refreshAttemptCompletedLogCount": 1,
    "runCompletedCount": 2,
    "refreshTokenReuseErrorCount": 0,
    "devRefreshStartEventCount": 1,
    "devRefreshFinishEventCount": 1,
    "raceAObserved": true,
    "raceBObserved": true,
    "forbiddenSentinelHits": []
  },
  "ok": true
}
```

- Observed result after fix: both gateway calls were accepted and completed, both agents entered refresh coordination, only one provider refresh ran, the follower skipped after re-reading the fresh credential, and seeded token sentinels did not appear in logs/events.
- What was not tested: real provider refresh against a live OpenAI/Codex account, by design.
- Before evidence (optional but encouraged): existing focused regression tests cover the historical race shape; this PR adds live-gateway proof around the same invariant.

## Root Cause (if applicable)

- Root cause: N/A for production logic; this PR adds observability/proof around the existing cross-agent OAuth refresh coordination invariant.
- Missing detection / guardrail: no live gateway proof harness showed the exact one-refresh / follower-skip behavior for two concurrent agents.
- Contributing context (if known): debug logs previously did not expose refresh request, queue entry, start/completion, or fresh-after-coordination skip as a single proofable path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/auth-profiles/oauth.concurrent-agents.test.ts`, `src/agents/auth-profiles/oauth-manager.test.ts`, `scripts/oauth-refresh-race-dev-gateway.mjs`
- Scenario the test should lock in: many agents sharing one expired OAuth profile perform exactly one provider refresh and followers return the refreshed credential after coordination.
- Why this is the smallest reliable guardrail: unit tests cover manager semantics; the script proves the same invariant through a real dev gateway without real credentials.
- Existing test that already covers this (if any): `src/agents/auth-profiles/oauth.concurrent-agents.test.ts`
- If no new test is added, why not: the added script is a live proof harness rather than a normal CI test because it starts a dev gateway.

## User-visible / Behavior Changes

None. New OAuth refresh logs are debug-level only.

## Diagram (if applicable)

```text
Before proof:
race-a + race-b -> expired shared OAuth profile -> coordination happened, but live proof was opaque

After proof:
race-a + race-b -> dev gateway -> shared OAuth lock -> one provider refresh -> follower re-reads fresh credential -> both runs complete
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm source checkout
- Model/provider: `openai-codex/gpt-5.4` via generated local proof-only provider plugin
- Integration/channel (if any): dev gateway loopback RPC
- Relevant config (redacted): isolated config and auth stores generated under `.mem/main/proofs/oauth-refresh-race/run`

### Steps

1. `node scripts/oauth-refresh-race-dev-gateway.mjs`
2. `UV_CACHE_DIR=/private/tmp/uv-cache UV_TOOL_DIR=/private/tmp/uv-tools uvx showboat verify .mem/main/proofs/demo-2-oauth-refresh-race-dev-gateway.md`
3. `pnpm test src/agents/auth-profiles/oauth.concurrent-agents.test.ts src/agents/auth-profiles/oauth-manager.test.ts`

### Expected

- Two concurrent gateway agent calls both complete.
- Gateway debug evidence shows two refresh requests/queue entries, exactly one refresh attempt, one fresh-after-coordination skip, zero refresh-token-reuse errors, and no token sentinel leakage.

### Actual

- Expected behavior observed.

## Evidence

- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `node scripts/oauth-refresh-race-dev-gateway.mjs`
  - `UV_CACHE_DIR=/private/tmp/uv-cache UV_TOOL_DIR=/private/tmp/uv-tools uvx showboat verify .mem/main/proofs/demo-2-oauth-refresh-race-dev-gateway.md`
  - `pnpm test src/agents/auth-profiles/oauth.concurrent-agents.test.ts src/agents/auth-profiles/oauth-manager.test.ts`
  - `pnpm exec oxfmt --check --threads=1 src/agents/auth-profiles/oauth-manager.ts scripts/oauth-refresh-race-dev-gateway.mjs`
  - `git diff --check`
- Edge cases checked: sentinel access/refresh/id token strings are absent from proof logs/events; the proof asserts zero refresh-token-reuse errors.
- What you did **not** verify: live refresh against real OpenAI/Codex credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: debug logs could expose too much credential context.
  - Mitigation: logs include provider/profile/agent/owner/expiry/queue state only, never access/refresh/id tokens or full auth-store paths.
- Risk: proof harness might accidentally use real credentials.
  - Mitigation: it writes isolated config/state and loads a generated local proof-only provider plugin.
