### PR TITLE
docs(lobster): clarify embedded openclaw.invoke limitation

### DIFF
--- a/docs/tools/llm-task.md
+++ b/docs/tools/llm-task.md
@@ -85,6 +85,23 @@ Returns `details.json` containing the parsed JSON (and validates against
 
 ## Example: Lobster workflow step
 
+### Important limitation
+
+The example below assumes the **standalone Lobster CLI** is running in an environment where `openclaw.invoke` already has the correct gateway URL/auth context.
+
+For the bundled **embedded** Lobster runner inside OpenClaw, this nested CLI pattern is **not currently reliable**:
+
+```lobster
+openclaw.invoke --tool llm-task --action json --args-json '{ ... }'
+```
+
+Until embedded Lobster has a supported bridge for this flow, prefer either:
+
+- direct `llm-task` tool calls outside Lobster, or
+- Lobster steps that do not rely on nested `openclaw.invoke` calls.
+
+Standalone Lobster CLI example:
+
 ```lobster
 openclaw.invoke --tool llm-task --action json --args-json '{
   "prompt": "Given the input email, return intent and draft.",

--- a/docs/tools/lobster.md
+++ b/docs/tools/lobster.md
@@ -100,7 +100,19 @@ Enable the tool:
 }
 ```
 
-Use it in a pipeline:
+### Important limitation: embedded Lobster vs `openclaw.invoke`
+
+The bundled Lobster plugin runs workflows **in-process** inside the gateway. In that embedded mode, `openclaw.invoke` does **not** automatically inherit a gateway URL/auth context for nested OpenClaw CLI tool calls.
+
+That means this pattern is **not currently reliable in the embedded runner**:
+
+```lobster
+openclaw.invoke --tool llm-task --action json --args-json '{ ... }'
+```
+
+Use the example below only when running the **standalone Lobster CLI** in an environment where `openclaw.invoke` is already configured with the correct gateway/auth context.
+
+Use it in a standalone Lobster CLI pipeline:
 
 ```lobster
 openclaw.invoke --tool llm-task --action json --args-json '{
@@ -118,6 +130,11 @@ openclaw.invoke --tool llm-task --action json --args-json '{
   }
 }'
 ```
+
+If you are using the embedded Lobster plugin today, prefer either:
+
+- a direct `llm-task` tool call outside Lobster, or
+- non-`openclaw.invoke` steps inside the Lobster pipeline until a supported embedded bridge is added.
 
 See [LLM Task](/tools/llm-task) for details and configuration options.
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Lobster docs showed `openclaw.invoke --tool llm-task` as if it worked the same way inside the embedded Lobster runner.
- Why it matters: users following the docs hit a broken workflow path because embedded Lobster does not automatically provide gateway URL/auth context for nested OpenClaw CLI calls.
- What changed: clarified in both `docs/tools/lobster.md` and `docs/tools/llm-task.md` that the `openclaw.invoke` example applies to the standalone Lobster CLI, not the embedded runner.
- What did NOT change (scope boundary): no runtime behavior or Lobster/llm-task implementation was changed; this PR is docs-only.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #76101

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: documentation implied that `openclaw.invoke --tool llm-task` was a supported nested CLI pattern inside the embedded Lobster runner.
- Real environment tested: local checkout of `openclaw/openclaw` on Linux.
- Exact steps or command run after this patch:
  - reviewed and updated `docs/tools/lobster.md`
  - reviewed and updated `docs/tools/llm-task.md`
  - ran `node scripts/format-docs.mjs --check docs/tools/lobster.md docs/tools/llm-task.md`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
```text
Docs formatting clean (603 files).
```
- Observed result after fix: both docs now explicitly warn that the nested `openclaw.invoke` example is for the standalone Lobster CLI and is not currently reliable in the embedded runner.
- What was not tested: runtime/product changes, because this PR intentionally does not change runtime behavior.

## Root Cause (if applicable)

- Root cause: docs did not distinguish between standalone Lobster CLI execution and the bundled embedded Lobster runner.
- Missing detection / guardrail: the examples were accurate for CLI usage but were not scoped clearly enough for embedded usage.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: docs-only validation on `docs/tools/lobster.md` and `docs/tools/llm-task.md`
- Why this is the smallest reliable guardrail: this PR only changes wording and examples, so docs formatting validation is the smallest meaningful check.

## User-visible / Behavior Changes

Users reading the Lobster / llm-task docs will now see that the nested `openclaw.invoke` example is intended for the standalone Lobster CLI and should not be assumed to work in the embedded runner.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo checkout
- Relevant docs: `docs/tools/lobster.md`, `docs/tools/llm-task.md`

### Steps

1. Review the previous docs examples for Lobster + `llm-task`.
2. Update both pages to call out the embedded-runner limitation.
3. Run `node scripts/format-docs.mjs --check docs/tools/lobster.md docs/tools/llm-task.md`.

### Expected

- docs clearly distinguish standalone Lobster CLI from embedded Lobster
- docs formatting stays clean

### Actual

- docs updated as expected
- docs formatting check passed

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified both affected docs pages now explicitly describe the limitation.
- Verified the example remains available but scoped to standalone Lobster CLI usage.
- Verified docs formatting check passes.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Risks and Mitigations

- Risk: docs-only fix may disappoint users expecting runtime support.
  - Mitigation: the issue is better documentation of current behavior, not changing runtime behavior in this PR.
