### PR TITLE
fix(discord): prompt agents to suppress link embeds

### DIFF
--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -31,6 +31,7 @@ describe("group runtime loading", () => {
       "You are in a WhatsApp group chat. Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group - just reply normally.",
     );
     expect(groupChatContext).toContain("Minimize empty lines and use normal chat conventions");
+    expect(groupChatContext).not.toContain("wrap URLs in angle brackets");
     expect(groupChatContext).toContain("prefer delegating bounded side investigations early");
     expect(groupChatContext).toContain("Keep the critical path local");
     expect(groupChatContext).toContain('reply with exactly "NO_REPLY"');
@@ -43,6 +44,8 @@ describe("group runtime loading", () => {
     expect(toolOnlyContext).toContain("Normal final replies are private");
     expect(toolOnlyContext).toContain("message tool with action=send");
     expect(toolOnlyContext).toContain("Be a good group participant");
+    expect(toolOnlyContext).toContain("wrap URLs in angle brackets");
+    expect(toolOnlyContext).toContain("<https://example.com>");
     expect(toolOnlyContext).toContain("do not call message(action=send)");
     expect(toolOnlyContext).not.toContain('reply with exactly "NO_REPLY"');
     expect(

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -31,7 +31,7 @@ describe("group runtime loading", () => {
       "You are in a WhatsApp group chat. Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group - just reply normally.",
     );
     expect(groupChatContext).toContain("Minimize empty lines and use normal chat conventions");
-    expect(groupChatContext).not.toContain("wrap URLs in angle brackets");
+    expect(groupChatContext).not.toContain("wrap bare URLs");
     expect(groupChatContext).toContain("prefer delegating bounded side investigations early");
     expect(groupChatContext).toContain("Keep the critical path local");
     expect(groupChatContext).toContain('reply with exactly "NO_REPLY"');
@@ -44,7 +44,7 @@ describe("group runtime loading", () => {
     expect(toolOnlyContext).toContain("Normal final replies are private");
     expect(toolOnlyContext).toContain("message tool with action=send");
     expect(toolOnlyContext).toContain("Be a good group participant");
-    expect(toolOnlyContext).toContain("wrap URLs in angle brackets");
+    expect(toolOnlyContext).toContain("wrap bare URLs");
     expect(toolOnlyContext).toContain("<https://example.com>");
     expect(toolOnlyContext).toContain("do not call message(action=send)");
     expect(toolOnlyContext).not.toContain('reply with exactly "NO_REPLY"');

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -246,9 +246,7 @@ export function buildGroupChatContext(params: {
     "Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \\n sequences; use real line breaks sparingly.",
   );
   if (normalizeOptionalLowercaseString(params.sessionCtx.Provider) === "discord") {
-    lines.push(
-      "On Discord, wrap URLs in angle brackets (`<https://example.com>`) to suppress link embeds when posting bare links.",
-    );
+    lines.push("Discord: wrap bare URLs like <https://example.com> to suppress embeds.");
   }
   lines.push(
     "When subagent or session-spawn tools are available and a directly requested group-chat task will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise group-visible updates when they add value.",

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -245,6 +245,11 @@ export function buildGroupChatContext(params: {
   lines.push(
     "Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \\n sequences; use real line breaks sparingly.",
   );
+  if (normalizeOptionalLowercaseString(params.sessionCtx.Provider) === "discord") {
+    lines.push(
+      "On Discord, wrap URLs in angle brackets (`<https://example.com>`) to suppress link embeds when posting bare links.",
+    );
+  }
   lines.push(
     "When subagent or session-spawn tools are available and a directly requested group-chat task will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise group-visible updates when they add value.",
   );


### PR DESCRIPTION
## Summary
- add a Discord-only group prompt hint to wrap bare URLs in angle brackets to suppress embeds
- cover the prompt behavior in the group context tests

## Tests
- pnpm exec vitest run src/auto-reply/reply/groups.test.ts --maxWorkers=1 --no-fileParallelism
- git diff --check