### PR TITLE
Fix cron default model inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: treat omitted, null, blank, and `default` payload model values as unset so isolated cron jobs inherit the stored session or agent/default model instead of failing model allowlist validation. Fixes #78549.
 - Doctor/OpenAI Codex: revert the 2026.5.5 `doctor --fix` repair that rewrote valid `openai-codex/*` ChatGPT/Codex OAuth routes to `openai/*`, which could break OAuth-only GPT-5.5 setups or accidentally move users onto the OpenAI API-key route. If 2026.5.5 already changed your default model, run `openclaw models set openai-codex/gpt-5.5 && openclaw config validate` to switch the default agent back to the Codex OAuth PI route. Fixes #78407.
 - Discord/groups: instruct group-chat agents to stay silent when a message is addressed to someone else, replying only when invited or correcting key facts. (#78615)
 - Discord/groups: tell Discord-channel agents to wrap bare URLs as `<https://example.com>` so link previews do not expand into uninvited embeds. (#78614)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Cron: treat omitted, null, blank, and `default` payload model values as unset so isolated cron jobs inherit the stored session or agent/default model instead of failing model allowlist validation. Fixes #78549.
+- Dependencies: override transitive `basic-ftp` to `5.3.1` so the runtime lockfile no longer includes the vulnerable `5.3.0` build flagged by Dependabot alert 1117726.
 - Doctor/OpenAI Codex: revert the 2026.5.5 `doctor --fix` repair that rewrote valid `openai-codex/*` ChatGPT/Codex OAuth routes to `openai/*`, which could break OAuth-only GPT-5.5 setups or accidentally move users onto the OpenAI API-key route. If 2026.5.5 already changed your default model, run `openclaw models set openai-codex/gpt-5.5 && openclaw config validate` to switch the default agent back to the Codex OAuth PI route. Fixes #78407.
 - Discord/groups: instruct group-chat agents to stay silent when a message is addressed to someone else, replying only when invited or correcting key facts. (#78615)
 - Discord/groups: tell Discord-channel agents to wrap bare URLs as `<https://example.com>` so link previews do not expand into uninvited embeds. (#78614)

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -134,6 +134,8 @@ This fires ~5–6 times per month instead of 0–1 times per month. OpenClaw use
 
 `--model` uses the selected allowed model as that job's primary model. It is not the same as a chat-session `/model` override: configured fallback chains still apply when the job primary fails. If the requested model is not allowed or cannot be resolved, cron fails the run with an explicit validation error instead of silently falling back to the job's agent/default model selection.
 
+If a cron job's payload model is omitted, `null`, blank, or the literal `default`, OpenClaw treats it as unset. The run continues through the remaining precedence list and inherits the stored cron-session model override or the agent/default model selection.
+
 Cron jobs can also carry payload-level `fallbacks`. When present, that list replaces the configured fallback chain for the job. Use `fallbacks: []` in the job payload/API when you want a strict cron run that tries only the selected model. If a job has `--model` but neither payload nor configured fallbacks, OpenClaw passes an explicit empty fallback override so the agent primary is not appended as a hidden extra retry target.
 
 Model-selection precedence for isolated jobs is:

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -113,6 +113,8 @@ Cron `--model` is a **job primary**, not a chat-session `/model` override. That 
 - An empty per-job fallback list (`fallbacks: []` in the job payload/API) makes the cron run strict.
 - When a job has `--model` but no fallback list is configured, OpenClaw passes an explicit empty fallback override so the agent primary is not appended as a hidden retry target.
 
+When a cron job's payload model is omitted, `null`, blank, or the literal `default`, OpenClaw treats it as unset and continues to the stored cron-session model override or agent/default model selection.
+
 ### Isolated cron model precedence
 
 Isolated cron resolves the active model in this order:

--- a/package.json
+++ b/package.json
@@ -1787,7 +1787,7 @@
       "fast-xml-parser": "5.7.0",
       "request": "npm:@cypress/request@3.0.10",
       "request-promise": "npm:@cypress/request-promise@5.0.0",
-      "basic-ftp": "5.3.0",
+      "basic-ftp": "5.3.1",
       "file-type": "22.0.1",
       "form-data": "2.5.4",
       "ip-address": "10.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   fast-xml-parser: 5.7.0
   request: npm:@cypress/request@3.0.10
   request-promise: npm:@cypress/request-promise@5.0.0
-  basic-ftp: 5.3.0
+  basic-ftp: 5.3.1
   file-type: 22.0.1
   form-data: 2.5.4
   ip-address: 10.2.0
@@ -4805,8 +4805,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  basic-ftp@5.3.0:
-    resolution: {integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==}
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
 
   bidi-js@1.0.3:
@@ -11645,7 +11645,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  basic-ftp@5.3.0: {}
+  basic-ftp@5.3.1: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -12446,7 +12446,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.3.0
+      basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
@@ -12454,7 +12454,7 @@ snapshots:
 
   get-uri@8.0.0:
     dependencies:
-      basic-ftp: 5.3.0
+      basic-ftp: 5.3.1
       data-uri-to-buffer: 8.0.0
       debug: 4.4.3
     transitivePeerDependencies:

--- a/src/cron/isolated-agent.model-formatting.test.ts
+++ b/src/cron/isolated-agent.model-formatting.test.ts
@@ -48,7 +48,7 @@ const DEFAULT_MESSAGE = "do it";
 type AgentTurnPayload = {
   kind: "agentTurn";
   message: string;
-  model?: string;
+  model?: string | null;
 };
 
 type SelectModelOptions = {
@@ -520,6 +520,27 @@ describe("cron model formatting and precedence edge cases", () => {
       await expectDefaultSelectedModel({
         payload: { kind: "agentTurn", message: DEFAULT_MESSAGE, model: "" },
       });
+    });
+
+    it("default model sentinel treated as unset", async () => {
+      await expectDefaultSelectedModel({
+        payload: { kind: "agentTurn", message: DEFAULT_MESSAGE, model: "default" },
+      });
+      expect(resolveAllowedModelRefMock).not.toHaveBeenCalled();
+    });
+
+    it("string null model sentinel treated as unset", async () => {
+      await expectDefaultSelectedModel({
+        payload: { kind: "agentTurn", message: DEFAULT_MESSAGE, model: " null " },
+      });
+      expect(resolveAllowedModelRefMock).not.toHaveBeenCalled();
+    });
+
+    it("null model value treated as unset", async () => {
+      await expectDefaultSelectedModel({
+        payload: { kind: "agentTurn", message: DEFAULT_MESSAGE, model: null },
+      });
+      expect(resolveAllowedModelRefMock).not.toHaveBeenCalled();
     });
 
     it("whitespace-only session modelOverride is ignored", async () => {

--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { normalizeCronPayloadModelOverride } from "../model-override.js";
 import type { CronJob } from "../types.js";
 import {
   DEFAULT_MODEL,
@@ -110,7 +111,7 @@ export async function resolveCronModelSelection(
   }
 
   const modelOverrideRaw = params.payload.kind === "agentTurn" ? params.payload.model : undefined;
-  const modelOverride = typeof modelOverrideRaw === "string" ? modelOverrideRaw.trim() : undefined;
+  const modelOverride = normalizeCronPayloadModelOverride(modelOverrideRaw);
   if (modelOverride !== undefined && modelOverride.length > 0) {
     const resolvedOverride = resolveAllowedModelRef({
       cfg: params.cfgWithAgentDefaults,

--- a/src/cron/isolated-agent/run-fallback-policy.test.ts
+++ b/src/cron/isolated-agent/run-fallback-policy.test.ts
@@ -83,4 +83,30 @@ describe("resolveCronFallbacksOverride", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("leaves fallback selection unset for inherited cron model sentinels", () => {
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: makeConfig(["openai/gpt-5.4"]),
+        agentId: "main",
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+          model: "default",
+        }),
+      }),
+    ).toBeUndefined();
+
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: makeConfig(["openai/gpt-5.4"]),
+        agentId: "main",
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+          model: " null ",
+        }),
+      }),
+    ).toBeUndefined();
+  });
 });

--- a/src/cron/isolated-agent/run-fallback-policy.ts
+++ b/src/cron/isolated-agent/run-fallback-policy.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { hasCronPayloadModelOverride as hasCronPayloadModelOverrideValue } from "../model-override.js";
 import type { CronJob } from "../types.js";
 import { resolveEffectiveModelFallbacks } from "./run-execution.runtime.js";
 
@@ -9,8 +10,7 @@ export function resolveCronFallbacksOverride(params: {
 }): string[] | undefined {
   const payload = params.job.payload.kind === "agentTurn" ? params.job.payload : undefined;
   const payloadFallbacks = Array.isArray(payload?.fallbacks) ? payload.fallbacks : undefined;
-  const hasCronPayloadModelOverride =
-    typeof payload?.model === "string" && payload.model.trim().length > 0;
+  const hasCronPayloadModelOverride = hasCronPayloadModelOverrideValue(payload?.model);
   return (
     payloadFallbacks ??
     resolveEffectiveModelFallbacks({

--- a/src/cron/model-override.ts
+++ b/src/cron/model-override.ts
@@ -1,0 +1,16 @@
+const CRON_MODEL_INHERIT_SENTINELS = new Set(["default", "null"]);
+
+export function normalizeCronPayloadModelOverride(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed || CRON_MODEL_INHERIT_SENTINELS.has(trimmed.toLowerCase())) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+export function hasCronPayloadModelOverride(value: unknown): boolean {
+  return normalizeCronPayloadModelOverride(value) !== undefined;
+}


### PR DESCRIPTION
## Summary

- Treat cron payload model values that mean "inherit" (`default`, `null`, blank, or omitted) as unset before isolated cron model resolution.
- Keep fallback-policy strictness aligned so only a real cron payload model override suppresses fallback inheritance.
- Document the unset payload model contract in the cron guide and CLI reference, and add a changelog entry for #78549.
- Update the root `basic-ftp` override to `5.3.1` so the production dependency audit no longer includes the vulnerable `5.3.0` build.

Fixes #78549.

## Real behavior proof

- **Behavior or issue addressed:** Cron jobs with `payload.model` set to `default` should inherit the configured agent/default model instead of being resolved as provider `minimax-portal/default` and rejected by the cron model allowlist.
- **Real environment tested:** Fresh OpenClaw integration Gateway workspace `cron-default-fixed-local-78549`, Gateway port `59337`, with an isolated cron job using `payload.model=default` and an intentionally unreachable local Ollama-compatible default model endpoint.
- **Exact steps or command run after this patch:** Ran the fixed integration proof script `node .mem/main/proofs/78549_fixed_summary.mjs` after applying the patch. The script summarizes a real Gateway cron run created and executed in the integration workspace.
- **Evidence after fix:** Copied terminal output from the fixed Showboat proof:

```output
workspace=cron-default-fixed-local-78549
port=59337
payload.model=default
status=skipped
diagnostic.source=model-preflight
provider=ollama
model=no-server
old_rejection_present=false
```

- **Observed result after fix:** The cron run no longer fails in `cron-preflight` with `cron payload.model 'default' rejected by agents.defaults.models allowlist: minimax-portal/default`. It inherits the configured default model and reaches `model-preflight` for provider `ollama` model `no-server`, where the deliberately unreachable local endpoint produces the expected skipped result.
- **What was not tested:** No known gaps for this bug. The broad docs gate still reports unrelated pre-existing markdownlint issues outside the touched docs.

## Verification

- `pnpm test src/cron/isolated-agent.model-formatting.test.ts src/cron/isolated-agent/run-fallback-policy.test.ts`
- `pnpm test src/cron/isolated-agent/run.skill-filter.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/automation/cron-jobs.md docs/cli/cron.md src/cron/model-override.ts src/cron/isolated-agent/model-selection.ts src/cron/isolated-agent/run-fallback-policy.ts src/cron/isolated-agent.model-formatting.test.ts src/cron/isolated-agent/run-fallback-policy.test.ts`
- `git diff --check`
- `pnpm changed:lanes --json`
- `node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high`
- `pnpm why basic-ftp --prod --recursive` shows `basic-ftp@5.3.1`
- Showboat repro: `.mem/main/proofs/78549-cron-default-model-repro.md`
- Showboat fixed proof: `.mem/main/proofs/78549-cron-default-model-fixed.md`

`pnpm check:docs` currently fails on existing markdownlint issues outside this change (`docs/research/2026-03-29-research-app-server-app-invocation-migration.md` and `docs/specs/codex-v2.md`) plus longstanding `CHANGELOG.md` lint debt; the touched docs were formatted cleanly by `format:docs:check` before lint reached the unrelated failures.
