### PR TITLE
perf(telegram): reduce message context setup work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - Docker/Gateway: harden the gateway container by dropping `NET_RAW` and `NET_ADMIN` capabilities and enabling `no-new-privileges` in the bundled `docker-compose.yml`. Thanks @VintageAyu.
 - Telegram: accept plugin-owned numeric forum-topic targets in the agent message tool and keep reply-dispatch provider chunks behind a real stable runtime alias during in-place package updates. Fixes #77137. Thanks @richardmqq.
 - Telegram/streaming: keep draft preview rotation from reusing a pre-tool assistant preview after visible tool or media output lands between compaction replay and the next assistant message. Thanks @vincentkoc.
+- Telegram/performance: skip non-forum topic-cache setup, defer status reaction variant work until reactions are needed, and reuse ack reaction gating during message context assembly. Thanks @vincentkoc.
 - Channels/WhatsApp: support explicit WhatsApp Channel/Newsletter `@newsletter` outbound message targets with channel session metadata instead of DM routing. Fixes #13417; carries forward the narrow outbound target idea from #13424. Thanks @vincentkoc and @agentz-manfred.
 - TTS/telephony: honor provider voice/model overrides in telephony synthesis providers so Google Meet agent speech logs match the backend that actually produced the audio. Thanks @vincentkoc.
 - Voice Call/realtime: bound the paced Twilio audio queue and close overloaded realtime streams before provider audio can pile up behind the websocket backpressure guard. Thanks @vincentkoc.

--- a/extensions/telegram/src/bot-message-context.dm-threads.test.ts
+++ b/extensions/telegram/src/bot-message-context.dm-threads.test.ts
@@ -244,6 +244,29 @@ describe("buildTelegramMessageContext group sessions without forum", () => {
     expect(ctxWithThread?.ctxPayload?.SessionKey).toBe(ctxWithoutThread?.ctxPayload?.SessionKey);
   });
 
+  it("does not add a topic-cache store lookup for non-forum group reply threads", async () => {
+    const resolveStorePath = vi.fn(() => "/tmp/openclaw/session-store.json");
+
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 9,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Group" },
+        date: 1700000008,
+        text: "@bot hello",
+        message_thread_id: 42,
+        from: { id: 42, first_name: "Alice" },
+      },
+      options: { forceWasMentioned: true },
+      resolveGroupActivation: () => true,
+      sessionRuntime: { resolveStorePath },
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.isForum).toBe(false);
+    expect(ctx?.ctxPayload?.MessageThreadId).toBeUndefined();
+    expect(resolveStorePath).toHaveBeenCalledTimes(1);
+  });
+
   it("uses topic session for forum groups with message_thread_id", async () => {
     const ctx = await buildContext({
       message_id: 1,

--- a/extensions/telegram/src/bot-message-context.reactions.test.ts
+++ b/extensions/telegram/src/bot-message-context.reactions.test.ts
@@ -1,8 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BuildTelegramMessageContextParams } from "./bot-message-context.types.js";
 
+type InboundBodyMock = (arg: unknown) => Promise<{
+  bodyText: string;
+  rawBody: string;
+  historyKey: undefined;
+  commandAuthorized: boolean;
+  effectiveWasMentioned: boolean;
+  canDetectMention: boolean;
+  shouldBypassMention: boolean;
+  stickerCacheHit: boolean;
+  locationData: undefined;
+}>;
+
 const inboundBodyMock = vi.hoisted(() =>
-  vi.fn(async () => ({
+  vi.fn<InboundBodyMock>(async () => ({
     bodyText: "hello",
     rawBody: "hello",
     historyKey: undefined,

--- a/extensions/telegram/src/bot-message-context.reactions.test.ts
+++ b/extensions/telegram/src/bot-message-context.reactions.test.ts
@@ -16,7 +16,7 @@ const inboundBodyMock = vi.hoisted(() =>
 );
 
 vi.mock("./bot-message-context.body.js", () => ({
-  resolveTelegramInboundBody: (...args: unknown[]) => inboundBodyMock(...args),
+  resolveTelegramInboundBody: (arg: unknown) => inboundBodyMock(arg),
 }));
 
 const { buildTelegramMessageContextForTest } =

--- a/extensions/telegram/src/bot-message-context.reactions.test.ts
+++ b/extensions/telegram/src/bot-message-context.reactions.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BuildTelegramMessageContextParams } from "./bot-message-context.types.js";
+
+const inboundBodyMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    bodyText: "hello",
+    rawBody: "hello",
+    historyKey: undefined,
+    commandAuthorized: false,
+    effectiveWasMentioned: false,
+    canDetectMention: true,
+    shouldBypassMention: false,
+    stickerCacheHit: false,
+    locationData: undefined,
+  })),
+);
+
+vi.mock("./bot-message-context.body.js", () => ({
+  resolveTelegramInboundBody: (...args: unknown[]) => inboundBodyMock(...args),
+}));
+
+const { buildTelegramMessageContextForTest } =
+  await import("./bot-message-context.test-harness.js");
+
+type CreateStatusReactionController = NonNullable<
+  NonNullable<BuildTelegramMessageContextParams["runtime"]>["createStatusReactionController"]
+>;
+type StatusReactionControllerParams = Parameters<CreateStatusReactionController>[0];
+
+function createStatusReactionControllerStub() {
+  const controller = {
+    setQueued: vi.fn(async () => undefined),
+    setThinking: vi.fn(async () => undefined),
+    setTool: vi.fn(async () => undefined),
+    setCompacting: vi.fn(async () => undefined),
+    cancelPending: vi.fn(),
+    setDone: vi.fn(async () => undefined),
+    setError: vi.fn(async () => undefined),
+    clear: vi.fn(async () => undefined),
+    restoreInitial: vi.fn(async () => undefined),
+  };
+  const createStatusReactionController = vi.fn((params: StatusReactionControllerParams) => {
+    return controller;
+  });
+  return { controller, createStatusReactionController };
+}
+
+describe("buildTelegramMessageContext reactions", () => {
+  beforeEach(() => {
+    inboundBodyMock.mockClear();
+  });
+
+  it("does not create status reactions when the ack gate blocks an unmentioned group message", async () => {
+    const setMessageReaction = vi.fn(async () => undefined);
+    const { createStatusReactionController } = createStatusReactionControllerStub();
+
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 12,
+        chat: { id: -1001234567890, type: "group", title: "Ops" },
+        date: 1_700_000_000,
+        text: "hello",
+        from: { id: 42, first_name: "Alice" },
+      },
+      cfg: {
+        agents: {
+          defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" },
+        },
+        channels: {
+          telegram: {
+            groupPolicy: "open",
+            groups: { "*": { requireMention: true } },
+          },
+        },
+        messages: {
+          ackReaction: "👀",
+          groupChat: { mentionPatterns: [] },
+          statusReactions: { enabled: true },
+        },
+      },
+      ackReactionScope: "group-mentions",
+      botApi: { setMessageReaction },
+      runtime: { createStatusReactionController },
+      resolveGroupActivation: () => true,
+      resolveGroupRequireMention: () => true,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: true },
+        topicConfig: undefined,
+      }),
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.ackReactionPromise).toBeNull();
+    expect(ctx?.statusReactionController).toBeNull();
+    expect(createStatusReactionController).not.toHaveBeenCalled();
+    expect(setMessageReaction).not.toHaveBeenCalled();
+  });
+
+  it("keeps Telegram status reaction variants available for configured emoji fallbacks", async () => {
+    const setMessageReaction = vi.fn(async () => undefined);
+    const { controller, createStatusReactionController } = createStatusReactionControllerStub();
+
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 34,
+        chat: {
+          id: 1234,
+          type: "private",
+          available_reactions: [{ type: "emoji", emoji: "👍" }],
+        },
+        date: 1_700_000_000,
+        text: "hello",
+        from: { id: 42, first_name: "Alice" },
+      },
+      cfg: {
+        agents: {
+          defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" },
+        },
+        channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+        messages: {
+          ackReaction: "👀",
+          groupChat: { mentionPatterns: [] },
+          statusReactions: {
+            enabled: true,
+            emojis: { done: "✅" },
+          },
+        },
+      },
+      ackReactionScope: "direct",
+      botApi: { setMessageReaction },
+      runtime: { createStatusReactionController },
+    });
+
+    await expect(ctx?.ackReactionPromise).resolves.toBe(true);
+    expect(controller.setQueued).toHaveBeenCalledTimes(1);
+    expect(createStatusReactionController).toHaveBeenCalledTimes(1);
+
+    const params = createStatusReactionController.mock.calls[0]?.[0];
+    expect(params?.initialEmoji).toBe("👀");
+    expect(params?.emojis?.done).toBe("✅");
+
+    await params?.adapter.setReaction("✅");
+
+    expect(setMessageReaction).toHaveBeenCalledWith(1234, 34, [{ type: "emoji", emoji: "👍" }]);
+  });
+});

--- a/extensions/telegram/src/bot-message-context.reactions.test.ts
+++ b/extensions/telegram/src/bot-message-context.reactions.test.ts
@@ -51,7 +51,7 @@ function createStatusReactionControllerStub() {
     clear: vi.fn(async () => undefined),
     restoreInitial: vi.fn(async () => undefined),
   };
-  const createStatusReactionController = vi.fn((params: StatusReactionControllerParams) => {
+  const createStatusReactionController = vi.fn((_params: StatusReactionControllerParams) => {
     return controller;
   });
   return { controller, createStatusReactionController };

--- a/extensions/telegram/src/bot-message-context.test-harness.ts
+++ b/extensions/telegram/src/bot-message-context.test-harness.ts
@@ -18,6 +18,8 @@ type BuildTelegramMessageContextForTestParams = {
   options?: BuildTelegramMessageContextParams["options"];
   cfg?: Record<string, unknown>;
   accountId?: string;
+  ackReactionScope?: BuildTelegramMessageContextParams["ackReactionScope"];
+  botApi?: Record<string, unknown>;
   runtime?: BuildTelegramMessageContextParams["runtime"];
   sessionRuntime?: BuildTelegramMessageContextParams["sessionRuntime"] | null;
   resolveGroupActivation?: BuildTelegramMessageContextParams["resolveGroupActivation"];
@@ -67,6 +69,7 @@ export async function buildTelegramMessageContextForTest(
       api: {
         sendChatAction: vi.fn(),
         setMessageReaction: vi.fn(),
+        ...params.botApi,
       },
     } as never,
     cfg: (params.cfg ?? baseTelegramMessageContextConfig) as never,
@@ -82,7 +85,7 @@ export async function buildTelegramMessageContextForTest(
     dmPolicy: "open",
     allowFrom: ["*"],
     groupAllowFrom: [],
-    ackReactionScope: "off",
+    ackReactionScope: params.ackReactionScope ?? "off",
     logger: { info: vi.fn() },
     resolveGroupActivation: params.resolveGroupActivation ?? (() => undefined),
     resolveGroupRequireMention: params.resolveGroupRequireMention ?? (() => false),

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -483,24 +483,23 @@ export const buildTelegramMessageContext = async ({
   const ackReactionEmoji =
     ackReaction && isTelegramSupportedReactionEmoji(ackReaction) ? ackReaction : undefined;
   const removeAckAfterReply = cfg.messages?.removeAckAfterReply ?? false;
-  const shouldAckReaction = () =>
-    Boolean(
-      ackReaction &&
-      shouldAckReactionGate({
-        scope: ackReactionScope,
-        isDirect: !isGroup,
-        isGroup,
-        isMentionableGroup: isGroup,
-        requireMention: Boolean(requireMention),
-        canDetectMention: bodyResult.canDetectMention,
-        effectiveWasMentioned: bodyResult.effectiveWasMentioned,
-        shouldBypassMention: bodyResult.shouldBypassMention,
-      }),
-    );
+  const shouldSendAckReaction = Boolean(
+    ackReaction &&
+    shouldAckReactionGate({
+      scope: ackReactionScope,
+      isDirect: !isGroup,
+      isGroup,
+      isMentionableGroup: isGroup,
+      requireMention: Boolean(requireMention),
+      canDetectMention: bodyResult.canDetectMention,
+      effectiveWasMentioned: bodyResult.effectiveWasMentioned,
+      shouldBypassMention: bodyResult.shouldBypassMention,
+    }),
+  );
   // Status Reactions controller (lifecycle reactions)
   const statusReactionsConfig = cfg.messages?.statusReactions;
   const statusReactionsEnabled =
-    statusReactionsConfig?.enabled === true && Boolean(reactionApi) && shouldAckReaction();
+    statusReactionsConfig?.enabled === true && Boolean(reactionApi) && shouldSendAckReaction;
   const resolvedStatusReactionEmojis = statusReactionsEnabled
     ? resolveTelegramStatusReactionEmojis({
         initialEmoji: ackReaction,
@@ -562,13 +561,13 @@ export const buildTelegramMessageContext = async ({
 
   // When status reactions are enabled, setQueued() replaces the simple ack reaction
   const ackReactionPromise: Promise<boolean> | null = statusReactionController
-    ? shouldAckReaction()
+    ? shouldSendAckReaction
       ? Promise.resolve(statusReactionController.setQueued()).then(
           () => true,
           () => false,
         )
       : null
-    : shouldAckReaction() && msg.message_id && reactionApi && ackReactionEmoji
+    : shouldSendAckReaction && msg.message_id && reactionApi && ackReactionEmoji
       ? withTelegramApiErrorLogging({
           operation: "setMessageReaction",
           fn: () =>

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -501,16 +501,18 @@ export const buildTelegramMessageContext = async ({
   const statusReactionsConfig = cfg.messages?.statusReactions;
   const statusReactionsEnabled =
     statusReactionsConfig?.enabled === true && Boolean(reactionApi) && shouldAckReaction();
-  const resolvedStatusReactionEmojis = resolveTelegramStatusReactionEmojis({
-    initialEmoji: ackReaction,
-    overrides: statusReactionsConfig?.emojis,
-  });
-  const statusReactionVariantsByEmoji = buildTelegramStatusReactionVariants(
-    resolvedStatusReactionEmojis,
-  );
+  const resolvedStatusReactionEmojis = statusReactionsEnabled
+    ? resolveTelegramStatusReactionEmojis({
+        initialEmoji: ackReaction,
+        overrides: statusReactionsConfig?.emojis,
+      })
+    : null;
+  const statusReactionVariantsByEmoji = resolvedStatusReactionEmojis
+    ? buildTelegramStatusReactionVariants(resolvedStatusReactionEmojis)
+    : new Map<string, string[]>();
   let allowedStatusReactionEmojisPromise: Promise<Set<TelegramReactionEmoji> | null> | null = null;
   const createStatusReactionController =
-    statusReactionsEnabled && msg.message_id
+    statusReactionsEnabled && resolvedStatusReactionEmojis && msg.message_id
       ? (runtime?.createStatusReactionController ??
         (await loadTelegramMessageContextRuntime()).createStatusReactionController)
       : null;

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -161,15 +161,15 @@ export const buildTelegramMessageContext = async ({
   const resolvedThreadId = threadSpec.scope === "forum" ? threadSpec.id : undefined;
   const replyThreadId = threadSpec.id;
   const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
-  const topicNameCachePath = resolveTopicNameCachePath(
-    await resolveTelegramMessageContextStorePath({
-      cfg,
-      agentId: account.accountId,
-      sessionRuntime,
-    }),
-  );
   let topicName: string | undefined;
   if (isForum && resolvedThreadId != null) {
+    const topicNameCachePath = resolveTopicNameCachePath(
+      await resolveTelegramMessageContextStorePath({
+        cfg,
+        agentId: account.accountId,
+        sessionRuntime,
+      }),
+    );
     const ftCreated = msg.forum_topic_created;
     const ftEdited = msg.forum_topic_edited;
     const ftClosed = msg.forum_topic_closed;

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -551,7 +551,7 @@ export const buildTelegramMessageContext = async ({
             // Telegram replaces atomically — no removeReaction needed
           },
           initialEmoji: ackReaction,
-          emojis: resolvedStatusReactionEmojis,
+          emojis: resolvedStatusReactionEmojis ?? undefined,
           timing: statusReactionsConfig?.timing,
           onError: (err) => {
             logVerbose(`telegram status-reaction error for chat ${chatId}: ${String(err)}`);


### PR DESCRIPTION
Summary
- Cherry-picks the small Telegram message-context perf bucket: skip non-forum topic-cache setup, defer status reaction variant setup, and reuse ack reaction gating.
- Adds focused regression coverage for non-forum reply-thread cache avoidance, blocked ack/status reaction setup, and Telegram status emoji fallback variants.
- Adds a changelog entry for the Telegram performance path.

Verification
- `pnpm exec oxfmt --check --threads=1 extensions/telegram/src/bot-message-context.ts extensions/telegram/src/bot-message-context.test-harness.ts extensions/telegram/src/bot-message-context.reactions.test.ts extensions/telegram/src/bot-message-context.dm-threads.test.ts`
- `pnpm test:serial extensions/telegram/src/bot-message-context.reactions.test.ts extensions/telegram/src/bot-message-context.dm-threads.test.ts -- --reporter=dot`
- `pnpm test:serial extensions/telegram -- --reporter=dot` (107 files / 1487 tests)
- `OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_ID=tbx_01kr06j2jd4p0zw17pmama9qqa pnpm check:changed` on `33d84d63069b76fac9f1162f14b527643978b508`
- Protected Telegram live QA: OpenClaw Release Checks / `Run QA Lab live Telegram lane` passed on `33d84d63069b76fac9f1162f14b527643978b508`: https://github.com/openclaw/openclaw/actions/runs/25474412146
