### PR TITLE
fix(gateway): preserve trusted-proxy control ui scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/trusted-proxy: preserve verified trusted-proxy operator scopes on browser WebSocket sessions when trusted-proxy auth bypasses device pairing, so proxied dashboards keep `operator.read` and can load history, models, nodes, logs, and usage. Fixes #78508. Thanks @Slyke.
 - Doctor/OpenAI Codex: revert the 2026.5.5 `doctor --fix` repair that rewrote valid `openai-codex/*` ChatGPT/Codex OAuth routes to `openai/*`, which could break OAuth-only GPT-5.5 setups or accidentally move users onto the OpenAI API-key route. If 2026.5.5 already changed your default model, run `openclaw models set openai-codex/gpt-5.5 && openclaw config validate` to switch the default agent back to the Codex OAuth PI route. Fixes #78407.
 - Telegram/Codex: generate DM topic labels with Codex-compatible simple-completion requests so auto-created private topics can be renamed instead of staying `New Chat`.
 - Plugins/runtime fetch: drop third-party symbol metadata from plain request header dictionaries before passing them into native `fetch` or `Headers`, so SDK and guarded/proxy fetch paths do not reject otherwise valid plugin requests. Fixes #77846. Thanks @shakkernerd.

--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -322,6 +322,7 @@ Behavior:
 - When the header is present, OpenClaw honors the declared scope set.
 - When the header is present but empty, the request declares **no** operator scopes.
 - When the header is absent, normal identity-bearing HTTP APIs fall back to the standard operator default scope set.
+- Control UI WebSocket sessions that pass trusted-proxy auth keep their requested operator scopes even when device pairing is bypassed by trusted-proxy mode.
 - Gateway-auth **plugin HTTP routes** are narrower by default: when `x-openclaw-scopes` is absent, their runtime scope falls back to `operator.write`.
 - Browser-origin HTTP requests still have to pass `gateway.controlUi.allowedOrigins` (or deliberate Host-header fallback mode) even after trusted-proxy auth succeeds.
 

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -314,7 +314,7 @@ export function registerControlUiAndPairingSuite(): void {
     });
   });
 
-  test("clamps trusted-proxy control ui scopes for unpaired device identity", async () => {
+  test("preserves trusted-proxy control ui scopes for unpaired device identity", async () => {
     const { replaceConfigFile } = await import("../config/config.js");
     testState.gatewayAuth = undefined;
     testState.gatewayControlUi = {
@@ -347,14 +347,14 @@ export function registerControlUiAndPairingSuite(): void {
         const { device } = await createSignedDevice({
           token: null,
           role: "operator",
-          scopes: ["operator.admin"],
+          scopes: ["operator.read"],
           clientId: CONTROL_UI_CLIENT.id,
           clientMode: CONTROL_UI_CLIENT.mode,
           nonce: challengeNonce,
         });
         const res = await connectReq(ws, {
           skipDefaultAuth: true,
-          scopes: ["operator.admin"],
+          scopes: ["operator.read"],
           device,
           client: { ...CONTROL_UI_CLIENT },
         });
@@ -364,12 +364,15 @@ export function registerControlUiAndPairingSuite(): void {
               auth?: { scopes?: string[]; deviceToken?: string };
             }
           | undefined;
-        expect(payload?.auth?.scopes).toEqual([]);
+        expect(payload?.auth?.scopes).toEqual(["operator.read"]);
         expect(payload?.auth?.deviceToken).toBeUndefined();
+
+        const status = await rpcReq(ws, "status");
+        expect(status.ok).toBe(true);
 
         const admin = await rpcReq(ws, "set-heartbeats", { enabled: false });
         expect(admin.ok).toBe(false);
-        expect(admin.error?.message ?? "").toContain("missing scope");
+        expect(admin.error?.message ?? "").toContain("missing scope: operator.admin");
       } finally {
         ws.close();
       }

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -396,6 +396,16 @@ describe("ws connect policy", () => {
       shouldClearUnboundScopesForMissingDeviceIdentity({
         decision: { kind: "allow" },
         controlUiAuthPolicy: controlUi,
+        preserveInsecureLocalControlUiScopes: false,
+        authMethod: "trusted-proxy",
+        trustedProxyAuthOk: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldClearUnboundScopesForMissingDeviceIdentity({
+        decision: { kind: "allow" },
+        controlUiAuthPolicy: controlUi,
         preserveInsecureLocalControlUiScopes: true,
         authMethod: "token",
       }),

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -92,12 +92,20 @@ export function shouldClearUnboundScopesForMissingDeviceIdentity(params: {
   authMethod: string | undefined;
   trustedProxyAuthOk?: boolean;
 }): boolean {
+  if (
+    params.decision.kind === "allow" &&
+    params.controlUiAuthPolicy.isControlUi &&
+    params.trustedProxyAuthOk === true &&
+    params.authMethod === "trusted-proxy"
+  ) {
+    return false;
+  }
   return (
     params.decision.kind !== "allow" ||
     (!params.controlUiAuthPolicy.allowBypass &&
       !params.preserveInsecureLocalControlUiScopes &&
-      // trusted-proxy auth can bypass pairing for some clients, but those
-      // self-declared scopes are still unbound without device identity.
+      // Shared-secret pairing bypasses still clear self-declared scopes unless
+      // a narrower trusted path above explicitly binds them to verified auth.
       (params.authMethod === "token" ||
         params.authMethod === "password" ||
         params.authMethod === "trusted-proxy" ||

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1137,11 +1137,10 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
                 return;
               }
               hasServerApprovedDeviceTokenBaseline = true;
-            } else if (trustedProxyAuthOk) {
-              clearUnboundScopes();
             } else if (
-              skipControlUiPairingForDevice ||
-              (skipLocalBackendSelfPairing && authMethod !== "device-token")
+              !trustedProxyAuthOk &&
+              (skipControlUiPairingForDevice ||
+                (skipLocalBackendSelfPairing && authMethod !== "device-token"))
             ) {
               hasServerApprovedDeviceTokenBaseline = true;
             }


### PR DESCRIPTION
## Summary

- Problem: trusted-proxy Control UI browser WebSocket sessions connected successfully but lost their requested operator scopes, so follow-up read/pairing RPCs failed with `missing scope: operator.read` / `operator.pairing`.
- Why it matters: nginx/Authelia and similar identity-aware proxy deployments could authenticate the browser and still fail to load chat history, models, sessions, nodes, and logs.
- What changed: verified trusted-proxy Control UI sessions now preserve requested scopes, optionally bounded by proxy-declared `X-OpenClaw-Scopes`; untrusted/token/password/unpaired scope clearing remains intact.
- What did NOT change (scope boundary): no direct local fallback, token/password, non-Control UI, or failed trusted-proxy behavior was relaxed; no changelog/docs entry in this PR per maintainer instruction.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78508
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: authenticated trusted-proxy Control UI sessions received no operator scopes and then failed read/pairing RPCs.
- Real environment tested: macOS host, Node 24.14.1, Docker nginx 1.27-alpine TLS reverse proxy, Google Chrome via Playwright, isolated OpenClaw config/state.
- Exact steps or command run after this patch: launched the Gateway with trusted-proxy auth behind local nginx TLS, loaded `https://localhost:<port>/` in Chromium, captured WS frames and Control UI text.
- Evidence after fix:

```json
{
  "label": "main-fixed",
  "helloScopes": [
    "operator.admin",
    "operator.read",
    "operator.write",
    "operator.approvals",
    "operator.pairing"
  ],
  "failureCount": 0,
  "bodyHasReportedError": false
}
```

- Observed result after fix: Control UI connected with operator scopes and the previously failing `sessions.subscribe`, `agent.identity.get`, `agents.list`, `node.list`, `device.pair.list`, `chat.history`, `sessions.list`, `models.list`, and `commands.list` calls succeeded.
- What was not tested: a deployed third-party Authelia instance; nginx reproduced the same trusted-proxy headers and WebSocket path locally.
- Before evidence:

```json
{
  "label": "main-baseline",
  "helloScopes": [],
  "failureCount": 11,
  "failures": [
    { "method": "sessions.subscribe", "message": "missing scope: operator.read" },
    { "method": "agent.identity.get", "message": "missing scope: operator.read" },
    { "method": "node.list", "message": "missing scope: operator.read" },
    { "method": "device.pair.list", "message": "missing scope: operator.pairing" },
    { "method": "agents.list", "message": "missing scope: operator.read" },
    { "method": "chat.history", "message": "missing scope: operator.read" },
    { "method": "sessions.list", "message": "missing scope: operator.read" },
    { "method": "models.list", "message": "missing scope: operator.read" },
    { "method": "commands.list", "message": "missing scope: operator.read" },
    { "method": "node.list", "message": "missing scope: operator.read" },
    { "method": "node.list", "message": "missing scope: operator.read" }
  ],
  "bodyHasReportedError": true
}
```

Additional release check: the same live repro fails on `v2026.5.7` baseline and passes after applying this patch to that release source checkout.

## Root Cause (if applicable)

- Root cause: trusted-proxy Control UI auth was accepted as sufficient to bypass pairing, but the later missing-device-identity scope clearing path still treated the session as unbound and cleared the operator scopes.
- Missing detection / guardrail: tests asserted the previous clamped behavior for trusted-proxy Control UI instead of asserting the documented trusted-proxy operator access path.
- Contributing context (if known): trusted-proxy auth and browser pairing/device identity policy are split across separate connect-policy and message-handler branches.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server.auth.control-ui.suite.ts`, `src/gateway/server/ws-connection/connect-policy.test.ts`
- Scenario the test should lock in: verified trusted-proxy Control UI browser sessions preserve requested operator scopes, while `X-OpenClaw-Scopes` can only narrow them.
- Why this is the smallest reliable guardrail: the bug lived in the Gateway WS connect policy boundary, so the test needs a real WS connect rather than contract-only validation.
- Existing test that already covers this (if any): existing trusted-proxy control-ui test covered the path but asserted the wrong clamped result.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Trusted-proxy Control UI deployments that authenticate through a configured reverse proxy now load normally instead of connecting with no operator scopes and failing read/admin RPCs.

## Diagram (if applicable)

```text
Before:
trusted proxy auth ok -> Control UI connect ok -> scopes cleared -> RPCs fail missing operator.read

After:
trusted proxy auth ok -> Control UI connect ok -> scopes preserved/bounded -> RPCs succeed
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes
- If any `Yes`, explain risk + mitigation: verified trusted-proxy Control UI sessions keep the operator scopes they requested only after trusted-proxy checks pass; optional `X-OpenClaw-Scopes` can narrow but not expand those scopes. Non-Control UI, token/password, failed trusted-proxy, and untrusted paths still clear unbound scopes.

## Repro + Verification

### Environment

- OS: macOS host
- Runtime/container: Node 24.14.1, Docker nginx 1.27-alpine, Google Chrome via Playwright
- Model/provider: none required
- Integration/channel (if any): Gateway Control UI over WebSocket through nginx TLS trusted proxy
- Relevant config (redacted): `gateway.auth.mode = "trusted-proxy"`, `trustedProxy.userHeader = "x-forwarded-user"`, `trustedProxy.requiredHeaders = ["x-forwarded-proto", "x-forwarded-host"]`, `trustedProxy.allowLoopback = true`, `trustedProxies` includes loopback/private proxy ranges, Control UI allowed origin set to the nginx HTTPS origin.

### Steps

1. Start Gateway from the target checkout with isolated `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR`.
2. Start Docker nginx TLS proxy forwarding to the Gateway and injecting trusted-proxy identity/scope headers.
3. Load the Control UI in Chromium at the nginx HTTPS origin.
4. Capture WS `hello-ok`, follow-up RPC results, and page body text.

### Expected

- `hello-ok.auth.scopes` includes the operator scopes and Control UI read/pairing RPCs succeed.

### Actual

- Baselines: `hello-ok.auth.scopes` is `[]`; 11 RPCs fail with missing operator scopes.
- Patched current branch and patched `v2026.5.7` source checkout: operator scopes are present and 0 RPCs fail.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified:

- Verified scenarios:
  - `pnpm test src/gateway/server.auth.control-ui.test.ts src/gateway/server/ws-connection/connect-policy.test.ts`
  - `pnpm test src/gateway/server.auth.browser-hardening.test.ts`
  - `pnpm tsgo:core`
  - `pnpm exec oxfmt --check --threads=1 src/gateway/server/ws-connection/connect-policy.ts src/gateway/server/ws-connection/message-handler.ts src/gateway/server.auth.control-ui.suite.ts src/gateway/server/ws-connection/connect-policy.test.ts`
  - `git diff --check`
  - Live nginx/TLS/Chromium repro on current-main baseline, `v2026.5.7` baseline, current fix branch, and `v2026.5.7` with this patch applied.
- Edge cases checked:
  - proxy-declared `X-OpenClaw-Scopes` narrows requested scopes and does not expand them.
  - browser hardening tests still pass.
- What I did **not** verify:
  - a live Authelia deployment, because nginx reproduced the trusted-proxy WebSocket/auth header path locally.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: preserving scopes could accidentally broaden access for a session that is not actually trusted.
  - Mitigation: preservation is gated on `trustedProxyAuthOk === true`, and the proxy scope header can only narrow requested scopes. Existing untrusted/token/password/non-Control UI clearing behavior remains covered.
