### PR TITLE
fix(gateway): remove password fallback in trusted-proxy auth mode

### DIFF
--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -964,7 +964,7 @@ describe("trusted-proxy auth", () => {
       expect(res.reason).toBe("trusted_proxy_loopback_source");
     });
 
-    it("accepts local-direct password fallback when trusted-proxy auth fails", async () => {
+    it("rejects local-direct password even when credentials match (no fallback in trusted-proxy mode)", async () => {
       const limiter = createLimiterSpy();
       const res = await authorizeLocalDirect({
         password: "local-password", // pragma: allowlist secret
@@ -972,51 +972,12 @@ describe("trusted-proxy auth", () => {
         rateLimiter: limiter,
       });
 
-      expect(res).toEqual({ ok: true, method: "password" });
-      expect(limiter.check).toHaveBeenCalledWith("127.0.0.1", "shared-secret");
-      expect(limiter.reset).toHaveBeenCalledWith("127.0.0.1", "shared-secret");
-      expect(limiter.recordFailure).not.toHaveBeenCalled();
+      expect(res.ok).toBe(false);
+      expect(res.reason).toBe("trusted_proxy_loopback_source");
+      expect(limiter.check).not.toHaveBeenCalled();
     });
 
-    it("rejects wrong local-direct password fallback and records the failure", async () => {
-      const limiter = createLimiterSpy();
-      const res = await authorizeLocalDirect({
-        password: "local-password", // pragma: allowlist secret
-        connectPassword: "wrong-password", // pragma: allowlist secret
-        rateLimiter: limiter,
-      });
-
-      expect(res).toEqual({ ok: false, reason: "password_mismatch" });
-      expect(limiter.check).toHaveBeenCalledWith("127.0.0.1", "shared-secret");
-      expect(limiter.recordFailure).toHaveBeenCalledWith("127.0.0.1", "shared-secret");
-      expect(limiter.reset).not.toHaveBeenCalled();
-    });
-
-    it("enforces rate-limit lockout before local-direct password fallback", async () => {
-      const limiter = createLimiterSpy();
-      limiter.check.mockReturnValueOnce({
-        allowed: false,
-        remaining: 0,
-        retryAfterMs: 2500,
-      });
-
-      const res = await authorizeLocalDirect({
-        password: "local-password", // pragma: allowlist secret
-        connectPassword: "local-password", // pragma: allowlist secret
-        rateLimiter: limiter,
-      });
-
-      expect(res).toEqual({
-        ok: false,
-        reason: "rate_limited",
-        rateLimited: true,
-        retryAfterMs: 2500,
-      });
-      expect(limiter.recordFailure).not.toHaveBeenCalled();
-      expect(limiter.reset).not.toHaveBeenCalled();
-    });
-
-    it("keeps local-direct trusted-proxy on proxy failure when no password is supplied", async () => {
+    it("rejects local-direct request when no password is supplied", async () => {
       const res = await authorizeLocalDirect({
         password: "local-password", // pragma: allowlist secret
       });

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -466,26 +466,6 @@ async function authorizeGatewayConnectCore(
       }
       return { ok: true, method: "trusted-proxy", user: result.user };
     }
-    if (localDirect && auth.password && connectAuth?.password) {
-      if (limiter) {
-        const rlCheck: RateLimitCheckResult = limiter.check(ip, rateLimitScope);
-        if (!rlCheck.allowed) {
-          return {
-            ok: false,
-            reason: "rate_limited",
-            rateLimited: true,
-            retryAfterMs: rlCheck.retryAfterMs,
-          };
-        }
-      }
-      return authorizePasswordAuth({
-        authPassword: auth.password,
-        connectPassword: connectAuth.password,
-        limiter,
-        ip,
-        rateLimitScope,
-      });
-    }
     return { ok: false, reason: result.reason };
   }
 


### PR DESCRIPTION
## Summary

Closes #78684.

When `gateway.auth.mode` is `"trusted-proxy"`, failed trusted-proxy checks now fail closed instead of falling back to local-direct password authentication.

## Problem

In the `authorizeGatewayConnectCore` function, when trusted-proxy identity verification failed on a local-direct (loopback) request, the code would check for a configured password and attempt password auth as a fallback. This created a second, unintended authentication path that bypasses the trusted-proxy requirement.

## Fix

Remove the conditional password fallback block within the trusted-proxy code path (lines 469–488 of `src/gateway/auth.ts`). When `auth.mode === "trusted-proxy"`, authentication now either succeeds via the proxy or fails — no fallback.

## Impact

Users relying on the implicit local-direct password fallback in trusted-proxy mode will need to either:
1. Switch to `auth.mode: "password"` for local-only deployments
2. Ensure their local CLI connects through the trusted proxy

## Real behavior proof

### Behavior or issue addressed

In trusted-proxy auth mode, failed proxy identity verification on loopback connections falls back to password authentication (#78684). This creates an unintended second auth path that undermines the trusted-proxy security model.

### Real environment tested

OpenClaw 2026.5.3-1 on Linux 6.17.0-22-generic (x64), Node.js v24.14.1. Gateway running with `gateway.auth.mode: "trusted-proxy"` configuration.

### Exact steps or command run after fix

```bash
cd ~/repos/forks/openclaw
git checkout fix/trusted-proxy-no-password-fallback
git rebase upstream/main
npx vitest run --config test/vitest/vitest.gateway-core.config.ts src/gateway/auth.test.ts
```

### Evidence after fix

Rebased onto latest main and re-ran auth tests:

```
$ npx vitest run --config test/vitest/vitest.gateway-core.config.ts src/gateway/auth.test.ts
 ✓ gateway-core  src/gateway/auth.test.ts (69 tests) 58ms
 Test Files  1 passed (1)
 Tests  69 passed (69)
```

Key test change: the previous test `"falls back to password when local-direct and password is set"` now asserts rejection with `trusted_proxy_loopback_source` — confirming the fallback path is removed and trusted-proxy mode fails closed.

### Observed result after fix

- Trusted-proxy mode with failed proxy check on loopback: returns `trusted_proxy_loopback_source` rejection (previously fell through to password auth).
- Removed 2 obsolete tests (wrong-password and rate-limit-before-fallback) since the fallback code path no longer exists.
- All 69 auth tests pass after rebase onto latest main.

### What was not tested

- Live gateway restart with trusted-proxy mode switch (would require reconfiguring running production gateway). The unit tests cover the `authorizeGatewayConnectCore` function directly with all relevant input combinations.
