### PR TITLE
perf(core): trim reply queue churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,6 +521,7 @@ Docs: https://docs.openclaw.ai
 
 - Channels/streaming: add unified `streaming.mode: "progress"` drafts with auto single-word status labels and shared progress configuration across Discord, Telegram, Matrix, Slack, and Microsoft Teams.
 - Agents/commands: add `/steer <message>` for queue-independent steering of the active current-session run without starting a new turn when the session is idle. (#76934)
+- Core/performance: trim reply payload routing, heartbeat filtering, tool display, core tool assembly, channel directory, task status, and Slack approval formatting helper chains with direct bounded scans. Thanks @vincentkoc.
 - Tools/BTW: add `/side` as a text and native slash-command alias for `/btw` side questions.
 - Doctor/config: `doctor --fix` now commits safe legacy migrations even when unrelated validation issues (e.g. a missing plugin) prevent full validation from passing, so `agents.defaults.llm` and other known-legacy keys are always cleaned up by `doctor --fix` regardless of other config problems. Fixes #76798. (#76800) Thanks @hclsys.
 - Agents/tools: skip optional media and PDF tool factories when the effective tool denylist already blocks them, avoiding unnecessary hot-path setup for tools that will be filtered out before model use. (#76773) Thanks @dorukardahan.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Docs: https://docs.openclaw.ai
 - Providers/OpenRouter: expand app-attribution categories so OpenClaw advertises coding, programming, writing, chat, and personal-agent usage on verified OpenRouter routes. Thanks @vincentkoc.
 - Agents/performance: pass the resolved workspace through BTW, compaction, embedded-run model generation, and PDF model setup so explicit agent-dir model refreshes can reuse the current workspace-scoped plugin metadata snapshot instead of falling back to cold plugin metadata scans. (#77519, #77532)
 - Plugins/performance: let unscoped model catalog and manifest-contract readers reuse the current workspace-compatible plugin metadata snapshot, avoiding repeated cold plugin metadata scans on hot control-plane paths while preserving env/config/workspace compatibility checks. (#77519, #77532)
+- Core/performance: trim reply payload routing, heartbeat filtering, tool display, core tool assembly, channel directory, task status, and Slack approval formatting helper chains with direct bounded scans. Thanks @vincentkoc.
 - Agents/sandbox: store sandbox container and browser registry entries as per-runtime shard files, reducing unrelated session lock contention while `openclaw doctor --fix` migrates legacy monolithic registry files. (#74831) Thanks @luckylhb90.
 - Plugins/runtime state: add `registerIfAbsent` for atomic keyed-store dedupe claims that return whether a plugin successfully claimed a key without overwriting an existing live value. Thanks @amknight.
 - Exec approvals: add a tree-sitter-backed shell command explainer for future approval and command-review surfaces. (#75004) Thanks @jesse-merhi.
@@ -521,7 +522,6 @@ Docs: https://docs.openclaw.ai
 
 - Channels/streaming: add unified `streaming.mode: "progress"` drafts with auto single-word status labels and shared progress configuration across Discord, Telegram, Matrix, Slack, and Microsoft Teams.
 - Agents/commands: add `/steer <message>` for queue-independent steering of the active current-session run without starting a new turn when the session is idle. (#76934)
-- Core/performance: trim reply payload routing, heartbeat filtering, tool display, core tool assembly, channel directory, task status, and Slack approval formatting helper chains with direct bounded scans. Thanks @vincentkoc.
 - Tools/BTW: add `/side` as a text and native slash-command alias for `/btw` side questions.
 - Doctor/config: `doctor --fix` now commits safe legacy migrations even when unrelated validation issues (e.g. a missing plugin) prevent full validation from passing, so `agents.defaults.llm` and other known-legacy keys are always cleaned up by `doctor --fix` regardless of other config problems. Fixes #76798. (#76800) Thanks @hclsys.
 - Agents/tools: skip optional media and PDF tool factories when the effective tool denylist already blocks them, avoiding unnecessary hot-path setup for tools that will be filtered out before model use. (#76773) Thanks @dorukardahan.

--- a/extensions/discord/src/internal/event-queue.ts
+++ b/extensions/discord/src/internal/event-queue.ts
@@ -31,6 +31,7 @@ const DEFAULT_SLOW_LISTENER_THRESHOLD_MS = 30_000;
 export class DiscordEventQueue {
   private readonly options: Required<DiscordEventQueueOptions>;
   private readonly queue: DiscordEventQueueJob[] = [];
+  private queueHead = 0;
   private processing = 0;
   private processedCount = 0;
   private droppedCount = 0;
@@ -52,7 +53,7 @@ export class DiscordEventQueue {
   }
 
   enqueue(params: Omit<DiscordEventQueueJob, "resolve" | "reject">): Promise<void> {
-    if (this.queue.length >= this.options.maxQueueSize) {
+    if (this.pendingQueueSize >= this.options.maxQueueSize) {
       this.droppedCount += 1;
       return Promise.reject(
         new Error(
@@ -68,7 +69,7 @@ export class DiscordEventQueue {
 
   getMetrics(): DiscordEventQueueMetrics {
     return {
-      queueSize: this.queue.length,
+      queueSize: this.pendingQueueSize,
       processing: this.processing,
       processed: this.processedCount,
       dropped: this.droppedCount,
@@ -78,9 +79,31 @@ export class DiscordEventQueue {
     };
   }
 
+  private get pendingQueueSize(): number {
+    return Math.max(0, this.queue.length - this.queueHead);
+  }
+
+  private takeNextJob(): DiscordEventQueueJob | undefined {
+    if (this.queueHead >= this.queue.length) {
+      this.queue.length = 0;
+      this.queueHead = 0;
+      return undefined;
+    }
+    const job = this.queue[this.queueHead];
+    this.queueHead += 1;
+    if (this.queueHead >= this.queue.length) {
+      this.queue.length = 0;
+      this.queueHead = 0;
+    } else if (this.queueHead > 256 && this.queueHead * 2 > this.queue.length) {
+      this.queue.splice(0, this.queueHead);
+      this.queueHead = 0;
+    }
+    return job;
+  }
+
   private processNext(): void {
-    while (this.processing < this.options.maxConcurrency && this.queue.length > 0) {
-      const job = this.queue.shift();
+    while (this.processing < this.options.maxConcurrency && this.pendingQueueSize > 0) {
+      const job = this.takeNextJob();
       if (!job) {
         return;
       }

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -394,16 +394,24 @@ function isRetryableError(error: Error): boolean {
     return false;
   }
 
-  const codes = candidates
-    .map((candidate) => readErrorCode(candidate))
-    .filter((code): code is string => Boolean(code));
+  const codes: string[] = [];
+  for (const candidate of candidates) {
+    const code = readErrorCode(candidate);
+    if (code) {
+      codes.push(code);
+    }
+  }
   if (codes.some((code) => RETRYABLE_NETWORK_ERROR_CODES.has(code))) {
     return true;
   }
 
-  const names = candidates
-    .map((candidate) => readErrorName(candidate))
-    .filter((name): name is string => Boolean(name));
+  const names: string[] = [];
+  for (const candidate of candidates) {
+    const name = readErrorName(candidate);
+    if (name) {
+      names.push(name);
+    }
+  }
   if (names.some((name) => RETRYABLE_NETWORK_ERROR_NAMES.has(name))) {
     return true;
   }
@@ -415,11 +423,13 @@ function isRetryableError(error: Error): boolean {
 
 function collectErrorCandidates(error: unknown): unknown[] {
   const queue: unknown[] = [error];
+  let queueIndex = 0;
   const seen = new Set<unknown>();
   const candidates: unknown[] = [];
 
-  while (queue.length > 0) {
-    const current = queue.shift();
+  while (queueIndex < queue.length) {
+    const current = queue[queueIndex];
+    queueIndex += 1;
     if (!current || seen.has(current)) {
       continue;
     }

--- a/extensions/slack/src/approval-handler.runtime.ts
+++ b/extensions/slack/src/approval-handler.runtime.ts
@@ -82,22 +82,35 @@ function formatSlackMetadataLine(label: string, value: string): string {
 }
 
 function buildSlackMetadataLines(metadata: readonly { label: string; value: string }[]): string[] {
-  return metadata.map((item) => formatSlackMetadataLine(item.label, item.value));
+  const lines: string[] = [];
+  for (const item of metadata) {
+    lines.push(formatSlackMetadataLine(item.label, item.value));
+  }
+  return lines;
 }
 
 function buildSlackMetadataContextElements(metadata: readonly { label: string; value: string }[]) {
   const lines = buildSlackMetadataLines(metadata);
-  const visibleLines =
-    lines.length > SLACK_CONTEXT_ELEMENTS_MAX
-      ? [
-          ...lines.slice(0, SLACK_CONTEXT_ELEMENTS_MAX - 1),
-          `…+${lines.length - (SLACK_CONTEXT_ELEMENTS_MAX - 1)} more`,
-        ]
-      : lines;
-  return visibleLines.map((line) => ({
-    type: "mrkdwn" as const,
-    text: truncateSlackMrkdwn(line, SLACK_TEXT_OBJECT_MAX),
-  }));
+  const visibleLineCount =
+    lines.length > SLACK_CONTEXT_ELEMENTS_MAX ? SLACK_CONTEXT_ELEMENTS_MAX - 1 : lines.length;
+  const elements: Array<{ type: "mrkdwn"; text: string }> = [];
+  for (let index = 0; index < visibleLineCount; index += 1) {
+    const line = lines[index];
+    if (line === undefined) {
+      continue;
+    }
+    elements.push({
+      type: "mrkdwn",
+      text: truncateSlackMrkdwn(line, SLACK_TEXT_OBJECT_MAX),
+    });
+  }
+  if (lines.length > SLACK_CONTEXT_ELEMENTS_MAX) {
+    elements.push({
+      type: "mrkdwn",
+      text: `…+${lines.length - visibleLineCount} more`,
+    });
+  }
+  return elements;
 }
 
 function resolveSlackApprovalDecisionLabel(
@@ -120,7 +133,7 @@ function buildSlackPendingApprovalText(view: ExecApprovalPendingView): string {
     buildSlackCodeBlock(view.commandText),
     ...metadataLines,
   ];
-  return lines.filter(Boolean).join("\n");
+  return lines.join("\n");
 }
 
 function buildSlackPendingApprovalBlocks(view: ExecApprovalPendingView): SlackBlock[] {

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -410,8 +410,9 @@ function collectErrorCodes(err: unknown): Set<string> {
   const queue: unknown[] = [err];
   const seen = new Set<unknown>();
 
-  while (queue.length > 0) {
-    const current = queue.shift();
+  let queueIndex = 0;
+  while (queueIndex < queue.length) {
+    const current = queue[queueIndex++];
     if (!current || seen.has(current)) {
       continue;
     }

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -249,11 +249,13 @@ function convertContentBlocks(
         source: { type: "base64"; media_type: string; data: string };
       }
   > = [];
+  let hasTextBlock = false;
   for (const block of content) {
     if (block.type === "text") {
       const text = sanitizeTransportPayloadText(block.text);
       if (text.trim().length > 0) {
         blocks.push({ type: "text", text });
+        hasTextBlock = true;
       }
     } else {
       blocks.push({
@@ -266,11 +268,8 @@ function convertContentBlocks(
       });
     }
   }
-  if (!blocks.some((block) => block.type === "text")) {
-    blocks.unshift({
-      type: "text",
-      text: "(see attached image)",
-    });
+  if (!hasTextBlock) {
+    return [{ type: "text", text: "(see attached image)" }, ...blocks];
   }
   return blocks;
 }
@@ -426,7 +425,16 @@ function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
   if (!tools) {
     return [];
   }
-  return tools.flatMap((tool) => {
+  const converted: Array<{
+    name: string;
+    description?: string;
+    input_schema: {
+      type: "object";
+      properties: unknown;
+      required: unknown;
+    };
+  }> = [];
+  for (const tool of tools) {
     // Main quarantine happens when plugin tools materialize; this keeps Anthropic
     // safe for direct/custom tool arrays that bypass the plugin registry.
     const parameters =
@@ -434,20 +442,19 @@ function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
         ? (tool.parameters as Record<string, unknown>)
         : undefined;
     if (!parameters) {
-      return [];
+      continue;
     }
-    return [
-      {
-        name: isOAuthToken ? toClaudeCodeName(tool.name) : tool.name,
-        description: tool.description,
-        input_schema: {
-          type: "object",
-          properties: parameters.properties || {},
-          required: parameters.required || [],
-        },
+    converted.push({
+      name: isOAuthToken ? toClaudeCodeName(tool.name) : tool.name,
+      description: tool.description,
+      input_schema: {
+        type: "object",
+        properties: parameters.properties || {},
+        required: parameters.required || [],
       },
-    ];
-  });
+    });
+  }
+  return converted;
 }
 
 function mapStopReason(reason: string | undefined): string {

--- a/src/agents/auth-health.ts
+++ b/src/agents/auth-health.ts
@@ -262,28 +262,46 @@ export function buildAuthHealthSummary(params: {
       continue;
     }
 
-    const oauthProfiles = provider.profiles.filter((p) => p.type === "oauth");
-    const tokenProfiles = provider.profiles.filter((p) => p.type === "token");
-    const apiKeyProfiles = provider.profiles.filter((p) => p.type === "api_key");
+    let hasApiKeyProfile = false;
+    let hasExpirableProfile = false;
+    let hasExpiredOrMissing = false;
+    let hasExpiring = false;
+    let earliestExpiry: number | undefined;
+    for (const profile of provider.profiles) {
+      if (profile.type === "api_key") {
+        hasApiKeyProfile = true;
+        continue;
+      }
+      if (profile.type !== "oauth" && profile.type !== "token") {
+        continue;
+      }
+      hasExpirableProfile = true;
+      if (typeof profile.expiresAt === "number" && Number.isFinite(profile.expiresAt)) {
+        earliestExpiry =
+          earliestExpiry === undefined
+            ? profile.expiresAt
+            : Math.min(earliestExpiry, profile.expiresAt);
+      }
+      if (profile.status === "expired" || profile.status === "missing") {
+        hasExpiredOrMissing = true;
+      } else if (profile.status === "expiring") {
+        hasExpiring = true;
+      }
+    }
 
-    const expirable = [...oauthProfiles, ...tokenProfiles];
-    if (expirable.length === 0) {
-      provider.status = apiKeyProfiles.length > 0 ? "static" : "missing";
+    if (!hasExpirableProfile) {
+      provider.status = hasApiKeyProfile ? "static" : "missing";
       continue;
     }
 
-    const expiryCandidates = expirable
-      .map((p) => p.expiresAt)
-      .filter((v): v is number => typeof v === "number" && Number.isFinite(v));
-    if (expiryCandidates.length > 0) {
-      provider.expiresAt = Math.min(...expiryCandidates);
+    if (earliestExpiry !== undefined) {
+      provider.expiresAt = earliestExpiry;
       provider.remainingMs = provider.expiresAt - now;
     }
 
-    const statuses = new Set(expirable.map((p) => p.status));
-    if (statuses.has("expired") || statuses.has("missing")) {
+    if (hasExpiredOrMissing) {
       provider.status = "expired";
-    } else if (statuses.has("expiring")) {
+    } else if (hasExpiring) {
       provider.status = "expiring";
     } else {
       provider.status = "ok";

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -247,9 +247,17 @@ function capPendingBuffer(buffer: string[], pendingChars: number, cap: number) {
     buffer.push(last.slice(last.length - cap));
     return cap;
   }
-  while (buffer.length && pendingChars - buffer[0].length >= cap) {
-    pendingChars -= buffer[0].length;
-    buffer.shift();
+  let dropCount = 0;
+  while (dropCount < buffer.length) {
+    const chunk = buffer[dropCount];
+    if (chunk === undefined || pendingChars - chunk.length < cap) {
+      break;
+    }
+    pendingChars -= chunk.length;
+    dropCount += 1;
+  }
+  if (dropCount > 0) {
+    buffer.splice(0, dropCount);
   }
   if (buffer.length && pendingChars > cap) {
     const overflow = pendingChars - cap;

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -200,9 +200,10 @@ function formatFallbackTurns(
     if (consumed + line.length + 1 > remainingBudget) {
       break;
     }
-    lines.unshift(line);
+    lines.push(line);
     consumed += line.length + 1;
   }
+  lines.reverse();
   return { text: lines.join("\n"), consumed };
 }
 

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -177,7 +177,12 @@ export function splitMessagesByTokenShare(
       const stopReason = (message as { stopReason?: unknown }).stopReason;
       const keepsPending =
         stopReason !== "aborted" && stopReason !== "error" && toolCalls.length > 0;
-      pendingToolCallIds = keepsPending ? new Set(toolCalls.map((t) => t.id)) : new Set();
+      pendingToolCallIds = new Set();
+      if (keepsPending) {
+        for (const toolCall of toolCalls) {
+          pendingToolCallIds.add(toolCall.id);
+        }
+      }
       pendingChunkStartIndex = keepsPending ? current.length - 1 : null;
     } else if (message.role === "toolResult" && pendingToolCallIds.size > 0) {
       const resultId = extractToolResultId(message);

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -631,7 +631,10 @@ export function buildAllowedModelSetWithFallbacks(params: {
         })
       : null;
   const defaultKey = defaultRef ? modelKey(defaultRef.provider, defaultRef.model) : undefined;
-  const catalogKeys = new Set(catalog.map((entry) => modelKey(entry.provider, entry.id)));
+  const catalogKeys = new Set<string>();
+  for (const entry of catalog) {
+    catalogKeys.add(modelKey(entry.provider, entry.id));
+  }
 
   if (allowAny) {
     if (defaultKey) {

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -420,10 +420,14 @@ export function createOpenClawTools(
     return tools;
   }
 
+  const existingToolNames = new Set<string>();
+  for (const tool of tools) {
+    existingToolNames.add(tool.name);
+  }
   const wrappedPluginTools = resolveOpenClawPluginToolsForOptions({
     options,
     resolvedConfig,
-    existingToolNames: new Set(tools.map((tool) => tool.name)),
+    existingToolNames,
   });
   options?.recordToolPrepStage?.("openclaw-tools:plugin-tools");
 

--- a/src/agents/pi-embedded-runner/compaction-successor-transcript.ts
+++ b/src/agents/pi-embedded-runner/compaction-successor-transcript.ts
@@ -152,9 +152,17 @@ function buildSuccessorEntries(params: {
     }
   }
 
-  const entryById = new Map(allEntries.map((entry) => [entry.id, entry]));
-  const activeBranchIds = new Set(branch.map((entry) => entry.id));
-  const originalIndexById = new Map(allEntries.map((entry, index) => [entry.id, index]));
+  const entryById = new Map<string, SessionEntry>();
+  const originalIndexById = new Map<string, number>();
+  for (let index = 0; index < allEntries.length; index += 1) {
+    const entry = allEntries[index];
+    entryById.set(entry.id, entry);
+    originalIndexById.set(entry.id, index);
+  }
+  const activeBranchIds = new Set<string>();
+  for (const entry of branch) {
+    activeBranchIds.add(entry.id);
+  }
   const keptEntries: SessionEntry[] = [];
   for (const entry of allEntries) {
     if (removedIds.has(entry.id)) {
@@ -185,7 +193,11 @@ function collectLatestStateEntryIds(entries: SessionEntry[]): Set<string> {
       latestByType.set(entry.type, entry);
     }
   }
-  return new Set(Array.from(latestByType.values(), (entry) => entry.id));
+  const ids = new Set<string>();
+  for (const entry of latestByType.values()) {
+    ids.add(entry.id);
+  }
+  return ids;
 }
 
 function isDedupedStateEntry(entry: SessionEntry): boolean {
@@ -202,7 +214,10 @@ function orderSuccessorEntries(params: {
   originalIndexById: Map<string, number>;
 }): SessionEntry[] {
   const { entries, activeBranchIds, originalIndexById } = params;
-  const entryIds = new Set(entries.map((entry) => entry.id));
+  const entryIds = new Set<string>();
+  for (const entry of entries) {
+    entryIds.add(entry.id);
+  }
   const childrenByParentId = new Map<string | null, SessionEntry[]>();
 
   for (const entry of entries) {

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -30,7 +30,10 @@ const IMAGE_EXTENSION_NAMES = [
   "heic",
   "heif",
 ] as const;
-const IMAGE_EXTENSIONS = new Set(IMAGE_EXTENSION_NAMES.map((ext) => `.${ext}`));
+const IMAGE_EXTENSIONS = new Set<string>();
+for (const ext of IMAGE_EXTENSION_NAMES) {
+  IMAGE_EXTENSIONS.add(`.${ext}`);
+}
 const IMAGE_EXTENSION_PATTERN = IMAGE_EXTENSION_NAMES.join("|");
 const MEDIA_ATTACHED_PATH_REGEX_SOURCE =
   "^\\s*(.+?\\.(?:" + IMAGE_EXTENSION_PATTERN + "))\\s*(?:\\(|$|\\|)";
@@ -159,9 +162,9 @@ function extractTrailingAttachmentMediaUris(prompt: string, count: number): stri
     if (!match?.[1]) {
       break;
     }
-    uris.unshift(match[1]);
+    uris.push(match[1]);
   }
-  return uris;
+  return uris.reverse();
 }
 
 export function splitPromptAndAttachmentRefs(params: {

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -164,7 +164,12 @@ function extractTrailingAttachmentMediaUris(prompt: string, count: number): stri
     }
     uris.push(match[1]);
   }
-  return uris.reverse();
+  for (let left = 0, right = uris.length - 1; left < right; left += 1, right -= 1) {
+    const uri = uris[left];
+    uris[left] = uris[right];
+    uris[right] = uri;
+  }
+  return uris;
 }
 
 export function splitPromptAndAttachmentRefs(params: {

--- a/src/agents/pi-embedded-runner/transcript-file-state.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.ts
@@ -114,9 +114,10 @@ export class TranscriptFileState {
     const branch: SessionEntry[] = [];
     let current = (fromId ?? this.leafId) ? this.byId.get((fromId ?? this.leafId)!) : undefined;
     while (current) {
-      branch.unshift(current);
+      branch.push(current);
       current = current.parentId ? this.byId.get(current.parentId) : undefined;
     }
+    branch.reverse();
     return branch;
   }
 

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -249,9 +249,12 @@ const TRUSTED_TOOL_RESULT_MEDIA = new Set([
   "x_search",
   "write",
 ]);
-const TRUSTED_BUNDLED_PLUGIN_MEDIA_TOOLS = new Set(
-  pluginRegistrationContractRegistry.flatMap((entry) => entry.toolNames),
-);
+const TRUSTED_BUNDLED_PLUGIN_MEDIA_TOOLS = new Set<string>();
+for (const entry of pluginRegistrationContractRegistry) {
+  for (const toolName of entry.toolNames) {
+    TRUSTED_BUNDLED_PLUGIN_MEDIA_TOOLS.add(toolName);
+  }
+}
 const HTTP_URL_RE = /^https?:\/\//i;
 
 function readToolResultDetails(result: unknown): Record<string, unknown> | undefined {

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -249,12 +249,9 @@ const TRUSTED_TOOL_RESULT_MEDIA = new Set([
   "x_search",
   "write",
 ]);
-const TRUSTED_BUNDLED_PLUGIN_MEDIA_TOOLS = new Set<string>();
-for (const entry of pluginRegistrationContractRegistry) {
-  for (const toolName of entry.toolNames) {
-    TRUSTED_BUNDLED_PLUGIN_MEDIA_TOOLS.add(toolName);
-  }
-}
+const TRUSTED_BUNDLED_PLUGIN_MEDIA_TOOLS = new Set(
+  pluginRegistrationContractRegistry.flatMap((entry) => entry.toolNames),
+);
 const HTTP_URL_RE = /^https?:\/\//i;
 
 function readToolResultDetails(result: unknown): Record<string, unknown> | undefined {

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -33,16 +33,22 @@ function formatReceivedParamHint(
   record: Record<string, unknown>,
   groups: readonly RequiredParamGroup[],
 ): string {
-  const allowEmptyKeys = new Set(
-    groups.filter((group) => group.allowEmpty).flatMap((group) => group.keys),
-  );
-  const received = Object.keys(record).flatMap((key) => {
+  const allowEmptyKeys = new Set<string>();
+  for (const group of groups) {
+    if (group.allowEmpty) {
+      for (const key of group.keys) {
+        allowEmptyKeys.add(key);
+      }
+    }
+  }
+  const received: string[] = [];
+  for (const key of Object.keys(record)) {
     const detail = describeReceivedParamValue(record[key], allowEmptyKeys.has(key));
     if (record[key] === undefined || record[key] === null) {
-      return [];
+      continue;
     }
-    return [detail ? `${key}=${detail}` : key];
-  });
+    received.push(detail ? `${key}=${detail}` : key);
+  }
   return received.length > 0 ? ` (received: ${received.join(", ")})` : "";
 }
 

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -508,51 +508,56 @@ export function createOpenClawCodingTools(options?: {
   const imageSanitization = resolveImageSanitizationLimits(options?.config);
   options?.recordToolPrepStage?.("workspace-policy");
 
-  const base = includeBaseCodingTools
-    ? (createCodingTools(workspaceRoot) as unknown as AnyAgentTool[]).flatMap((tool) => {
-        if (tool.name === "read") {
-          if (sandboxRoot) {
-            const sandboxed = createSandboxedReadTool({
-              root: sandboxRoot,
-              bridge: sandboxFsBridge!,
-              modelContextWindowTokens: options?.modelContextWindowTokens,
-              imageSanitization,
-            });
-            return [
-              workspaceOnly
-                ? wrapToolWorkspaceRootGuardWithOptions(sandboxed, sandboxRoot, {
-                    containerWorkdir: sandbox.containerWorkdir,
-                  })
-                : sandboxed,
-            ];
-          }
-          const freshReadTool = createReadTool(workspaceRoot);
-          const wrapped = createOpenClawReadTool(freshReadTool, {
+  const base: AnyAgentTool[] = [];
+  if (includeBaseCodingTools) {
+    for (const tool of createCodingTools(workspaceRoot) as unknown as AnyAgentTool[]) {
+      if (tool.name === "read") {
+        if (sandboxRoot) {
+          const sandboxed = createSandboxedReadTool({
+            root: sandboxRoot,
+            bridge: sandboxFsBridge!,
             modelContextWindowTokens: options?.modelContextWindowTokens,
             imageSanitization,
           });
-          return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+          base.push(
+            workspaceOnly
+              ? wrapToolWorkspaceRootGuardWithOptions(sandboxed, sandboxRoot, {
+                  containerWorkdir: sandbox.containerWorkdir,
+                })
+              : sandboxed,
+          );
+          continue;
         }
-        if (tool.name === "bash" || tool.name === execToolName) {
-          return [];
+        const freshReadTool = createReadTool(workspaceRoot);
+        const wrapped = createOpenClawReadTool(freshReadTool, {
+          modelContextWindowTokens: options?.modelContextWindowTokens,
+          imageSanitization,
+        });
+        base.push(workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped);
+        continue;
+      }
+      if (tool.name === "bash" || tool.name === execToolName) {
+        continue;
+      }
+      if (tool.name === "write") {
+        if (sandboxRoot) {
+          continue;
         }
-        if (tool.name === "write") {
-          if (sandboxRoot) {
-            return [];
-          }
-          const wrapped = createHostWorkspaceWriteTool(workspaceRoot, { workspaceOnly });
-          return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+        const wrapped = createHostWorkspaceWriteTool(workspaceRoot, { workspaceOnly });
+        base.push(workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped);
+        continue;
+      }
+      if (tool.name === "edit") {
+        if (sandboxRoot) {
+          continue;
         }
-        if (tool.name === "edit") {
-          if (sandboxRoot) {
-            return [];
-          }
-          const wrapped = createHostWorkspaceEditTool(workspaceRoot, { workspaceOnly });
-          return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
-        }
-        return [tool];
-      })
-    : [];
+        const wrapped = createHostWorkspaceEditTool(workspaceRoot, { workspaceOnly });
+        base.push(workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped);
+        continue;
+      }
+      base.push(tool);
+    }
+  }
   options?.recordToolPrepStage?.("base-coding-tools");
   const { cleanupMs: cleanupMsOverride, ...execDefaults } = options?.exec ?? {};
   const execTool = includeShellTools
@@ -754,28 +759,29 @@ export function createOpenClawCodingTools(options?: {
       : pluginToolsOnly),
   ];
   options?.recordToolPrepStage?.("openclaw-tools");
-  const toolsForMemoryFlush =
-    isMemoryFlushRun && memoryFlushWritePath
-      ? tools.flatMap((tool) => {
-          if (!MEMORY_FLUSH_ALLOWED_TOOL_NAMES.has(tool.name)) {
-            return [];
-          }
-          if (tool.name === "write") {
-            return [
-              wrapToolMemoryFlushAppendOnlyWrite(tool, {
-                root: sandboxRoot ?? workspaceRoot,
-                relativePath: memoryFlushWritePath,
-                containerWorkdir: sandbox?.containerWorkdir,
-                sandbox:
-                  sandboxRoot && sandboxFsBridge
-                    ? { root: sandboxRoot, bridge: sandboxFsBridge }
-                    : undefined,
-              }),
-            ];
-          }
-          return [tool];
-        })
-      : tools;
+  const toolsForMemoryFlush: AnyAgentTool[] = isMemoryFlushRun && memoryFlushWritePath ? [] : tools;
+  if (isMemoryFlushRun && memoryFlushWritePath) {
+    for (const tool of tools) {
+      if (!MEMORY_FLUSH_ALLOWED_TOOL_NAMES.has(tool.name)) {
+        continue;
+      }
+      if (tool.name === "write") {
+        toolsForMemoryFlush.push(
+          wrapToolMemoryFlushAppendOnlyWrite(tool, {
+            root: sandboxRoot ?? workspaceRoot,
+            relativePath: memoryFlushWritePath,
+            containerWorkdir: sandbox?.containerWorkdir,
+            sandbox:
+              sandboxRoot && sandboxFsBridge
+                ? { root: sandboxRoot, bridge: sandboxFsBridge }
+                : undefined,
+          }),
+        );
+        continue;
+      }
+      toolsForMemoryFlush.push(tool);
+    }
+  }
   const toolsForMessageProvider = filterToolsByMessageProvider(
     toolsForMemoryFlush,
     options?.messageProvider,

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -502,8 +502,12 @@ export function repairToolUseResultPairing(
       continue;
     }
 
-    const toolCallIds = new Set(toolCalls.map((t) => t.id));
-    const toolCallNamesById = new Map(toolCalls.map((t) => [t.id, t.name] as const));
+    const toolCallIds = new Set<string>();
+    const toolCallNamesById = new Map<string, string>();
+    for (const toolCall of toolCalls) {
+      toolCallIds.add(toolCall.id);
+      toolCallNamesById.set(toolCall.id, toolCall.name);
+    }
 
     const spanResultsById = new Map<string, Extract<AgentMessage, { role: "toolResult" }>>();
     const remainder: AgentMessage[] = [];

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -506,7 +506,9 @@ export function repairToolUseResultPairing(
     const toolCallNamesById = new Map<string, string>();
     for (const toolCall of toolCalls) {
       toolCallIds.add(toolCall.id);
-      toolCallNamesById.set(toolCall.id, toolCall.name);
+      if (typeof toolCall.name === "string") {
+        toolCallNamesById.set(toolCall.id, toolCall.name);
+      }
     }
 
     const spanResultsById = new Map<string, Extract<AgentMessage, { role: "toolResult" }>>();

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -34,14 +34,15 @@ export function defaultTitle(name: string): string {
   if (!cleaned) {
     return "Tool";
   }
-  return cleaned
-    .split(/\s+/)
-    .map((part) =>
+  const parts: string[] = [];
+  for (const part of cleaned.split(/\s+/)) {
+    parts.push(
       part.length <= 2 && part.toUpperCase() === part
         ? part
         : `${part.at(0)?.toUpperCase() ?? ""}${part.slice(1)}`,
-    )
-    .join(" ");
+    );
+  }
+  return parts.join(" ");
 }
 
 function normalizeVerb(value?: string): string | undefined {
@@ -131,14 +132,23 @@ function coerceDisplayValue(
     return String(value);
   }
   if (Array.isArray(value)) {
-    const values = value
-      .map((item) => coerceDisplayValue(item, opts))
-      .filter((item): item is string => Boolean(item));
-    if (values.length === 0) {
+    const values: string[] = [];
+    let displayValueCount = 0;
+    for (const item of value) {
+      const display = coerceDisplayValue(item, opts);
+      if (!display) {
+        continue;
+      }
+      displayValueCount += 1;
+      if (values.length < maxArrayEntries) {
+        values.push(display);
+      }
+    }
+    if (displayValueCount === 0) {
       return undefined;
     }
-    const preview = values.slice(0, maxArrayEntries).join(", ");
-    return values.length > maxArrayEntries ? `${preview}…` : preview;
+    const preview = values.join(", ");
+    return displayValueCount > maxArrayEntries ? `${preview}…` : preview;
   }
   return undefined;
 }
@@ -162,8 +172,13 @@ function lookupValueByPath(args: unknown, path: string): unknown {
 }
 
 export function formatDetailKey(raw: string, overrides: Record<string, string> = {}): string {
-  const segments = raw.split(".").filter(Boolean);
-  const last = segments.at(-1) ?? raw;
+  let last = "";
+  for (const segment of raw.split(".")) {
+    if (segment) {
+      last = segment;
+    }
+  }
+  last ||= raw;
   const override = overrides[last];
   if (override) {
     return override;
@@ -295,12 +310,13 @@ function resolveWebFetchDetail(args: unknown): string | undefined {
       ? Math.floor(record.maxChars)
       : undefined;
 
-  const suffix = [
-    mode ? `mode ${mode}` : undefined,
-    maxChars !== undefined ? `max ${maxChars} chars` : undefined,
-  ]
-    .filter((value): value is string => Boolean(value))
-    .join(", ");
+  let suffix = "";
+  if (mode) {
+    suffix = `mode ${mode}`;
+  }
+  if (maxChars !== undefined) {
+    suffix = suffix ? `${suffix}, max ${maxChars} chars` : `max ${maxChars} chars`;
+  }
 
   return suffix ? `from ${url} (${suffix})` : `from ${url}`;
 }
@@ -366,10 +382,15 @@ function resolveDetailFromKeys(
     return undefined;
   }
 
-  return unique
-    .slice(0, opts.maxEntries ?? 8)
-    .map((entry) => `${entry.label} ${entry.value}`)
-    .join(" · ");
+  const maxEntries = opts.maxEntries ?? 8;
+  const parts: string[] = [];
+  for (let index = 0; index < unique.length && index < maxEntries; index += 1) {
+    const entry = unique[index];
+    if (entry) {
+      parts.push(`${entry.label} ${entry.value}`);
+    }
+  }
+  return parts.join(" · ");
 }
 
 function resolveToolVerbAndDetail(params: {
@@ -438,11 +459,16 @@ export function formatToolDetailText(
     return undefined;
   }
   const normalized = detail.includes(" · ")
-    ? detail
-        .split(" · ")
-        .map((part) => part.trim())
-        .filter((part) => part.length > 0)
-        .join(", ")
+    ? (() => {
+        const parts: string[] = [];
+        for (const part of detail.split(" · ")) {
+          const trimmed = part.trim();
+          if (trimmed) {
+            parts.push(trimmed);
+          }
+        }
+        return parts.join(", ");
+      })()
     : detail;
   if (!normalized) {
     return undefined;

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -660,7 +660,7 @@ export function recordToolCall(
   });
 
   if (state.toolCallHistory.length > resolvedConfig.historySize) {
-    state.toolCallHistory.shift();
+    state.toolCallHistory.splice(0, state.toolCallHistory.length - resolvedConfig.historySize);
   }
 }
 

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -70,11 +70,13 @@ function registerAlias(commands: ChatCommandDefinition[], key: string, ...aliase
   if (!command) {
     throw new Error(`registerAlias: unknown command key: ${key}`);
   }
-  const existing = new Set(
-    command.textAliases
-      .map((alias) => normalizeOptionalLowercaseString(alias))
-      .filter((alias): alias is string => Boolean(alias)),
-  );
+  const existing = new Set<string>();
+  for (const alias of command.textAliases) {
+    const lowered = normalizeOptionalLowercaseString(alias);
+    if (lowered) {
+      existing.add(lowered);
+    }
+  }
   for (const alias of aliases) {
     const trimmed = alias.trim();
     if (!trimmed) {

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -13,24 +13,23 @@ function resolveMessageText(content: unknown): { text: string; hasNonTextContent
     return { text: "", hasNonTextContent: content != null };
   }
   let hasNonTextContent = false;
-  const text = content
-    .filter((block): block is { type: "text"; text: string } => {
-      if (typeof block !== "object" || block === null || !("type" in block)) {
-        hasNonTextContent = true;
-        return false;
-      }
-      if (block.type !== "text") {
-        hasNonTextContent = true;
-        return false;
-      }
-      if (typeof (block as { text?: unknown }).text !== "string") {
-        hasNonTextContent = true;
-        return false;
-      }
-      return true;
-    })
-    .map((block) => block.text)
-    .join("");
+  let text = "";
+  for (const block of content) {
+    if (typeof block !== "object" || block === null || !("type" in block)) {
+      hasNonTextContent = true;
+      continue;
+    }
+    if (block.type !== "text") {
+      hasNonTextContent = true;
+      continue;
+    }
+    const blockText = (block as { text?: unknown }).text;
+    if (typeof blockText !== "string") {
+      hasNonTextContent = true;
+      continue;
+    }
+    text += blockText;
+  }
   return { text, hasNonTextContent };
 }
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -909,8 +909,9 @@ function resolveRestartLifecycleError(
   const pending = [err];
   const seen = new Set<unknown>();
 
-  while (pending.length > 0) {
-    const candidate = pending.shift();
+  let pendingIndex = 0;
+  while (pendingIndex < pending.length) {
+    const candidate = pending[pendingIndex++];
     if (!candidate || seen.has(candidate)) {
       continue;
     }

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -163,39 +163,47 @@ export async function buildReplyPayloads(params: {
     }
   }
 
-  const replyTaggedPayloads = (
-    await Promise.all(
-      applyReplyThreading({
-        payloads: sanitizedPayloads,
-        replyToMode: params.replyToMode,
-        replyToChannel: params.replyToChannel,
+  const replyTaggedPayloadCandidates = await Promise.all(
+    applyReplyThreading({
+      payloads: sanitizedPayloads,
+      replyToMode: params.replyToMode,
+      replyToChannel: params.replyToChannel,
+      currentMessageId: params.currentMessageId,
+      replyThreading: params.replyThreading,
+    }).map(async (payload) => {
+      const parsed = normalizeReplyPayloadDirectives({
+        payload,
         currentMessageId: params.currentMessageId,
-        replyThreading: params.replyThreading,
-      }).map(async (payload) => {
-        const parsed = normalizeReplyPayloadDirectives({
-          payload,
-          currentMessageId: params.currentMessageId,
-          silentToken: SILENT_REPLY_TOKEN,
-          parseMode: "always",
-          extractMarkdownImages: params.extractMarkdownImages,
-        });
-        const mediaNormalizedPayload = await normalizeReplyPayloadMedia({
-          payload: parsed.payload,
-          normalizeMediaPaths: params.normalizeMediaPaths,
-        });
-        if (
-          parsed.isSilent &&
-          !resolveSendableOutboundReplyParts(mediaNormalizedPayload).hasMedia
-        ) {
-          mediaNormalizedPayload.text = undefined;
-        }
-        return mediaNormalizedPayload;
-      }),
-    )
-  ).filter(isRenderablePayload);
-  const silentFilteredPayloads = params.silentExpected
-    ? replyTaggedPayloads.filter(shouldKeepPayloadDuringSilentTurn)
-    : replyTaggedPayloads;
+        silentToken: SILENT_REPLY_TOKEN,
+        parseMode: "always",
+        extractMarkdownImages: params.extractMarkdownImages,
+      });
+      const mediaNormalizedPayload = await normalizeReplyPayloadMedia({
+        payload: parsed.payload,
+        normalizeMediaPaths: params.normalizeMediaPaths,
+      });
+      if (parsed.isSilent && !resolveSendableOutboundReplyParts(mediaNormalizedPayload).hasMedia) {
+        mediaNormalizedPayload.text = undefined;
+      }
+      return mediaNormalizedPayload;
+    }),
+  );
+  const replyTaggedPayloads: ReplyPayload[] = [];
+  for (const payload of replyTaggedPayloadCandidates) {
+    if (isRenderablePayload(payload)) {
+      replyTaggedPayloads.push(payload);
+    }
+  }
+  const silentFilteredPayloads: ReplyPayload[] = [];
+  if (params.silentExpected) {
+    for (const payload of replyTaggedPayloads) {
+      if (shouldKeepPayloadDuringSilentTurn(payload)) {
+        silentFilteredPayloads.push(payload);
+      }
+    }
+  } else {
+    silentFilteredPayloads.push(...replyTaggedPayloads);
+  }
 
   // Drop final payloads only when block streaming succeeded end-to-end.
   // If streaming aborted (e.g., timeout), fall back to final payloads.
@@ -312,15 +320,28 @@ export async function buildReplyPayloads(params: {
         return preserved;
       })()
     : params.blockStreamingEnabled
-      ? dedupedPayloads.filter(
-          (payload) =>
-            !params.blockReplyPipeline?.hasSentPayload(payload) &&
-            !isDirectlySentBlockPayload(payload),
-        )
+      ? (() => {
+          const unsent: ReplyPayload[] = [];
+          for (const payload of dedupedPayloads) {
+            if (
+              !params.blockReplyPipeline?.hasSentPayload(payload) &&
+              !isDirectlySentBlockPayload(payload)
+            ) {
+              unsent.push(payload);
+            }
+          }
+          return unsent;
+        })()
       : params.directlySentBlockKeys?.size
-        ? dedupedPayloads.filter(
-            (payload) => !params.directlySentBlockKeys!.has(createBlockReplyContentKey(payload)),
-          )
+        ? (() => {
+            const unsent: ReplyPayload[] = [];
+            for (const payload of dedupedPayloads) {
+              if (!params.directlySentBlockKeys.has(createBlockReplyContentKey(payload))) {
+                unsent.push(payload);
+              }
+            }
+            return unsent;
+          })()
         : dedupedPayloads;
   const blockSentMediaUrls = params.blockStreamingEnabled
     ? await normalizeSentMediaUrlsForDedupe({
@@ -337,7 +358,14 @@ export async function buildReplyPayloads(params: {
           sentMediaUrls: blockSentMediaUrls,
         })
       : contentSuppressedPayloads;
-  const replyPayloads = filteredPayloads.filter(isRenderablePayload);
+  const replyPayloads: ReplyPayload[] = [];
+  if (!messagingToolPayloadDedupe.suppressReplies) {
+    for (const payload of filteredPayloads) {
+      if (isRenderablePayload(payload)) {
+        replyPayloads.push(payload);
+      }
+    }
+  }
 
   return {
     replyPayloads,

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -131,29 +131,37 @@ export async function buildReplyPayloads(params: {
   normalizeMediaPaths?: (payload: ReplyPayload) => Promise<ReplyPayload>;
 }): Promise<{ replyPayloads: ReplyPayload[]; didLogHeartbeatStrip: boolean }> {
   let didLogHeartbeatStrip = params.didLogHeartbeatStrip;
-  const sanitizedPayloads = params.isHeartbeat
-    ? params.payloads.map((payload) => sanitizeHeartbeatPayload(payload))
-    : params.payloads.flatMap((payload) => {
-        let text = payload.text;
+  const sanitizedPayloads: ReplyPayload[] = [];
+  if (params.isHeartbeat) {
+    for (const payload of params.payloads) {
+      sanitizedPayloads.push(sanitizeHeartbeatPayload(payload));
+    }
+  } else {
+    for (const payload of params.payloads) {
+      let text = payload.text;
 
-        if (payload.isError && text && isBunFetchSocketError(text)) {
-          text = formatBunFetchSocketError(text);
-        }
+      if (payload.isError && text && isBunFetchSocketError(text)) {
+        text = formatBunFetchSocketError(text);
+      }
 
-        if (!text || !text.includes("HEARTBEAT_OK")) {
-          return [copyReplyPayloadMetadata(payload, { ...payload, text })];
-        }
-        const stripped = stripHeartbeatToken(text, { mode: "message" });
-        if (stripped.didStrip && !didLogHeartbeatStrip) {
-          didLogHeartbeatStrip = true;
-          logVerbose("Stripped stray HEARTBEAT_OK token from reply");
-        }
-        const hasMedia = resolveSendableOutboundReplyParts(payload).hasMedia;
-        if (stripped.shouldSkip && !hasMedia) {
-          return [];
-        }
-        return [copyReplyPayloadMetadata(payload, { ...payload, text: stripped.text })];
-      });
+      if (!text || !text.includes("HEARTBEAT_OK")) {
+        sanitizedPayloads.push(copyReplyPayloadMetadata(payload, { ...payload, text }));
+        continue;
+      }
+      const stripped = stripHeartbeatToken(text, { mode: "message" });
+      if (stripped.didStrip && !didLogHeartbeatStrip) {
+        didLogHeartbeatStrip = true;
+        logVerbose("Stripped stray HEARTBEAT_OK token from reply");
+      }
+      const hasMedia = resolveSendableOutboundReplyParts(payload).hasMedia;
+      if (stripped.shouldSkip && !hasMedia) {
+        continue;
+      }
+      sanitizedPayloads.push(
+        copyReplyPayloadMetadata(payload, { ...payload, text: stripped.text }),
+      );
+    }
+  }
 
   const replyTaggedPayloads = (
     await Promise.all(
@@ -293,7 +301,16 @@ export async function buildReplyPayloads(params: {
     });
   };
   const contentSuppressedPayloads = shouldDropFinalPayloads
-    ? dedupedPayloads.flatMap((payload) => preserveUnsentMediaAfterBlockStream(payload) ?? [])
+    ? (() => {
+        const preserved: ReplyPayload[] = [];
+        for (const payload of dedupedPayloads) {
+          const next = preserveUnsentMediaAfterBlockStream(payload);
+          if (next) {
+            preserved.push(next);
+          }
+        }
+        return preserved;
+      })()
     : params.blockStreamingEnabled
       ? dedupedPayloads.filter(
           (payload) =>

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -359,11 +359,9 @@ export async function buildReplyPayloads(params: {
         })
       : contentSuppressedPayloads;
   const replyPayloads: ReplyPayload[] = [];
-  if (!messagingToolPayloadDedupe.suppressReplies) {
-    for (const payload of filteredPayloads) {
-      if (isRenderablePayload(payload)) {
-        replyPayloads.push(payload);
-      }
+  for (const payload of filteredPayloads) {
+    if (isRenderablePayload(payload)) {
+      replyPayloads.push(payload);
     }
   }
 

--- a/src/auto-reply/reply/commands-tasks.ts
+++ b/src/auto-reply/reply/commands-tasks.ts
@@ -70,7 +70,10 @@ function formatVisibleTask(task: TaskRecord, index: number): string {
   const status = task.status.replaceAll("_", " ");
   const timing = formatTaskTiming(task);
   const detail = formatTaskDetail(task);
-  const meta = [TASK_RUNTIME_LABELS[task.runtime], status, timing].filter(Boolean).join(" · ");
+  let meta = `${TASK_RUNTIME_LABELS[task.runtime]} · ${status}`;
+  if (timing) {
+    meta += ` · ${timing}`;
+  }
   const lines = [`${index + 1}. ${TASK_STATUS_ICONS[task.status]} ${title}`, `   ${meta}`];
   if (detail) {
     lines.push(`   ${detail}`);

--- a/src/auto-reply/reply/followup-delivery.ts
+++ b/src/auto-reply/reply/followup-delivery.ts
@@ -46,18 +46,20 @@ export function resolveFollowupDeliveryPayloads(params: {
     params.originatingAccountId,
     params.originatingChatType,
   );
-  const sanitizedPayloads = params.payloads.flatMap((payload) => {
+  const sanitizedPayloads: ReplyPayload[] = [];
+  for (const payload of params.payloads) {
     const text = payload.text;
     if (!text || !text.includes("HEARTBEAT_OK")) {
-      return [payload];
+      sanitizedPayloads.push(payload);
+      continue;
     }
     const stripped = stripHeartbeatToken(text, { mode: "message" });
     const hasMedia = hasReplyPayloadMedia(payload);
     if (stripped.shouldSkip && !hasMedia) {
-      return [];
+      continue;
     }
-    return [{ ...payload, text: stripped.text }];
-  });
+    sanitizedPayloads.push({ ...payload, text: stripped.text });
+  }
   const replyTaggedPayloads = applyReplyThreading({
     payloads: sanitizedPayloads,
     replyToMode,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1,8 +1,5 @@
 import crypto from "node:crypto";
-import {
-  hasOutboundReplyContent,
-  resolveSendableOutboundReplyParts,
-} from "openclaw/plugin-sdk/reply-payload";
+import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
@@ -19,7 +16,6 @@ import { registerAgentRunContext } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { defaultRuntime } from "../../runtime.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
-import { stripHeartbeatToken } from "../heartbeat.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { runPreflightCompactionIfNeeded } from "./agent-runner-memory.js";
 import {
@@ -402,21 +398,9 @@ export function createFollowupRunner(params: {
       if (payloadArray.length === 0) {
         return;
       }
-      const sanitizedPayloads = payloadArray.flatMap((payload) => {
-        const text = payload.text;
-        if (!text || !text.includes("HEARTBEAT_OK")) {
-          return [payload];
-        }
-        const stripped = stripHeartbeatToken(text, { mode: "message" });
-        const hasMedia = resolveSendableOutboundReplyParts(payload).hasMedia;
-        if (stripped.shouldSkip && !hasMedia) {
-          return [];
-        }
-        return [{ ...payload, text: stripped.text }];
-      });
       const finalPayloads = resolveFollowupDeliveryPayloads({
         cfg: runtimeConfig,
-        payloads: sanitizedPayloads,
+        payloads: payloadArray,
         messageProvider: run.messageProvider,
         originatingAccountId: queued.originatingAccountId ?? run.agentAccountId,
         originatingChannel: queued.originatingChannel,
@@ -431,6 +415,7 @@ export function createFollowupRunner(params: {
         return;
       }
 
+      let deliveryPayloads = finalPayloads;
       if (autoCompactionCount > 0) {
         const previousSessionId = run.sessionId;
         const count = await incrementRunCompactionCount({
@@ -461,9 +446,12 @@ export function createFollowupRunner(params: {
         }
         if (run.verboseLevel && run.verboseLevel !== "off") {
           const suffix = typeof count === "number" ? ` (count ${count})` : "";
-          finalPayloads.unshift({
-            text: `🧹 Auto-compaction complete${suffix}.`,
-          });
+          deliveryPayloads = [
+            {
+              text: `🧹 Auto-compaction complete${suffix}.`,
+            },
+            ...finalPayloads,
+          ];
         }
       }
 
@@ -474,7 +462,7 @@ export function createFollowupRunner(params: {
         return;
       }
 
-      await sendFollowupPayloads(finalPayloads, effectiveQueued, {
+      await sendFollowupPayloads(deliveryPayloads, effectiveQueued, {
         provider: providerUsed,
         modelId: modelUsed,
       });

--- a/src/auto-reply/reply/history.ts
+++ b/src/auto-reply/reply/history.ts
@@ -61,8 +61,9 @@ export function appendHistoryEntry<T extends HistoryEntry>(params: {
   }
   const history = historyMap.get(historyKey) ?? [];
   history.push(entry);
-  while (history.length > params.limit) {
-    history.shift();
+  const overflowCount = history.length - params.limit;
+  if (overflowCount > 0) {
+    history.splice(0, overflowCount);
   }
   if (historyMap.has(historyKey)) {
     // Refresh insertion order so eviction keeps recently used histories.

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -49,15 +49,29 @@ type OriginRoutingMetadata = Pick<
 >;
 
 function resolveOriginRoutingMetadata(items: FollowupRun[]): OriginRoutingMetadata {
-  return {
-    originatingChannel: items.find((item) => item.originatingChannel)?.originatingChannel,
-    originatingTo: items.find((item) => item.originatingTo)?.originatingTo,
-    originatingAccountId: items.find((item) => item.originatingAccountId)?.originatingAccountId,
+  const metadata: OriginRoutingMetadata = {};
+  for (const item of items) {
+    metadata.originatingChannel ??= item.originatingChannel;
+    metadata.originatingTo ??= item.originatingTo;
+    metadata.originatingAccountId ??= item.originatingAccountId;
     // Support both number (Telegram topic) and string (Slack thread_ts) thread IDs.
-    originatingThreadId: items.find(
-      (item) => item.originatingThreadId != null && item.originatingThreadId !== "",
-    )?.originatingThreadId,
-  };
+    if (
+      metadata.originatingThreadId == null &&
+      item.originatingThreadId != null &&
+      item.originatingThreadId !== ""
+    ) {
+      metadata.originatingThreadId = item.originatingThreadId;
+    }
+    if (
+      metadata.originatingChannel &&
+      metadata.originatingTo &&
+      metadata.originatingAccountId &&
+      metadata.originatingThreadId != null
+    ) {
+      break;
+    }
+  }
+  return metadata;
 }
 
 // Keep this key aligned with the fields that affect per-message authorization or
@@ -118,8 +132,16 @@ function renderCollectItem(item: FollowupRun, idx: number): string {
 }
 
 function collectQueuedImages(items: FollowupRun[]): Pick<FollowupRun, "images" | "imageOrder"> {
-  const images = items.flatMap((item) => item.images ?? []);
-  const imageOrder = items.flatMap((item) => item.imageOrder ?? []);
+  const images: NonNullable<FollowupRun["images"]> = [];
+  const imageOrder: NonNullable<FollowupRun["imageOrder"]> = [];
+  for (const item of items) {
+    if (item.images) {
+      images.push(...item.images);
+    }
+    if (item.imageOrder) {
+      imageOrder.push(...item.imageOrder);
+    }
+  }
   return {
     ...(images.length > 0 ? { images } : {}),
     ...(imageOrder.length > 0 ? { imageOrder } : {}),

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -51,9 +51,15 @@ type OriginRoutingMetadata = Pick<
 function resolveOriginRoutingMetadata(items: FollowupRun[]): OriginRoutingMetadata {
   const metadata: OriginRoutingMetadata = {};
   for (const item of items) {
-    metadata.originatingChannel ??= item.originatingChannel;
-    metadata.originatingTo ??= item.originatingTo;
-    metadata.originatingAccountId ??= item.originatingAccountId;
+    if (!metadata.originatingChannel && item.originatingChannel) {
+      metadata.originatingChannel = item.originatingChannel;
+    }
+    if (!metadata.originatingTo && item.originatingTo) {
+      metadata.originatingTo = item.originatingTo;
+    }
+    if (!metadata.originatingAccountId && item.originatingAccountId) {
+      metadata.originatingAccountId = item.originatingAccountId;
+    }
     // Support both number (Telegram topic) and string (Slack thread_ts) thread IDs.
     if (
       metadata.originatingThreadId == null &&

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -35,43 +35,83 @@ export function filterMessagingToolMediaDuplicates(params: {
   payloads: ReplyPayload[];
   sentMediaUrls: string[];
 }): ReplyPayload[] {
-  const normalizeMediaForDedupe = (value: string): string => {
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return "";
-    }
-    if (!normalizeLowercaseStringOrEmpty(trimmed).startsWith("file://")) {
-      return trimmed;
-    }
-    try {
-      const parsed = new URL(trimmed);
-      if (parsed.protocol === "file:") {
-        return decodeURIComponent(parsed.pathname || "");
-      }
-    } catch {
-      // Keep fallback below for non-URL-like inputs.
-    }
-    return trimmed.replace(/^file:\/\//i, "");
-  };
-
   const { payloads, sentMediaUrls } = params;
   if (sentMediaUrls.length === 0) {
     return payloads;
   }
-  const sentSet = new Set(sentMediaUrls.map(normalizeMediaForDedupe).filter(Boolean));
-  return payloads.map((payload) => {
+  const sentSet = new Set<string>();
+  for (const sentMediaUrl of sentMediaUrls) {
+    const normalized = normalizeMediaForDedupe(sentMediaUrl);
+    if (normalized) {
+      sentSet.add(normalized);
+    }
+  }
+  if (sentSet.size === 0) {
+    return payloads;
+  }
+
+  let nextPayloads: ReplyPayload[] | undefined;
+  for (let index = 0; index < payloads.length; index++) {
+    const payload = payloads[index]!;
     const mediaUrl = payload.mediaUrl;
     const mediaUrls = payload.mediaUrls;
     const stripSingle = mediaUrl && sentSet.has(normalizeMediaForDedupe(mediaUrl));
-    const filteredUrls = mediaUrls?.filter((u) => !sentSet.has(normalizeMediaForDedupe(u)));
-    if (!stripSingle && (!mediaUrls || filteredUrls?.length === mediaUrls.length)) {
-      return payload;
+
+    let filteredUrls: string[] | undefined;
+    let strippedMediaUrls = false;
+    if (mediaUrls?.length) {
+      for (let mediaIndex = 0; mediaIndex < mediaUrls.length; mediaIndex++) {
+        const url = mediaUrls[mediaIndex]!;
+        if (sentSet.has(normalizeMediaForDedupe(url))) {
+          strippedMediaUrls = true;
+          if (!filteredUrls) {
+            filteredUrls = mediaUrls.slice(0, mediaIndex);
+          }
+          continue;
+        }
+        if (filteredUrls) {
+          filteredUrls.push(url);
+        }
+      }
     }
-    return Object.assign({}, payload, {
+
+    if (!stripSingle && !strippedMediaUrls) {
+      if (nextPayloads) {
+        nextPayloads.push(payload);
+      }
+      continue;
+    }
+
+    const nextPayload = Object.assign({}, payload, {
       mediaUrl: stripSingle ? undefined : mediaUrl,
       mediaUrls: filteredUrls?.length ? filteredUrls : undefined,
     });
-  });
+    if (!nextPayloads) {
+      nextPayloads = payloads.slice(0, index);
+    }
+    nextPayloads.push(nextPayload);
+  }
+
+  return nextPayloads ?? payloads;
+}
+
+function normalizeMediaForDedupe(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (!normalizeLowercaseStringOrEmpty(trimmed).startsWith("file://")) {
+    return trimmed;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol === "file:") {
+      return decodeURIComponent(parsed.pathname || "");
+    }
+  } catch {
+    // Keep fallback below for non-URL-like inputs.
+  }
+  return trimmed.replace(/^file:\/\//i, "");
 }
 
 function normalizeProviderForComparison(value?: string): string | undefined {

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -52,7 +52,7 @@ export function filterMessagingToolMediaDuplicates(params: {
 
   let nextPayloads: ReplyPayload[] | undefined;
   for (let index = 0; index < payloads.length; index++) {
-    const payload = payloads[index]!;
+    const payload = payloads[index];
     const mediaUrl = payload.mediaUrl;
     const mediaUrls = payload.mediaUrls;
     const stripSingle = mediaUrl && sentSet.has(normalizeMediaForDedupe(mediaUrl));
@@ -61,7 +61,7 @@ export function filterMessagingToolMediaDuplicates(params: {
     let strippedMediaUrls = false;
     if (mediaUrls?.length) {
       for (let mediaIndex = 0; mediaIndex < mediaUrls.length; mediaIndex++) {
-        const url = mediaUrls[mediaIndex]!;
+        const url = mediaUrls[mediaIndex];
         if (sentSet.has(normalizeMediaForDedupe(url))) {
           strippedMediaUrls = true;
           if (!filteredUrls) {

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -155,11 +155,15 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
   };
 
   let text = externalPayload.text ?? "";
-  let mediaUrls = (externalPayload.mediaUrls?.filter(Boolean) ?? []).length
-    ? (externalPayload.mediaUrls?.filter(Boolean) as string[])
-    : externalPayload.mediaUrl
-      ? [externalPayload.mediaUrl]
-      : [];
+  let mediaUrls: string[] = [];
+  for (const url of externalPayload.mediaUrls ?? []) {
+    if (url) {
+      mediaUrls.push(url);
+    }
+  }
+  if (mediaUrls.length === 0 && externalPayload.mediaUrl) {
+    mediaUrls = [externalPayload.mediaUrl];
+  }
   const replyToId = externalPayload.replyToId;
   const hasChannelData = messaging?.hasStructuredReplyPayload?.({
     payload: externalPayload,

--- a/src/auto-reply/reply/session-system-events.ts
+++ b/src/auto-reply/reply/session-system-events.ts
@@ -17,8 +17,15 @@ import {
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
 
-const selectGenericSystemEvents = (events: readonly SystemEvent[]): SystemEvent[] =>
-  events.filter((event) => !isExecCompletionEvent(event.text));
+const selectGenericSystemEvents = (events: readonly SystemEvent[]): SystemEvent[] => {
+  const selected: SystemEvent[] = [];
+  for (const event of events) {
+    if (!isExecCompletionEvent(event.text)) {
+      selected.push(event);
+    }
+  }
+  return selected;
+};
 
 /** Drain queued system events, format as `System:` lines, return the block (or undefined). */
 export async function drainFormattedSystemEvents(params: {
@@ -90,6 +97,7 @@ export async function drainFormattedSystemEvents(params: {
     );
   };
 
+  const summaryLines: string[] = [];
   const systemLines: string[] = [];
   // Exec completions have a dedicated heartbeat prompt; leave those entries queued
   // so the heartbeat path can consume and deliver them.
@@ -97,32 +105,36 @@ export async function drainFormattedSystemEvents(params: {
     params.sessionKey,
     selectGenericSystemEvents(peekSystemEventEntries(params.sessionKey)),
   );
-  systemLines.push(
-    ...queued.flatMap((event) => {
-      const compacted = compactSystemEvent(event.text);
-      if (!compacted) {
-        return [];
-      }
-      const prefix = event.trusted === false ? "System (untrusted)" : "System";
-      const timestamp = `[${formatSystemEventTimestamp(event.ts, params.cfg)}]`;
-      return compacted
-        .split("\n")
-        .map((subline, index) => `${prefix}: ${index === 0 ? `${timestamp} ` : ""}${subline}`);
-    }),
-  );
+  for (const event of queued) {
+    const compacted = compactSystemEvent(event.text);
+    if (!compacted) {
+      continue;
+    }
+    const prefix = event.trusted === false ? "System (untrusted)" : "System";
+    const timestamp = `[${formatSystemEventTimestamp(event.ts, params.cfg)}]`;
+    let index = 0;
+    for (const subline of compacted.split("\n")) {
+      systemLines.push(`${prefix}: ${index === 0 ? `${timestamp} ` : ""}${subline}`);
+      index += 1;
+    }
+  }
   if (params.isMainSession && params.isNewSession) {
     const summary = await buildChannelSummary(params.cfg);
     if (summary.length > 0) {
-      systemLines.unshift(
-        ...summary.flatMap((line) => line.split("\n").map((subline) => `System: ${subline}`)),
-      );
+      for (const line of summary) {
+        for (const subline of line.split("\n")) {
+          summaryLines.push(`System: ${subline}`);
+        }
+      }
     }
   }
-  if (systemLines.length === 0) {
+  if (summaryLines.length === 0 && systemLines.length === 0) {
     return undefined;
   }
 
   // Each sub-line gets its own prefix so continuation lines can't be mistaken
   // for regular user content.
-  return systemLines.join("\n");
+  return summaryLines.length > 0
+    ? [...summaryLines, ...systemLines].join("\n")
+    : systemLines.join("\n");
 }

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -50,22 +50,24 @@ export function buildToolsMessage(
   result: EffectiveToolInventoryResult,
   options?: { verbose?: boolean },
 ): string {
-  const groups = result.groups
-    .map((group) => ({
-      label: group.label,
-      tools: sortToolsMessageItems(
-        group.tools.map((tool) => ({
-          id: normalizeToolName(tool.id),
-          name: tool.label,
-          description: tool.description || "Tool",
-          rawDescription: tool.rawDescription || tool.description || "Tool",
-          source: tool.source,
-          pluginId: tool.pluginId,
-          channelId: tool.channelId,
-        })),
-      ),
-    }))
-    .filter((group) => group.tools.length > 0);
+  const groups: Array<{ label: string; tools: ToolsMessageItem[] }> = [];
+  for (const group of result.groups) {
+    const tools: ToolsMessageItem[] = [];
+    for (const tool of group.tools) {
+      tools.push({
+        id: normalizeToolName(tool.id),
+        name: tool.label,
+        description: tool.description || "Tool",
+        rawDescription: tool.rawDescription || tool.description || "Tool",
+        source: tool.source,
+        pluginId: tool.pluginId,
+        channelId: tool.channelId,
+      });
+    }
+    if (tools.length > 0) {
+      groups.push({ label: group.label, tools: sortToolsMessageItems(tools) });
+    }
+  }
 
   if (groups.length === 0) {
     const lines = [
@@ -89,7 +91,11 @@ export function buildToolsMessage(
       }
       continue;
     }
-    lines.push(`  ${group.tools.map((tool) => formatCompactToolEntry(tool)).join(", ")}`);
+    const compactTools: string[] = [];
+    for (const tool of group.tools) {
+      compactTools.push(formatCompactToolEntry(tool));
+    }
+    lines.push(`  ${compactTools.join(", ")}`);
   }
 
   if (verbose) {

--- a/src/channels/plugins/directory-config-helpers.ts
+++ b/src/channels/plugins/directory-config-helpers.ts
@@ -20,50 +20,76 @@ export function applyDirectoryQueryAndLimit(
 ): string[] {
   const q = resolveDirectoryQuery(params.query);
   const limit = resolveDirectoryLimit(params.limit);
-  const filtered = ids.filter((id) => (q ? normalizeLowercaseStringOrEmpty(id).includes(q) : true));
-  return typeof limit === "number" ? filtered.slice(0, limit) : filtered;
+  const filtered: string[] = [];
+  for (const id of ids) {
+    if (q && !normalizeLowercaseStringOrEmpty(id).includes(q)) {
+      continue;
+    }
+    filtered.push(id);
+    if (typeof limit === "number" && filtered.length >= limit) {
+      break;
+    }
+  }
+  return filtered;
 }
 
 export function toDirectoryEntries(kind: "user" | "group", ids: string[]): ChannelDirectoryEntry[] {
-  return ids.map((id) => ({ kind, id }) as const);
-}
-
-function normalizeDirectoryIds(params: {
-  rawIds: readonly string[];
-  normalizeId?: (entry: string) => string | null | undefined;
-}): string[] {
-  return params.rawIds
-    .map((entry) => normalizeOptionalString(entry) ?? "")
-    .filter((entry) => Boolean(entry) && entry !== "*")
-    .map((entry) => {
-      const normalized = params.normalizeId ? params.normalizeId(entry) : entry;
-      return normalizeOptionalString(normalized) ?? "";
-    })
-    .filter(Boolean);
+  const entries: ChannelDirectoryEntry[] = [];
+  for (const id of ids) {
+    entries.push({ kind, id });
+  }
+  return entries;
 }
 
 function collectDirectoryIdsFromEntries(params: {
   entries?: readonly unknown[];
   normalizeId?: (entry: string) => string | null | undefined;
 }): string[] {
-  return normalizeDirectoryIds({
-    rawIds: (params.entries ?? []).map((entry) => String(entry)),
-    normalizeId: params.normalizeId,
-  });
+  const ids: string[] = [];
+  for (const value of params.entries ?? []) {
+    const entry = normalizeOptionalString(String(value)) ?? "";
+    if (!entry || entry === "*") {
+      continue;
+    }
+    const normalized = params.normalizeId ? params.normalizeId(entry) : entry;
+    const id = normalizeOptionalString(normalized) ?? "";
+    if (id) {
+      ids.push(id);
+    }
+  }
+  return ids;
 }
 
 function collectDirectoryIdsFromMapKeys(params: {
   groups?: Record<string, unknown>;
   normalizeId?: (entry: string) => string | null | undefined;
 }): string[] {
-  return normalizeDirectoryIds({
-    rawIds: Object.keys(params.groups ?? {}),
-    normalizeId: params.normalizeId,
-  });
+  const ids: string[] = [];
+  for (const key of Object.keys(params.groups ?? {})) {
+    const entry = normalizeOptionalString(key) ?? "";
+    if (!entry || entry === "*") {
+      continue;
+    }
+    const normalized = params.normalizeId ? params.normalizeId(entry) : entry;
+    const id = normalizeOptionalString(normalized) ?? "";
+    if (id) {
+      ids.push(id);
+    }
+  }
+  return ids;
 }
 
 function dedupeDirectoryIds(ids: string[]): string[] {
-  return Array.from(new Set(ids));
+  const deduped: string[] = [];
+  const seen = new Set<string>();
+  for (const id of ids) {
+    if (seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    deduped.push(id);
+  }
+  return deduped;
 }
 
 export function collectNormalizedDirectoryIds(params: {

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -221,7 +221,7 @@ function toSystemAuditFindings(params: {
   severityFilter?: TaskSystemAuditSeverity;
   codeFilter?: TaskSystemAuditCode;
 }) {
-  const taskFindings = listTaskAuditFindings();
+  const taskFindings = listTaskAuditFindings({ tasks: reconcileInspectableTasks() });
   const flowFindings = listTaskFlowAuditFindings();
   const allFindings: TaskSystemAuditFinding[] = [
     ...taskFindings.map((finding) => ({

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -539,6 +539,8 @@ export type {
  * plugin-owned transport family.
  */
 export type ProviderNormalizeTransportContext = {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
   provider: string;
   api?: string | null;
   baseUrl?: string;


### PR DESCRIPTION
## Summary

- Problem: reply and queue hot paths still used avoidable array churn and temporary helper allocations.
- Why it matters: these paths sit under auto-reply, agent execution payloads, channel event queues, and user-visible tool/status formatting.
- What changed: cherry-picked the four bucket commits, resolved drift conflicts, and fixed the follow-up type/lint issues found by the changed gate.
- What did NOT change: no new channel behavior, config, permissions, or provider contracts.

## Change Type (select all)

- [x] Refactor required for the fix
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Integrations
- [x] API / contracts

## Linked Issue/PR

- Related: bucket cherry-pick review for commits `5e1888bac5`, `f0bfef81bf`, `95973ee1ed`, `4d8082b1c7`
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: internal performance bucket for reply helpers and queue churn.
- Real environment tested: Blacksmith Testbox via Crabbox.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply.config.ts`
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts`
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-discord.config.ts`
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-mattermost.config.ts`
  - `OPENCLAW_TESTBOX=1 pnpm check:changed`
- Evidence after fix: Crabbox/Testbox focused run `tbx_01kr07vehdegss5ps5g4c68v53`, GitHub Actions run `25474528360`, exit 0; latest changed gate `tbx_01kr095ve35zfesv4btwz82asg`, GitHub Actions run `25475183288`, exit 0.
- Observed result after fix: focused auto-reply/agents/Discord/Mattermost suites passed; changed gate passed after remediation.
- What was not tested: live Discord/Mattermost delivery against real services.
- Before evidence: initial changed gate caught a real `session-transcript-repair.ts` type error; next run caught lint drift in `images.ts` and `reply-payloads-dedupe.ts`; GitHub OpenGrep caught a trusted-media scanner trip from a tiny allocation rewrite, so that file was restored to main and left out of this PR.

## Root Cause (if applicable)

- Root cause: cherry-picked perf commits were older than current main and needed drift repair around stricter typing/lint rules plus current reply metadata helpers.
- Missing detection / guardrail: existing gate caught the drift; no new guardrail needed.
- Contributing context: one conflict resolution initially preserved stale reply metadata/dedupe assumptions, fixed in follow-up commits.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Existing coverage already sufficient
- Target test or file: focused auto-reply, agents, Discord, Mattermost suites plus `pnpm check:changed`.
- Scenario the test should lock in: reply metadata preservation, duplicate suppression, queue order, and display/status formatting compile/lint cleanly.
- Why this is the smallest reliable guardrail: this bucket is broad; the focused suite covers the riskiest runtime surfaces while changed gate covers type/lint/import guards.
- Existing test that already covers this (if any): see Crabbox evidence above.
- If no new test is added, why not: behavior is intended to remain equivalent; failures were drift/type/lint issues caught by existing gates.

## User-visible / Behavior Changes

None intended.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux via Blacksmith Testbox
- Runtime/container: repo Testbox CI environment
- Model/provider: N/A
- Integration/channel (if any): auto-reply, agents, Discord, Mattermost
- Relevant config (redacted): N/A

### Steps

1. Cherry-pick the four bucket commits onto current main.
2. Resolve conflicts and remediate type/lint drift.
3. Run focused Crabbox suites.
4. Run `OPENCLAW_TESTBOX=1 pnpm check:changed`.

### Expected

- Focused suites and changed gate pass.

### Actual

- Focused suites and changed gate passed.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: conflict resolution review, focused auto-reply/agents/Discord/Mattermost Crabbox suites, changed gate, post-rebase `git diff --check origin/main...HEAD`.
- Edge cases checked: stale reply suppress/dedupe metadata, empty origin routing metadata, optional transcript repair tool names, lint-safe reversed media URI order.
- What you did **not** verify: live external Discord/Mattermost delivery.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: subtle queue ordering or reply metadata regressions.
  - Mitigation: focused queue/reply suites and changed gate passed on Crabbox; conflict-specific metadata and dedupe drift was manually reviewed and fixed.
