### PR TITLE
fix: recognize PI native API provider streams in embedded session stream resolution

### DIFF
--- a/src/agents/pi-embedded-runner/stream-resolution.test.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.test.ts
@@ -1,5 +1,5 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
-import { streamSimple } from "@mariozechner/pi-ai";
+import { getApiProvider, streamSimple } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import * as providerTransportStream from "../provider-transport-stream.js";
 import {
@@ -83,6 +83,23 @@ describe("describeEmbeddedAgentStreamStrategy", () => {
         } as never,
       }),
     ).toBe("session-custom");
+  });
+
+  it("routes PI native openai-completions streams through boundary-aware shaping (#78661)", () => {
+    const nativeStreamFn = getApiProvider("openai-completions")?.streamSimple;
+    expect(nativeStreamFn).toBeDefined();
+
+    expect(
+      describeEmbeddedAgentStreamStrategy({
+        currentStreamFn: nativeStreamFn,
+        shouldUseWebSocketTransport: false,
+        model: {
+          api: "openai-completions",
+          provider: "llama",
+          id: "qwen36-35b-a3b",
+        } as never,
+      }),
+    ).toBe("boundary-aware:openai-completions");
   });
 });
 
@@ -357,5 +374,34 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     await expect(
       streamFn({ provider: "openai-codex", id: "gpt-5.5" } as never, { systemPrompt } as never, {}),
     ).resolves.toMatchObject({ systemPrompt });
+  });
+
+  it("routes PI native openai-completions streams through boundary-aware transport (#78661)", async () => {
+    const nativeStreamFn = getApiProvider("openai-completions")?.streamSimple;
+    expect(nativeStreamFn).toBeDefined();
+
+    const innerStreamFn = vi.fn(async (_model, _context, options) => options);
+    overrideBoundaryAwareStreamFnOnce(innerStreamFn as never);
+
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: nativeStreamFn,
+      shouldUseWebSocketTransport: false,
+      sessionId: "session-1",
+      model: {
+        api: "openai-completions",
+        provider: "llama",
+        id: "qwen36-35b-a3b",
+      } as never,
+      resolvedApiKey: "local-token",
+    });
+
+    // Must NOT be the native stream — boundary-aware transport should replace it
+    expect(streamFn).not.toBe(nativeStreamFn);
+
+    await expect(
+      streamFn({ provider: "llama", id: "qwen36-35b-a3b" } as never, {} as never, {}),
+    ).resolves.toMatchObject({ apiKey: "local-token" });
+
+    expect(innerStreamFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/pi-embedded-runner/stream-resolution.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.ts
@@ -1,5 +1,6 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
-import { streamSimple } from "@mariozechner/pi-ai";
+import type { Api } from "@mariozechner/pi-ai";
+import { getApiProvider, streamSimple } from "@mariozechner/pi-ai";
 import { createAnthropicVertexStreamFnForModel } from "../anthropic-vertex-stream.js";
 import { createOpenAIWebSocketStreamFn } from "../openai-ws-stream.js";
 import { getModelProviderRequestTransport } from "../provider-request-config.js";
@@ -25,6 +26,20 @@ export function resetEmbeddedAgentBaseStreamFnCacheForTest(): void {
   embeddedAgentBaseStreamFnCache = new WeakMap<object, StreamFn | undefined>();
 }
 
+/**
+ * Returns true when `fn` is either the global `streamSimple` fallback or a
+ * PI-native API provider stream registered for the given `api`.  These are
+ * treated as defaults that OpenClaw should replace with its boundary-aware
+ * transport so that `stream_options.include_usage` is injected correctly.
+ */
+function isPiNativeDefaultStream(fn: StreamFn | undefined, api: string): boolean {
+  if (fn === undefined || fn === streamSimple) {
+    return true;
+  }
+  const nativeProvider = getApiProvider(api as Api);
+  return nativeProvider?.streamSimple === fn;
+}
+
 export function describeEmbeddedAgentStreamStrategy(params: {
   currentStreamFn: StreamFn | undefined;
   providerStreamFn?: StreamFn;
@@ -41,7 +56,7 @@ export function describeEmbeddedAgentStreamStrategy(params: {
   if (params.model.provider === "anthropic-vertex") {
     return "anthropic-vertex";
   }
-  if (params.currentStreamFn === undefined || params.currentStreamFn === streamSimple) {
+  if (isPiNativeDefaultStream(params.currentStreamFn, params.model.api)) {
     return createBoundaryAwareStreamFnForModel(params.model)
       ? `boundary-aware:${params.model.api}`
       : "stream-simple";
@@ -104,7 +119,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
     return createAnthropicVertexStreamFnForModel(params.model);
   }
 
-  if (params.currentStreamFn === undefined || params.currentStreamFn === streamSimple) {
+  if (isPiNativeDefaultStream(params.currentStreamFn, params.model.api)) {
     const boundaryAwareStreamFn = createBoundaryAwareStreamFnForModel(params.model);
     if (boundaryAwareStreamFn) {
       // Boundary-aware transports read credentials from options.apiKey just


### PR DESCRIPTION
## Summary

Fixes the regression where embedded sessions using PI-native `openai-completions` streams bypassed the boundary-aware transport, causing `stream_options.include_usage` to not be injected and token usage to be reported as zero.

## Related Issue

Closes #78661

## Root Cause

In `resolveEmbeddedAgentStreamFn()`, the check `params.currentStreamFn === streamSimple` only matched the module-level `streamSimple` export from `@mariozechner/pi-ai`. When a session was initialized with a PI-native API provider stream (obtained via `getApiProvider("openai-completions")?.streamSimple`), the wrapped function had a different reference identity, causing the check to fall through to `return currentStreamFn` — bypassing the boundary-aware transport entirely.

This meant `stream_options.include_usage: true` was never injected, and token usage was reported as zero.

## Changes

- Added `isPiNativeDefaultStream()` helper in `stream-resolution.ts` that checks if a stream function is:
  1. `undefined` (no session stream set)
  2. The module-level `streamSimple` export (existing behavior)
  3. A registered PI-native API provider's `streamSimple` for the given model API (**new**)
- Updated both `resolveEmbeddedAgentStreamFn()` and `describeEmbeddedAgentStreamStrategy()` to use this helper instead of the direct reference comparison
- Added `getApiProvider` and `Api` type imports from `@mariozechner/pi-ai`

## Real behavior proof

### Behavior or issue addressed

Embedded sessions using PI-native `openai-completions` streams bypass the boundary-aware transport (#78661). Token usage reported as zero because `stream_options.include_usage: true` is never injected.

### Real environment tested

OpenClaw 2026.5.3-1 on Linux 6.17.0-22-generic (x64), Node.js v24.14.1. Fork rebased onto latest upstream/main.

### Exact steps or command run after fix

```bash
cd ~/repos/forks/openclaw
git checkout fix/embedded-stream-native-openai-bypass
git rebase upstream/main
npx vitest run --config test/vitest/vitest.agents-core.config.ts src/agents/pi-embedded-runner/stream-resolution.test.ts
```

### Evidence after fix

Rebased onto latest main and ran stream-resolution tests:

```
$ npx vitest run --config test/vitest/vitest.agents-core.config.ts src/agents/pi-embedded-runner/stream-resolution.test.ts
 ✓ agents-core  src/agents/pi-embedded-runner/stream-resolution.test.ts (19 tests) 20ms
 Test Files  1 passed (1)
 Tests  19 passed (19)
```

The regression tests use `getApiProvider("openai-completions")?.streamSimple` — the actual registered PI provider stream function (not mocks) — to verify the fix handles the real wrapped reference:
- `routes PI native openai-completions streams through boundary-aware shaping (#78661)` ✓
- `routes PI native openai-completions streams through boundary-aware transport (#78661)` ✓

Before this fix, both would fail because `isPiNativeDefaultStream` did not exist and the native provider stream was classified as `session-custom`.

### Observed result after fix

- PI-native `openai-completions` streams are now correctly routed through boundary-aware transport (not returned as-is).
- Stream strategy described as `boundary-aware:openai-completions` instead of `session-custom`.
- All 19 existing stream-resolution tests pass — no regressions.

### What was not tested

- End-to-end token usage recovery with a live `openai-completions` endpoint (no local API key available). The tests exercise the exact stream resolution code path using real PI API provider registrations.
