### PR TITLE
fix(telegram): serialize final reply after last streaming progress edit

### DIFF
--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -41,6 +41,8 @@ export type TelegramDraftStream = {
   forceNewMessage: () => void;
   /** True when a preview sendMessage was attempted but the response was lost. */
   sendMayHaveLanded?: () => boolean;
+  /** Wait for any in-flight Telegram API send/edit to be acknowledged. */
+  waitForDrain?: () => Promise<void>;
 };
 
 type TelegramDraftPreview = {
@@ -304,5 +306,6 @@ export function createTelegramDraftStream(params: {
     materialize,
     forceNewMessage,
     sendMayHaveLanded: () => messageSendAttempted && typeof streamMessageId !== "number",
+    waitForDrain: loop.waitForInFlight,
   };
 }

--- a/src/channels/draft-stream-controls.ts
+++ b/src/channels/draft-stream-controls.ts
@@ -57,8 +57,9 @@ export function createFinalizableDraftStreamControls(params: {
 
   const stopForClear = async (): Promise<void> => {
     params.markStopped();
-    loop.stop();
-    await loop.waitForInFlight();
+    await loop.stopAndDrain();
+    // Give Telegram time to process the edit before the next sendMessage call
+    await new Promise((resolve) => setTimeout(resolve, 50));
   };
 
   const seal = async (): Promise<void> => {
@@ -74,6 +75,7 @@ export function createFinalizableDraftStreamControls(params: {
     seal,
     discardPending: stopForClear,
     stopForClear,
+    stopAndDrain: loop.stopAndDrain,
   };
 }
 

--- a/src/channels/draft-stream-controls.ts
+++ b/src/channels/draft-stream-controls.ts
@@ -56,8 +56,9 @@ export function createFinalizableDraftStreamControls(params: {
   };
 
   const stopForClear = async (): Promise<void> => {
-    params.markStopped();
+    // Drain BEFORE marking stopped so flush() actually waits for in-flight work
     await loop.stopAndDrain();
+    params.markStopped();
     // Give Telegram time to process the edit before the next sendMessage call
     await new Promise((resolve) => setTimeout(resolve, 50));
   };

--- a/src/channels/draft-stream-loop.ts
+++ b/src/channels/draft-stream-loop.ts
@@ -5,6 +5,7 @@ export type DraftStreamLoop = {
   resetPending: () => void;
   resetThrottleWindow: () => void;
   waitForInFlight: () => Promise<void>;
+  stopAndDrain: () => Promise<void>;
 };
 
 export function createDraftStreamLoop(params: {
@@ -99,6 +100,10 @@ export function createDraftStreamLoop(params: {
       if (inFlightPromise) {
         await inFlightPromise;
       }
+    },
+    stopAndDrain: async () => {
+      await flush();
+      stop();
     },
   };
 }


### PR DESCRIPTION
## Summary

- Fix race condition where the final assembled reply occasionally arrived in Telegram before the last streaming progress messages during tool-heavy turns
- Root cause: `stopForClear` didn't properly wait for the last `editMessageText` to be processed by Telegram before `sendPayload` sent the final reply

## Changes

- **src/channels/draft-stream-loop.ts**: Add `stopAndDrain()` method to properly drain the stream before stopping
- **src/channels/draft-stream-controls.ts**: Update `stopForClear` to use `stopAndDrain()` and add 50ms delay to ensure Telegram has processed the edit before the next send
- **extensions/telegram/src/draft-stream.ts**: Expose `waitForDrain` on `TelegramDraftStream` interface

## Test plan

- [ ] Verify that during tool-heavy turns with `streaming.mode: "partial"`, messages arrive in correct order (progress messages first, then final reply)
- [ ] Test with 3+ sequential tool calls to reproduce the ~30-40% failure rate

## Real Behavior Proof

**Behavior or issue addressed:** Race condition during Telegram streaming where final assembled reply occasionally arrived before last streaming progress messages during tool-heavy turns with `streaming.mode: "partial"`. The issue was that `stopForClear` didn't properly wait for the last `editMessageText` to be acknowledged before `sendPayload` sent the final reply.

**Real environment tested:** OpenClaw gateway with Telegram bot configured (bot: @testclawopen_bot), streaming mode set to `partial`, tested with multi-tool prompts triggering 3+ sequential tool calls.

**Exact steps or command run after this patch:**
1. Configure Telegram channel with `streaming.mode: "partial"` in gateway config
2. Send a prompt triggering 3+ sequential tool calls (web fetch + exec + another tool)
3. Observe messages in Telegram - with the fix, final reply should always appear after all progress updates

**Evidence after fix:** Screenshots from Telegram showing correct message ordering - all streaming progress messages appear first, then the final assembled reply:

![image](https://github.com/user-attachments/assets/f96e7116-2629-47bb-904b-d4e0e4cefd33)

![image](https://github.com/user-attachments/assets/a98baeb1-a8d4-48c2-b1f2-4e361b9e3a6d)

**Observed result after fix:** Messages arrive in correct chronological order. Without the fix, the final assembled reply would occasionally arrive before the last streaming progress messages (~30-40% of tool-heavy turns). With the fix applied (drain ordering corrected in `stopForClear`), all progress edits are properly acknowledged before the final sendMessage is dispatched.

**What was not tested:** Edge cases with unreliable network conditions, or very rapid sequential tool calls (< 100ms apart).

Closes #77401