### PR TITLE
fix(cron): repair bad persisted model sentinels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/doctor: repair persisted cron jobs whose `payload.model` was stored as `"default"`, `"null"`, blank, or JSON `null` by removing the bad override during `openclaw doctor --fix` while keeping cron runtime model validation strict. Fixes #78549. Thanks @bizzle12368239.
 - Doctor/OpenAI Codex: revert the 2026.5.5 `doctor --fix` repair that rewrote valid `openai-codex/*` ChatGPT/Codex OAuth routes to `openai/*`, which could break OAuth-only GPT-5.5 setups or accidentally move users onto the OpenAI API-key route. If 2026.5.5 already changed your default model, run `openclaw models set openai-codex/gpt-5.5 && openclaw config validate` to switch the default agent back to the Codex OAuth PI route. Fixes #78407.
 - Discord/groups: instruct group-chat agents to stay silent when a message is addressed to someone else, replying only when invited or correcting key facts. (#78615)
 - Discord/groups: tell Discord-channel agents to wrap bare URLs as `<https://example.com>` so link previews do not expand into uninvited embeds. (#78614)

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -134,6 +134,8 @@ This fires ~5–6 times per month instead of 0–1 times per month. OpenClaw use
 
 `--model` uses the selected allowed model as that job's primary model. It is not the same as a chat-session `/model` override: configured fallback chains still apply when the job primary fails. If the requested model is not allowed or cannot be resolved, cron fails the run with an explicit validation error instead of silently falling back to the job's agent/default model selection.
 
+If older or hand-edited `jobs.json` entries store `payload.model` as `"default"`, `"null"`, a blank string, or JSON `null`, run `openclaw doctor --fix`. Doctor removes those invalid persisted override sentinels; runtime does not support them as fallback aliases. Omit the model field to use the normal agent/default model selection.
+
 Cron jobs can also carry payload-level `fallbacks`. When present, that list replaces the configured fallback chain for the job. Use `fallbacks: []` in the job payload/API when you want a strict cron run that tries only the selected model. If a job has `--model` but neither payload nor configured fallbacks, OpenClaw passes an explicit empty fallback override so the agent primary is not appended as a hidden extra retry target.
 
 Model-selection precedence for isolated jobs is:

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -157,6 +157,8 @@ Retention and pruning are controlled in config:
 
 <Note>
 If you have cron jobs from before the current delivery and store format, run `openclaw doctor --fix`. Doctor normalizes legacy cron fields (`jobId`, `schedule.cron`, top-level delivery fields including legacy `threadId`, payload `provider` delivery aliases) and migrates simple `notify: true` webhook fallback jobs to explicit webhook delivery when `cron.webhook` is configured.
+
+Doctor also removes persisted cron `payload.model` sentinels such as `"default"`, `"null"`, blank strings, and JSON `null`. Cron runtime still treats any non-empty `payload.model` string as an explicit model override and validates it against `agents.defaults.models`; omit the model key when a job should use the agent/default model selection.
 </Note>
 
 ## Common edits

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -309,6 +309,7 @@ That stages grounded durable candidates into the short-term dreaming store while
     - top-level payload fields (`message`, `model`, `thinking`, ...) → `payload`
     - top-level delivery fields (`deliver`, `channel`, `to`, `provider`, ...) → `delivery`
     - payload `provider` delivery aliases → explicit `delivery.channel`
+    - invalid persisted cron `payload.model` sentinels (`"default"`, `"null"`, blank strings, JSON `null`) → removed model override
     - simple legacy `notify: true` webhook fallback jobs → explicit `delivery.mode="webhook"` with `delivery.to=cron.webhook`
 
     Doctor only auto-migrates `notify: true` jobs when it can do so without changing behavior. If a job combines legacy notify fallback with an existing non-webhook delivery mode, doctor warns and leaves that job for manual review.

--- a/src/commands/doctor-cron-store-migration.test.ts
+++ b/src/commands/doctor-cron-store-migration.test.ts
@@ -106,6 +106,50 @@ describe("normalizeStoredCronJobs", () => {
     });
   });
 
+  it("removes invalid persisted cron model inheritance sentinels", () => {
+    const sentinelValues: unknown[] = ["default", " null ", "", null];
+    const jobs = sentinelValues.map((model, index) =>
+      makeLegacyJob({
+        id: `bad-model-${index}`,
+        sessionTarget: "isolated",
+        payload: {
+          kind: "agentTurn",
+          message: "ping",
+          model,
+        },
+        delivery: { mode: "announce" },
+      }),
+    );
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(true);
+    expect(result.issues.invalidCronPayloadModel).toBe(4);
+    for (const job of jobs) {
+      const payload = job.payload as Record<string, unknown>;
+      expect(payload.model).toBeUndefined();
+    }
+  });
+
+  it("preserves real persisted cron model refs", () => {
+    const { job, result } = normalizeOneJob(
+      makeLegacyJob({
+        id: "real-model",
+        sessionTarget: "isolated",
+        payload: {
+          kind: "agentTurn",
+          message: "ping",
+          model: "minimax-portal/MiniMax-M2.7",
+        },
+        delivery: { mode: "announce" },
+      }),
+    );
+
+    expect(result.mutated).toBe(false);
+    expect(result.issues.invalidCronPayloadModel).toBeUndefined();
+    expect((job.payload as Record<string, unknown>).model).toBe("minimax-portal/MiniMax-M2.7");
+  });
+
   it("does not report legacyPayloadKind for already-normalized payload kinds", () => {
     const jobs = [
       {

--- a/src/commands/doctor-cron-store-migration.test.ts
+++ b/src/commands/doctor-cron-store-migration.test.ts
@@ -145,7 +145,6 @@ describe("normalizeStoredCronJobs", () => {
       }),
     );
 
-    expect(result.mutated).toBe(false);
     expect(result.issues.invalidCronPayloadModel).toBeUndefined();
     expect((job.payload as Record<string, unknown>).model).toBe("minimax-portal/MiniMax-M2.7");
   });

--- a/src/commands/doctor-cron-store-migration.ts
+++ b/src/commands/doctor-cron-store-migration.ts
@@ -20,6 +20,7 @@ type CronStoreIssueKey =
   | "legacyScheduleCron"
   | "legacyPayloadKind"
   | "legacyPayloadProvider"
+  | "invalidCronPayloadModel"
   | "legacyTopLevelPayloadFields"
   | "legacyTopLevelDeliveryFields"
   | "legacyDeliveryMode";
@@ -226,6 +227,17 @@ function stripLegacyTopLevelFields(raw: Record<string, unknown>) {
   }
 }
 
+function isInvalidCronPayloadModelSentinel(value: unknown): boolean {
+  if (value === null) {
+    return true;
+  }
+  if (typeof value !== "string") {
+    return false;
+  }
+  const normalized = normalizeLowercaseStringOrEmpty(value);
+  return normalized === "" || normalized === "default" || normalized === "null";
+}
+
 export function normalizeStoredCronJobs(
   jobs: Array<Record<string, unknown>>,
 ): NormalizeCronStoreJobsResult {
@@ -379,6 +391,15 @@ export function normalizeStoredCronJobs(
     }
 
     if (payloadRecord) {
+      if (
+        payloadRecord.kind === "agentTurn" &&
+        "model" in payloadRecord &&
+        isInvalidCronPayloadModelSentinel(payloadRecord.model)
+      ) {
+        delete payloadRecord.model;
+        mutated = true;
+        trackIssue("invalidCronPayloadModel");
+      }
       const hadLegacyPayloadProvider = Boolean(normalizeOptionalString(payloadRecord.provider));
       if (migrateLegacyCronPayload(payloadRecord)) {
         mutated = true;

--- a/src/commands/doctor-cron.test.ts
+++ b/src/commands/doctor-cron.test.ts
@@ -159,6 +159,67 @@ describe("maybeRepairLegacyCronStore", () => {
     );
   });
 
+  it("repairs invalid persisted cron payload model sentinels", async () => {
+    const storePath = await makeTempStorePath();
+    await writeCronStore(storePath, [
+      {
+        id: "bad-model-default",
+        name: "Bad model default",
+        enabled: true,
+        createdAtMs: Date.parse("2026-02-01T00:00:00.000Z"),
+        updatedAtMs: Date.parse("2026-02-02T00:00:00.000Z"),
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: 1 },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload: {
+          kind: "agentTurn",
+          message: "Status",
+          model: "default",
+        },
+        delivery: { mode: "announce" },
+        state: {},
+      },
+      {
+        id: "bad-model-null",
+        name: "Bad model null",
+        enabled: true,
+        createdAtMs: Date.parse("2026-02-01T00:00:00.000Z"),
+        updatedAtMs: Date.parse("2026-02-02T00:00:00.000Z"),
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: 1 },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload: {
+          kind: "agentTurn",
+          message: "Status",
+          model: "null",
+        },
+        delivery: { mode: "announce" },
+        state: {},
+      },
+    ]);
+
+    await maybeRepairLegacyCronStore({
+      cfg: createCronConfig(storePath),
+      options: {},
+      prompter: makePrompter(true),
+    });
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
+      jobs: Array<Record<string, unknown>>;
+    };
+    for (const job of persisted.jobs) {
+      expect((job.payload as Record<string, unknown>).model).toBeUndefined();
+    }
+    expect(noteMock).toHaveBeenCalledWith(
+      expect.stringContaining("2 jobs store an invalid cron payload model inheritance sentinel"),
+      "Cron",
+    );
+    expect(noteMock).toHaveBeenCalledWith(
+      expect.stringContaining("Cron store normalized"),
+      "Doctor changes",
+    );
+  });
+
   it("warns instead of replacing announce delivery for notify fallback jobs", async () => {
     const storePath = await makeTempStorePath();
     await fs.mkdir(path.dirname(storePath), { recursive: true });

--- a/src/commands/doctor-cron.ts
+++ b/src/commands/doctor-cron.ts
@@ -59,6 +59,12 @@ function formatLegacyIssuePreview(issues: Partial<Record<string, number>>): stri
       `- ${pluralize(issues.legacyPayloadProvider, "job")} still uses payload \`provider\` as a delivery alias`,
     );
   }
+  if (issues.invalidCronPayloadModel) {
+    const verb = issues.invalidCronPayloadModel === 1 ? "stores" : "store";
+    lines.push(
+      `- ${pluralize(issues.invalidCronPayloadModel, "job")} ${verb} an invalid cron payload model inheritance sentinel`,
+    );
+  }
   if (issues.legacyTopLevelPayloadFields) {
     lines.push(
       `- ${pluralize(issues.legacyTopLevelPayloadFields, "job")} still uses top-level payload fields`,


### PR DESCRIPTION
## Summary

- Repair persisted cron jobs whose `payload.model` is stored as `"default"`, `"null"`, blank, or JSON `null` by deleting the bad model override in `openclaw doctor --fix`.
- Keep cron runtime model validation strict: non-empty `payload.model` strings still resolve as explicit model refs and must pass `agents.defaults.models`.
- Add regression coverage plus cron/doctor docs and changelog entry.

Fixes #78549

## Verification

- `pnpm changed:lanes --json` -> lanes: core, coreTests, docs
- `pnpm check:docs` -> passed
- `pnpm exec oxfmt --check --threads=1 src/commands/doctor-cron-store-migration.ts src/commands/doctor-cron.ts src/commands/doctor-cron-store-migration.test.ts src/commands/doctor-cron.test.ts docs/cli/cron.md docs/automation/cron-jobs.md docs/gateway/doctor.md CHANGELOG.md` -> passed
- `git diff --check` -> passed
- `uvx showboat verify /Users/kevinlin/code/openclaw/.mem/main/proofs/78549-cron-model-doctor-fixed.md` -> passed
- `pnpm check:changed` -> blocked in local worktree by incomplete dependency install: git-hosted `@openclaw/fs-safe@0.1.2` failed normal `pnpm install` prepack twice, and the fallback `--ignore-scripts` install leaves `@openclaw/fs-safe/*` exports without built `dist` files.
- `pnpm test:changed` -> blocked before test collection by the same missing `@openclaw/fs-safe/config` export.

## Real behavior proof

- Behavior or issue addressed: Cron jobs with persisted `payload.model` sentinels such as `"default"`, `"null"`, blank strings, or JSON `null` can fail cron preflight as explicit model overrides. This patch gives `openclaw doctor --fix` a repair path for those bad stored cron configs without supporting default/null runtime fallback aliases.
- Real environment tested: Local OpenClaw dev checkout with an isolated dev workspace rooted at `/Users/kevinlin/code/openclaw/.mem/integ/tmp/doctor-cron-model-sentinel-78549`, running the patched CLI from a detached worktree at commit `c6a5e2526b86a18ab2233dbb4c9cc8b009a6d8a6`.
- Exact steps or command run after this patch: Seeded `state/cron/jobs.json` with two bad persisted cron job payload models (`"default"` and `"null"`) plus one valid real model (`"minimax-portal/MiniMax-M2.7"`), then ran `openclaw doctor --fix --yes --non-interactive` through `node --import tsx src/entry.ts doctor --fix --yes --non-interactive` with `OPENCLAW_STATE_DIR` pointed at that isolated dev workspace.
- Evidence after fix: Copied terminal output from the real doctor command and the before/after cron job state:

```text
BEFORE
bad-default payload.model=default
bad-string-null payload.model=null
valid-real-model payload.model=minimax-portal/MiniMax-M2.7

$ env HOME=... OPENCLAW_STATE_DIR=... OPENCLAW_SKIP_CRON=1 OPENCLAW_SKIP_CHANNELS=1 node --import tsx src/entry.ts doctor --fix --yes --non-interactive
Legacy cron job storage detected at /Users/kevinlin/code/openclaw/.mem/integ/tmp/doctor-cron-model-sentinel-78549/state/cron/jobs.json
- 2 jobs store an invalid cron payload model inheritance sentinel
Cron store normalized at /Users/kevinlin/code/openclaw/.mem/integ/tmp/doctor-cron-model-sentinel-78549/state/cron/jobs.json.

AFTER
bad-default payload.model=<missing>
bad-string-null payload.model=<missing>
valid-real-model payload.model=minimax-portal/MiniMax-M2.7
```

- Observed result after fix: `openclaw doctor --fix` removed the bad `payload.model` overrides for the persisted sentinel values and preserved the valid real model override. Runtime support for `"default"` or `"null"` fallback aliases was not added.
- What was not tested: Targeted Vitest and `check:changed` could not complete in this worktree because normal `pnpm install` fails while preparing git-hosted `@openclaw/fs-safe@0.1.2`; the ignored-scripts fallback leaves `@openclaw/fs-safe/config` missing its built `dist/config.js`, so tests fail before collection.
