### PR TITLE
docs(litellm): add supply chain advisory

### DIFF
--- a/docs/providers/litellm.md
+++ b/docs/providers/litellm.md
@@ -8,6 +8,18 @@ read_when:
 
 [LiteLLM](https://litellm.ai) is an open-source LLM gateway that provides a unified API to 100+ model providers. Route OpenClaw through LiteLLM to get centralized cost tracking, logging, and the flexibility to switch backends without changing your OpenClaw config.
 
+<Warning>
+**Security advisory (March 2026):** malicious LiteLLM versions **1.82.7** and **1.82.8** were briefly published to PyPI during a supply chain compromise. If you self-host LiteLLM, do **not** install those versions. `1.82.6` is the last confirmed clean release in that range.
+
+If you previously ran `1.82.7` or `1.82.8`:
+
+- downgrade immediately to a safe version
+- rotate any API keys that were configured in or sent through the proxy
+- audit the LiteLLM host for unexpected outbound activity
+
+OpenClaw does not bundle LiteLLM directly, but users operating their own LiteLLM proxy may still have been impacted on the proxy host.
+</Warning>
+
 <Tip>
 **Why use LiteLLM with OpenClaw?**
 
@@ -47,7 +59,7 @@ read_when:
     <Steps>
       <Step title="Start LiteLLM Proxy">
         ```bash
-        pip install 'litellm[proxy]'
+        pip install 'litellm[proxy]==1.82.6'
         litellm --model claude-opus-4-6
         ```
       </Step>


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the LiteLLM provider docs still showed an unpinned `pip install 'litellm[proxy]'` command and did not warn about the March 2026 LiteLLM supply-chain compromise.
- Why it matters: users following the docs could install or trust the affected `1.82.7` / `1.82.8` versions without any warning.
- What changed: pinned the documented LiteLLM install command to `1.82.6` and added a security warning with remediation guidance.
- What did NOT change (scope boundary): no runtime LiteLLM integration behavior was changed; this is docs-only.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Docs
- [ ] Refactor required for the fix
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #53941

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: docs should warn users away from compromised LiteLLM versions and recommend a safe pinned install.
- Real environment tested: local checkout of `openclaw/openclaw` on Linux.
- Exact steps or command run after this patch:
  - update `docs/providers/litellm.md`
  - run `node scripts/format-docs.mjs --check docs/providers/litellm.md`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
```text
Docs formatting clean (603 files).
```
- Observed result after fix: LiteLLM docs now include a supply-chain warning and the install command is pinned to `litellm[proxy]==1.82.6`.
- What was not tested: runtime LiteLLM proxy behavior, because this PR intentionally only changes documentation.

## Root Cause (if applicable)

- Root cause: provider docs predated the LiteLLM PyPI compromise and still documented an unpinned install path.
- Missing detection / guardrail: docs were not updated to reflect the security incident and safe-version guidance.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `docs/providers/litellm.md`
- Why this is the smallest reliable guardrail: this PR is docs-only, so docs formatting validation is the meaningful check.

## User-visible / Behavior Changes

Users reading the LiteLLM provider guide will now see:

- a supply-chain security warning for versions `1.82.7` and `1.82.8`
- remediation guidance if they ran those versions
- a safe pinned install command using `1.82.6`

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo checkout
- Area: `docs/providers/litellm.md`

### Steps

1. Open the LiteLLM provider doc.
2. Confirm the install command is pinned to `litellm[proxy]==1.82.6`.
3. Confirm the advisory warning and remediation guidance are present.
4. Run `node scripts/format-docs.mjs --check docs/providers/litellm.md`.

### Expected

- docs reflect the LiteLLM supply-chain advisory
- docs formatting remains clean

### Actual

- docs updated as expected
- docs formatting check passed

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified the install command is pinned to `1.82.6`.
- Verified the advisory warning and remediation bullets are present.
- Verified docs formatting passes.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Risks and Mitigations

- Risk: the recommended safe version may need future updates if LiteLLM publishes newer post-incident safe releases.
  - Mitigation: the docs now at least prevent unpinned installs from drifting into known compromised versions and establish a clear advisory notice.
