### PR TITLE
chore(plugin-sdk): update api baseline

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-fe1d0d9bde4ab216a92e4fce8c01d699601c3f033f6449352382ff902b129a6f  plugin-sdk-api-baseline.json
-15eb9a88276f066cddb645f072f57f25f1ff59174cf2277b6014ca2565dbe09a  plugin-sdk-api-baseline.jsonl
+83c7b0a2953a24cac8d576bb561948ccd70d4bac3c06d0a39814a766b7a330b6  plugin-sdk-api-baseline.json
+387c0a4b34b0edd3c576658d71f13cdeb64d74bc949c36698798563de08f570d  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
## Summary
- update the generated Plugin SDK API baseline hash for the Talk logging exports landed in #78401

## Verification
- `pnpm plugin-sdk:api:check`
- `pnpm plugin-sdk:check-exports`
- `pnpm test:serial src/talk/logging.test.ts extensions/diagnostics-otel/src/service.test.ts extensions/diagnostics-prometheus/src/service.test.ts`
- `pnpm changed:lanes --json`
- `git diff --check origin/main...HEAD`
