### PR TITLE
Telegram/streaming: default to off instead of partial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/streaming: default to `off` streaming mode instead of `partial` so Telegram DMs do not emit noisy intermediate tool/status messages during tool-heavy operations. Users who prefer `partial` streaming can still set it explicitly. Fixes #77267.
+
 - Doctor/OpenAI Codex: revert the 2026.5.5 `doctor --fix` repair that rewrote valid `openai-codex/*` ChatGPT/Codex OAuth routes to `openai/*`, which could break OAuth-only GPT-5.5 setups or accidentally move users onto the OpenAI API-key route. If 2026.5.5 already changed your default model, run `openclaw models set openai-codex/gpt-5.5 && openclaw config validate` to switch the default agent back to the Codex OAuth PI route. Fixes #78407.
 - Telegram/Codex: generate DM topic labels with Codex-compatible simple-completion requests so auto-created private topics can be renamed instead of staying `New Chat`.
 - Plugins/runtime fetch: drop third-party symbol metadata from plain request header dictionaries before passing them into native `fetch` or `Headers`, so SDK and guarded/proxy fetch paths do not reject otherwise valid plugin requests. Fixes #77846. Thanks @shakkernerd.

--- a/extensions/telegram/src/preview-streaming.ts
+++ b/extensions/telegram/src/preview-streaming.ts
@@ -11,5 +11,5 @@ export function resolveTelegramPreviewStreamMode(
     streaming?: unknown;
   } = {},
 ): TelegramPreviewStreamMode {
-  return resolveChannelPreviewStreamMode(params, "partial");
+  return resolveChannelPreviewStreamMode(params, "off");
 }


### PR DESCRIPTION
## Summary

- Problem: Telegram DMs using `streaming.mode = "partial"` emit noisy intermediate tool/status messages during tool-heavy operations (e.g., "Process:", "Image Generation", "Exec" updates, "Nautiling..." status messages).
- Why it matters: Users see unwanted, fragmented progress messages that make the experience feel slow and cluttered.
- What changed: Changed the default streaming mode for Telegram from `"partial"` to `"off"` in `resolveTelegramPreviewStreamMode`.
- What did NOT change: Users who explicitly set `streaming.mode = "partial"` in their account config will still get partial streaming.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #77267

## Root Cause

- Root cause: Telegram's `resolveTelegramPreviewStreamMode` defaulted to `"partial"`, which enabled all tool lifecycle and status message streams.
- Missing detection / guardrail: The default was never scoped to user intent or operation type.

## User-visible / Behavior Changes

- Telegram DMs now default to `streaming.mode = "off"` instead of `"partial"`.
- Users who prefer `partial` streaming can still set it explicitly in their account config.
- No change for users who already have an explicit `streaming.mode` configured.

## Security Impact

- No new permissions/capabilities
- No secrets/tokens handling changed
- No new/changed network calls
- No command/tool execution surface changed
