### PR TITLE
fix: classify Kimi billing-cycle quota errors as retryable 402

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -292,7 +292,7 @@ const BILLING_402_PLAN_HINTS = [
   "subscription",
 ] as const;
 
-const PERIODIC_402_HINTS = ["daily", "weekly", "monthly"] as const;
+const PERIODIC_402_HINTS = ["daily", "weekly", "monthly", "billing cycle", "next cycle"] as const;
 const RETRYABLE_402_RETRY_HINTS = ["try again", "retry", "temporary", "cooldown"] as const;
 const RETRYABLE_402_LIMIT_HINTS = ["usage limit", "rate limit", "organization usage"] as const;
 const RETRYABLE_402_SCOPED_HINTS = ["organization", "workspace"] as const;
@@ -520,12 +520,14 @@ function hasQuotaRefreshWindowSignal(text: string): boolean {
 function hasRetryable402TransientSignal(text: string): boolean {
   const hasPeriodicHint = includesAnyHint(text, PERIODIC_402_HINTS);
   const hasSpendLimit = text.includes("spend limit") || text.includes("spending limit");
+  const hasCycleRefreshHint = text.includes("billing cycle") || text.includes("next cycle");
   const hasScopedHint = includesAnyHint(text, RETRYABLE_402_SCOPED_HINTS);
   return (
     (includesAnyHint(text, RETRYABLE_402_RETRY_HINTS) &&
       includesAnyHint(text, RETRYABLE_402_LIMIT_HINTS)) ||
     (hasPeriodicHint && (text.includes("usage limit") || hasSpendLimit)) ||
     (hasPeriodicHint && text.includes("limit") && text.includes("reset")) ||
+    (hasCycleRefreshHint && text.includes("usage limit")) ||
     (hasScopedHint &&
       text.includes("limit") &&
       (hasSpendLimit || includesAnyHint(text, RETRYABLE_402_SCOPED_RESULT_HINTS)))


### PR DESCRIPTION
## Summary
- extend periodic 402 hint detection to include `billing cycle` and `next cycle`
- classify Kimi-style quota refresh wording as retryable 402/rate_limit instead of letting it fall through

## Problem
Kimi can return quota exhaustion wording like:

> You've reached your usage limit for this billing cycle. Your quota will be refreshed in the next cycle.

This appears to slip past the existing periodic/retryable 402 heuristics because they recognize `daily`, `weekly`, and `monthly`, but not `billing cycle` / `next cycle`.

That leaves a hole where a quota-refresh message can be misclassified downstream instead of routing through the retryable 402 path.

## Validation
- verified current mainline logic does not explicitly match `billing cycle` / `next cycle`
- verified this patch causes the exact observed Kimi message to match the retryable 402 path
- local live reproduction was not available because the Kimi quota window had already reset
