### PR TITLE
fix(cli/completion): guard shell profile source line with file-exists check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/completion: guard the shell-profile source line written by `openclaw completion --install` with a file existence check (`[ -f ... ] && source ...` for bash/zsh, `test -f ...; and source ...` for fish) so uninstalling OpenClaw no longer makes new login shells error on a missing completion cache.
 - Cron/doctor: repair persisted cron jobs whose `payload.model` was stored as `"default"`, `"null"`, blank, or JSON `null` by removing the bad override during `openclaw doctor --fix` while keeping cron runtime model validation strict. Fixes #78549. Thanks @bizzle12368239.
 - Doctor/OpenAI Codex: revert the 2026.5.5 `doctor --fix` repair that rewrote valid `openai-codex/*` ChatGPT/Codex OAuth routes to `openai/*`, which could break OAuth-only GPT-5.5 setups or accidentally move users onto the OpenAI API-key route. If 2026.5.5 already changed your default model, run `openclaw models set openai-codex/gpt-5.5 && openclaw config validate` to switch the default agent back to the Codex OAuth PI route. Fixes #78407.
 - Discord/groups: instruct group-chat agents to stay silent when a message is addressed to someone else, replying only when invited or correcting key facts. (#78615)

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -69,9 +69,9 @@ function formatCompletionSourceLine(
   cachePath: string,
 ): string {
   if (shell === "fish") {
-    return `source "${cachePath}"`;
+    return `test -f "${cachePath}"; and source "${cachePath}"`;
   }
-  return `source "${cachePath}"`;
+  return `[ -f "${cachePath}" ] && source "${cachePath}"`;
 }
 
 function isCompletionProfileHeader(line: string): boolean {


### PR DESCRIPTION
## Summary

`openclaw completion --install` writes a `source "<cache>"` line into `~/.bashrc`, `~/.zshrc`, or `config.fish`. If the user later uninstalls OpenClaw and the cache file is removed, every new login shell errors on the missing file.

This wraps the source line in a file-exists guard so a stale entry stays silent:

- bash/zsh: `[ -f "<cache>" ] && source "<cache>"`
- fish: `test -f "<cache>"; and source "<cache>"`

`isCompletionProfileLine` matches by cache-path substring, which the new line preserves, so existing installs are still recognized for upgrade and removal — no migration needed.

## Verification

### Real behavior proof — bash before/after with a missing cache file

```
$ ls -la /tmp/openclaw-source-guard-proof/openclaw.bash
ls: cannot access '/tmp/openclaw-source-guard-proof/openclaw.bash': No such file or directory

# OLD format (current main): plain 'source ...' line
$ cat .bashrc-old
# OpenClaw Completion
source "/tmp/openclaw-source-guard-proof/openclaw.bash"

$ bash --rcfile .bashrc-old -i -c true
bash: /tmp/openclaw-source-guard-proof/openclaw.bash: No such file or directory   <-- user-visible error
exit code: 0

# NEW format (this PR): guarded with [ -f ... ] &&
$ cat .bashrc-new
# OpenClaw Completion
[ -f "/tmp/openclaw-source-guard-proof/openclaw.bash" ] && source "/tmp/openclaw-source-guard-proof/openclaw.bash"

$ bash --rcfile .bashrc-new -i -c true
exit code: 0   <-- silent, no error

# NEW format still sources the file when it exists
$ echo 'export OPENCLAW_GUARD_DEMO=loaded' > /tmp/openclaw-source-guard-proof/openclaw.bash
$ bash --rcfile .bashrc-new -i -c 'echo $OPENCLAW_GUARD_DEMO'
loaded   <-- source line ran as expected
```

(Bash also prints `cannot set terminal process group / no job control in this shell` in non-tty subshells; that's identical in both runs and unrelated to this change.)

### Detection compatibility

`isCompletionProfileLine` matches both old and new lines via the `line.includes(cachePath)` branch, since the cache path remains in the line. `updateCompletionProfile` additionally drives upgrade/removal off the `# OpenClaw Completion` header (the line right after the header is dropped blindly), so detection works even when the cache file has already been deleted.

| Form | Contains cachePath? | Matched by `isCompletionProfileLine`? |
|---|---|---|
| Old: `source "<path>"` | yes | yes |
| New: `[ -f "<path>" ] && source "<path>"` | yes | yes |
| Legacy slow-dynamic: `source <(openclaw completion bash)` | no | yes (via `binName completion` branch) |

### Static checks

- `pnpm tsgo:core` reports no errors in `src/cli/completion-runtime.ts`. (Other tsgo errors come from a broken `@openclaw/fs-safe` git fetch on the local clone — same failures appear on `main` without this change.)
- No existing test pins the source-line format; `setup.completion.test.ts` mocks `installCompletion`. The internal helper `formatCompletionSourceLine` is not directly asserted on.
- Fish syntax was not exercised because fish is not installed locally; the form `test -f "<path>"; and source "<path>"` is the documented fish idiom for conditional source.

CHANGELOG entry added under Unreleased > Fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


