### PR TITLE
fix(discord): keep agents quiet when others are addressed

### DIFF
--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -32,8 +32,8 @@ describe("group runtime loading", () => {
     );
     expect(groupChatContext).toContain("Minimize empty lines and use normal chat conventions");
     expect(groupChatContext).not.toContain("wrap bare URLs");
-    expect(groupChatContext).toContain("If a message addresses another agent/person and not you");
-    expect(groupChatContext).toContain("stay silent unless explicitly invited");
+    expect(groupChatContext).toContain("If addressed to someone else");
+    expect(groupChatContext).toContain("stay silent unless invited or correcting key facts");
     expect(groupChatContext).toContain("prefer delegating bounded side investigations early");
     expect(groupChatContext).toContain("Keep the critical path local");
     expect(groupChatContext).toContain('reply with exactly "NO_REPLY"');

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -32,6 +32,8 @@ describe("group runtime loading", () => {
     );
     expect(groupChatContext).toContain("Minimize empty lines and use normal chat conventions");
     expect(groupChatContext).not.toContain("wrap bare URLs");
+    expect(groupChatContext).toContain("If a message addresses another agent/person and not you");
+    expect(groupChatContext).toContain("stay silent unless explicitly invited");
     expect(groupChatContext).toContain("prefer delegating bounded side investigations early");
     expect(groupChatContext).toContain("Keep the critical path local");
     expect(groupChatContext).toContain('reply with exactly "NO_REPLY"');

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -240,11 +240,12 @@ export function buildGroupChatContext(params: {
     );
   }
   lines.push(
-    "Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. If a message addresses another agent/person and not you, stay silent unless explicitly invited or correcting important facts. Emoji reactions are welcome when available.",
+    "Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available.",
   );
   lines.push(
     "Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \\n sequences; use real line breaks sparingly.",
   );
+  lines.push("If addressed to someone else, stay silent unless invited or correcting key facts.");
   if (normalizeOptionalLowercaseString(params.sessionCtx.Provider) === "discord") {
     lines.push("Discord: wrap bare URLs like <https://example.com> to suppress embeds.");
   }

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -240,7 +240,7 @@ export function buildGroupChatContext(params: {
     );
   }
   lines.push(
-    "Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available.",
+    "Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. If a message addresses another agent/person and not you, stay silent unless explicitly invited or correcting important facts. Emoji reactions are welcome when available.",
   );
   lines.push(
     "Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \\n sequences; use real line breaks sparingly.",


### PR DESCRIPTION
## Summary
- add a concise group-chat prompt rule: if a message addresses another agent/person and not this agent, stay silent unless explicitly invited or correcting important facts
- cover the rule in the group prompt tests

## Tests
- pnpm exec vitest run src/auto-reply/reply/groups.test.ts --maxWorkers=1 --no-fileParallelism
- git diff --check