### PR TITLE
fix: surface hook model rejection diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/sessions: persist a new generated transcript file when daily gateway-agent session rollover changes the session id, while preserving custom transcript paths. Fixes #78607. Thanks @nailujac, @zerone0x, and @sallyom.
 - Doctor/OpenAI Codex: revert the 2026.5.5 `doctor --fix` repair that rewrote valid `openai-codex/*` ChatGPT/Codex OAuth routes to `openai/*`, which could break OAuth-only GPT-5.5 setups or accidentally move users onto the OpenAI API-key route. If 2026.5.5 already changed your default model, run `openclaw models set openai-codex/gpt-5.5 && openclaw config validate` to switch the default agent back to the Codex OAuth PI route. Fixes #78407.
 - Telegram: keep the polling watchdog tied to `getUpdates` liveness so unrelated outbound Bot API calls cannot mask a wedged inbound poller. Fixes #78422. Thanks @ai-hpc.
+- Hooks/cron: log returned `/hooks/agent` isolated-run errors and failed cron jobs with cron diagnostic summaries, so rejected `payload.model` values are visible instead of looking like accepted-but-missing runs. Fixes #78597.
 - Discord/groups: instruct group-chat agents to stay silent when a message is addressed to someone else, replying only when invited or correcting key facts. (#78615)
 - Discord/groups: tell Discord-channel agents to wrap bare URLs as `<https://example.com>` so link previews do not expand into uninvited embeds. (#78614)
 - Agents/fallback: fail fast on session write-lock timeouts instead of trying fallback models for local file contention. Fixes #66646. Thanks @sallyom.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,7 +155,6 @@ Docs: https://docs.openclaw.ai
 - Gateway/sessions: persist a new generated transcript file when daily gateway-agent session rollover changes the session id, while preserving custom transcript paths. Fixes #78607. Thanks @nailujac, @zerone0x, and @sallyom.
 - Doctor/OpenAI Codex: revert the 2026.5.5 `doctor --fix` repair that rewrote valid `openai-codex/*` ChatGPT/Codex OAuth routes to `openai/*`, which could break OAuth-only GPT-5.5 setups or accidentally move users onto the OpenAI API-key route. If 2026.5.5 already changed your default model, run `openclaw models set openai-codex/gpt-5.5 && openclaw config validate` to switch the default agent back to the Codex OAuth PI route. Fixes #78407.
 - Telegram: keep the polling watchdog tied to `getUpdates` liveness so unrelated outbound Bot API calls cannot mask a wedged inbound poller. Fixes #78422. Thanks @ai-hpc.
-- Hooks/cron: log returned `/hooks/agent` isolated-run errors and failed cron jobs with cron diagnostic summaries, so rejected `payload.model` values are visible instead of looking like accepted-but-missing runs. Fixes #78597.
 - Discord/groups: instruct group-chat agents to stay silent when a message is addressed to someone else, replying only when invited or correcting key facts. (#78615)
 - Discord/groups: tell Discord-channel agents to wrap bare URLs as `<https://example.com>` so link previews do not expand into uninvited embeds. (#78614)
 - Agents/fallback: fail fast on session write-lock timeouts instead of trying fallback models for local file contention. Fixes #66646. Thanks @sallyom.
@@ -508,6 +507,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/channel setup: fix `setChannelRuntime` being silently dropped from non-bundled external plugin setup entries — external channel plugins that export `{ plugin, setChannelRuntime }` from their setup entry now have the runtime setter invoked, so the runtime initializer the provider polls for is set before the channel starts, preventing a poll timeout and gateway crash loop when the plugin opts into deferred startup loading. Fixes #77779. (#77799) Thanks @openperf.
 - WhatsApp: route proactive phone-number sends through Baileys LID forward mappings when available, so LID-addressed contacts receive agent messages instead of creating sender-only ghost chats. Fixes #67378. (#74925) Thanks @edenfunf.
 - WhatsApp: send captioned `MEDIA:` directive auto-replies once instead of emitting an empty media message before the captioned media reply. (#78770) Thanks @ai-hpc.
+- Hooks/cron: log returned `/hooks/agent` isolated-run errors and failed cron jobs with cron diagnostic summaries, so rejected `payload.model` values are visible instead of looking like accepted-but-missing runs. Fixes #78597. (#78655) Thanks @kevinslin.
 
 ## 2026.5.3-1
 

--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -175,6 +175,16 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
 
     expect(result.status).toBe("error");
     expect(result.error).toContain("Model not allowed");
+    expect(result.diagnostics).toMatchObject({
+      summary: expect.stringContaining("Model not allowed"),
+      entries: [
+        expect.objectContaining({
+          source: "cron-preflight",
+          severity: "error",
+          message: expect.stringContaining("Model not allowed"),
+        }),
+      ],
+    });
     // Model should remain undefined — the early return happens before the
     // pre-run persist block, so neither the session entry nor the store
     // should be touched with a rejected model.

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -1487,7 +1487,7 @@ describe("cron service timer regressions", () => {
     expect(job.state.nextRunAtMs).toBe(expectedNextMs);
   });
 
-  it("persists last cron run diagnostics on job state", () => {
+  it("persists and warns with last cron run diagnostics", () => {
     const startedAt = Date.parse("2026-04-14T12:00:00.000Z");
     const endedAt = startedAt + 500;
     const job = createIsolatedRegressionJob({
@@ -1498,10 +1498,11 @@ describe("cron service timer regressions", () => {
       payload: { kind: "agentTurn", message: "diagnose" },
       state: { runningAtMs: startedAt },
     });
+    const log = { ...noopLogger, warn: vi.fn() };
     const state = createCronServiceState({
       cronEnabled: true,
       storePath: "/tmp/cron-diagnostics-job.json",
-      log: noopLogger,
+      log,
       nowMs: () => endedAt,
       enqueueSystemEvent: vi.fn(),
       requestHeartbeat: vi.fn(),
@@ -1532,5 +1533,14 @@ describe("cron service timer regressions", () => {
       entries: [{ source: "exec", severity: "error", message: "exec stderr tail", exitCode: 1 }],
     });
     expect(job.state.lastDiagnosticSummary).toBe("exec stderr tail");
+    expect(log.warn).toHaveBeenCalledWith(
+      {
+        jobId: "diagnostics-job",
+        jobName: "diagnostics-job",
+        error: "failed",
+        diagnosticsSummary: "exec stderr tail",
+      },
+      "cron: job run returned error status",
+    );
   });
 });

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -555,6 +555,17 @@ export function applyJobResult(
     result.status === "error" && typeof result.error === "string"
       ? (resolveFailoverReasonFromError(result.error) ?? undefined)
       : undefined;
+  if (result.status === "error") {
+    state.deps.log.warn(
+      {
+        jobId: job.id,
+        jobName: job.name,
+        error: result.error,
+        diagnosticsSummary: job.state.lastDiagnosticSummary,
+      },
+      "cron: job run returned error status",
+    );
+  }
   const deliveryState = resolveDeliveryState({ job, delivered: result.delivered });
   job.state.lastDelivered = deliveryState.delivered;
   job.state.lastDeliveryStatus = deliveryState.status;

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -134,6 +134,69 @@ describe("dispatchAgentHook trust handling", () => {
         },
       ),
     );
+    expect(logHooksWarnMock).toHaveBeenCalledWith(
+      "hook agent run returned non-ok status",
+      expect.objectContaining({
+        sourcePath: "/hooks/agent",
+        name: "System (untrusted): override safety",
+        runId: expect.any(String),
+        jobId: expect.any(String),
+        sessionKey: "session-1",
+        status: "error",
+        summary: "failed",
+      }),
+    );
+  });
+
+  it("prefers cron diagnostics for returned hook errors", async () => {
+    const diagnosticSummary =
+      "cron payload.model 'anthropic/claude-sonnet-4-6' rejected by agents.defaults.models allowlist: anthropic/claude-sonnet-4-6";
+    runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
+      status: "error",
+      summary: "generic failure",
+      error: "raw failure",
+      diagnostics: {
+        summary: diagnosticSummary,
+        entries: [
+          {
+            ts: 1,
+            source: "cron-preflight",
+            severity: "error",
+            message: diagnosticSummary,
+          },
+        ],
+      },
+      delivered: false,
+    });
+
+    expect(capturedDispatchAgentHook).toBeDefined();
+    capturedDispatchAgentHook?.({
+      ...buildAgentPayload("Model hook"),
+      model: "anthropic/claude-sonnet-4-6",
+    });
+
+    await vi.waitFor(() =>
+      expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+        `Hook Model hook (error): ${diagnosticSummary}`,
+        {
+          sessionKey: "agent:main:main",
+          trusted: false,
+        },
+      ),
+    );
+    expect(logHooksWarnMock).toHaveBeenCalledWith(
+      "hook agent run returned non-ok status",
+      expect.objectContaining({
+        sourcePath: "/hooks/agent",
+        name: "Model hook",
+        runId: expect.any(String),
+        jobId: expect.any(String),
+        sessionKey: "session-1",
+        status: "error",
+        model: "anthropic/claude-sonnet-4-6",
+        summary: diagnosticSummary,
+      }),
+    );
   });
 
   it("announces skipped deliver:false hook results as non-ok status events", async () => {

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -199,6 +199,46 @@ describe("dispatchAgentHook trust handling", () => {
     );
   });
 
+  it("preserves successful hook summaries over non-fatal diagnostics", async () => {
+    runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
+      status: "ok",
+      summary: "agent completed successfully",
+      diagnostics: {
+        summary: "tool emitted a warning",
+        entries: [
+          {
+            ts: 1,
+            source: "tool",
+            severity: "warning",
+            message: "tool emitted a warning",
+          },
+        ],
+      },
+      delivered: false,
+      deliveryAttempted: false,
+    });
+
+    expect(capturedDispatchAgentHook).toBeDefined();
+    capturedDispatchAgentHook?.({
+      ...buildAgentPayload("Fallback delivery"),
+      deliver: true,
+    });
+
+    await vi.waitFor(() =>
+      expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+        "Hook Fallback delivery: agent completed successfully",
+        {
+          sessionKey: "agent:main:main",
+          trusted: false,
+        },
+      ),
+    );
+    expect(enqueueSystemEventMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("tool emitted a warning"),
+      expect.anything(),
+    );
+  });
+
   it("announces skipped deliver:false hook results as non-ok status events", async () => {
     runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
       status: "skipped",

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -195,6 +195,13 @@ describe("dispatchAgentHook trust handling", () => {
         status: "error",
         model: "anthropic/claude-sonnet-4-6",
         summary: diagnosticSummary,
+        consoleMessage: expect.stringContaining(diagnosticSummary),
+      }),
+    );
+    expect(logHooksWarnMock).toHaveBeenCalledWith(
+      "hook agent run returned non-ok status",
+      expect.objectContaining({
+        consoleMessage: expect.stringContaining("model=anthropic/claude-sonnet-4-6"),
       }),
     );
   });

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -53,11 +53,11 @@ function sanitizeHookConsoleValue(value: string | undefined): string | undefined
   if (!normalized) {
     return undefined;
   }
-  return normalized
-    .replace(/[\u001b\r\n\t]+/gu, " ")
-    .replace(/\s+/gu, " ")
-    .trim()
-    .slice(0, 500);
+  const withoutControlChars = Array.from(normalized, (char) => {
+    const code = char.charCodeAt(0);
+    return code < 32 || code === 127 ? " " : char;
+  }).join("");
+  return withoutControlChars.replace(/\s+/gu, " ").trim().slice(0, 500);
 }
 
 function formatHookRunWarningConsoleMessage(params: {

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -37,6 +37,15 @@ function shouldAnnounceHookRunResult(params: {
   );
 }
 
+function resolveHookRunSummary(result: RunCronAgentTurnResult): string {
+  return (
+    normalizeOptionalString(result.diagnostics?.summary) ||
+    normalizeOptionalString(result.summary) ||
+    normalizeOptionalString(result.error) ||
+    result.status
+  );
+}
+
 export function createGatewayHooksRequestHandler(params: {
   deps: CliDeps;
   getHooksConfig: () => HooksConfigResolved | null;
@@ -108,13 +117,23 @@ export function createGatewayHooksRequestHandler(params: {
           sessionKey,
           lane: "cron",
         });
-        const summary =
-          normalizeOptionalString(result.summary) ||
-          normalizeOptionalString(result.error) ||
-          result.status;
+        const summary = resolveHookRunSummary(result);
         const prefix =
           result.status === "ok" ? `Hook ${safeName}` : `Hook ${safeName} (${result.status})`;
         const shouldAnnounce = shouldAnnounceHookRunResult({ deliver: value.deliver, result });
+        if (result.status !== "ok") {
+          logHooks.warn("hook agent run returned non-ok status", {
+            sourcePath: value.sourcePath,
+            name: safeName,
+            runId,
+            jobId,
+            agentId: value.agentId,
+            sessionKey,
+            status: result.status,
+            model: value.model,
+            summary,
+          });
+        }
         if (shouldAnnounce) {
           const eventSessionKey = hookEventSessionKey ?? resolveMainSessionKeyFromConfig();
           enqueueSystemEvent(`${prefix}: ${summary}`.trim(), {

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -38,8 +38,10 @@ function shouldAnnounceHookRunResult(params: {
 }
 
 function resolveHookRunSummary(result: RunCronAgentTurnResult): string {
+  const diagnosticsSummary =
+    result.status !== "ok" ? normalizeOptionalString(result.diagnostics?.summary) : undefined;
   return (
-    normalizeOptionalString(result.diagnostics?.summary) ||
+    diagnosticsSummary ||
     normalizeOptionalString(result.summary) ||
     normalizeOptionalString(result.error) ||
     result.status

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -48,6 +48,38 @@ function resolveHookRunSummary(result: RunCronAgentTurnResult): string {
   );
 }
 
+function sanitizeHookConsoleValue(value: string | undefined): string | undefined {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized
+    .replace(/[\u001b\r\n\t]+/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim()
+    .slice(0, 500);
+}
+
+function formatHookRunWarningConsoleMessage(params: {
+  status: string;
+  model: string | undefined;
+  summary: string;
+}): string {
+  const parts = [
+    "hook agent run returned non-ok status",
+    `status=${sanitizeHookConsoleValue(params.status) ?? "unknown"}`,
+  ];
+  const model = sanitizeHookConsoleValue(params.model);
+  if (model) {
+    parts.push(`model=${model}`);
+  }
+  const summary = sanitizeHookConsoleValue(params.summary);
+  if (summary) {
+    parts.push(`summary=${summary}`);
+  }
+  return parts.join(" ");
+}
+
 export function createGatewayHooksRequestHandler(params: {
   deps: CliDeps;
   getHooksConfig: () => HooksConfigResolved | null;
@@ -134,6 +166,11 @@ export function createGatewayHooksRequestHandler(params: {
             status: result.status,
             model: value.model,
             summary,
+            consoleMessage: formatHookRunWarningConsoleMessage({
+              status: result.status,
+              model: value.model,
+              summary,
+            }),
           });
         }
         if (shouldAnnounce) {


### PR DESCRIPTION
## Summary

- Problem: `/hooks/agent` could accept a run whose `payload.model` was rejected by the cron model allowlist, then only surface a quiet returned error path.
- Why it matters: operators saw HTTP `200`/`runId` but no transcript, no model call, and no obvious Gateway warning for the rejected model.
- What changed: hook-triggered isolated-run errors now log a structured `gateway/hooks` warning, direct failed cron jobs now log a scheduler warning with the diagnostic summary, and hook announcements prefer cron diagnostic summaries.
- What did NOT change (scope boundary): explicit disallowed `payload.model` values still fail closed; hook HTTP semantics still return an async run id.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78597
- Related #75928
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: disallowed `/hooks/agent` `payload.model` is discoverable at the hook boundary.
- Real environment tested: local isolated integration Gateway from this branch, workspace `issue-78597-fixed`, port `54506`.
- Exact steps or command run after this patch: started `./.mem/integ/scripts/run_integ_gateway.mjs issue-78597-fixed 54506`, POSTed `/hooks/agent` with `model: "anthropic/claude-sonnet-4-6"` while only `openai/gpt-5.5` was in `agents.defaults.models`, then checked the Gateway log.
- Evidence after fix: `.mem/main/integ/issue-78597-fixed.md` verifies `hook_warning_lines=1` and `diagnostic_summary_lines=2`. After-fix console output from the real integration Gateway run:

  ```text
  hook_http_status=200
  hook_returned_run_id=yes
  hook_warning_lines=1
  diagnostic_summary_lines=2
  session_or_transcript_files=1
  issue_fixed=yes

  gateway/hooks hook agent run returned non-ok status
  status=error
  model=anthropic/claude-sonnet-4-6
  sessionKey=hook:issue-78597
  summary=cron payload.model 'anthropic/claude-sonnet-4-6' rejected by agents.defaults.models allowlist: anthropic/claude-sonnet-4-6
  ```
- Observed result after fix: Gateway log includes `hook agent run returned non-ok status` with model, session key, run id, job id, and the cron allowlist rejection summary.
- What was not tested: real model delivery of the follow-up announcement, because the isolated proof workspace intentionally had no OpenAI auth profile.
- Before evidence: `.mem/main/integ/issue-78597-repro.md` records HTTP `200` with run id, zero session/transcript files, and zero hook/model rejection warning lines before the patch.

## Root Cause

- Root cause: `/hooks/agent` dispatches isolated cron-style work asynchronously and only logged thrown exceptions, while disallowed `payload.model` is a returned `status: "error"` result before the agent runner starts.
- Missing detection / guardrail: hook tests asserted the quiet system event but not `logHooks.warn`, and cron tests did not pin the preflight diagnostic object for disallowed payload models.
- Contributing context: #75928 added cron diagnostics, but the hook boundary was still summarizing returned errors without logging them.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server/hooks.agent-trust.test.ts` and `src/cron/isolated-agent/run.cron-model-override.test.ts`.
- Scenario the test should lock in: returned hook `status: "error"` uses cron diagnostic summaries for announcements and emits a structured warning; failed cron job results log their diagnostic summary; disallowed cron payload model carries `cron-preflight` diagnostics.
- Why this is the smallest reliable guardrail: it exercises the exact returned-error seam without needing live model credentials.
- Existing test that already covers this (if any): existing hook trust tests covered announcement trust, but not warning visibility or diagnostic-summary precedence.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Rejected hook-triggered cron model overrides now produce a visible Gateway warning and a more specific hook announcement summary. Direct failed cron jobs now also produce a scheduler warning with the stored diagnostic summary.

## Diagram

```text
Before:
/hooks/agent -> async isolated run -> payload.model rejection -> quiet returned error

After:
/hooks/agent -> async isolated run -> payload.model rejection -> cron diagnostic summary -> hook warning + announcement summary
cron job -> isolated run -> payload.model rejection -> cron diagnostic summary -> cron warning + job state
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local development host
- Runtime/container: Node 25.6.0 via repo scripts
- Model/provider: configured allowlist `openai/gpt-5.5`; rejected payload model `anthropic/claude-sonnet-4-6`
- Integration/channel: local `/hooks/agent`
- Relevant config (redacted): hooks enabled with local token, `hooks.defaultSessionKey = "hook:issue-78597"`, `agents.defaults.models["openai/gpt-5.5"] = {}`

### Steps

1. Create isolated integration workspace and enable hooks.
2. Start Gateway on a random loopback port.
3. POST `/hooks/agent` with a payload model outside `agents.defaults.models`.
4. Inspect Gateway logs and state artifacts.

### Expected

- Rejected payload model is visible in hook diagnostics/logging.

### Actual

- Before patch: HTTP `200`/run id, no transcript, no hook/model rejection warning.
- After patch: HTTP `200`/run id, plus a structured `gateway/hooks` warning with the cron diagnostic summary.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification

- Verified scenarios: targeted tests, changed checks, changed tests, repro Showboat proof, fixed Showboat proof.
- Edge cases checked: hook diagnostic summary takes precedence over generic summary/error; cron preflight diagnostic source/severity is preserved.
- What you did **not** verify: authenticated delivery of the follow-up announcement in a live channel.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: warning volume increases for non-ok hook runs that were already being announced.
  - Mitigation: only returned non-ok isolated hook results warn; successful delivered and suppressed runs are unchanged.

## Verification

- `pnpm test src/cron/isolated-agent/run.cron-model-override.test.ts src/gateway/server/hooks.agent-trust.test.ts -- --reporter=dot`
- `pnpm test src/cron/service/timer.regression.test.ts src/cron/isolated-agent/run.cron-model-override.test.ts -- --reporter=dot`
- `pnpm exec oxfmt --check --threads=1 src/gateway/server/hooks.ts src/gateway/server/hooks.agent-trust.test.ts src/cron/isolated-agent/run.cron-model-override.test.ts CHANGELOG.md`
- `git diff --check`
- `uvx showboat verify /Users/kevinlin/code/openclaw/.mem/main/integ/issue-78597-repro.md`
- `uvx showboat verify /Users/kevinlin/code/openclaw/.mem/main/integ/issue-78597-fixed.md`
- `pnpm check:changed`
- `pnpm test:changed`
