### PR TITLE
fix(embedded): route auth-wrapped session streams through boundary-aware transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Agents/embedded: route PI auth-wrapped session streams through boundary-aware transport for supported APIs (openai-completions, openai-responses, etc.) so custom OpenAI-compatible providers receive `stream_options.include_usage: true` without requiring per-model `compat.supportsUsageInStreaming`. Fixes #78661.
 - Docs/iMessage: deprecate BlueBubbles for new OpenClaw setups, document the upstream server-release rationale, and point new iMessage deployments toward the native `imsg` path while keeping BlueBubbles as a supported legacy fallback.
 - Discord/streaming: default Discord replies to progress draft previews so tool/work activity appears in one edited Discord message unless `channels.discord.streaming.mode` is set to `off`.
 - Plugins/install: add `npm-pack:<path.tgz>` installs so local npm pack artifacts run through the same managed npm-root install, lockfile verification, dependency scan, and install-record path as registry npm plugins.

--- a/src/agents/pi-embedded-runner/stream-resolution.test.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.test.ts
@@ -358,4 +358,69 @@ describe("resolveEmbeddedAgentStreamFn", () => {
       streamFn({ provider: "openai-codex", id: "gpt-5.5" } as never, { systemPrompt } as never, {}),
     ).resolves.toMatchObject({ systemPrompt });
   });
+
+  // Regression test for #78661: PI installs an auth wrapper that is not
+  // identity-equal to streamSimple, so embedded sessions were bypassing
+  // the boundary-aware transport and losing stream_options.include_usage.
+  it("routes PI auth-wrapped session streams through boundary-aware transport for openai-completions", async () => {
+    const innerStreamFn = vi.fn(async (_model, _context, options) => options);
+    overrideBoundaryAwareStreamFnOnce(innerStreamFn as never);
+    // Simulate PI's auth wrapper (not identity-equal to streamSimple)
+    const authWrappedStreamFn = vi.fn(async (model, context, options) => {
+      const apiKey = "pi-auth-wrapper-token";
+      return streamSimple(model, context, { ...options, apiKey });
+    }) as never;
+
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: authWrappedStreamFn,
+      shouldUseWebSocketTransport: false,
+      sessionId: "session-1",
+      model: {
+        api: "openai-completions",
+        provider: "llama",
+        id: "qwen36-35b-a3b",
+      } as never,
+      resolvedApiKey: "resolved-token",
+    });
+
+    // Should NOT be the auth wrapper; should be boundary-aware transport
+    expect(streamFn).not.toBe(authWrappedStreamFn);
+    expect(streamFn).not.toBe(streamSimple);
+
+    // Should inject resolved api key
+    await expect(
+      streamFn({ provider: "llama", id: "qwen36-35b-a3b" } as never, {} as never, {}),
+    ).resolves.toMatchObject({ apiKey: "resolved-token" });
+    expect(innerStreamFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("describes auth-wrapped session streams as boundary-aware for supported APIs", () => {
+    const authWrappedStreamFn = vi.fn() as never;
+    expect(
+      describeEmbeddedAgentStreamStrategy({
+        currentStreamFn: authWrappedStreamFn,
+        shouldUseWebSocketTransport: false,
+        model: {
+          api: "openai-completions",
+          provider: "llama",
+          id: "qwen36-35b-a3b",
+        } as never,
+      }),
+    ).toBe("boundary-aware:openai-completions");
+  });
+
+  it("keeps auth-wrapped session streams labeled as custom for unsupported APIs", () => {
+    const authWrappedStreamFn = vi.fn() as never;
+    expect(
+      describeEmbeddedAgentStreamStrategy({
+        currentStreamFn: authWrappedStreamFn,
+        shouldUseWebSocketTransport: false,
+        model: {
+          api: "some-unsupported-api",
+          provider: "custom",
+          id: "custom-model",
+        } as never,
+      }),
+    ).toBe("session-custom");
+  });
 });

--- a/src/agents/pi-embedded-runner/stream-resolution.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.ts
@@ -3,7 +3,10 @@ import { streamSimple } from "@mariozechner/pi-ai";
 import { createAnthropicVertexStreamFnForModel } from "../anthropic-vertex-stream.js";
 import { createOpenAIWebSocketStreamFn } from "../openai-ws-stream.js";
 import { getModelProviderRequestTransport } from "../provider-request-config.js";
-import { createBoundaryAwareStreamFnForModel } from "../provider-transport-stream.js";
+import {
+  createBoundaryAwareStreamFnForModel,
+  isTransportAwareApiSupported,
+} from "../provider-transport-stream.js";
 import { stripSystemPromptCacheBoundary } from "../system-prompt-cache-boundary.js";
 import type { EmbeddedRunAttemptParams } from "./run/types.js";
 
@@ -45,6 +48,13 @@ export function describeEmbeddedAgentStreamStrategy(params: {
     return createBoundaryAwareStreamFnForModel(params.model)
       ? `boundary-aware:${params.model.api}`
       : "stream-simple";
+  }
+  // PI installs an auth wrapper that is not identity-equal to streamSimple,
+  // but for supported transport APIs we still route through boundary-aware
+  // transport to preserve stream_options.include_usage and other OpenClaw
+  // request shaping. Report regression #78661.
+  if (isTransportAwareApiSupported(params.model.api)) {
+    return `boundary-aware:${params.model.api}`;
   }
   return "session-custom";
 }
@@ -112,6 +122,23 @@ export function resolveEmbeddedAgentStreamFn(params: {
       // inject the resolved runtime key for them. Without this wrap, OAuth
       // providers (e.g. openai-codex/gpt-5.5) hit the Responses API with an
       // empty bearer and fail with 401 Missing bearer auth header.
+      return wrapEmbeddedAgentStreamFn(boundaryAwareStreamFn, {
+        runSignal: params.signal,
+        resolvedApiKey: params.resolvedApiKey,
+        authStorage: params.authStorage,
+        providerId: params.model.provider,
+      });
+    }
+    return currentStreamFn;
+  }
+
+  // PI installs an auth wrapper that is not identity-equal to streamSimple,
+  // but for supported transport APIs we still route through boundary-aware
+  // transport to preserve stream_options.include_usage and other OpenClaw
+  // request shaping. Report regression #78661.
+  if (isTransportAwareApiSupported(params.model.api)) {
+    const boundaryAwareStreamFn = createBoundaryAwareStreamFnForModel(params.model);
+    if (boundaryAwareStreamFn) {
       return wrapEmbeddedAgentStreamFn(boundaryAwareStreamFn, {
         runSignal: params.signal,
         resolvedApiKey: params.resolvedApiKey,


### PR DESCRIPTION
## Summary

- **Problem:** PI installs an auth wrapper `streamFn` that is not identity-equal to `streamSimple`. Embedded sessions with custom `openai-completions` providers bypassed the boundary-aware transport and omitted `stream_options.include_usage`, causing zero token usage in transcripts.
- **What changed:** `resolveEmbeddedAgentStreamFn` now routes supported transport APIs through boundary-aware transport even when `currentStreamFn` is any non-`streamSimple` function.
- **Why it matters:** Custom OpenAI-compatible providers (llama.cpp, local endpoints) receive `stream_options.include_usage: true` without requiring per-model `compat.supportsUsageInStreaming`.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security
- [ ] Chore

## Scope

- [ ] Gateway/orchestration
- [x] Agents/embedded runner
- [ ] Auth/tokens
- [ ] Memory/storage
- [ ] Integrations
- [ ] API/contracts
- [ ] UI/DX
- [ ] CI/CD

## Linked Issue

- Fixes #78661
- Related to #75357 (prior fix for stream_options.include_usage)
- Distinct from #73990 (fallback estimation when telemetry missing)

## Root Cause

| Condition | Before | After |
|-----------|--------|-------|
| `currentStreamFn === undefined` | ✅ boundary-aware | ✅ boundary-aware |
| `currentStreamFn === streamSimple` | ✅ boundary-aware | ✅ boundary-aware |
| `currentStreamFn === PI auth wrapper` | ❌ **bypass** | ✅ **boundary-aware** |

PI's `createAgentSession` installs an async wrapper that fetches auth then calls `streamSimple`. This wrapper is not identity-equal to the imported `streamSimple`, so the resolver treated it as a "custom" session stream.

## Regression Test Plan

- [x] Unit tests added
- New test: "routes PI auth-wrapped session streams through boundary-aware transport for openai-completions"
- New test: "describes auth-wrapped session streams as boundary-aware for supported APIs"
- New test: "keeps auth-wrapped session streams labeled as custom for unsupported APIs"

## Security Impact

- No new permissions/capabilities
- No security implications - purely stream routing logic

## User-visible Changes

- Custom OpenAI-compatible providers now report token usage in transcripts
- No config changes required

## Verification

- Code review of `resolveEmbeddedAgentStreamFn` routing logic
- Tests verify PI auth wrapper scenario
- Existing tests for streamSimple fallback still pass

## Compatibility

- Backward compatible
- No migration needed