### PR TITLE
fix(doctor): consolidate Gateway service config panels into a single note (#80287)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,6 @@ Docs: https://docs.openclaw.ai
 
 - Cron: keep long manual cron runs active in the task registry until completion, preventing transient `lost` markers before durable recovery reconciles. Fixes #78233. (#78243) Thanks @Feelw00.
 - Doctor/GitHub CLI: surface a `GH_CONFIG_DIR` hint when the GitHub skill is usable but `gh` auth lives under a different operator HOME than the agent process, without warning for disabled or filtered skills. Fixes #78063. (#78095) Thanks @tmimmanuel.
-- Gateway: consolidate duplicate `openclaw doctor` service config panels while preserving the declined-repair `--force` hint. Fixes #80287. (#78688) Thanks @YB0y.
 - Gateway: clear speculative node wake state when APNs registration is missing, preventing unregistered or mistyped node IDs from retaining wake throttle entries. Fixes #68847. (#68848) Thanks @Feelw00.
 - Auto-reply: keep late follow-up queue drain finalizers from deleting a replacement queue registered after `/stop`, preventing immediate follow-up messages from being orphaned. Fixes #68838. (#68839) Thanks @Feelw00.
 - Feishu: make manual App ID/App Secret setup the default channel-binding path while keeping QR scan-to-create as an optional best-effort flow, and document the manual fallback for domestic Feishu mobile clients that do not react to the QR code. Fixes #80591. Thanks @wei-wei-zhao.
@@ -70,6 +69,7 @@ Docs: https://docs.openclaw.ai
 - Channels: cache selected channel registry lookups against the active fallback snapshot so pinned-empty registries refresh native command and alias routing after active registry swaps. (#80333) Thanks @samzong.
 - Gateway: scope `sessions.resolve` sessionId and label store loads to the requested agent so large unrelated agent stores are not parsed for scoped lookups. Fixes #51264. (#79474) Thanks @samzong.
 - Gateway: share serialized streaming event envelopes across eligible WebSocket and node subscribers while preserving per-client sequence numbers. (#80299) Thanks @samzong.
+- Gateway: consolidate duplicate `openclaw doctor` service config panels while preserving the declined-repair `--force` hint. Fixes #80287. (#78688) Thanks @YB0y.
 - Browser: report Chrome MCP existing-session page readiness in browser status without letting status probes exceed the client timeout. Fixes #80268. (#80280) Thanks @ai-hpc.
 - WhatsApp: route opening-phase Baileys 428 connectionClosed through the WhatsApp reconnect policy and keep post-open 428 closes retryable, so transient setup socket closes retry with WhatsApp diagnostics instead of escaping as a bare `channel exited` error. Fixes #75736; mitigates #77443. Thanks @dataCenter430.
 - Agents: disable Pi's default filesystem resource discovery for embedded runs while keeping OpenClaw inline extension factories active, avoiding Windows event-loop stalls during first WhatsApp-triggered agent startup. Fixes #77443. Thanks @dataCenter430.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Docs: https://docs.openclaw.ai
 
 - Cron: keep long manual cron runs active in the task registry until completion, preventing transient `lost` markers before durable recovery reconciles. Fixes #78233. (#78243) Thanks @Feelw00.
 - Doctor/GitHub CLI: surface a `GH_CONFIG_DIR` hint when the GitHub skill is usable but `gh` auth lives under a different operator HOME than the agent process, without warning for disabled or filtered skills. Fixes #78063. (#78095) Thanks @tmimmanuel.
+- Gateway: consolidate duplicate `openclaw doctor` service config panels while preserving the declined-repair `--force` hint. Fixes #80287. (#78688) Thanks @YB0y.
 - Gateway: clear speculative node wake state when APNs registration is missing, preventing unregistered or mistyped node IDs from retaining wake throttle entries. Fixes #68847. (#68848) Thanks @Feelw00.
 - Auto-reply: keep late follow-up queue drain finalizers from deleting a replacement queue registered after `/stop`, preventing immediate follow-up messages from being orphaned. Fixes #68838. (#68839) Thanks @Feelw00.
 - Feishu: make manual App ID/App Secret setup the default channel-binding path while keeping QR scan-to-create as an optional best-effort flow, and document the manual fallback for domestic Feishu mobile clients that do not react to the QR code. Fixes #80591. Thanks @wei-wei-zhao.

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -1023,6 +1023,49 @@ describe("maybeRepairGatewayServiceConfig", () => {
           installWorkingDirectory: "/tmp",
         });
 
+        await runRepair({ gateway: {} });
+
+        const gatewayServiceConfigNotes = mocks.note.mock.calls.filter(
+          ([, title]) => title === "Gateway service config",
+        );
+        expect(gatewayServiceConfigNotes).toHaveLength(1);
+        const consolidated = gatewayServiceConfigNotes[0]?.[0] ?? "";
+        expect(consolidated).toContain(
+          "Gateway service entrypoint does not match the current install.",
+        );
+        expect(consolidated).not.toContain("resolves to a source checkout");
+        const forceMatches = consolidated.match(/openclaw gateway install --force/g) ?? [];
+        expect(forceMatches).toHaveLength(0);
+      } finally {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    });
+  });
+
+  it("keeps the gateway install force hint when a source-checkout warning is suppressed and repair is declined", async () => {
+    await withEnvAsync({}, async () => {
+      const root = await fs.mkdtemp(
+        path.join(os.tmpdir(), "openclaw-doctor-service-config-force-hint-"),
+      );
+      try {
+        await fs.mkdir(path.join(root, ".git"), { recursive: true });
+        await fs.mkdir(path.join(root, "src"), { recursive: true });
+        await fs.mkdir(path.join(root, "extensions"), { recursive: true });
+        await fs.mkdir(path.join(root, "dist"), { recursive: true });
+        await fs.writeFile(
+          path.join(root, "package.json"),
+          JSON.stringify({ name: "openclaw", version: "0.0.0-test" }),
+          "utf8",
+        );
+        const sourceCheckoutEntrypoint = path.join(root, "dist", "index.js");
+        await fs.writeFile(sourceCheckoutEntrypoint, "export {};\n", "utf8");
+        const installEntrypoint = "/usr/local/lib/node_modules/openclaw/dist/index.js";
+        setupGatewayEntrypointRepairScenario({
+          currentEntrypoint: sourceCheckoutEntrypoint,
+          installEntrypoint,
+          installWorkingDirectory: "/tmp",
+        });
+
         const declinePrompts = {
           ...makeDoctorPrompts(),
           confirmAutoFix: vi.fn().mockResolvedValue(false),
@@ -1039,14 +1082,13 @@ describe("maybeRepairGatewayServiceConfig", () => {
         const gatewayServiceConfigNotes = mocks.note.mock.calls.filter(
           ([, title]) => title === "Gateway service config",
         );
-        expect(gatewayServiceConfigNotes).toHaveLength(1);
-        const consolidated = gatewayServiceConfigNotes[0]?.[0] ?? "";
-        expect(consolidated).toContain(
+        expect(gatewayServiceConfigNotes).toHaveLength(2);
+        const auditNote = gatewayServiceConfigNotes[0]?.[0] ?? "";
+        expect(auditNote).toContain(
           "Gateway service entrypoint does not match the current install.",
         );
-        expect(consolidated).not.toContain("resolves to a source checkout");
-        const forceMatches = consolidated.match(/openclaw gateway install --force/g) ?? [];
-        expect(forceMatches).toHaveLength(0);
+        expect(auditNote).not.toContain("resolves to a source checkout");
+        expect(gatewayServiceConfigNotes[1]?.[0]).toContain("openclaw gateway install --force");
       } finally {
         await fs.rm(root, { recursive: true, force: true });
       }

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -998,6 +998,60 @@ describe("maybeRepairGatewayServiceConfig", () => {
       }
     });
   });
+
+  it("does not duplicate Gateway service config panels for a source-checkout entrypoint with audit findings", async () => {
+    await withEnvAsync({}, async () => {
+      const root = await fs.mkdtemp(
+        path.join(os.tmpdir(), "openclaw-doctor-service-config-dedup-"),
+      );
+      try {
+        await fs.mkdir(path.join(root, ".git"), { recursive: true });
+        await fs.mkdir(path.join(root, "src"), { recursive: true });
+        await fs.mkdir(path.join(root, "extensions"), { recursive: true });
+        await fs.mkdir(path.join(root, "dist"), { recursive: true });
+        await fs.writeFile(
+          path.join(root, "package.json"),
+          JSON.stringify({ name: "openclaw", version: "0.0.0-test" }),
+          "utf8",
+        );
+        const sourceCheckoutEntrypoint = path.join(root, "dist", "index.js");
+        await fs.writeFile(sourceCheckoutEntrypoint, "export {};\n", "utf8");
+        const installEntrypoint = "/usr/local/lib/node_modules/openclaw/dist/index.js";
+        setupGatewayEntrypointRepairScenario({
+          currentEntrypoint: sourceCheckoutEntrypoint,
+          installEntrypoint,
+          installWorkingDirectory: "/tmp",
+        });
+
+        const declinePrompts = {
+          ...makeDoctorPrompts(),
+          confirmAutoFix: vi.fn().mockResolvedValue(false),
+          confirmAggressiveAutoFix: vi.fn().mockResolvedValue(false),
+          confirmRuntimeRepair: vi.fn().mockResolvedValue(false),
+        };
+        await maybeRepairGatewayServiceConfig(
+          { gateway: {} },
+          "local",
+          makeDoctorIo(),
+          declinePrompts,
+        );
+
+        const gatewayServiceConfigNotes = mocks.note.mock.calls.filter(
+          ([, title]) => title === "Gateway service config",
+        );
+        expect(gatewayServiceConfigNotes).toHaveLength(1);
+        const consolidated = gatewayServiceConfigNotes[0]?.[0] ?? "";
+        expect(consolidated).toContain(
+          "Gateway service entrypoint does not match the current install.",
+        );
+        expect(consolidated).not.toContain("resolves to a source checkout");
+        const forceMatches = consolidated.match(/openclaw gateway install --force/g) ?? [];
+        expect(forceMatches).toHaveLength(0);
+      } finally {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    });
+  });
 });
 
 describe("maybeScanExtraGatewayServices", () => {

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -486,8 +486,8 @@ export async function maybeRepairGatewayServiceConfig(
   const showSourceCheckoutWarning = sourceCheckoutWarning !== null && !hasEntrypointMismatch;
 
   if (audit.issues.length === 0) {
-    if (showSourceCheckoutWarning) {
-      note(sourceCheckoutWarning!, "Gateway service config");
+    if (sourceCheckoutWarning !== null && !hasEntrypointMismatch) {
+      note(sourceCheckoutWarning, "Gateway service config");
     }
     return;
   }
@@ -496,9 +496,11 @@ export async function maybeRepairGatewayServiceConfig(
   const serviceRepairExternal = isServiceRepairExternallyManaged(serviceRepairPolicy);
 
   const consolidatedLines: string[] = [];
-  if (showSourceCheckoutWarning) {
-    consolidatedLines.push(sourceCheckoutWarning!);
+  let emittedSourceCheckoutWarning = false;
+  if (sourceCheckoutWarning !== null && showSourceCheckoutWarning) {
+    consolidatedLines.push(sourceCheckoutWarning);
     consolidatedLines.push("");
+    emittedSourceCheckoutWarning = true;
   }
   consolidatedLines.push(
     ...audit.issues.map((issue) =>
@@ -563,7 +565,7 @@ export async function maybeRepairGatewayServiceConfig(
         requiresInteractiveConfirmation: true,
       });
   if (!repair) {
-    if (sourceCheckoutWarning === null) {
+    if (!emittedSourceCheckoutWarning) {
       note(
         "Run `openclaw gateway install --force` when you want to replace the gateway service definition.",
         "Gateway service config",

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -381,15 +381,12 @@ export async function maybeRepairGatewayServiceConfig(
     note(`Gateway service invokes ${OPENCLAW_WRAPPER_ENV_KEY}: ${serviceWrapperPath}`, "Gateway");
   }
   const serviceLayout = await summarizeGatewayServiceLayout(command);
-  if (serviceLayout?.entrypointSourceCheckout) {
-    note(
-      [
+  const sourceCheckoutWarning = serviceLayout?.entrypointSourceCheckout
+    ? [
         `Gateway service entrypoint resolves to a source checkout: ${serviceLayout.packageRootReal ?? serviceLayout.packageRoot ?? serviceLayout.entrypointReal ?? serviceLayout.entrypoint}.`,
         "Run `openclaw doctor --fix` from the intended package install, or reinstall the gateway service with `openclaw gateway install --force`.",
-      ].join("\n"),
-      "Gateway service config",
-    );
-  }
+      ].join("\n")
+    : null;
 
   const tokenRefConfigured = Boolean(
     resolveSecretInputRef({
@@ -483,21 +480,32 @@ export async function maybeRepairGatewayServiceConfig(
     issues: audit.issues,
   });
 
+  const hasEntrypointMismatch = audit.issues.some(
+    (issue) => issue.code === SERVICE_AUDIT_CODES.gatewayEntrypointMismatch,
+  );
+  const showSourceCheckoutWarning = sourceCheckoutWarning !== null && !hasEntrypointMismatch;
+
   if (audit.issues.length === 0) {
+    if (showSourceCheckoutWarning) {
+      note(sourceCheckoutWarning!, "Gateway service config");
+    }
     return;
   }
 
   const serviceRepairPolicy = resolveServiceRepairPolicy();
   const serviceRepairExternal = isServiceRepairExternallyManaged(serviceRepairPolicy);
 
-  note(
-    audit.issues
-      .map((issue) =>
-        issue.detail ? `- ${issue.message} (${issue.detail})` : `- ${issue.message}`,
-      )
-      .join("\n"),
-    "Gateway service config",
+  const consolidatedLines: string[] = [];
+  if (showSourceCheckoutWarning) {
+    consolidatedLines.push(sourceCheckoutWarning!);
+    consolidatedLines.push("");
+  }
+  consolidatedLines.push(
+    ...audit.issues.map((issue) =>
+      issue.detail ? `- ${issue.message} (${issue.detail})` : `- ${issue.message}`,
+    ),
   );
+  note(consolidatedLines.join("\n"), "Gateway service config");
 
   const aggressiveIssues = audit.issues.filter((issue) => issue.level === "aggressive");
   const needsAggressive = aggressiveIssues.length > 0;
@@ -555,10 +563,12 @@ export async function maybeRepairGatewayServiceConfig(
         requiresInteractiveConfirmation: true,
       });
   if (!repair) {
-    note(
-      "Run `openclaw gateway install --force` when you want to replace the gateway service definition.",
-      "Gateway service config",
-    );
+    if (sourceCheckoutWarning === null) {
+      note(
+        "Run `openclaw gateway install --force` when you want to replace the gateway service definition.",
+        "Gateway service config",
+      );
+    }
     return;
   }
   const serviceEmbeddedToken = readEmbeddedGatewayToken(command);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw doctor` emits **three** consecutive `◇ Gateway service config` panels for one condition. Panel 1 is the source-checkout warning (with an `openclaw gateway install --force` CTA). Panel 2 is the aggregated audit-issue bullets, which already restate the entrypoint mismatch as `X -> Y`. Panel 3 is the post-decline `--force` hint, which duplicates Panel 1's CTA verbatim.
- Why it matters: two separable defects in one run. The duplicate `--force` CTA in Panel 1 + Panel 3 invites *"did the first one not take?"*, and the entrypoint mismatch is reported twice (Panel 1's source-checkout prose + Panel 2's `X -> Y` bullet). Doctor output is also what users paste into issues / Discord; three panels under one heading make the snippet harder to triage. Reproduces 100% on `v2026.5.7` and current `origin/main` whenever `auditGatewayServiceConfig` returns a non-empty issue list together with `serviceLayout.entrypointSourceCheckout = true`.
- What changed: in `src/commands/doctor-gateway-services.ts`, defer the source-checkout warning until after the audit, fold it into the audit-bullet emit so a single `note(..., "Gateway service config")` is produced per pass, and gate the warning on `audit.issues.every((issue) => issue.code !== gatewayEntrypointMismatch)` so the same entrypoint mismatch is not reported twice. Suppress the post-decline `--force` hint when the source-checkout warning already emitted that same advice (otherwise keep it so users without a source checkout still see how to replace the service definition).
- What did NOT change (scope boundary): `summarizeGatewayServiceLayout`, the audit module's wording, the existing post-decline behavior when there is no source checkout (Panel 3 still fires in that case), the four secondary conditional notes at `:391-394`, `:494-497`, `:501`, `:506-509` (only the three primary emit sites consolidate), the `Gateway runtime` warning path, and the entrypoint-mismatch detection / repair flow.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #80287
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Triple `Gateway service config` panel emission with duplicate `openclaw gateway install --force` CTAs and doubly-reported entrypoint mismatch in `openclaw doctor`. See #80287.
- Real environment tested: Ubuntu 24.04 (Linux 6.8.0-110-generic). System Node `/usr/bin/node` reports `v20.20.2`, version-manager Node `~/.nvm/versions/node/v22.22.2/bin/node` is on PATH. The host has a source checkout at `/home/orin/Gittensor/Ycom/openclaw` (`.git`, `src/`, `extensions/`, `dist/`, `package.json`) so `summarizeGatewayServiceLayout` reports `entrypointSourceCheckout = true`. The current daemon was last installed from a different cwd, so the audit surfaces a non-empty issue set including `gatewayEntrypointMismatch`. OpenClaw source checkout at this branch tip rebased onto upstream `f298999597`.
- Exact steps or command run after this patch:
  1. `pnpm install --frozen-lockfile`
  2. `pnpm build`
  3. `pnpm openclaw doctor --non-interactive`
- Evidence after fix (terminal capture, redacted to the relevant panel section):

```text
$ pnpm openclaw doctor --non-interactive

…
◇  Gateway service config ─────────────────────────────────────────────────╮
│                                                                          │
│  - Gateway service PATH includes version managers or package managers;   │
│    recommend a minimal PATH.                                             │
│  - Gateway service uses Node from a version manager; …                   │
│  - Gateway service entrypoint does not match the current install.        │
│    (/home/orin/Gittensor/Test/openclaw/dist/index.js -> …)               │
│                                                                          │
├──────────────────────────────────────────────────────────────────────────╯
…
```

  *(One consolidated `Gateway service config` panel — was three before this patch. The source-checkout warning is gated out because the audit's entrypoint-mismatch bullet already covers the same condition; the post-decline `--force` hint is the only remaining occurrence of `openclaw gateway install --force` and only fires when the user actually declines.)*
- Observed result after fix: a single `◇ Gateway service config` panel is emitted in the bug-trigger configuration. The entrypoint mismatch is reported exactly once (as the audit bullet). The `openclaw gateway install --force` advice does not appear twice in the same run. When the user accepts the repair prompt (default `--non-interactive` flow), no post-decline hint fires.
- What was not tested:
  - The decline branch path with `confirmRuntimeRepair` returning false interactively (covered by an existing unit test that asserts the post-decline `--force` hint fires when the source-checkout warning would not have been emitted).
  - Windows / macOS source-checkout layouts (only Linux reproduced on this host; the layout signal `entrypointSourceCheckout` is platform-agnostic in `summarizeGatewayServiceLayout`).
  - External / systemd-active service-repair policy paths (already covered by existing tests; this PR only refactors the three primary emit sites).

## Root Cause (if applicable)

- Root cause: `maybeRepairGatewayServiceConfig` had three independent `note(..., "Gateway service config")` emit sites for one condition: a pre-audit source-checkout warning, a post-audit aggregated bullet list, and a post-decline `--force` reminder. The first and third repeated the same `openclaw gateway install --force` remediation, and the first warning's prose described the same entrypoint mismatch that the second panel listed as `X -> Y`.
- Missing detection / guardrail: there was no test asserting "exactly one `Gateway service config` note when source-checkout layout coincides with audit findings". Existing tests covered each emit site in isolation (and the post-decline hint in non-interactive flow) but never the bug-shape combination.
- Contributing context (if known): the source-checkout warning was added before the audit's `gatewayEntrypointMismatch` issue code existed, so its prose did not anticipate the audit later restating the same mismatch. The post-decline hint was layered on top later as a generic actionable footer without considering whether the source-checkout warning already provided the same CTA.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/doctor-gateway-services.test.ts` (one new `it(...)` case at the bottom of the `maybeRepairGatewayServiceConfig` describe block).
- Scenario the test should lock in: source-checkout layout (real fs scaffold with `.git`, `src/`, `extensions/`, `dist/`, `package.json`) plus `setupGatewayEntrypointRepairScenario` (current entrypoint inside the source checkout, install entrypoint elsewhere), default-accept prompter. After `runRepair`, exactly one `note(..., "Gateway service config")` is emitted; that note contains the audit bullet "Gateway service entrypoint does not match the current install"; it does **not** contain "resolves to a source checkout" (gated out by the entrypoint-mismatch presence); and it does **not** contain `openclaw gateway install --force` (the post-decline hint never fires when the user accepts).
- Why this is the smallest reliable guardrail: the bug is purely about which `note(...)` calls fire and what they contain. Mocking the audit and command surface and asserting the exact emit pattern is sufficient; a seam or e2e test would add scaffolding without catching anything the unit cannot.
- Existing test that already covers this (if any): None. The existing `warns when the gateway service entrypoint resolves to a source checkout` test covers source-checkout + empty audit (one panel by construction); the existing `skips entrypoint rewrite in non-interactive fix mode` test covers entrypoint mismatch + decline path with no source checkout (so Panel 3 fires there). Neither exercises the source-checkout + non-empty audit combination that produces the bug.
- If no new test is added, why not: N/A (added).

## User-visible / Behavior Changes

In the reported configuration (entrypoint inside a source checkout + non-empty audit including entrypoint mismatch):

- Before: three `◇ Gateway service config` panels — Panel 1 source-checkout warning with `--force` CTA, Panel 2 audit bullets restating the mismatch, Panel 3 post-decline `--force` hint.
- After: one consolidated `◇ Gateway service config` panel containing only the audit bullets. The source-checkout warning is suppressed (the audit's `gatewayEntrypointMismatch` bullet already states the actionable condition). The post-decline `--force` hint is suppressed when the source-checkout warning would have emitted, otherwise it still fires.

When there is a source checkout but no audit findings, the source-checkout warning still emits as a single panel (existing test `warns when the gateway service entrypoint resolves to a source checkout` continues to pass).

When there is no source checkout, the audit-bullets panel and the post-decline `--force` hint emit independently as before — unchanged.

## Diagram (if applicable)

```text
Bug-trigger configuration (source-checkout entrypoint + non-empty audit incl. entrypoint mismatch):

Before:
openclaw doctor
  └── Gateway service config (Panel 1 — "resolves to a source checkout. Run …--force.")
  └── Gateway service config (Panel 2 — audit bullets, including "entrypoint does not match (X -> Y)")
  └── Gateway service config (Panel 3 — "Run `openclaw gateway install --force` when …")  ← duplicates Panel 1's CTA

After (user accepts):
openclaw doctor
  └── Gateway service config (audit bullets only — single panel)

After (user declines):
openclaw doctor
  └── Gateway service config (audit bullets)
  └── Gateway service config (`--force` hint)  ← only emit of this advice, no duplicate
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A — the change is a wording / dedup adjustment in a diagnostics output path.

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (Linux 6.8.0-110-generic)
- Runtime/container: Node v22.22.2 via nvm; OpenClaw source checkout at `~/Gittensor/Ycom/openclaw` rebased onto upstream `f298999597`
- Model/provider: N/A — pure doctor diagnostic emit-path
- Integration/channel (if any): N/A
- Relevant config (redacted): default-shape config with a single `claude-cli` auth profile; daemon was previously installed from a different cwd, so the audit surfaces non-empty issues including `gatewayEntrypointMismatch`

### Steps

1. From a source checkout where the gateway service entrypoint resolves to that checkout (so `summarizeGatewayServiceLayout` reports `entrypointSourceCheckout = true`), and the audit returns non-empty findings (e.g., the install resolves a different entrypoint than the running service).
2. `pnpm install --frozen-lockfile && pnpm build`.
3. `pnpm openclaw doctor --non-interactive`.

### Expected

- Exactly one `◇ Gateway service config` panel listing the audit findings, including `Gateway service entrypoint does not match the current install. (X -> Y)`.
- No standalone `Gateway service config` panel saying "resolves to a source checkout".
- No `openclaw gateway install --force` advice repeated within the same run when the user accepts the repair.

### Actual (after this patch — matches expected)

- One consolidated `Gateway service config` panel; no duplicate `--force` CTA; entrypoint mismatch reported once.

## Evidence

- [x] Failing test/log before + passing after — without the source change, the new regression test fails (Panel 1 still emits, asserting `not.toContain("resolves to a source checkout")` fails).
- [ ] Trace/log snippets
- [x] Screenshot/recording — fenced terminal capture from `pnpm openclaw doctor --non-interactive` is in the Real-behavior-proof section above.
- [ ] Perf numbers (if relevant) — N/A.

## Human Verification (required)

- Verified scenarios:
  - Source checkout + non-empty audit (with entrypoint mismatch) + accept → 1 `Gateway service config` panel (audit bullets only).
  - Source checkout + empty audit → 1 `Gateway service config` panel (source-checkout warning, unchanged).
  - No source checkout + non-empty audit + decline → 2 `Gateway service config` notes (audit bullets, then `--force` hint), unchanged from prior behavior.
  - `pnpm test src/commands/doctor-gateway-services.test.ts` → 26/26 pass on Node 22.22.2.
  - `pnpm exec oxfmt --check --threads=1 src/commands/doctor-gateway-services.ts src/commands/doctor-gateway-services.test.ts` → clean.
- Edge cases checked:
  - Bun-runtime path — untouched (this PR only changes `Gateway service config` emit sites; the `Gateway runtime` path is unaffected).
  - External / systemd-active service-repair policies — untouched; their conditional notes still emit independently.
  - `audit.issues.length === 0` with source-checkout — single Panel 1 emit preserved.
- What you did **not** verify:
  - Windows / macOS source-checkout layouts (no host available locally; the layout signal is platform-agnostic in `summarizeGatewayServiceLayout`).
  - Interactive prompter decline flow on a real shell — covered by the existing non-interactive decline test in this file.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: when a source-checkout layout is present but the audit happens to NOT include `gatewayEntrypointMismatch` (e.g., the only finding is a port mismatch), the source-checkout warning is now emitted as part of the consolidated panel rather than as its own panel. The user-visible content is the same; the panel count drops from two to one.
  - Mitigation: this is the intended consolidation. The existing `warns when the gateway service entrypoint resolves to a source checkout` test (audit empty) still passes — that path is unchanged. The new path (audit non-empty without mismatch) correctly merges both messages into one panel.
- Risk: the post-decline `--force` hint no longer fires when a source-checkout warning was emitted in the same pass. A user who declined the repair could miss the explicit "run `openclaw gateway install --force`" reminder if they skim past the consolidated panel.
  - Mitigation: the consolidated panel itself still contains the `openclaw gateway install --force` text (inherited from the source-checkout warning), so the actionable advice is still visible in the same run — just not repeated in a second panel. The decline path without a source-checkout warning is unchanged: Panel 3 still fires there, preserving the actionable hint for users without a source-checkout layout.
