### PR TITLE
Fix Tavily tool SecretRef runtime config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Tavily: resolve dedicated `tavily_search` and `tavily_extract` tool credentials from the active runtime config snapshot, so `exec` SecretRef-backed API keys do not reach the tools unresolved. (#78610) Thanks @VACInc.
 - Gateway/sessions: clear cached skills snapshots during `/new` and `sessions.reset` so long-lived channel sessions rebuild the visible skill list after skills change. (#78873) Thanks @Evizero.
 - fix(auto-reply): gate inline skill tool dispatch [AI]. (#78517) Thanks @pgondhi987.
 - Canvas plugin: keep legacy root `canvasHost` configs valid until `openclaw doctor --fix` migrates them into `plugins.entries.canvas.config.host`, move Canvas/A2UI clients to gateway protocol v4 plugin surfaces, and refresh the generated A2UI bundle hash so normal builds stay clean.

--- a/extensions/tavily/index.ts
+++ b/extensions/tavily/index.ts
@@ -1,4 +1,4 @@
-import { definePluginEntry, type AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { createTavilyExtractTool } from "./src/tavily-extract-tool.js";
 import { createTavilyWebSearchProvider } from "./src/tavily-search-provider.js";
 import { createTavilySearchTool } from "./src/tavily-search-tool.js";
@@ -9,7 +9,7 @@ export default definePluginEntry({
   description: "Bundled Tavily search and extract plugin",
   register(api) {
     api.registerWebSearchProvider(createTavilyWebSearchProvider());
-    api.registerTool(createTavilySearchTool(api) as AnyAgentTool);
-    api.registerTool(createTavilyExtractTool(api) as AnyAgentTool);
+    api.registerTool((ctx) => createTavilySearchTool(api, ctx), { name: "tavily_search" });
+    api.registerTool((ctx) => createTavilyExtractTool(api, ctx), { name: "tavily_extract" });
   },
 });

--- a/extensions/tavily/src/tavily-extract-tool.ts
+++ b/extensions/tavily/src/tavily-extract-tool.ts
@@ -1,3 +1,5 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
 import {
   jsonResult,
@@ -7,6 +9,18 @@ import {
 import { Type } from "typebox";
 import { runTavilyExtract } from "./tavily-client.js";
 import { optionalStringEnum } from "./tavily-tool-schema.js";
+
+type TavilyToolConfigContext = Pick<
+  OpenClawPluginToolContext,
+  "config" | "runtimeConfig" | "getRuntimeConfig"
+>;
+
+function resolveTavilyToolConfig(
+  api: OpenClawPluginApi,
+  ctx?: TavilyToolConfigContext,
+): OpenClawConfig {
+  return ctx?.getRuntimeConfig?.() ?? ctx?.runtimeConfig ?? ctx?.config ?? api.config;
+}
 
 const TavilyExtractToolSchema = Type.Object(
   {
@@ -39,7 +53,7 @@ const TavilyExtractToolSchema = Type.Object(
   { additionalProperties: false },
 );
 
-export function createTavilyExtractTool(api: OpenClawPluginApi) {
+export function createTavilyExtractTool(api: OpenClawPluginApi, ctx?: TavilyToolConfigContext) {
   return {
     name: "tavily_extract",
     label: "Tavily Extract",
@@ -65,7 +79,7 @@ export function createTavilyExtractTool(api: OpenClawPluginApi) {
 
       return jsonResult(
         await runTavilyExtract({
-          cfg: api.config,
+          cfg: resolveTavilyToolConfig(api, ctx),
           urls,
           query,
           extractDepth,

--- a/extensions/tavily/src/tavily-search-tool.ts
+++ b/extensions/tavily/src/tavily-search-tool.ts
@@ -1,3 +1,5 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
 import {
   jsonResult,
@@ -7,6 +9,18 @@ import {
 import { Type } from "typebox";
 import { runTavilySearch } from "./tavily-client.js";
 import { optionalStringEnum } from "./tavily-tool-schema.js";
+
+type TavilyToolConfigContext = Pick<
+  OpenClawPluginToolContext,
+  "config" | "runtimeConfig" | "getRuntimeConfig"
+>;
+
+function resolveTavilyToolConfig(
+  api: OpenClawPluginApi,
+  ctx?: TavilyToolConfigContext,
+): OpenClawConfig {
+  return ctx?.getRuntimeConfig?.() ?? ctx?.runtimeConfig ?? ctx?.config ?? api.config;
+}
 
 const TavilySearchToolSchema = Type.Object(
   {
@@ -46,7 +60,7 @@ const TavilySearchToolSchema = Type.Object(
   { additionalProperties: false },
 );
 
-export function createTavilySearchTool(api: OpenClawPluginApi) {
+export function createTavilySearchTool(api: OpenClawPluginApi, ctx?: TavilyToolConfigContext) {
   return {
     name: "tavily_search",
     label: "Tavily Search",
@@ -69,7 +83,7 @@ export function createTavilySearchTool(api: OpenClawPluginApi) {
 
       return jsonResult(
         await runTavilySearch({
-          cfg: api.config,
+          cfg: resolveTavilyToolConfig(api, ctx),
           query,
           searchDepth,
           topic,

--- a/extensions/tavily/src/tavily-tools.test.ts
+++ b/extensions/tavily/src/tavily-tools.test.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_TAVILY_BASE_URL,
@@ -33,6 +34,7 @@ describe("tavily tools", () => {
   let createTavilySearchTool: typeof import("./tavily-search-tool.js").createTavilySearchTool;
   let createTavilyExtractTool: typeof import("./tavily-extract-tool.js").createTavilyExtractTool;
   let tavilyClientTesting: typeof import("./tavily-client.js").__testing;
+  let tavilyPlugin: typeof import("../index.js").default;
 
   beforeAll(async () => {
     ({ createTavilyWebSearchProvider } = await import("./tavily-search-provider.js"));
@@ -40,6 +42,7 @@ describe("tavily tools", () => {
     ({ createTavilyExtractTool } = await import("./tavily-extract-tool.js"));
     ({ __testing: tavilyClientTesting } =
       await vi.importActual<typeof import("./tavily-client.js")>("./tavily-client.js"));
+    ({ default: tavilyPlugin } = await import("../index.js"));
   });
 
   beforeEach(() => {
@@ -138,6 +141,85 @@ describe("tavily tools", () => {
     expect(result.content[0]).toMatchObject({
       type: "text",
     });
+  });
+
+  it("late-binds dedicated tools to the resolved runtime config snapshot", async () => {
+    const rawConfig = {
+      plugins: {
+        entries: {
+          tavily: {
+            config: {
+              webSearch: {
+                apiKey: { source: "exec", provider: "default", id: "printf resolved-key" },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const runtimeConfig = {
+      plugins: {
+        entries: {
+          tavily: {
+            config: {
+              webSearch: {
+                apiKey: "resolved-key",
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const registeredTools: Array<Parameters<OpenClawPluginApi["registerTool"]>[0]> = [];
+    const registeredOptions: Array<Parameters<OpenClawPluginApi["registerTool"]>[1]> = [];
+    const api = createTestPluginApi({
+      config: rawConfig,
+      registerTool(tool, opts) {
+        registeredTools.push(tool);
+        registeredOptions.push(opts);
+      },
+    });
+
+    tavilyPlugin.register(api);
+    const searchFactory = registeredTools.find(
+      (tool, index) =>
+        registeredOptions[index]?.name === "tavily_search" && typeof tool === "function",
+    );
+    const extractFactory = registeredTools.find(
+      (tool, index) =>
+        registeredOptions[index]?.name === "tavily_extract" && typeof tool === "function",
+    );
+    if (typeof searchFactory !== "function" || typeof extractFactory !== "function") {
+      throw new Error("Expected Tavily tools to register as runtime-context factories");
+    }
+
+    const searchTool = searchFactory({
+      config: rawConfig,
+      runtimeConfig,
+    });
+    const extractTool = extractFactory({
+      config: rawConfig,
+      getRuntimeConfig: () => runtimeConfig,
+    });
+    if (Array.isArray(searchTool) || !searchTool || Array.isArray(extractTool) || !extractTool) {
+      throw new Error("Expected single Tavily tool definitions");
+    }
+
+    await searchTool.execute("search-call", { query: "openclaw" });
+    await extractTool.execute("extract-call", { urls: ["https://example.com"] });
+
+    expect(runTavilySearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: runtimeConfig,
+        query: "openclaw",
+      }),
+    );
+    expect(runTavilyExtract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: runtimeConfig,
+        urls: ["https://example.com"],
+      }),
+    );
   });
 
   it("drops empty domain arrays and forwards query-scoped chunking", async () => {


### PR DESCRIPTION
## Summary
- register Tavily's dedicated tools as runtime-context factories instead of one-time objects bound to plugin-load config
- resolve `tavily_search` and `tavily_extract` credentials from the active runtime config snapshot when available
- add a regression test for raw `exec` SecretRef source config plus resolved runtime config

## Real Behavior Proof
Behavior or issue addressed: Dedicated Tavily tools were created from plugin-load `api.config`, so a configured `exec` SecretRef could remain raw even when the active runtime snapshot already had the resolved Tavily API key.

Real environment tested: Separate temp OpenClaw worktree at `/tmp/openclaw-tavily-secretref.ILwex2`, Node 25.9.0, pnpm 10.33.2, branch `tavily-secretref-runtime-config`, using the real `resolvePluginTools` path with a raw source config and a resolved runtime config snapshot.

Exact steps or command run after this patch: Ran the real plugin tool resolver with `env -u TAVILY_API_KEY pnpm exec tsx -e ...`, where source config contained `plugins.entries.tavily.config.webSearch.apiKey = { source: "exec", provider: "default", id: "printf resolved-key" }` and runtime config contained `apiKey: "resolved-key"` plus `baseUrl: "https://api.tavily.test"`.

Evidence after fix: Copied terminal output from the after-fix probe:

```text
error getaddrinfo ENOTFOUND api.tavily.test
```

Observed result after fix: The previous unresolved SecretRef exception no longer occurs. The dedicated `tavily_search` tool reads the resolved runtime snapshot, including the runtime-only fake Tavily base URL, and advances to the request path; the DNS error is expected because `api.tavily.test` is deliberately not a real host.

What was not tested: A live Tavily API request was not run because `TAVILY_API_KEY` is not present in `~/.profile` in this environment.

Before evidence optional: Before the fix, the same resolver path failed before making any request:

```text
{"toolNames":["tavily_search","tavily_extract"]}
error plugins.entries.tavily.config.webSearch.apiKey: unresolved SecretRef "exec:default:printf resolved-key". Resolve this command against an active gateway runtime snapshot before reading it.
```

## Verification
- `pnpm test extensions/tavily/src/tavily-tools.test.ts -- --reporter=verbose`
- `pnpm exec oxfmt --check --threads=1 extensions/tavily/index.ts extensions/tavily/src/tavily-extract-tool.ts extensions/tavily/src/tavily-search-tool.ts extensions/tavily/src/tavily-tools.test.ts`
- `git diff --check`
- `pnpm check:changed`
- `pnpm test:changed`