### PR TITLE
fix(agents): bound live exec output events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@ Docs: https://docs.openclaw.ai
 - Google Meet/Voice Call: wait longer before playing PIN-derived Twilio DTMF for Meet dial-in prompts and retire stale delegated phone sessions instead of reusing completed calls.
 - PDF/Codex: include extraction-fallback instructions for `openai-codex/*` PDF tool requests so Codex Responses receives its required system prompt. Fixes #77872. Thanks @anyech.
 - Onboard/channels: recover externalized channel plugins from stale `channels.<id>` config by falling back to `ensureChannelSetupPluginInstalled` via the trusted catalog when the plugin is missing on disk, so leftover `appId`/token entries no longer dead-end onboard with "<channel> plugin not available." (#78328) Thanks @sliverp.
+- Agents/Gateway: throttle and cap live exec command-output events so noisy tool runs cannot flood Gateway WebSocket clients or starve RPC handling. (#78645) Thanks @joshavant.
 - Codex/app-server: forward the OpenClaw workspace bootstrap block through Codex `developerInstructions` instead of `config.instructions`, so persona/style guidance reaches the behavior-shaping app-server lane. Fixes #77363. Thanks @lonexreb.
 - MS Teams: route proactive channel sends with stored thread roots through the configured threaded reply path instead of forcing every CLI/message-tool send into a new top-level post. Fixes #78298. Thanks @amknight.
 - CLI/infer: pass minimal instructions to local `openai-codex/*` model probes and surface provider error details when `infer model run` returns no text. Fixes #76464. Thanks @lilesjtu.

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -755,6 +755,53 @@ describe("handleToolExecutionEnd derived tool events", () => {
     );
   });
 
+  it("throttles high-frequency exec output update events", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    try {
+      const { ctx, onAgentEvent } = createTestContext();
+
+      await handleToolExecutionStart(
+        ctx as never,
+        {
+          type: "tool_execution_start",
+          toolName: "exec",
+          toolCallId: "tool-exec-throttled-output",
+          args: { command: "yes" },
+        } as never,
+      );
+
+      const update = (aggregated: string) =>
+        handleToolExecutionUpdate(
+          ctx as never,
+          {
+            type: "tool_execution_update",
+            toolName: "exec",
+            toolCallId: "tool-exec-throttled-output",
+            partialResult: {
+              details: {
+                aggregated,
+              },
+            },
+          } as never,
+        );
+
+      update("first");
+      update("second");
+      update("x".repeat(1024 * 1024));
+      vi.setSystemTime(1_300);
+      update("third");
+
+      const commandOutputCalls = onAgentEvent.mock.calls
+        .map((call) => call[0] as { stream?: string; data?: { output?: string } })
+        .filter((event) => event.stream === "command_output");
+
+      expect(commandOutputCalls.map((event) => event.data?.output)).toEqual(["first", "third"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("emits command output events for exec results", async () => {
     const { ctx, onAgentEvent } = createTestContext();
 
@@ -1178,6 +1225,57 @@ describe("control UI credential redaction (issue #72283)", () => {
     expect(lastOutput?.data?.output).not.toContain("sk-or-v1-abcdef0123456789");
     expect(lastOutput?.data?.output).not.toContain("ghp_abcdefghij1234567890");
     expect(lastOutput?.data?.output).toContain("OPENROUTER_API_KEY=");
+  });
+
+  it("caps live exec command output events without changing the tool result shape", async () => {
+    const events: Array<{ stream?: string; data?: Record<string, unknown> }> = [];
+    registerAgentEventListener((evt) => {
+      events.push(evt as never);
+    });
+    const { ctx, onAgentEvent } = createTestContext();
+    const aggregated = `head-${"x".repeat(90 * 1024)}-tail`;
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-long-output",
+        args: { command: "yes" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-long-output",
+        isError: false,
+        result: {
+          details: {
+            status: "completed",
+            aggregated,
+            exitCode: 0,
+          },
+        },
+      } as never,
+    );
+
+    const commandOutputCalls = onAgentEvent.mock.calls
+      .map((call) => call[0])
+      .filter((arg: unknown) => (arg as { stream?: string })?.stream === "command_output");
+    const lastOutput = commandOutputCalls.at(-1) as { data?: { output?: string } } | undefined;
+    expect(lastOutput?.data?.output).toContain("live command output truncated");
+    expect(lastOutput?.data?.output).toContain("-tail");
+    expect(lastOutput?.data?.output).not.toContain("head-");
+
+    const resultEvent = events.find(
+      (evt) => evt.stream === "tool" && (evt.data as { phase?: string })?.phase === "result",
+    );
+    const result = resultEvent?.data?.result as { details?: { aggregated?: string } } | undefined;
+    expect(result?.details?.aggregated).toContain("live command output truncated");
+    expect(result?.details?.aggregated).toContain("-tail");
   });
 
   it("redacts details-only results before emitting the tool result event", async () => {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -20,6 +20,7 @@ import type { ExecApprovalDecision } from "../infra/exec-approvals.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { normalizeOptionalLowercaseString, readStringValue } from "../shared/string-coerce.js";
+import { truncateUtf16Safe } from "../utils.js";
 import type { ApplyPatchSummary } from "./apply-patch.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import { parseExecApprovalResultText } from "./exec-approval-result.js";
@@ -87,9 +88,48 @@ type ToolStartRecord = {
 
 /** Track tool execution start data for after_tool_call hook. */
 const toolStartData = new Map<string, ToolStartRecord>();
+const EXEC_OUTPUT_DELTA_MIN_INTERVAL_MS = 250;
+const LIVE_COMMAND_OUTPUT_MAX_CHARS = 64 * 1024;
+type ExecOutputDeltaEmission = {
+  emittedAt: number;
+};
+const execOutputDeltaEmissions = new Map<string, ExecOutputDeltaEmission>();
 
 function buildToolStartKey(runId: string, toolCallId: string): string {
   return `${runId}:${toolCallId}`;
+}
+
+function buildExecOutputDeltaKey(runId: string, toolCallId: string): string {
+  return `${runId}:${toolCallId}`;
+}
+
+function shouldEmitExecOutputDelta(params: {
+  runId: string;
+  toolCallId: string;
+  output: string;
+  now?: number;
+}): boolean {
+  const key = buildExecOutputDeltaKey(params.runId, params.toolCallId);
+  const now = params.now ?? Date.now();
+  const previous = execOutputDeltaEmissions.get(key);
+  if (!previous) {
+    execOutputDeltaEmissions.set(key, {
+      emittedAt: now,
+    });
+    return true;
+  }
+  const elapsedMs = now - previous.emittedAt;
+  if (elapsedMs < EXEC_OUTPUT_DELTA_MIN_INTERVAL_MS) {
+    return false;
+  }
+  execOutputDeltaEmissions.set(key, {
+    emittedAt: now,
+  });
+  return true;
+}
+
+function clearExecOutputDeltaEmission(runId: string, toolCallId: string): void {
+  execOutputDeltaEmissions.delete(buildExecOutputDeltaKey(runId, toolCallId));
 }
 
 export function countActiveToolExecutions(runId: string): number {
@@ -187,6 +227,39 @@ function readExecToolDetails(result: unknown): ExecToolDetails | null {
     return null;
   }
   return details as ExecToolDetails;
+}
+
+function readExecOutputText(result: unknown): string | undefined {
+  const details = readToolResultDetailsRecord(result);
+  if (typeof details?.aggregated === "string") {
+    return details.aggregated;
+  }
+  return extractToolResultText(result);
+}
+
+function limitLiveCommandOutput(output: string): string {
+  if (output.length <= LIVE_COMMAND_OUTPUT_MAX_CHARS) {
+    return output;
+  }
+  const tail = truncateUtf16Safe(
+    output.slice(-LIVE_COMMAND_OUTPUT_MAX_CHARS),
+    LIVE_COMMAND_OUTPUT_MAX_CHARS,
+  );
+  return `[openclaw: live command output truncated to last ${tail.length} of ${output.length} chars]\n${tail}`;
+}
+
+function limitExecToolResultForLiveEvent(result: unknown): unknown {
+  const details = readToolResultDetailsRecord(result);
+  if (!details || typeof details.aggregated !== "string") {
+    return result;
+  }
+  return {
+    ...(result as Record<string, unknown>),
+    details: {
+      ...details,
+      aggregated: limitLiveCommandOutput(details.aggregated),
+    },
+  };
 }
 
 function readApplyPatchSummary(result: unknown): ApplyPatchSummary | null {
@@ -741,6 +814,19 @@ export function handleToolExecutionUpdate(
   const toolName = normalizeToolName(evt.toolName);
   const toolCallId = evt.toolCallId;
   const partial = evt.partialResult;
+  if (isExecToolName(toolName)) {
+    const output = readExecOutputText(partial);
+    if (
+      output &&
+      !shouldEmitExecOutputDelta({
+        runId: ctx.params.runId,
+        toolCallId,
+        output,
+      })
+    ) {
+      return;
+    }
+  }
   const sanitized = sanitizeToolResult(partial);
   emitAgentEvent({
     runId: ctx.params.runId,
@@ -772,11 +858,8 @@ export function handleToolExecutionUpdate(
     },
   });
   if (isExecToolName(toolName)) {
-    const execDetails = readExecToolDetails(sanitized);
-    const output =
-      execDetails && "aggregated" in execDetails
-        ? execDetails.aggregated
-        : extractToolResultText(sanitized);
+    const rawOutput = readExecOutputText(sanitized);
+    const output = rawOutput ? limitLiveCommandOutput(rawOutput) : undefined;
     const commandData: AgentItemEventData = {
       itemId: buildCommandItemId(toolCallId),
       phase: "update",
@@ -829,9 +912,13 @@ export async function handleToolExecutionEnd(
   const result = evt.result;
   const isToolError = isError || isToolResultError(result);
   const sanitizedResult = sanitizeToolResult(result);
+  const liveEventResult = isExecToolName(toolName)
+    ? limitExecToolResultForLiveEvent(sanitizedResult)
+    : sanitizedResult;
   const toolStartKey = buildToolStartKey(runId, toolCallId);
   const startData = toolStartData.get(toolStartKey);
   toolStartData.delete(toolStartKey);
+  clearExecOutputDeltaEmission(runId, toolCallId);
   const callSummary = ctx.state.toolMetaById.get(toolCallId);
   const completedMutatingAction = !isToolError && Boolean(callSummary?.mutatingAction);
   const meta = callSummary?.meta;
@@ -934,7 +1021,7 @@ export async function handleToolExecutionEnd(
       toolCallId,
       meta,
       isError: isToolError,
-      result: sanitizedResult,
+      result: liveEventResult,
     },
   });
   const endedAt = Date.now();
@@ -1027,10 +1114,11 @@ export async function handleToolExecutionEnd(
             }),
       });
     } else {
-      const output =
+      const rawOutput =
         execDetails && "aggregated" in execDetails
           ? execDetails.aggregated
           : extractToolResultText(sanitizedResult);
+      const output = rawOutput ? limitLiveCommandOutput(rawOutput) : undefined;
       const commandStatus =
         execDetails?.status === "failed" || isToolError ? "failed" : "completed";
       emitTrackedItemEvent(ctx, {
@@ -1075,8 +1163,8 @@ export async function handleToolExecutionEnd(
         data: outputData,
       });
 
-      if (typeof output === "string") {
-        const parsedApprovalResult = parseExecApprovalResultText(output);
+      if (typeof rawOutput === "string") {
+        const parsedApprovalResult = parseExecApprovalResultText(rawOutput);
         if (parsedApprovalResult.kind === "denied") {
           const approvalData: AgentApprovalEventData = {
             phase: "resolved",


### PR DESCRIPTION
## Summary

- Problem: high-volume exec output could emit thousands of live Gateway agent events with growing aggregated output, starving unrelated Gateway RPCs and making clients/channels look disconnected.
- Why it matters: issue #78402 reports WebSocket reconnects, Telegram timeouts, and slow `sessions.list` / `chat.history` / `node.list` while tool-heavy agents run.
- What changed: exec/bashing live output deltas are rate-limited per tool call, skipped before redaction/serialization, and oversized live command-output payloads are capped to a bounded tail.
- What did NOT change (scope boundary): command execution, exit status, approval parsing, provider calls, and underlying tool semantics are not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78402
- Related #78479
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Gateway event-loop/RPC starvation during noisy live exec output.
- Real environment tested: local macOS source checkout, rebuilt runtime bundle, isolated Gateway state under `/private/tmp/openclaw-78402-natural`, live OpenAI `openai/gpt-5.5` API route.
- Exact steps or command run after this patch: `node scripts/tsdown-build.mjs`, then `pnpm exec tsx /private/tmp/openclaw-78402-natural-repro.ts` with credentials loaded from `/private/tmp/openclaw-78402-live-creds.env`.

Human-readable result: before this patch, the noisy exec run turned one command into a live Gateway event flood. The Gateway sent 9,297 agent WebSocket events while also trying to answer normal RPCs, so unrelated client calls saw multi-second tail latency. After this patch, the same live repro sent 57 agent WebSocket events, command-output updates appeared at a bounded cadence, the final live output was capped, and the normal RPC p99s stayed around half a second. The remaining isolated max values line up with cold plugin-tool loading at agent startup rather than the exec-output stream.

| Measurement | Before patch | After patch | What changed |
| --- | ---: | ---: | --- |
| Agent WebSocket events | 9,297 | 57 | Live event volume dropped by about 99.4%. |
| WebSocket close | Clean harness shutdown | Clean harness shutdown | No disconnect introduced by the fix. |
| `sessions.list` p99 / max | 1,728ms / 12,173ms | 551ms / 5,735ms | Tail latency dropped; remaining max is startup/plugin-load shaped. |
| `chat.history` p99 / max | 3,529ms / 4,685ms | 516ms / 1,947ms | Tail latency dropped from multi-second to roughly half-second p99. |
| `node.list` p99 / max | 1,925ms / 6,111ms | 566ms / 5,194ms | Tail latency dropped; no request failures. |
| Event-loop warning | max about 5,087ms during event flood | max about 3,706ms after bounded stream | Improved, with residual cold-start work still visible. |

- Evidence after fix: copied summary from `/private/tmp/openclaw-78402-natural/summary.json`:
  - WebSocket agent events: 57 total, down from 9,297 in the same repro before the fix.
  - `sessions.list`: count 125, failures 0, p50 23ms, p95 33ms, p99 551ms, max 5735ms.
  - `chat.history`: count 125, failures 0, p50 5ms, p95 9ms, p99 516ms, max 1947ms.
  - `node.list`: count 125, failures 0, p50 3ms, p95 6ms, p99 566ms, max 5194ms.
  - WebSocket closed cleanly with code 1000 after the repro completed.
- Observed result after fix: live exec command-output events are emitted about every 250ms, final live output is capped, and normal RPC p99s stay around 0.5s instead of multi-second tails from event flood.
- What was not tested: full channel-specific Telegram or Discord live roundtrip after the patch; the root bottleneck was reproduced at the shared Gateway/agent event stream layer.
- Before evidence: same harness before the fix emitted 9,297 agent events; `sessions.list` p99 1728ms/max 12173ms, `chat.history` p99 3529ms/max 4685ms, `node.list` p99 1925ms/max 6111ms, with event-loop delay max about 5087ms.

## Root Cause (if applicable)

- Root cause: exec tool updates could carry growing `details.aggregated` output, and the embedded agent event handler sanitized, serialized, and broadcast every live update plus an unbounded final output payload.
- Missing detection / guardrail: no rate limit or payload cap existed on the live command-output event stream.
- Contributing context (if known): PR #78479 addressed stale WebSocket cleanup, but did not remove the event production pressure that starved the Gateway.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-subscribe.handlers.tools.test.ts`
- Scenario the test should lock in: high-frequency exec output updates are throttled even when output grows quickly, and oversized live final command output is capped.
- Why this is the smallest reliable guardrail: the bug lives in the embedded event translation layer, so direct handler tests cover the rate/cap behavior without needing provider/network flakiness.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Live command-output streams for very noisy exec/bash runs are now bounded. Clients see periodic output updates and a capped final live tail instead of every byte over the Gateway event stream.

## Diagram (if applicable)

```text
Before:
exec noisy output -> every aggregated update -> sanitize + serialize + broadcast thousands of Gateway events -> unrelated RPCs stall

After:
exec noisy output -> first/periodic live updates + capped final tail -> bounded Gateway events -> RPC handling remains responsive
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any Yes, explain risk + mitigation: live exec output presentation is now rate-limited/capped. Command execution and approval semantics are unchanged; the cap reduces the amount of command output broadcast through live Gateway events.

## Repro + Verification

### Environment

- OS: macOS local development machine
- Runtime/container: local source checkout, rebuilt `dist` via `node scripts/tsdown-build.mjs`
- Model/provider: OpenAI `openai/gpt-5.5`
- Integration/channel (if any): shared Gateway/WebSocket event stream, no channel-specific transport required
- Relevant config (redacted): isolated Gateway on loopback port 19814, token auth, seeded session store, live API credentials loaded from `/private/tmp/openclaw-78402-live-creds.env`

### Steps

1. Build the runtime bundle with `node scripts/tsdown-build.mjs`.
2. Run the natural repro harness: `pnpm exec tsx /private/tmp/openclaw-78402-natural-repro.ts`.
3. The harness seeds 420 sessions, runs concurrent `sessions.list`, `chat.history`, and `node.list` probes, creates 20 WebChat-like sessions, then runs a live OpenAI agent that executes a noisy command.

### Expected

- No WebSocket disconnect during the live run.
- Bounded agent event count.
- RPC p99 remains near sub-second under noisy exec output.

### Actual

- No WebSocket disconnect; close code 1000 at harness shutdown.
- 57 agent events after the fix, versus 9,297 before.
- `sessions.list`, `chat.history`, and `node.list` p99s were roughly 0.5s in the final live pass.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/agents/pi-embedded-subscribe.handlers.tools.test.ts`
  - `pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-subscribe.handlers.tools.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts`
  - `git diff --check`
  - `node scripts/tsdown-build.mjs`
  - live OpenAI repro via `/private/tmp/openclaw-78402-natural-repro.ts`
- Edge cases checked: status-less live update payloads with `details.aggregated`, large immediate output growth, final oversized output capping, and secret redaction still applies before live output emission.
- What you did **not** verify: broad `pnpm check`, full `pnpm test`, and channel-specific Telegram/Discord live E2E.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a live client that expected complete command output from Gateway `command_output` events will now see a capped tail for very large outputs.
  - Mitigation: live command-output events are presentation/progress events; keeping them unbounded is the starvation source. Command execution, status, and approval parsing remain intact.
