### PR TITLE
chore(deps): bump @openclaw/fs-safe pin to 3412e03

### DIFF
--- a/package.json
+++ b/package.json
@@ -1695,7 +1695,7 @@
     "@mariozechner/pi-tui": "0.73.0",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@mozilla/readability": "^0.6.0",
-    "@openclaw/fs-safe": "github:openclaw/fs-safe#3c508734af0baaad4f61cf70619bea98c783043b",
+    "@openclaw/fs-safe": "github:openclaw/fs-safe#3412e03c09cdfd31c2da04b7d74e39ad7a92d07d",
     "@slack/bolt": "^4.7.2",
     "@slack/types": "^2.21.0",
     "@slack/web-api": "^7.15.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: ^0.6.0
         version: 0.6.0
       '@openclaw/fs-safe':
-        specifier: github:openclaw/fs-safe#3c508734af0baaad4f61cf70619bea98c783043b
-        version: https://codeload.github.com/openclaw/fs-safe/tar.gz/3c508734af0baaad4f61cf70619bea98c783043b
+        specifier: github:openclaw/fs-safe#3412e03c09cdfd31c2da04b7d74e39ad7a92d07d
+        version: https://codeload.github.com/openclaw/fs-safe/tar.gz/3412e03c09cdfd31c2da04b7d74e39ad7a92d07d
       '@slack/bolt':
         specifier: ^4.7.2
         version: 4.7.2(@types/express@5.0.6)
@@ -3234,8 +3234,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@openclaw/fs-safe@https://codeload.github.com/openclaw/fs-safe/tar.gz/3c508734af0baaad4f61cf70619bea98c783043b':
-    resolution: {tarball: https://codeload.github.com/openclaw/fs-safe/tar.gz/3c508734af0baaad4f61cf70619bea98c783043b}
+  '@openclaw/fs-safe@https://codeload.github.com/openclaw/fs-safe/tar.gz/3412e03c09cdfd31c2da04b7d74e39ad7a92d07d':
+    resolution: {tarball: https://codeload.github.com/openclaw/fs-safe/tar.gz/3412e03c09cdfd31c2da04b7d74e39ad7a92d07d}
     version: 0.1.2
     engines: {node: '>=20.11'}
 
@@ -4448,6 +4448,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@urbit/aura@3.0.0':
     resolution: {integrity: sha512-N8/FHc/lmlMDCumMuTXyRHCxlov5KZY6unmJ9QR2GOw+OpROZMBsXYGwE+ZMtvN21ql9+Xb8KhGNBj08IrG3Wg==}
@@ -10003,7 +10004,7 @@ snapshots:
   '@openai/codex@0.128.0-win32-x64':
     optional: true
 
-  '@openclaw/fs-safe@https://codeload.github.com/openclaw/fs-safe/tar.gz/3c508734af0baaad4f61cf70619bea98c783043b':
+  '@openclaw/fs-safe@https://codeload.github.com/openclaw/fs-safe/tar.gz/3412e03c09cdfd31c2da04b7d74e39ad7a92d07d':
     optionalDependencies:
       jszip: 3.10.1
       tar: 7.5.13


### PR DESCRIPTION
## Summary

- Bumps `@openclaw/fs-safe` from `3c50873` to `3412e03` (26 commits).
- Headline reason: fresh `pnpm install` was failing with `ERR_PNPM_PREPARE_PACKAGE` / `ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION` because the previously pinned commit shipped a `pnpm-workspace.yaml` with no `packages:` field. Fixed upstream in [openclaw/fs-safe#10](https://github.com/openclaw/fs-safe/pull/10) and included in this bump.
- Also pulls in upstream filesystem boundary-guard hardening: centralized boundary primitives, guarded fallback handle cleanup, prune/trash race fixes, durable queue id validation, archive staged-merge pinning, public path mode preservation in the guard refactor, `json` copy-fallback symlink fix, `temp` private-dir helpers, and workspace leaf filename contract preservation.

## Verification

- [x] `corepack pnpm install` — clean install, no prepare error.
- [x] `pnpm openclaw setup` — wrote `~/.openclaw/openclaw.json`, workspace, and sessions dirs.
- [x] `pnpm test src/infra/{fs-safe,boundary-file-read,fs-safe-defaults,fs-safe-import-boundary}.test.ts` — 37/37 passed.
- [ ] Broad changed-gate (`all: true`) — left for Testbox / CI.

## Notes

The lockfile diff includes a deprecation annotation for `@ungap/structured-clone@1.3.0` ("Potential CWE-502 - Update to 1.3.1 or higher"); that's an npm-registry annotation surfaced on re-resolution, unrelated to the fs-safe bump.
