### PR TITLE
chore(deps): bump basic-ftp to 5.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1787,7 +1787,7 @@
       "fast-xml-parser": "5.7.0",
       "request": "npm:@cypress/request@3.0.10",
       "request-promise": "npm:@cypress/request-promise@5.0.0",
-      "basic-ftp": "5.3.0",
+      "basic-ftp": "5.3.1",
       "file-type": "22.0.1",
       "form-data": "2.5.4",
       "ip-address": "10.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   fast-xml-parser: 5.7.0
   request: npm:@cypress/request@3.0.10
   request-promise: npm:@cypress/request-promise@5.0.0
-  basic-ftp: 5.3.0
+  basic-ftp: 5.3.1
   file-type: 22.0.1
   form-data: 2.5.4
   ip-address: 10.2.0
@@ -4805,8 +4805,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  basic-ftp@5.3.0:
-    resolution: {integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==}
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
 
   bidi-js@1.0.3:
@@ -11645,7 +11645,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  basic-ftp@5.3.0: {}
+  basic-ftp@5.3.1: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -12446,7 +12446,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.3.0
+      basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
@@ -12454,7 +12454,7 @@ snapshots:
 
   get-uri@8.0.0:
     dependencies:
-      basic-ftp: 5.3.0
+      basic-ftp: 5.3.1
       data-uri-to-buffer: 8.0.0
       debug: 4.4.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `security-dependency-audit` fails on a high-severity production dependency advisory for `basic-ftp` (`GHSA-rpmf-866q-6p89`).
- Why it matters: the repository currently pins `basic-ftp: 5.3.0` via `pnpm.overrides`, which keeps the vulnerable version in the production dependency graph.
- What changed: bumped the pinned `basic-ftp` override from `5.3.0` to `5.3.1` and updated the lockfile references accordingly.
- What did NOT change (scope boundary): no feature logic, runtime behavior, or unrelated dependency cleanup was included.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #78648
- Related #78335
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: production dependency security advisory for `basic-ftp`.
- Real environment tested: local checkout of `openclaw/openclaw` on Linux with branch `chore/basic-ftp-advisory`.
- Exact steps or command run after this patch:
  - `git checkout chore/basic-ftp-advisory`
  - `pnpm audit --prod --audit-level high`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
```text
No known vulnerabilities found
```
- Observed result after fix: the high-severity `basic-ftp` advisory no longer appears in production dependency audit results.
- What was not tested: unrelated CI lanes and unrelated dependency upgrades outside this one advisory fix.
- Before evidence (optional but encouraged): prior CI failures reported `basic-ftp` high-severity advisory `GHSA-rpmf-866q-6p89` against `<=5.3.0`.

## Root Cause (if applicable)

- Root cause: repo-level `pnpm.overrides` pinned `basic-ftp` to vulnerable version `5.3.0`.
- Missing detection / guardrail: production dependency audit correctly caught it, but it was being surfaced through unrelated PR validation rather than tracked in its own issue/PR.
- Contributing context (if known): CI failures on unrelated feature PRs can mask whether the feature branch itself is healthy.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: production dependency audit (`pnpm audit --prod --audit-level high` / `security-dependency-audit` lane)
- Scenario the test should lock in: no high-severity advisories remain for `basic-ftp` in production dependencies.
- Why this is the smallest reliable guardrail: the issue is dependency graph/security posture, so the dependency audit itself is the correct verification surface.
- Existing test that already covers this (if any): `security-dependency-audit`
- If no new test is added, why not: the existing audit job is the right guardrail.

## User-visible / Behavior Changes

No intended user-visible product behavior change. This PR only updates a pinned production dependency to resolve a known advisory.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): repo-level `pnpm.overrides`

### Steps

1. Check out `chore/basic-ftp-advisory`.
2. Run `pnpm audit --prod --audit-level high`.

### Expected

- No high-severity advisory reported for `basic-ftp`.

### Actual

- Passed: `No known vulnerabilities found`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified the only scoped change is the `basic-ftp` override + matching lockfile entries.
- Verified `pnpm audit --prod --audit-level high` passes locally after the bump.
- Did not broaden the PR to fix unrelated CI or dependency issues.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: transitive consumers could behave differently on the patched `basic-ftp` release.
  - Mitigation: keep scope to the minimal patched version bump and rely on existing CI + dependency audit coverage.
- Risk: unrelated CI failures may still exist elsewhere.
  - Mitigation: this PR is scoped only to resolving the `basic-ftp` advisory so other failures can be tracked independently.
