### PR TITLE
feat: re-open clean tool template generator PR

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Create, edit, improve, tidy, review, audit, or restructure AgentSkills and SKILL.md files.
+description: Create, edit, improve, or audit AgentSkills. Use when creating a new skill from scratch or when asked to improve, review, audit, tidy up, or clean up an existing skill or SKILL.md file. Also use when editing or restructuring a skill directory (moving files to references/ or scripts/, removing stale content, validating against the AgentSkills spec). Triggers on phrases like "create a skill", "author a skill", "tidy up a skill", "improve this skill", "review the skill", "clean up the skill", "audit the skill".
 ---
 
 # Skill Creator
@@ -268,7 +268,7 @@ Skip this step only if the skill being developed already exists, and iteration o
 
 When creating a new skill from scratch, always run the `init_skill.py` script. The script conveniently generates a new template skill directory that automatically includes everything a skill requires, making the skill creation process much more efficient and reliable.
 
-Usage:
+#### Basic Usage
 
 ```bash
 scripts/init_skill.py <skill-name> --path <output-directory> [--resources scripts,references,assets] [--examples]
@@ -277,8 +277,13 @@ scripts/init_skill.py <skill-name> --path <output-directory> [--resources script
 Examples:
 
 ```bash
+# Minimal skill
 scripts/init_skill.py my-skill --path skills/public
+
+# With scripts and references
 scripts/init_skill.py my-skill --path skills/public --resources scripts,references
+
+# With example files in resources
 scripts/init_skill.py my-skill --path skills/public --resources scripts --examples
 ```
 
@@ -290,6 +295,36 @@ The script:
 - Optionally adds example files when `--examples` is set
 
 After initialization, customize the SKILL.md and add resources as needed. If you used `--examples`, replace or delete placeholder files.
+
+#### Generating Tools (NEW)
+
+Speed up tool creation by generating standardized tool templates directly inside your skill's `scripts/` directory. This is inspired by Claude Code's unified tool structure and promotes consistency across OpenClaw skills.
+
+Usage:
+
+```bash
+scripts/init_skill.py <skill-name> --path <output-directory> --tool <tool-name> --type <bash|python|node> --tool-desc "Description" --tool-args "flag:type:help,flag:type:help"
+```
+
+Example - create a skill with a Python tool that has arguments:
+
+```bash
+scripts/init_skill.py file-utils --path skills/public --tool compress --type python --tool-desc "Compress files" --tool-args "--input:str:Input file path,--output:str:Output file path,--level:int:Compression level 1-9"
+```
+
+This will:
+
+- Create the skill directory and SKILL.md as usual
+- Create `scripts/` (implied when `--tool` is used)
+- Generate a ready-to-implement tool script (e.g., `scripts/compress.py`) with:
+  - Standardized argument parsing (argparse for Python, getopts for bash, minimist for node)
+  - Error handling scaffolding
+  - Clear TODO markers for logic implementation
+  - Help and examples already configured
+
+After generation, edit the tool script to implement the actual functionality, then add usage documentation to your SKILL.md.
+
+**Note**: `--tool-args` format uses comma-separated items. Each item is `flag[:type][:help]`. Flags starting with `--` become optional arguments; otherwise they are positional. Supported types: `str`, `int`, `float`, `bool`. Avoid commas in help text for now.
 
 ### Step 4: Edit the Skill
 

--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -4,17 +4,18 @@ Skill Initializer - Creates a new skill from template
 
 Usage:
     init_skill.py <skill-name> --path <path> [--resources scripts,references,assets] [--examples]
+    init_skill.py <skill-name> --path <path> --tool <tool-name> [--type bash|python|node] [--tool-desc "..."]
 
 Examples:
     init_skill.py my-new-skill --path skills/public
-    init_skill.py my-new-skill --path skills/public --resources scripts,references
     init_skill.py my-api-helper --path skills/private --resources scripts --examples
-    init_skill.py custom-skill --path /custom/location
+    init_skill.py data-processor --path skills/public --tool compress-pdf --type python --tool-desc "Compress PDF files"
 """
 
 import argparse
 import re
 import sys
+import subprocess
 from pathlib import Path
 
 MAX_SKILL_NAME_LENGTH = 64
@@ -317,12 +318,39 @@ def init_skill(skill_name, path, resources, include_examples):
     return skill_dir
 
 
+def generate_tool(skill_dir, tool_name, tool_type, tool_desc, tool_args):
+    """Generate a tool using toolgen.py"""
+    toolgen_path = Path(__file__).parent / "toolgen.py"
+    output_dir = skill_dir / "scripts"
+    output_dir.mkdir(exist_ok=True)
+
+    cmd = [
+        sys.executable, str(toolgen_path),
+        tool_name,
+        "--type", tool_type,
+        "--output", str(output_dir),
+        "--description", tool_desc
+    ]
+    if tool_args:
+        cmd.append(f"--args={tool_args}")
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        print(result.stdout)
+        return True
+    except subprocess.CalledProcessError as e:
+        print(f"[ERROR] Tool generation failed: {e.stderr}")
+        return False
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Create a new skill directory with a SKILL.md template.",
     )
     parser.add_argument("skill_name", help="Skill name (normalized to hyphen-case)")
     parser.add_argument("--path", required=True, help="Output directory for the skill")
+
+    # Resource options
     parser.add_argument(
         "--resources",
         default="",
@@ -333,7 +361,35 @@ def main():
         action="store_true",
         help="Create example files inside the selected resource directories",
     )
-    args = parser.parse_args()
+
+    # Tool generation options
+    parser.add_argument(
+        "--tool",
+        help="Generate a tool with the given name (implies scripts/)",
+    )
+    parser.add_argument(
+        "--type",
+        choices=["bash", "python", "node"],
+        default="python",
+        help="Tool type/language (default: python)",
+    )
+    parser.add_argument(
+        "--tool-desc",
+        default="",
+        help="Short description of the tool",
+    )
+    parser.add_argument(
+        "--tool-args",
+        nargs='*',
+        default=[],
+        help="Tool arguments as flag/type/desc tuples, e.g. '--input:str:Input file' '--output:str:Output file'",
+    )
+
+    # Use parse_known_args to capture --tool-args values that start with dashes
+    args, remaining = parser.parse_known_args()
+    if remaining:
+        # Merge remaining into tool_args (they are the flag/type/desc tuples)
+        args.tool_args = (args.tool_args or []) + remaining
 
     raw_skill_name = args.skill_name
     skill_name = normalize_skill_name(raw_skill_name)
@@ -349,7 +405,19 @@ def main():
     if skill_name != raw_skill_name:
         print(f"Note: Normalized skill name from '{raw_skill_name}' to '{skill_name}'.")
 
-    resources = parse_resources(args.resources)
+    # Handle tool generation
+    if args.tool:
+        if not args.tool_desc:
+            print("[WARN] No --tool-desc provided; using generic description")
+            args.tool_desc = f"Tool for {skill_name}"
+        resources_parsed = parse_resources(args.resources)
+        if "scripts" not in resources_parsed:
+            resources = resources_parsed + ["scripts"]
+        else:
+            resources = resources_parsed
+    else:
+        resources = parse_resources(args.resources)
+
     if args.examples and not resources:
         print("[ERROR] --examples requires --resources to be set.")
         sys.exit(1)
@@ -362,16 +430,40 @@ def main():
         print(f"   Resources: {', '.join(resources)}")
         if args.examples:
             print("   Examples: enabled")
+    if args.tool:
+        print(f"   Tool: {args.tool} ({args.type}) - {args.tool_desc}")
     else:
         print("   Resources: none (create as needed)")
     print()
 
+    # Create skill
     result = init_skill(skill_name, path, resources, args.examples)
 
     if result:
+        skill_dir = result
+
+        # Generate tool if requested
+        if args.tool:
+            print(f"\nGenerating tool '{args.tool}'...")
+            # Convert tool_args list to comma-separated string for generate_tool
+            tool_args_str = ','.join(args.tool_args) if args.tool_args else ''
+            success = generate_tool(skill_dir, args.tool, args.type, args.tool_desc, tool_args_str)
+            if success:
+                print(f"✅ Tool generated: {skill_dir}/scripts/{args.tool}.{args_type_to_ext(args.type)}")
+                print("\nNext steps:")
+                print("1. Implement the tool logic (look for TODO in the file)")
+                print("2. Add usage examples to your SKILL.md")
+                print(f"3. Test: {skill_dir}/scripts/{args.tool}.{args_type_to_ext(args.type)} --help")
+            else:
+                print("[WARN] Tool generation had errors; check above")
+
         sys.exit(0)
     else:
         sys.exit(1)
+
+
+def args_type_to_ext(t):
+    return {"bash": "sh", "python": "py", "node": "js"}[t]
 
 
 if __name__ == "__main__":

--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -14,8 +14,8 @@ Examples:
 
 import argparse
 import re
-import sys
 import subprocess
+import sys
 from pathlib import Path
 
 MAX_SKILL_NAME_LENGTH = 64

--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -18,6 +18,33 @@ import subprocess
 import sys
 from pathlib import Path
 
+
+def parse_args_with_tool_args(parser):
+    """Preserve dash-prefixed tool arg values without swallowing unrelated unknown args."""
+    argv = sys.argv[1:]
+    if "--tool-args" not in argv:
+        return parser.parse_args()
+
+    tool_args_index = argv.index("--tool-args")
+    prefix = argv[: tool_args_index + 1]
+    suffix = argv[tool_args_index + 1 :]
+
+    tool_args = []
+    rest = []
+    for index, token in enumerate(suffix):
+        if rest:
+            rest.append(token)
+            continue
+        if token.startswith("--") and token.count(":") >= 1:
+            tool_args.append(token)
+        else:
+            rest = suffix[index:]
+            break
+
+    args = parser.parse_args(prefix + rest)
+    args.tool_args = tool_args
+    return args
+
 MAX_SKILL_NAME_LENGTH = 64
 ALLOWED_RESOURCES = {"scripts", "references", "assets"}
 
@@ -385,11 +412,7 @@ def main():
         help="Tool arguments as flag/type/desc tuples, e.g. '--input:str:Input file' '--output:str:Output file'",
     )
 
-    # Use parse_known_args to capture --tool-args values that start with dashes
-    args, remaining = parser.parse_known_args()
-    if remaining:
-        # Merge remaining into tool_args (they are the flag/type/desc tuples)
-        args.tool_args = (args.tool_args or []) + remaining
+    args = parse_args_with_tool_args(parser)
 
     raw_skill_name = args.skill_name
     skill_name = normalize_skill_name(raw_skill_name)

--- a/skills/skill-creator/scripts/test_init_skill.py
+++ b/skills/skill-creator/scripts/test_init_skill.py
@@ -40,6 +40,24 @@ class TestInitSkill(TestCase):
                 result.stderr + result.stdout,
             )
 
+    def test_unknown_args_still_fail_without_tool_args(self):
+        with tempfile.TemporaryDirectory(prefix="test_init_skill_unknown_") as tmp:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "demo-skill",
+                    "--path",
+                    tmp,
+                    "--bogus",
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("unrecognized arguments: --bogus", result.stderr)
+
 
 if __name__ == "__main__":
     main()

--- a/skills/skill-creator/scripts/test_init_skill.py
+++ b/skills/skill-creator/scripts/test_init_skill.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Regression tests for init_skill.py tool generation."""
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from unittest import TestCase, main
+
+SCRIPT_PATH = Path(__file__).with_name("init_skill.py")
+
+
+class TestInitSkill(TestCase):
+    def test_tool_args_starting_with_dashes_generate_tool_file(self):
+        with tempfile.TemporaryDirectory(prefix="test_init_skill_") as tmp:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "demo-skill",
+                    "--path",
+                    tmp,
+                    "--tool",
+                    "compress",
+                    "--type",
+                    "python",
+                    "--tool-desc",
+                    "Compress files",
+                    "--tool-args",
+                    "--input:str:Input",
+                    "--output:str:Output",
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+            self.assertTrue(
+                Path(tmp, "demo-skill", "scripts", "compress.py").exists(),
+                result.stderr + result.stdout,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/skill-creator/scripts/test_toolgen.py
+++ b/skills/skill-creator/scripts/test_toolgen.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Regression tests for toolgen.py."""
 
+import importlib.util
 from pathlib import Path
 from unittest import TestCase, main
-import importlib.util
 
 MODULE_PATH = Path(__file__).with_name("toolgen.py")
 spec = importlib.util.spec_from_file_location("toolgen", MODULE_PATH)

--- a/skills/skill-creator/scripts/test_toolgen.py
+++ b/skills/skill-creator/scripts/test_toolgen.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Regression tests for toolgen.py."""
+
+from pathlib import Path
+from unittest import TestCase, main
+import importlib.util
+
+MODULE_PATH = Path(__file__).with_name("toolgen.py")
+spec = importlib.util.spec_from_file_location("toolgen", MODULE_PATH)
+toolgen = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(toolgen)
+
+
+class TestToolgen(TestCase):
+    def test_generate_node_escapes_literal_js_object_braces(self):
+        content = toolgen.generate_node(
+            "fetcher",
+            "Fetch URLs",
+            [{"flag": "--url", "type": "string", "help": "URL"}],
+        )
+
+        self.assertIn("const args = {};", content)
+        self.assertIn("console.log('Running fetcher with args:', args);", content)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/skill-creator/scripts/test_toolgen.py
+++ b/skills/skill-creator/scripts/test_toolgen.py
@@ -2,6 +2,9 @@
 """Regression tests for toolgen.py."""
 
 import importlib.util
+import subprocess
+import sys
+import tempfile
 from pathlib import Path
 from unittest import TestCase, main
 
@@ -21,6 +24,56 @@ class TestToolgen(TestCase):
 
         self.assertIn("const args = {};", content)
         self.assertIn("console.log('Running fetcher with args:', args);", content)
+
+    def test_generated_node_script_consumes_flag_values(self):
+        content = toolgen.generate_node(
+            "fetcher",
+            "Fetch URLs",
+            [
+                {"flag": "--url", "type": "string", "help": "URL"},
+                {"flag": "--timeout", "type": "int", "help": "Timeout"},
+            ],
+        )
+
+        with tempfile.TemporaryDirectory(prefix="test_toolgen_node_") as tmp:
+            script = Path(tmp, "fetcher.js")
+            script.write_text(content)
+            result = subprocess.run(
+                [
+                    "node",
+                    str(script),
+                    "--url",
+                    "https://example.com",
+                    "--timeout",
+                    "5",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("url: 'https://example.com'", result.stdout)
+        self.assertIn("timeout: '5'", result.stdout)
+
+    def test_generate_python_escapes_single_quotes_in_help_text(self):
+        content = toolgen.generate_python(
+            "demo",
+            "Bob's tool",
+            [{"flag": "--name", "type": "str", "help": "Person's name"}],
+        )
+
+        with tempfile.TemporaryDirectory(prefix="test_toolgen_python_") as tmp:
+            script = Path(tmp, "demo.py")
+            script.write_text(content)
+            result = subprocess.run(
+                [sys.executable, "-m", "py_compile", str(script)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
 
 
 if __name__ == "__main__":

--- a/skills/skill-creator/scripts/toolgen.py
+++ b/skills/skill-creator/scripts/toolgen.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Tool Template Generator for OpenClaw skills
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+ALLOWED_TYPES = {"bash", "python", "node"}
+
+def generate_bash(tool_name, description, arguments):
+    options = []
+    positional = []
+    for arg in arguments:
+        if arg['flag'].startswith('-'):
+            options.append(arg)
+        else:
+            positional.append(arg)
+
+    lines = [f'''#!/usr/bin/env bash
+# Tool: {tool_name}
+# Description: {description}
+
+set -euo pipefail
+
+# Defaults''']
+    for opt in options:
+        # Sanitize flag name: replace hyphens with underscores for valid bash variable
+        name = opt['flag'].lstrip('-').replace('-', '_')
+        default = opt.get('default', '')
+        lines.append(f"{name}=\"{default}\"")
+    lines.append("")
+
+    if options:
+        lines.append("while [[ $# -gt 0 ]]; do")
+        lines.append("    case $1 in")
+        for opt in options:
+            flag = opt['flag']
+            name = flag.lstrip('-').replace('-', '_')
+            # Only emit option itself (no duplicate), since short aliases not supported
+            lines.append(f"        {flag})")
+            # Boolean flags don't consume a value; others do
+            if opt.get('type') == 'bool':
+                lines.append(f"            {name}=true; shift 1;;")
+            else:
+                lines.append(f"            {name}=\"$2\"; shift 2;;")
+        lines.append("        *) break;;")
+        lines.append("    esac")
+        lines.append("done\n")
+
+    for i, pos in enumerate(positional):
+        name = pos.get('name', f"arg{i}")
+        lines.append(f"if [ $# -lt {i+1} ]; then")
+        lines.append(f"    echo 'Error: missing positional: {name}' >&2")
+        lines.append("    exit 1")
+        lines.append(f"fi")
+        lines.append(f"{name}=${{1}}")
+        lines.append("shift")
+        lines.append("")
+
+    lines.append(f'''# TODO: Implement tool logic
+echo "Running {tool_name}"
+# Access variables:''')
+    for opt in options:
+        name = opt['flag'].lstrip('-').replace('-', '_')
+        lines.append(f"#   ${name}: ${name}")
+    for pos in positional:
+        name = pos.get('name', 'arg')
+        lines.append(f"#   {name}: ${name}")
+    lines.append("")
+    return "\n".join(lines)
+
+def generate_python(tool_name, description, arguments):
+    arg_lines = []
+    extract_lines = []
+    validation_lines = []
+
+    for arg in arguments:
+        flag = arg['flag']
+        name = arg.get('name', flag.lstrip('-').replace('-', '_'))
+        arg_type = arg.get('type', 'str')
+        help_text = arg.get('help', '')
+
+        if flag.startswith('--'):
+            # optional flag
+            if arg_type == 'bool':
+                line = f"parser.add_argument('{flag}', action='store_true', help='{help_text}')"
+            else:
+                line = f"parser.add_argument('{flag}', type={arg_type}, help='{help_text}')"
+            arg_lines.append(line)
+            extract_lines.append(f"{name} = args.{name}")
+        else:
+            # positional argument
+            arg_lines.append(f"parser.add_argument('{name}', type={arg_type}, help='{help_text}')")
+            extract_lines.append(f"{name} = args.{name}")
+
+    arg_code = "\\n    ".join(arg_lines)
+    extract_code = "\\n    ".join(extract_lines)
+
+    arg_code = "\n    ".join(arg_lines)
+    extract_code = "\n    ".join(extract_lines)
+    # We currently have no automatic validation
+
+    content = f'''#!/usr/bin/env python3
+"""
+Tool: {tool_name}
+Description: {description}
+"""
+
+import argparse
+import sys
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="{description}",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  {tool_name} --input file.txt --output out.txt
+  {tool_name} --verbose
+        """
+    )
+    {arg_code}
+
+    args = parser.parse_args()
+
+    # TODO: implement your tool logic here
+    {extract_code}
+
+    print("Running {tool_name} with:", args)
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\\nInterrupted", file=sys.stderr)
+        sys.exit(130)
+    except Exception as e:
+        print(f"Error: {{e}}", file=sys.stderr)
+        sys.exit(1)
+'''
+    return content
+
+def generate_node(tool_name, description, arguments):
+    options = []
+    for arg in arguments:
+        if arg['flag'].startswith('-'):
+            name = arg.get('name', arg['flag'].lstrip('-').replace('-', '_'))
+            opt_type = arg.get('type', 'string')
+            options.append(f"    '{name}': {{ type: '{opt_type}' }}")
+
+    # opts_str computed but not used - removed
+
+    content = '''#!/usr/bin/env node
+/**
+ * Tool: {tool_name}
+ * Description: {description}
+ */
+
+// Simple argument parsing without external deps
+const args = {{}};
+// Parse flags
+for (let i = 2; i < process.argv.length; i++) {{
+  const arg = process.argv[i];
+  if (arg.startsWith('--')) {{
+    const parts = arg.slice(2).split(':');
+    const key = parts[0];
+    if (parts.length > 1) {{
+      // Has type hint, ignore for now; store raw
+      args[key] = process.argv[i+1] || true;
+      i++; // consume value
+    }} else {{
+      args[key] = true;
+    }}
+  }}
+}}
+
+// TODO: implement
+console.log('Running {tool_name} with args:', args);
+'''.format(tool_name=tool_name, description=description)
+    return content
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate tool scripts")
+    parser.add_argument("tool_name")
+    parser.add_argument("--type", choices=ALLOWED_TYPES, required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--description", default="")
+    parser.add_argument("--args", default="")
+    ns = parser.parse_args()
+
+    tool_name = ns.tool_name.lower()
+    output_dir = Path(ns.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    arguments = []
+    if ns.args:
+        for arg_str in ns.args.split(','):
+            parts = [p.strip() for p in arg_str.split(':')]
+            if not parts:
+                continue
+            flag = parts[0]
+            arg_def = {'flag': flag}
+            if len(parts) > 1:
+                arg_def['type'] = parts[1]
+            if len(parts) > 2:
+                arg_def['help'] = parts[2]
+            arguments.append(arg_def)
+
+    if ns.type == "bash":
+        ext = "sh"
+        content = generate_bash(tool_name, ns.description, arguments)
+    elif ns.type == "python":
+        ext = "py"
+        content = generate_python(tool_name, ns.description, arguments)
+    elif ns.type == "node":
+        ext = "js"
+        content = generate_node(tool_name, ns.description, arguments)
+    else:
+        parser.error("invalid type")
+
+    out_file = output_dir / f"{tool_name}.{ext}"
+    out_file.write_text(content)
+    out_file.chmod(0o755)
+    print(f"✅ Generated: {out_file}")
+
+if __name__ == "__main__":
+    main()

--- a/skills/skill-creator/scripts/toolgen.py
+++ b/skills/skill-creator/scripts/toolgen.py
@@ -4,10 +4,15 @@ Tool Template Generator for OpenClaw skills
 """
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
 ALLOWED_TYPES = {"bash", "python", "node"}
+
+
+def py_string_literal(value):
+    return json.dumps(value)
 
 def generate_bash(tool_name, description, arguments):
     options = []
@@ -74,7 +79,6 @@ echo "Running {tool_name}"
 def generate_python(tool_name, description, arguments):
     arg_lines = []
     extract_lines = []
-    validation_lines = []
 
     for arg in arguments:
         flag = arg['flag']
@@ -85,22 +89,20 @@ def generate_python(tool_name, description, arguments):
         if flag.startswith('--'):
             # optional flag
             if arg_type == 'bool':
-                line = f"parser.add_argument('{flag}', action='store_true', help='{help_text}')"
+                line = f"parser.add_argument({py_string_literal(flag)}, action='store_true', help={py_string_literal(help_text)})"
             else:
-                line = f"parser.add_argument('{flag}', type={arg_type}, help='{help_text}')"
+                line = f"parser.add_argument({py_string_literal(flag)}, type={arg_type}, help={py_string_literal(help_text)})"
             arg_lines.append(line)
             extract_lines.append(f"{name} = args.{name}")
         else:
             # positional argument
-            arg_lines.append(f"parser.add_argument('{name}', type={arg_type}, help='{help_text}')")
+            arg_lines.append(
+                f"parser.add_argument({py_string_literal(name)}, type={arg_type}, help={py_string_literal(help_text)})"
+            )
             extract_lines.append(f"{name} = args.{name}")
-
-    arg_code = "\\n    ".join(arg_lines)
-    extract_code = "\\n    ".join(extract_lines)
 
     arg_code = "\n    ".join(arg_lines)
     extract_code = "\n    ".join(extract_lines)
-    # We currently have no automatic validation
 
     content = f'''#!/usr/bin/env python3
 """
@@ -113,7 +115,7 @@ import sys
 
 def main():
     parser = argparse.ArgumentParser(
-        description="{description}",
+        description={py_string_literal(description)},
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -143,15 +145,6 @@ if __name__ == "__main__":
     return content
 
 def generate_node(tool_name, description, arguments):
-    options = []
-    for arg in arguments:
-        if arg['flag'].startswith('-'):
-            name = arg.get('name', arg['flag'].lstrip('-').replace('-', '_'))
-            opt_type = arg.get('type', 'string')
-            options.append(f"    '{name}': {{ type: '{opt_type}' }}")
-
-    # opts_str computed but not used - removed
-
     content = '''#!/usr/bin/env node
 /**
  * Tool: {tool_name}
@@ -164,11 +157,10 @@ const args = {{}};
 for (let i = 2; i < process.argv.length; i++) {{
   const arg = process.argv[i];
   if (arg.startsWith('--')) {{
-    const parts = arg.slice(2).split(':');
-    const key = parts[0];
-    if (parts.length > 1) {{
-      // Has type hint, ignore for now; store raw
-      args[key] = process.argv[i+1] || true;
+    const key = arg.slice(2);
+    const next = process.argv[i + 1];
+    if (next && !next.startsWith('--')) {{
+      args[key] = next;
       i++; // consume value
     }} else {{
       args[key] = true;


### PR DESCRIPTION
## Summary
- recreate the tool template generator work from a clean branch off `main`
- keep the PR scoped to `skills/skill-creator/**` only (no unrelated daemon changes)
- add regression tests for the issues found while validating the branch locally
- fix `toolgen.py` node template generation and `init_skill.py` forwarding of dash-prefixed `--tool-args`
- fix Python import ordering so the `skills-python` CI lint lane passes

## Supersedes
- closes/replaces #58667

## Validation
- `cd skills/skill-creator/scripts && python3 -m unittest test_init_skill.py test_toolgen.py test_quick_validate.py -v`
- `uvx ruff check --config skills/pyproject.toml skills/skill-creator/scripts`
- smoke-tested `init_skill.py` for both Python and Node tool generation
- `python3 -m py_compile` on generated Python tool and generator scripts
- `node --check` on generated Node tool

## Real behavior proof
- **Behavior or issue addressed**: `init_skill.py --tool ... --tool-args ...` should generate working Python and Node tool templates even when the forwarded tool args themselves start with dashes, and the generated Node template must stay syntactically valid.
- **Real environment tested**: local Linux OpenClaw contributor checkout in `/tmp/openclaw-reddeath`, using the repo's real `skills/skill-creator/scripts/init_skill.py` and generated artifacts.
- **Exact steps or command run after the patch**:
  ```bash
  cd /tmp/openclaw-reddeath
  uvx ruff check --config skills/pyproject.toml skills/skill-creator/scripts
  cd skills/skill-creator/scripts && python3 -m unittest test_init_skill.py test_toolgen.py test_quick_validate.py -v
  cd /tmp/openclaw-reddeath
  TMP=$(mktemp -d)
  python3 skills/skill-creator/scripts/init_skill.py demo-skill --path "$TMP" --tool compress --type python --tool-desc "Compress files" --tool-args --input:str:Input --output:str:Output --level:int:Level
  python3 skills/skill-creator/scripts/init_skill.py demo-node --path "$TMP" --tool fetcher --type node --tool-desc "Fetch URLs" --tool-args --url:str:URL --timeout:int:Timeout
  python3 -m py_compile "$TMP"/demo-skill/scripts/compress.py skills/skill-creator/scripts/init_skill.py skills/skill-creator/scripts/toolgen.py
  node --check "$TMP"/demo-node/scripts/fetcher.js
  ```
- **Evidence after fix**: copied live terminal output showed `All checks passed!`, all 5 unittest cases passed, `✅ Generated: /tmp/.../demo-skill/scripts/compress.py`, `✅ Generated: /tmp/.../demo-node/scripts/fetcher.js`, `python3 -m py_compile` completed without errors, and `node --check` completed without syntax errors.
- **Observed result after fix**: both generated tools were created successfully, the Python generator path no longer trips on dash-prefixed forwarded args, the Node template emits valid JavaScript, and the Python skill lint check is clean.
- **What was not tested**: I did not run the repo-wide full CI suite locally; validation here was targeted to the touched skill-creator Python/Node generator surface.
