### PR TITLE
feat(gateway): expose OpenClaw response presentation metadata

### DIFF
--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -88,6 +88,42 @@ Supported:
 
 - `previous_response_id`: OpenClaw reuses the earlier response session when the request stays within the same agent/user/requested-session scope.
 
+## OpenClaw extension metadata
+
+When an agent reply payload includes channel-agnostic OpenClaw presentation metadata, the endpoint preserves it under `x_openclaw` on the response resource. This is an OpenClaw extension to the OpenAI Responses API-compatible surface; clients that only need plain text can ignore it.
+
+Current fields:
+
+- `x_openclaw.presentation`: the first semantic `MessagePresentation` payload from the agent response.
+- `x_openclaw.presentations`: all semantic presentation payloads when a response contains more than one.
+- `x_openclaw.suggestedTopics`: the first suggested-topic payload from the agent response, when present.
+- `x_openclaw.suggestedTopicSets`: all suggested-topic payloads when a response contains more than one.
+
+Use `presentation.blocks[type="buttons"]` as the canonical channel-agnostic action contract. Channel or web clients should render the buttons natively when possible and send the hidden button `value` back as the selected action.
+
+Example response fragment:
+
+```json
+{
+  "x_openclaw": {
+    "presentation": {
+      "title": "Suggested next steps",
+      "blocks": [
+        {
+          "type": "buttons",
+          "buttons": [
+            {
+              "label": "Create social media content",
+              "value": "work_topic.open:social_media_content"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
 ## Items (input)
 
 ### `message`
@@ -285,6 +321,7 @@ Event types currently emitted:
 - `response.output_text.done`
 - `response.content_part.done`
 - `response.output_item.done`
+- `response.openclaw_metadata.done` (OpenClaw extension; emitted when `x_openclaw` metadata is present)
 - `response.completed`
 - `response.failed` (on error)
 

--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -274,6 +274,17 @@ export const UsageSchema = z.object({
 
 export type Usage = z.infer<typeof UsageSchema>;
 
+export const OpenClawResponseExtensionsSchema = z
+  .object({
+    presentation: z.unknown().optional(),
+    presentations: z.array(z.unknown()).optional(),
+    suggestedTopics: z.unknown().optional(),
+    suggestedTopicSets: z.array(z.unknown()).optional(),
+  })
+  .passthrough();
+
+export type OpenClawResponseExtensions = z.infer<typeof OpenClawResponseExtensionsSchema>;
+
 export const ResponseResourceSchema = z.object({
   id: z.string(),
   object: z.literal("response"),
@@ -289,6 +300,7 @@ export const ResponseResourceSchema = z.object({
       message: z.string(),
     })
     .optional(),
+  x_openclaw: OpenClawResponseExtensionsSchema.optional(),
 });
 
 export type ResponseResource = z.infer<typeof ResponseResourceSchema>;
@@ -361,6 +373,11 @@ export const OutputTextDoneEventSchema = z.object({
   text: z.string(),
 });
 
+export const OpenClawMetadataDoneEventSchema = z.object({
+  type: z.literal("response.openclaw_metadata.done"),
+  x_openclaw: OpenClawResponseExtensionsSchema,
+});
+
 export type StreamingEvent =
   | z.infer<typeof ResponseCreatedEventSchema>
   | z.infer<typeof ResponseInProgressEventSchema>
@@ -371,4 +388,5 @@ export type StreamingEvent =
   | z.infer<typeof ContentPartAddedEventSchema>
   | z.infer<typeof ContentPartDoneEventSchema>
   | z.infer<typeof OutputTextDeltaEventSchema>
-  | z.infer<typeof OutputTextDoneEventSchema>;
+  | z.infer<typeof OutputTextDoneEventSchema>
+  | z.infer<typeof OpenClawMetadataDoneEventSchema>;

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -651,6 +651,36 @@ describe("OpenResponses HTTP API (e2e)", () => {
       expect(content[0]?.text).toBe("hello");
       await ensureResponseConsumed(resShape);
 
+      agentCommand.mockClear();
+      const presentation = {
+        title: "Suggested next steps",
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Create social post", value: "work_topic.open:social_media" }],
+          },
+        ],
+      };
+      const suggestedTopics = {
+        version: 1,
+        topics: [{ id: "social_media", value: "work_topic.open:social_media" }],
+      };
+      agentCommand.mockResolvedValueOnce({
+        payloads: [{ text: "hello", presentation, suggestedTopics }],
+      } as never);
+
+      const resOpenClawMetadata = await postResponses(port, {
+        stream: false,
+        model: "openclaw",
+        input: "hi",
+      });
+      expect(resOpenClawMetadata.status).toBe(200);
+      const metadataJson = (await resOpenClawMetadata.json()) as {
+        x_openclaw?: { presentation?: unknown; suggestedTopics?: unknown };
+      };
+      expect(metadataJson.x_openclaw?.presentation).toEqual(presentation);
+      expect(metadataJson.x_openclaw?.suggestedTopics).toEqual(suggestedTopics);
+
       const resNoUser = await postResponses(port, {
         model: "openclaw",
         input: [{ type: "message", role: "system", content: "yo" }],
@@ -731,6 +761,44 @@ describe("OpenResponses HTTP API (e2e)", () => {
       const fallbackText = await resFallback.text();
       expect(fallbackText).toContain("[DONE]");
       expect(fallbackText).toContain("hello");
+
+      agentCommand.mockClear();
+      const streamPresentation = {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Improve KB", value: "work_topic.open:kb" }],
+          },
+        ],
+      };
+      agentCommand.mockResolvedValueOnce({
+        payloads: [{ text: "hello", presentation: streamPresentation }],
+      } as never);
+
+      const resMetadataStream = await postResponses(port, {
+        stream: true,
+        model: "openclaw",
+        input: "hi",
+      });
+      expect(resMetadataStream.status).toBe(200);
+      const metadataStreamEvents = parseSseEvents(await resMetadataStream.text());
+      const metadataDone = metadataStreamEvents.find(
+        (event) => event.event === "response.openclaw_metadata.done",
+      );
+      expect(metadataDone).toBeDefined();
+      const parsedMetadata = JSON.parse(metadataDone?.data ?? "{}") as {
+        x_openclaw?: { presentation?: unknown };
+      };
+      expect(parsedMetadata.x_openclaw?.presentation).toEqual(streamPresentation);
+      const completedWithMetadata = metadataStreamEvents.find(
+        (event) => event.event === "response.completed",
+      );
+      const completedWithMetadataData = JSON.parse(completedWithMetadata?.data ?? "{}") as {
+        response?: { x_openclaw?: { presentation?: unknown } };
+      };
+      expect(completedWithMetadataData.response?.x_openclaw?.presentation).toEqual(
+        streamPresentation,
+      );
 
       agentCommand.mockClear();
       agentCommand.mockResolvedValueOnce({

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -50,6 +50,7 @@ import { normalizeInputHostnameAllowlist } from "./input-allowlist.js";
 import {
   CreateResponseBodySchema,
   type CreateResponseBody,
+  type OpenClawResponseExtensions,
   type OutputItem,
   type ResponseResource,
   type StreamingEvent,
@@ -377,6 +378,7 @@ function createResponseResource(params: {
   output: OutputItem[];
   usage?: Usage;
   error?: { code: string; message: string };
+  xOpenClaw?: OpenClawResponseExtensions;
 }): ResponseResource {
   return {
     id: params.id,
@@ -387,7 +389,64 @@ function createResponseResource(params: {
     output: params.output,
     usage: params.usage ?? createEmptyUsage(),
     error: params.error,
+    ...(params.xOpenClaw ? { x_openclaw: params.xOpenClaw } : {}),
   };
+}
+
+function isNonNullObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function firstDefined<T>(values: T[]): T | undefined {
+  return values.length > 0 ? values[0] : undefined;
+}
+
+function collectOpenClawResponseExtensions(
+  payloads: unknown,
+): OpenClawResponseExtensions | undefined {
+  if (!Array.isArray(payloads)) {
+    return undefined;
+  }
+
+  const presentations: unknown[] = [];
+  const suggestedTopicSets: unknown[] = [];
+  for (const payload of payloads) {
+    if (!isNonNullObject(payload)) {
+      continue;
+    }
+    if (payload.presentation !== undefined) {
+      presentations.push(payload.presentation);
+    }
+    const suggestedTopics = payload.suggestedTopics ?? payload.suggested_topics;
+    if (suggestedTopics !== undefined) {
+      suggestedTopicSets.push(suggestedTopics);
+    }
+  }
+
+  if (presentations.length === 0 && suggestedTopicSets.length === 0) {
+    return undefined;
+  }
+
+  return {
+    ...(firstDefined(presentations) !== undefined
+      ? { presentation: firstDefined(presentations) }
+      : {}),
+    ...(presentations.length > 1 ? { presentations } : {}),
+    ...(firstDefined(suggestedTopicSets) !== undefined
+      ? { suggestedTopics: firstDefined(suggestedTopicSets) }
+      : {}),
+    ...(suggestedTopicSets.length > 1 ? { suggestedTopicSets } : {}),
+  };
+}
+
+function writeOpenClawMetadataSseEvent(
+  res: ServerResponse,
+  xOpenClaw: OpenClawResponseExtensions | undefined,
+) {
+  if (!xOpenClaw) {
+    return;
+  }
+  writeSseEvent(res, { type: "response.openclaw_metadata.done", x_openclaw: xOpenClaw });
 }
 
 async function runResponsesAgentCommand(params: {
@@ -701,6 +760,7 @@ export async function handleOpenResponsesHttpRequest(
       }
 
       const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
+      const xOpenClaw = collectOpenClawResponseExtensions(payloads);
       const usage = extractUsageFromResult(result);
       const meta = (result as { meta?: unknown } | null)?.meta;
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
@@ -747,6 +807,7 @@ export async function handleOpenResponsesHttpRequest(
           status: "incomplete",
           output,
           usage,
+          xOpenClaw,
         });
         rememberResponseSession();
         sendJson(res, 200, response);
@@ -774,6 +835,7 @@ export async function handleOpenResponsesHttpRequest(
           }),
         ],
         usage,
+        xOpenClaw,
       });
 
       rememberResponseSession();
@@ -821,6 +883,7 @@ export async function handleOpenResponsesHttpRequest(
   let unsubscribe = () => {};
   let stopWatchingDisconnect = () => {};
   let finalUsage: Usage | undefined;
+  let finalXOpenClaw: OpenClawResponseExtensions | undefined;
   let finalizeRequested: { status: ResponseResource["status"]; text: string } | null = null;
 
   const maybeFinalize = () => {
@@ -874,9 +937,11 @@ export async function handleOpenResponsesHttpRequest(
       status: finalizeRequested.status,
       output: [completedItem],
       usage,
+      xOpenClaw: finalXOpenClaw,
     });
 
     rememberResponseSession();
+    writeOpenClawMetadataSseEvent(res, finalXOpenClaw);
     writeSseEvent(res, { type: "response.completed", response: finalResponse });
     writeDone(res);
     res.end();
@@ -992,6 +1057,7 @@ export async function handleOpenResponsesHttpRequest(
       // Check for pending client tool calls BEFORE maybeFinalize() because the
       // lifecycle:end event may already have requested finalization.
       const resultAny = result as { payloads?: Array<{ text?: string }>; meta?: unknown };
+      finalXOpenClaw = collectOpenClawResponseExtensions(resultAny.payloads);
       const meta = resultAny.meta;
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
 
@@ -1082,11 +1148,13 @@ export async function handleOpenResponsesHttpRequest(
           status: "incomplete",
           output: [completedItem, ...functionCallItems],
           usage,
+          xOpenClaw: finalXOpenClaw,
         });
         closed = true;
         stopWatchingDisconnect();
         unsubscribe();
         rememberResponseSession();
+        writeOpenClawMetadataSseEvent(res, finalXOpenClaw);
         writeSseEvent(res, { type: "response.completed", response: incompleteResponse });
         writeDone(res);
         res.end();


### PR DESCRIPTION
## Summary
- add `x_openclaw` response extensions for semantic MessagePresentation payloads and suggested-topic metadata
- emit `response.openclaw_metadata.done` for streaming /v1/responses clients when metadata is present
- document the OpenClaw-specific extension and canonical presentation button contract

## Real behavior proof
- **Behavior or issue addressed:** `/v1/responses` now carries OpenClaw semantic presentation/action metadata instead of forcing web-chat-specific DTOs. Non-streaming responses expose `x_openclaw.presentation` / `x_openclaw.suggestedTopics`; streaming responses emit `response.openclaw_metadata.done` and include the same extension on `response.completed`.
- **Real environment tested:** Local OpenClaw source checkout on `ops-openclaw-01` at `/data/ops/.openclaw/workspace/openclaw-source`, Node v22.22.1, pnpm via Corepack. This exercised the actual gateway HTTP handler path in the repository checkout used for this PR.
- **Exact steps or command run after this patch:** From the PR branch, ran `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/openresponses-http.test.ts` through `corepack pnpm exec vitest ...`, then ran `corepack pnpm tsgo:core:test` for core test types.
- **Evidence after fix:** Terminal capture / actual output from the patched checkout:

  ```text
  $ corepack pnpm exec vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/openresponses-http.test.ts
  ✓ gateway src/gateway/openresponses-http.test.ts (17 tests) 9686ms
  Test Files 1 passed (1)
  Tests 17 passed (17)

  Assertions added in this run verified:
  - metadataJson.x_openclaw.presentation equals the semantic buttons presentation payload
  - metadataJson.x_openclaw.suggestedTopics equals the suggested-topic payload
  - streaming SSE includes response.openclaw_metadata.done
  - response.completed includes response.x_openclaw.presentation
  ```

- **Observed result after fix:** The actual gateway Responses HTTP test path preserved semantic `presentation.blocks[type="buttons"]` metadata in the response extension and emitted the streaming metadata event without regressing the existing 17 gateway response tests. `corepack pnpm tsgo:core:test` also exited with `EXIT_CODE=0`.
- **What was not tested:** I did not run a full live model/provider conversation or browser-render the web chat chips in this PR; this core change stops at carrying the semantic payload through `/v1/responses`.

## Tests
- `corepack pnpm exec vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/openresponses-http.test.ts`
- `PATH="$PWD/.local-bin:$PATH" corepack pnpm tsgo:core:test`