### PR TITLE
fix(discord): parse provider-prefixed channel targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Docs: https://docs.openclaw.ai
 - QA/Mantis: add `pnpm openclaw qa mantis slack-desktop-smoke` to run Slack live QA inside a Crabbox VNC desktop, open Slack Web, and capture desktop screenshots beside the Slack QA artifacts.
 - QA/Mantis: add an opt-in Discord thread attachment before/after scenario that creates a real thread, calls `message.thread-reply` with `filePath`, and captures baseline/candidate screenshot evidence.
 - Discord: preserve `filePath` and `path` attachments when replying to a thread with the message tool.
+- Discord/message: parse provider-prefixed targets like `discord:channel:<id>` as channel sends instead of legacy Discord DM targets, so cross-channel agent `message(action="send")` calls no longer misroute channel IDs into misleading `Unknown Channel` failures. Fixes #78572.
 - QA/Mantis: add visual desktop tasks with Crabbox MP4 recording, screenshot capture, and optional image-understanding assertions, and preserve video artifacts in Mantis before/after reports.
 - QA/WhatsApp: add `pnpm openclaw qa whatsapp` for live DM canary and pairing-gate coverage using two pre-linked WhatsApp Web sessions from the QA credential pool.
 - QA/Mantis: pass the runtime env through desktop-browser Crabbox and artifact-copy child commands, so embedded Mantis callers can provide Crabbox credentials without mutating the parent process. Thanks @vincentkoc.

--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -172,6 +172,33 @@ describe("discordPlugin outbound", () => {
     });
   });
 
+  it("resolves bare allowlisted Discord user IDs as message-tool DM targets", async () => {
+    const resolveTarget = discordPlugin.messaging?.targetResolver?.resolveTarget;
+    if (!resolveTarget) {
+      throw new Error(
+        "Expected discordPlugin.messaging.targetResolver.resolveTarget to be defined",
+      );
+    }
+
+    await expect(
+      resolveTarget({
+        cfg: {
+          channels: {
+            discord: {
+              allowFrom: ["1439091261670948987"],
+            },
+          },
+        } as OpenClawConfig,
+        input: "1439091261670948987",
+        normalized: "channel:1439091261670948987",
+        preferredKind: "channel",
+      }),
+    ).resolves.toMatchObject({
+      to: "user:1439091261670948987",
+      kind: "user",
+    });
+  });
+
   it("honors per-account replyToMode overrides", () => {
     const resolveReplyToMode = discordPlugin.threading?.resolveReplyToMode;
     if (!resolveReplyToMode) {

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -79,6 +79,7 @@ import { discordSetupAdapter } from "./setup-adapter.js";
 import { createDiscordPluginBase, discordConfigAdapter } from "./shared.js";
 import { collectDiscordStatusIssues } from "./status-issues.js";
 import { parseDiscordTarget } from "./target-parsing.js";
+import { resolveDiscordTarget } from "./target-resolver.js";
 
 const REQUIRED_DISCORD_PERMISSIONS = ["ViewChannel", "SendMessages"] as const;
 const DISCORD_ACCOUNT_STARTUP_STAGGER_MS = 10_000;
@@ -326,6 +327,21 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount, DiscordProbe> 
         targetResolver: {
           looksLikeId: looksLikeDiscordTargetId,
           hint: "<channelId|user:ID|channel:ID>",
+          resolveTarget: async ({ cfg, accountId, input, preferredKind }) => {
+            const target = await resolveDiscordTarget(
+              input,
+              { cfg, accountId: accountId ?? undefined },
+              { defaultKind: preferredKind === "user" ? "user" : "channel" },
+            );
+            return target
+              ? {
+                  to: target.normalized,
+                  kind: target.kind,
+                  display: target.raw,
+                  source: "normalized",
+                }
+              : null;
+          },
         },
       },
       approvalCapability: getDiscordApprovalCapability(),

--- a/extensions/discord/src/normalize.ts
+++ b/extensions/discord/src/normalize.ts
@@ -31,6 +31,9 @@ export function normalizeDiscordOutboundTarget(
     }
     return { ok: true, to: `channel:${trimmed}` };
   }
+  if (/^discord:(?:channel|user):/i.test(trimmed)) {
+    return { ok: true, to: normalizeDiscordMessagingTarget(trimmed) ?? trimmed };
+  }
   return { ok: true, to: trimmed };
 }
 

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -30,6 +30,13 @@ describe("normalizeDiscordOutboundTarget", () => {
     expect(normalizeDiscordOutboundTarget("channel:123")).toEqual({ ok: true, to: "channel:123" });
   });
 
+  it("normalizes provider-prefixed channel targets", () => {
+    expect(normalizeDiscordOutboundTarget("discord:channel:123")).toEqual({
+      ok: true,
+      to: "channel:123",
+    });
+  });
+
   it("passes through user: prefixed targets", () => {
     expect(normalizeDiscordOutboundTarget("user:123")).toEqual({ ok: true, to: "user:123" });
   });

--- a/extensions/discord/src/outbound-session-route.test.ts
+++ b/extensions/discord/src/outbound-session-route.test.ts
@@ -31,4 +31,36 @@ describe("resolveDiscordOutboundSessionRoute", () => {
     });
     expect(route?.threadId).toBeUndefined();
   });
+
+  it("routes provider-prefixed channel targets as channels", () => {
+    const route = resolveDiscordOutboundSessionRoute({
+      cfg: {},
+      agentId: "main",
+      target: "discord:channel:123",
+    });
+
+    expect(route).toMatchObject({
+      sessionKey: "agent:main:discord:channel:123",
+      baseSessionKey: "agent:main:discord:channel:123",
+      chatType: "channel",
+      from: "discord:channel:123",
+      to: "channel:123",
+    });
+  });
+
+  it("keeps legacy provider-prefixed numeric targets as direct messages", () => {
+    const route = resolveDiscordOutboundSessionRoute({
+      cfg: {},
+      agentId: "main",
+      target: "discord:123",
+    });
+
+    expect(route).toMatchObject({
+      sessionKey: "agent:main:main",
+      baseSessionKey: "agent:main:main",
+      chatType: "direct",
+      from: "discord:123",
+      to: "user:123",
+    });
+  });
 });

--- a/extensions/discord/src/target-parsing.ts
+++ b/extensions/discord/src/target-parsing.ts
@@ -21,6 +21,10 @@ export function parseDiscordTarget(
   if (!trimmed) {
     return undefined;
   }
+  const providerPrefixedTarget = parseDiscordProviderPrefixedTarget(trimmed);
+  if (providerPrefixedTarget) {
+    return providerPrefixedTarget;
+  }
   const userTarget = parseMentionPrefixOrAtUserTarget({
     raw: trimmed,
     mentionPattern: /^<@!?(\d+)>$/,
@@ -45,6 +49,19 @@ export function parseDiscordTarget(
     );
   }
   return buildMessagingTarget("channel", trimmed, trimmed);
+}
+
+function parseDiscordProviderPrefixedTarget(raw: string): DiscordTarget | undefined {
+  const match = /^discord:(channel|user):(.+)$/i.exec(raw);
+  if (!match) {
+    return undefined;
+  }
+  const kind = match[1]?.toLowerCase() as "channel" | "user" | undefined;
+  const id = match[2]?.trim();
+  if (!kind || !id) {
+    return undefined;
+  }
+  return buildMessagingTarget(kind, id, `${kind}:${id}`);
 }
 
 export function resolveDiscordChannelId(raw: string): string {

--- a/extensions/discord/src/targets.test.ts
+++ b/extensions/discord/src/targets.test.ts
@@ -18,6 +18,7 @@ describe("parseDiscordTarget", () => {
       { input: "<@123>", id: "123", normalized: "user:123" },
       { input: "<@!456>", id: "456", normalized: "user:456" },
       { input: "user:789", id: "789", normalized: "user:789" },
+      { input: "discord:user:789", id: "789", normalized: "user:789" },
       { input: "discord:987", id: "987", normalized: "user:987" },
     ] as const;
     for (const testCase of cases) {
@@ -32,6 +33,7 @@ describe("parseDiscordTarget", () => {
   it("parses channel targets", () => {
     const cases = [
       { input: "channel:555", id: "555", normalized: "channel:555" },
+      { input: "discord:channel:555", id: "555", normalized: "channel:555" },
       { input: "general", id: "general", normalized: "channel:general" },
     ] as const;
     for (const testCase of cases) {
@@ -224,6 +226,10 @@ describe("resolveDiscordTarget", () => {
 describe("normalizeDiscordMessagingTarget", () => {
   it("defaults raw numeric ids to channels", () => {
     expect(normalizeDiscordMessagingTarget("123")).toBe("channel:123");
+  });
+
+  it("normalizes provider-prefixed channel targets as channels", () => {
+    expect(normalizeDiscordMessagingTarget("discord:channel:123")).toBe("channel:123");
   });
 });
 


### PR DESCRIPTION
## Summary

- Fixes #78572 by resolving bare numeric Discord message-tool targets through Discord's allowFrom-aware target resolver, so allowlisted DM user IDs route as `user:<id>` instead of being treated as channels.
- Parse Discord provider-prefixed channel/user targets before the legacy `discord:<id>` DM shorthand, so `discord:channel:<id>` remains a channel target.
- Preserve legacy `discord:<userId>` direct-message routing.
- Add Discord-owned parser, normalizer, outbound route, outbound adapter, and plugin resolver coverage.

Fixes #78572.

## Real behavior proof

**Behavior addressed:** Discord `message(action="send")` target resolution for the #78572 repro shape: a bare numeric Discord user ID that appears in `channels.discord.allowFrom` must route as `user:<id>` for DM delivery, not as `channel:<id>`. Also verifies provider-prefixed `discord:channel:<id>` routes as a channel target and can deliver a real Discord channel message.

**Real environment tested:** Local OpenClaw CLI built from this PR branch on macOS, using a temporary `OPENCLAW_HOME`/`XDG_CONFIG_HOME` and a temp Discord config with the local Discord bot token provided through `DISCORD_BOT_TOKEN`. The live channel delivery target was Discord channel `1501672157829140502`.

**Exact steps or command run after the patch:**
1. Create a temp OpenClaw home and patch config with `channels.discord.enabled=true`, `channels.discord.token={ source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" }`, and `channels.discord.allowFrom=["*"]`.
2. Run `pnpm openclaw message send --channel discord --target "discord:channel:1501672157829140502" --message "OpenClaw live Discord delivery check for PR 78625 2026-05-06T21:25:34Z" --json`.
3. Separately run the #78572 target-resolution dry-run with `channels.discord.allowFrom=["1439091261670948987"]`: `pnpm openclaw message send --channel discord --target "1439091261670948987" --message "dry-run allowFrom DM target check" --dry-run --json`.

**Evidence after fix:**
Live Discord channel delivery returned:
```json
{
  "action": "send",
  "channel": "discord",
  "dryRun": false,
  "handledBy": "core",
  "payload": {
    "channel": "discord",
    "to": "channel:1501672157829140502",
    "via": "direct",
    "result": {
      "messageId": "1501696468438880377",
      "channel": "discord",
      "receipt": {
        "primaryPlatformMessageId": "1501696468438880377",
        "parts": [
          {
            "platformMessageId": "1501696468438880377",
            "kind": "text",
            "raw": {
              "channel": "discord",
              "messageId": "1501696468438880377",
              "channelId": "1501672157829140502"
            }
          }
        ]
      }
    }
  }
}
```

The #78572 bare numeric allowlisted DM dry-run returned:
```json
{
  "action": "send",
  "channel": "discord",
  "dryRun": true,
  "handledBy": "core",
  "payload": {
    "channel": "discord",
    "to": "user:1439091261670948987",
    "via": "direct",
    "mediaUrl": null,
    "dryRun": true
  }
}
```

**Observed result after fix:** The provider-prefixed Discord channel target delivered a real Discord message with platform message id `1501696468438880377`, and the #78572 bare numeric allowlisted Discord target resolves to `user:1439091261670948987`, which is the DM send target expected by Discord instead of `channel:<id>`.

**What was not tested:** Live Discord DM delivery to the #78572 reporter's user id was not run because we do not have that user's bot/channel relationship locally; the DM fix was verified at the target-resolution layer that produced the reported `Unknown Channel` misroute, and live channel delivery verified the Discord send path after provider-prefixed normalization.

## Verification

- `pnpm exec oxfmt --check --threads=1 extensions/discord/src/channel.ts extensions/discord/src/channel.test.ts extensions/discord/src/target-parsing.ts extensions/discord/src/normalize.ts extensions/discord/src/targets.test.ts extensions/discord/src/outbound-adapter.test.ts extensions/discord/src/outbound-session-route.test.ts CHANGELOG.md`
- `pnpm test extensions/discord/src/channel.test.ts extensions/discord/src/targets.test.ts extensions/discord/src/normalize.test.ts extensions/discord/src/outbound-adapter.test.ts extensions/discord/src/outbound-session-route.test.ts src/agents/tools/message-tool.test.ts -- --run`
