### PR TITLE
Harden browser download output writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -617,6 +617,7 @@ Docs: https://docs.openclaw.ai
 - Channels/iMessage: surface the silent group-allowlist drop at default log level by emitting a one-time `warn` per account at monitor startup when `channels.imessage.groupPolicy: "allowlist"` is set without a `channels.imessage.groups` block, plus a one-time `warn` per `chat_id` when the runtime gate drops a specific group, naming the exact `channels.imessage.groups[...]` key to add to allow it. Fixes #78749. (#79190) Thanks @omarshahine.
 - WhatsApp: stop Gateway-originated outbound echoes from advancing inbound activity in `openclaw channels status`, so outbound self-sends no longer look like handled inbound messages. Fixes #79056. (#79057) Thanks @ai-hpc and @bittoby.
 - Gateway/nodes: preserve the live node registry session and invoke ownership when an older same-node WebSocket closes after reconnecting. (#78351) Thanks @samzong.
+- Browser/downloads: route explicit and managed browser download output directories through `fs-safe` validation before staging final files, so symlinked output roots are rejected before writes. (#78780) Thanks @jesse-merhi.
 
 ## 2026.5.3-1
 

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-fecac0023b0a8de6334740483ef03500c72f3235e5b636e089bf581b00e8734a  plugin-sdk-api-baseline.json
-b427b2c8bddefb6c0ab4f411065adeec230d1e126a792ed30e6d0a45053dd4e3  plugin-sdk-api-baseline.jsonl
+259c4d22d5fe84ca6b27f9d061dddca4459e4eddd516729564f250d823dbd819  plugin-sdk-api-baseline.json
+b2bf16d3c5859b06240b5f41ed5803af8e82338da3e56ace1569520ac0732a5a  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-259c4d22d5fe84ca6b27f9d061dddca4459e4eddd516729564f250d823dbd819  plugin-sdk-api-baseline.json
-b2bf16d3c5859b06240b5f41ed5803af8e82338da3e56ace1569520ac0732a5a  plugin-sdk-api-baseline.jsonl
+9f7ea91407a66fee6bcdebaf64bd15d0a6ae8b48cf100753c96f2ad29ad86390  plugin-sdk-api-baseline.json
+4d516f6ac681cf55e916f712601abb8f5a7ddcd92a7710e8947f89c38e4054e7  plugin-sdk-api-baseline.jsonl

--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -96,6 +96,14 @@ function effectiveSpawnCommand(call: unknown[] | undefined): unknown {
   return command;
 }
 
+function mockExpiredLaunchPollingClock(): void {
+  let now = 1_000_000;
+  vi.spyOn(Date, "now").mockImplementation(() => {
+    now += 1_000;
+    return now;
+  });
+}
+
 async function withMockChromeCdpServer(params: {
   wsPath: string;
   onConnection?: (wss: WebSocketServer) => void;
@@ -507,15 +515,16 @@ describe("chrome.ts internal", () => {
       let spawnCalls = 0;
       const firstProc = makeFakeProc();
       const secondProc = makeFakeProc();
+      mockExpiredLaunchPollingClock();
       spawnMock.mockImplementation(() => {
         spawnCalls += 1;
         if (spawnCalls === 1) {
-          setTimeout(() => {
+          void Promise.resolve().then(() => {
             firstProc.stderr.emit(
               "data",
               Buffer.from("The profile appears to be in use by another Chromium process"),
             );
-          }, 0);
+          });
           return firstProc;
         }
         cdpReachable = true;
@@ -566,7 +575,10 @@ describe("chrome.ts internal", () => {
         const fakeProc = makeFakeProc();
         spawnMock.mockReturnValue(fakeProc);
         // Leak some stderr into the buffer so the hint renders.
-        setTimeout(() => fakeProc.stderr.emit("data", Buffer.from("crash dump\n")), 10);
+        void Promise.resolve().then(() =>
+          fakeProc.stderr.emit("data", Buffer.from("crash dump\n")),
+        );
+        mockExpiredLaunchPollingClock();
 
         // fetch always fails → isChromeReachable returns false every poll.
         vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
@@ -599,6 +611,7 @@ describe("chrome.ts internal", () => {
       });
       const fakeProc = makeFakeProc();
       spawnMock.mockReturnValue(fakeProc);
+      mockExpiredLaunchPollingClock();
       vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
 
       const resolved = {
@@ -990,9 +1003,12 @@ describe("chrome.ts internal", () => {
       const fakeProc = makeFakeProc();
       spawnMock.mockImplementation(() => {
         // Synthesize stderr data shortly after spawn.
-        setTimeout(() => fakeProc.stderr.emit("data", Buffer.from("chrome crash log\n")), 5);
+        void Promise.resolve().then(() =>
+          fakeProc.stderr.emit("data", Buffer.from("chrome crash log\n")),
+        );
         return fakeProc;
       });
+      mockExpiredLaunchPollingClock();
       vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
       const profile = {
         name: "openclaw-stderr",
@@ -1029,6 +1045,7 @@ describe("chrome.ts internal", () => {
           return false;
         });
         spawnMock.mockImplementation(() => makeFakeProc());
+        mockExpiredLaunchPollingClock();
         vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
         const profile = {
           name: "openclaw-mac",
@@ -1057,13 +1074,9 @@ describe("chrome.ts internal", () => {
 
     it("breaks out of the bootstrap prefs-wait loop as soon as both files exist", async () => {
       // Covers the `if (exists(localStatePath) && exists(preferencesPath)) break;` branch.
-      // Use a wallclock flag that the mock checks each call so the loop
-      // iterates (awaiting its 100ms setTimeout) once with prefs-absent,
-      // then the flag flips and the next iteration hits the break.
-      let prefsVisible = false;
-      setTimeout(() => {
-        prefsVisible = true;
-      }, 50);
+      // The first prefs probe makes bootstrap necessary; subsequent probes
+      // make both prefs files visible so the polling loop breaks immediately.
+      let prefsProbeCount = 0;
       vi.spyOn(fs, "existsSync").mockImplementation((p) => {
         const s = String(p);
         if (
@@ -1074,7 +1087,8 @@ describe("chrome.ts internal", () => {
           return true;
         }
         if (s.endsWith("Local State") || s.endsWith("Preferences")) {
-          return prefsVisible;
+          prefsProbeCount += 1;
+          return prefsProbeCount > 1;
         }
         return false;
       });
@@ -1129,17 +1143,15 @@ describe("chrome.ts internal", () => {
       });
       const bootstrapProc = makeFakeProc();
       const runtimeProc = makeFakeProc();
+      bootstrapProc.kill = vi.fn((_sig?: string) => {
+        bootstrapProc.killed = true;
+        bootstrapProc.exitCode = 0;
+        return true;
+      });
       let callCount = 0;
       spawnMock.mockImplementation(() => {
         callCount += 1;
-        if (callCount === 1) {
-          // Set exitCode shortly after spawn so the exit-wait loop breaks.
-          setTimeout(() => {
-            bootstrapProc.exitCode = 0;
-          }, 25);
-          return bootstrapProc;
-        }
-        return runtimeProc;
+        return callCount === 1 ? bootstrapProc : runtimeProc;
       });
       await withMockChromeCdpServer({
         wsPath: "/devtools/browser/EXIT_BREAK",

--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -587,38 +587,31 @@ describe("chrome.ts internal", () => {
     });
 
     it("uses the configured local launch timeout while waiting for CDP discovery", async () => {
-      vi.useFakeTimers();
-      try {
-        const executablePath = path.join(tmpDir, "chrome");
-        await fsp.writeFile(executablePath, "");
-        const existsSync = fs.existsSync.bind(fs);
-        vi.spyOn(fs, "existsSync").mockImplementation((p) => {
-          const s = String(p);
-          if (s.endsWith("Local State") || s.endsWith("Preferences")) {
-            return true;
-          }
-          return existsSync(p);
-        });
-        const fakeProc = makeFakeProc();
-        spawnMock.mockReturnValue(fakeProc);
-        vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
+      const executablePath = path.join(tmpDir, "chrome");
+      await fsp.writeFile(executablePath, "");
+      const existsSync = fs.existsSync.bind(fs);
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (s.endsWith("Local State") || s.endsWith("Preferences")) {
+          return true;
+        }
+        return existsSync(p);
+      });
+      const fakeProc = makeFakeProc();
+      spawnMock.mockReturnValue(fakeProc);
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
 
-        const resolved = {
-          ...makeResolved(),
-          executablePath,
-          localLaunchTimeoutMs: 1,
-        };
-        const profile = makeProfile(55556);
-        const rejection = expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
-          /Failed to start Chrome CDP/,
-        );
+      const resolved = {
+        ...makeResolved(),
+        executablePath,
+        localLaunchTimeoutMs: 1,
+      };
+      const profile = makeProfile(55556);
 
-        await vi.advanceTimersByTimeAsync(10);
-        await rejection;
-        expect(fakeProc.kill).toHaveBeenCalledWith("SIGKILL");
-      } finally {
-        vi.useRealTimers();
-      }
+      await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+        /Failed to start Chrome CDP/,
+      );
+      expect(fakeProc.kill).toHaveBeenCalledWith("SIGKILL");
     });
   });
 

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -59,6 +59,7 @@ import {
   DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,
 } from "./constants.js";
 import { BrowserProfileUnavailableError } from "./errors.js";
+import { ensureOutputDirectory } from "./output-directories.js";
 import { DEFAULT_DOWNLOAD_DIR } from "./paths.js";
 
 const log = createSubsystemLogger("browser").child("chrome");
@@ -423,7 +424,7 @@ export async function launchOpenClawChrome(
 
   const userDataDir = resolveOpenClawUserDataDir(profile.name);
   fs.mkdirSync(userDataDir, { recursive: true });
-  fs.mkdirSync(DEFAULT_DOWNLOAD_DIR, { recursive: true });
+  await ensureOutputDirectory(DEFAULT_DOWNLOAD_DIR);
 
   const needsDecorate = !isProfileDecorated(
     userDataDir,

--- a/extensions/browser/src/browser/output-atomic.ts
+++ b/extensions/browser/src/browser/output-atomic.ts
@@ -1,12 +1,12 @@
-import fs from "node:fs/promises";
 import { writeExternalFileWithinRoot } from "../sdk-security-runtime.js";
+import { ensureOutputDirectory } from "./output-directories.js";
 
 export async function writeViaSiblingTempPath(params: {
   rootDir: string;
   targetPath: string;
   writeTemp: (tempPath: string) => Promise<void>;
 }): Promise<void> {
-  await fs.mkdir(params.rootDir, { recursive: true });
+  await ensureOutputDirectory(params.rootDir);
   await writeExternalFileWithinRoot({
     rootDir: params.rootDir,
     path: params.targetPath,

--- a/extensions/browser/src/browser/output-directories.test.ts
+++ b/extensions/browser/src/browser/output-directories.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { ensureOutputDirectory } from "./output-directories.js";
+
+async function withTempDir<T>(run: (tempDir: string) => Promise<T>): Promise<T> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-output-dir-test-"));
+  try {
+    return await run(tempDir);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+describe("ensureOutputDirectory", () => {
+  it("creates nested missing output directories", async () => {
+    await withTempDir(async (tempDir) => {
+      const outputDir = path.join(tempDir, "reports", "downloads");
+
+      await ensureOutputDirectory(outputDir);
+
+      const stat = await fs.stat(outputDir);
+      expect(stat.isDirectory()).toBe(true);
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects symlinked output directory ancestors",
+    async () => {
+      await withTempDir(async (tempDir) => {
+        const outsideDir = path.join(tempDir, "outside");
+        await fs.mkdir(outsideDir);
+        const symlinkDir = path.join(tempDir, "downloads");
+        await fs.symlink(outsideDir, symlinkDir);
+
+        await expect(ensureOutputDirectory(path.join(symlinkDir, "nested"))).rejects.toThrow(
+          /symlink|output directory/i,
+        );
+        await expect(fs.access(path.join(outsideDir, "nested"))).rejects.toThrow();
+      });
+    },
+  );
+});

--- a/extensions/browser/src/browser/output-directories.ts
+++ b/extensions/browser/src/browser/output-directories.ts
@@ -1,46 +1,35 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { isNotFoundPathError, pathScope } from "../sdk-security-runtime.js";
+import { ensureAbsoluteDirectory } from "../sdk-security-runtime.js";
 
-async function findExistingAncestor(dirPath: string): Promise<{
-  ancestorDir: string;
-  relativeDir: string;
-}> {
-  let current = path.resolve(dirPath);
-  const missingSegments: string[] = [];
-
-  while (true) {
+async function resolveSystemDirectoryAlias(dirPath: string): Promise<string> {
+  // macOS exposes /tmp and /var as fixed system symlinks into /private.
+  // Canonicalize only those roots before rejecting symlinks below them.
+  for (const aliasRoot of ["/tmp", "/var"]) {
+    if (dirPath !== aliasRoot && !dirPath.startsWith(`${aliasRoot}${path.sep}`)) {
+      continue;
+    }
     try {
-      const stat = await fs.lstat(current);
-      if (!stat.isDirectory() || stat.isSymbolicLink()) {
-        throw new Error("Invalid path: output directory must be a real directory");
+      const stat = await fs.lstat(aliasRoot);
+      if (!stat.isSymbolicLink()) {
+        return dirPath;
       }
-      return {
-        ancestorDir: current,
-        relativeDir: missingSegments.length === 0 ? "." : path.join(...missingSegments.reverse()),
-      };
-    } catch (error) {
-      if (!isNotFoundPathError(error)) {
-        throw error;
-      }
-      const parentDir = path.dirname(current);
-      if (parentDir === current) {
-        throw error;
-      }
-      missingSegments.push(path.basename(current));
-      current = parentDir;
+      return path.join(await fs.realpath(aliasRoot), path.relative(aliasRoot, dirPath));
+    } catch {
+      return dirPath;
     }
   }
+  return dirPath;
 }
 
 export async function ensureOutputDirectory(dirPath: string): Promise<void> {
-  const resolvedDir = path.resolve(dirPath);
-  const { ancestorDir, relativeDir } = await findExistingAncestor(resolvedDir);
-  if (relativeDir === ".") {
-    return;
-  }
-  const result = await pathScope(ancestorDir, { label: "output directory" }).ensureDir(relativeDir);
+  const result = await ensureAbsoluteDirectory(
+    await resolveSystemDirectoryAlias(path.resolve(dirPath)),
+    {
+      scopeLabel: "output directory",
+    },
+  );
   if (!result.ok) {
-    throw new Error(result.error);
+    throw result.error;
   }
 }

--- a/extensions/browser/src/browser/output-directories.ts
+++ b/extensions/browser/src/browser/output-directories.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isNotFoundPathError, pathScope } from "../sdk-security-runtime.js";
+
+async function findExistingAncestor(dirPath: string): Promise<{
+  ancestorDir: string;
+  relativeDir: string;
+}> {
+  let current = path.resolve(dirPath);
+  const missingSegments: string[] = [];
+
+  while (true) {
+    try {
+      const stat = await fs.lstat(current);
+      if (!stat.isDirectory() || stat.isSymbolicLink()) {
+        throw new Error("Invalid path: output directory must be a real directory");
+      }
+      return {
+        ancestorDir: current,
+        relativeDir: missingSegments.length === 0 ? "." : path.join(...missingSegments.reverse()),
+      };
+    } catch (error) {
+      if (!isNotFoundPathError(error)) {
+        throw error;
+      }
+      const parentDir = path.dirname(current);
+      if (parentDir === current) {
+        throw error;
+      }
+      missingSegments.push(path.basename(current));
+      current = parentDir;
+    }
+  }
+}
+
+export async function ensureOutputDirectory(dirPath: string): Promise<void> {
+  const resolvedDir = path.resolve(dirPath);
+  const { ancestorDir, relativeDir } = await findExistingAncestor(resolvedDir);
+  if (relativeDir === ".") {
+    return;
+  }
+  const result = await pathScope(ancestorDir, { label: "output directory" }).ensureDir(relativeDir);
+  if (!result.ok) {
+    throw new Error(result.error);
+  }
+}

--- a/extensions/browser/src/browser/output-files.ts
+++ b/extensions/browser/src/browser/output-files.ts
@@ -1,0 +1,26 @@
+import path from "node:path";
+import { writeExternalFileWithinRoot } from "../sdk-security-runtime.js";
+import { ensureOutputDirectory } from "./output-directories.js";
+
+export async function writeExternalFileWithinOutputRoot(params: {
+  rootDir?: string;
+  path: string;
+  write: (filePath: string) => Promise<void>;
+}): Promise<string> {
+  const outputPath = params.path.trim();
+  if (!outputPath) {
+    throw new Error("output path is required");
+  }
+
+  const rootDir = params.rootDir
+    ? path.resolve(params.rootDir)
+    : path.dirname(path.resolve(outputPath));
+  await ensureOutputDirectory(rootDir);
+
+  const result = await writeExternalFileWithinRoot({
+    rootDir,
+    path: outputPath,
+    write: params.write,
+  });
+  return result.path;
+}

--- a/extensions/browser/src/browser/pw-session.test.ts
+++ b/extensions/browser/src/browser/pw-session.test.ts
@@ -175,7 +175,7 @@ describe("pw-session ensurePageState", () => {
     expect(saveAsB.mock.calls[0]?.[0]).not.toBe(managedPathB);
     await expect(fs.readFile(managedPathA ?? "", "utf8")).resolves.toBe("download-a");
     await expect(fs.readFile(managedPathB ?? "", "utf8")).resolves.toBe("download-b");
-    expect(mkdirSpy).toHaveBeenCalledWith(DEFAULT_DOWNLOAD_DIR, { recursive: true });
+    expect(mkdirSpy).toHaveBeenCalled();
   });
 
   it("suppresses unmanaged download save rejections until path is awaited", async () => {

--- a/extensions/browser/src/browser/pw-tools-core.downloads.ts
+++ b/extensions/browser/src/browser/pw-tools-core.downloads.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import path from "node:path";
 import type { Page } from "playwright-core";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
-import { writeViaSiblingTempPath } from "./output-atomic.js";
+import { writeExternalFileWithinOutputRoot } from "./output-files.js";
 import { DEFAULT_UPLOAD_DIR, resolveStrictExistingPathsWithinRoot } from "./paths.js";
 import {
   ensurePageState,
@@ -88,33 +88,22 @@ type DownloadPayload = {
   saveAs?: (outPath: string) => Promise<void>;
 };
 
-async function saveDownloadPayload(download: DownloadPayload, outPath: string) {
+async function saveDownloadPayload(download: DownloadPayload, outPath: string, rootDir?: string) {
   const suggested = download.suggestedFilename?.() || "download.bin";
   const requestedPath = outPath?.trim();
   const resolvedOutPath = path.resolve(requestedPath || buildTempDownloadPath(suggested));
-
-  if (!requestedPath) {
-    await writeViaSiblingTempPath({
-      rootDir: path.dirname(resolvedOutPath),
-      targetPath: resolvedOutPath,
-      writeTemp: async (tempPath) => {
-        await download.saveAs?.(tempPath);
-      },
-    });
-  } else {
-    await writeViaSiblingTempPath({
-      rootDir: path.dirname(resolvedOutPath),
-      targetPath: resolvedOutPath,
-      writeTemp: async (tempPath) => {
-        await download.saveAs?.(tempPath);
-      },
-    });
-  }
+  const finalPath = await writeExternalFileWithinOutputRoot({
+    rootDir,
+    path: resolvedOutPath,
+    write: async (tempPath) => {
+      await download.saveAs?.(tempPath);
+    },
+  });
 
   return {
     url: download.url?.() || "",
     suggestedFilename: suggested,
-    path: resolvedOutPath,
+    path: finalPath,
   };
 }
 
@@ -123,13 +112,14 @@ async function awaitDownloadPayload(params: {
   state: ReturnType<typeof ensurePageState>;
   armId: number;
   outPath?: string;
+  rootDir?: string;
 }) {
   try {
     const download = (await params.waiter.promise) as DownloadPayload;
     if (params.state.armIdDownload !== params.armId) {
       throw new Error("Download was superseded by another waiter");
     }
-    return await saveDownloadPayload(download, params.outPath ?? "");
+    return await saveDownloadPayload(download, params.outPath ?? "", params.rootDir);
   } catch (err) {
     params.waiter.cancel();
     throw err;
@@ -233,6 +223,7 @@ export async function waitForDownloadViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   path?: string;
+  rootDir?: string;
   timeoutMs?: number;
 }): Promise<{
   url: string;
@@ -247,7 +238,13 @@ export async function waitForDownloadViaPlaywright(opts: {
   const armId = state.armIdDownload;
 
   const waiter = createPageDownloadWaiter(page, timeout);
-  return await awaitDownloadPayload({ waiter, state, armId, outPath: opts.path });
+  return await awaitDownloadPayload({
+    waiter,
+    state,
+    armId,
+    outPath: opts.path,
+    rootDir: opts.rootDir,
+  });
 }
 
 export async function downloadViaPlaywright(opts: {
@@ -255,6 +252,7 @@ export async function downloadViaPlaywright(opts: {
   targetId?: string;
   ref: string;
   path: string;
+  rootDir?: string;
   timeoutMs?: number;
 }): Promise<{
   url: string;
@@ -283,7 +281,13 @@ export async function downloadViaPlaywright(opts: {
     } catch (err) {
       throw toAIFriendlyError(err, ref);
     }
-    return await awaitDownloadPayload({ waiter, state, armId, outPath });
+    return await awaitDownloadPayload({
+      waiter,
+      state,
+      armId,
+      outPath,
+      rootDir: opts.rootDir,
+    });
   } catch (err) {
     waiter.cancel();
     throw err;

--- a/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
@@ -138,7 +138,8 @@ describe("pw-tools-core", () => {
     expect(typeof savedPath).toBe("string");
     expect(savedPath).not.toBe(params.targetPath);
     expect(path.basename(path.dirname(String(savedPath)))).toContain("fs-safe-output");
-    expect(path.basename(String(savedPath))).toBe(path.basename(params.targetPath));
+    expect(path.basename(String(savedPath))).toContain(path.basename(params.targetPath));
+    expect(path.basename(String(savedPath))).toMatch(/\.part$/);
     expect(await fs.readFile(params.targetPath, "utf8")).toBe(params.content);
     await expect(fs.access(String(savedPath))).rejects.toThrow();
   }
@@ -317,7 +318,8 @@ describe("pw-tools-core", () => {
     );
     const expectedDownloadsTail = `${path.join("tmp", "openclaw-preferred", "downloads")}${path.sep}`;
     expect(path.dirname(outPath)).not.toBe(expectedRootedDownloadsDir);
-    expect(path.basename(outPath)).toBe(path.basename(res.path));
+    expect(path.basename(outPath)).toContain(path.basename(res.path));
+    expect(path.basename(outPath)).toMatch(/\.part$/);
     await expect(fs.readFile(res.path, "utf8")).resolves.toBe("download-content");
     expect(path.normalize(res.path)).toContain(path.normalize(expectedDownloadsTail));
     expect(tmpDirMocks.resolvePreferredOpenClawTmpDir).toHaveBeenCalled();
@@ -333,7 +335,8 @@ describe("pw-tools-core", () => {
     expect(path.dirname(outPath)).not.toBe(
       path.resolve(path.join(path.sep, "tmp", "openclaw-preferred", "downloads")),
     );
-    expect(path.basename(outPath)).toBe(path.basename(res.path));
+    expect(path.basename(outPath)).toContain(path.basename(res.path));
+    expect(path.basename(outPath)).toMatch(/\.part$/);
     await expect(fs.readFile(res.path, "utf8")).resolves.toBe("download-content");
     expect(path.normalize(res.path)).toContain(
       path.normalize(`${path.join("tmp", "openclaw-preferred", "downloads")}${path.sep}`),

--- a/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
@@ -137,6 +137,7 @@ describe("pw-tools-core", () => {
     const savedPath = params.saveAs.mock.calls[0]?.[0];
     expect(typeof savedPath).toBe("string");
     expect(savedPath).not.toBe(params.targetPath);
+    expect(path.basename(path.dirname(String(savedPath)))).toContain("fs-safe-output");
     expect(path.basename(String(savedPath))).toBe(path.basename(params.targetPath));
     expect(await fs.readFile(params.targetPath, "utf8")).toBe(params.content);
     await expect(fs.access(String(savedPath))).rejects.toThrow();
@@ -170,6 +171,39 @@ describe("pw-tools-core", () => {
       const res = await p;
       await expectAtomicDownloadSave({ saveAs, targetPath, content: "file-content" });
       await expect(fs.realpath(res.path)).resolves.toBe(await fs.realpath(targetPath));
+    });
+  });
+
+  it("creates missing explicit download output parents through the safe output directory path", async () => {
+    await withTempDir(async (tempDir) => {
+      const harness = createDownloadEventHarness();
+      const targetPath = path.join(tempDir, "nested", "deeper", "file.bin");
+
+      const saveAs = vi.fn(async (outPath: string) => {
+        await fs.writeFile(outPath, "nested-content", "utf8");
+      });
+
+      const p = mod.waitForDownloadViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "T1",
+        path: targetPath,
+        timeoutMs: 1000,
+      });
+
+      await Promise.resolve();
+      harness.expectArmed();
+      harness.trigger({
+        url: () => "https://example.com/file.bin",
+        suggestedFilename: () => "file.bin",
+        saveAs,
+      });
+
+      await p;
+      await expectAtomicDownloadSave({
+        saveAs,
+        targetPath,
+        content: "nested-content",
+      });
     });
   });
 
@@ -282,7 +316,7 @@ describe("pw-tools-core", () => {
       path.join(path.sep, "tmp", "openclaw-preferred", "downloads"),
     );
     const expectedDownloadsTail = `${path.join("tmp", "openclaw-preferred", "downloads")}${path.sep}`;
-    expect(path.dirname(res.path)).toBe(expectedRootedDownloadsDir);
+    expect(path.dirname(outPath)).not.toBe(expectedRootedDownloadsDir);
     expect(path.basename(outPath)).toBe(path.basename(res.path));
     await expect(fs.readFile(res.path, "utf8")).resolves.toBe("download-content");
     expect(path.normalize(res.path)).toContain(path.normalize(expectedDownloadsTail));
@@ -296,7 +330,7 @@ describe("pw-tools-core", () => {
       suggestedFilename: "../../../../etc/passwd",
     });
     expect(typeof outPath).toBe("string");
-    expect(path.dirname(res.path)).toBe(
+    expect(path.dirname(outPath)).not.toBe(
       path.resolve(path.join(path.sep, "tmp", "openclaw-preferred", "downloads")),
     );
     expect(path.basename(outPath)).toBe(path.basename(res.path));
@@ -305,6 +339,41 @@ describe("pw-tools-core", () => {
       path.normalize(`${path.join("tmp", "openclaw-preferred", "downloads")}${path.sep}`),
     );
   });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects implicit downloads when the output directory is a symlink",
+    async () => {
+      await withTempDir(async (tempDir) => {
+        const outsideDir = path.join(tempDir, "outside");
+        await fs.mkdir(outsideDir, { recursive: true });
+        await fs.symlink(outsideDir, path.join(tempDir, "downloads"));
+        tmpDirMocks.resolvePreferredOpenClawTmpDir.mockReturnValue(tempDir);
+
+        const harness = createDownloadEventHarness();
+        const saveAs = vi.fn(async (outPath: string) => {
+          await fs.writeFile(outPath, "should-not-write", "utf8");
+        });
+
+        const p = mod.waitForDownloadViaPlaywright({
+          cdpUrl: "http://127.0.0.1:18792",
+          targetId: "T1",
+          timeoutMs: 1000,
+        });
+
+        await Promise.resolve();
+        harness.expectArmed();
+        harness.trigger({
+          url: () => "https://example.com/file.bin",
+          suggestedFilename: () => "file.bin",
+          saveAs,
+        });
+
+        await expect(p).rejects.toThrow(/output directory/i);
+        expect(saveAs).not.toHaveBeenCalled();
+        await expect(fs.readdir(outsideDir)).resolves.toEqual([]);
+      });
+    },
+  );
   it("waits for a matching response and returns its body", async () => {
     let responseHandler: ((resp: unknown) => void) | undefined;
     const on = vi.fn((event: string, handler: (resp: unknown) => void) => {

--- a/extensions/browser/src/browser/routes/agent.act.download.ts
+++ b/extensions/browser/src/browser/routes/agent.act.download.ts
@@ -63,6 +63,7 @@ export function registerBrowserAgentActDownloadRoutes(
           const result = await pw.waitForDownloadViaPlaywright({
             ...requestBase,
             path: downloadPath,
+            rootDir: DEFAULT_DOWNLOAD_DIR,
           });
           res.json({ ok: true, targetId: tab.targetId, download: result });
         },
@@ -113,6 +114,7 @@ export function registerBrowserAgentActDownloadRoutes(
             ...requestBase,
             ref,
             path: downloadPath,
+            rootDir: DEFAULT_DOWNLOAD_DIR,
           });
           res.json({ ok: true, targetId: tab.targetId, download: result });
         },

--- a/extensions/browser/src/browser/routes/output-paths.ts
+++ b/extensions/browser/src/browser/routes/output-paths.ts
@@ -1,9 +1,9 @@
-import fs from "node:fs/promises";
+import { ensureOutputDirectory } from "../output-directories.js";
 import { pathScope } from "./path-output.js";
 import type { BrowserResponse } from "./types.js";
 
 export async function ensureOutputRootDir(rootDir: string): Promise<void> {
-  await fs.mkdir(rootDir, { recursive: true });
+  await ensureOutputDirectory(rootDir);
 }
 
 export async function resolveWritableOutputPathOrRespond(params: {

--- a/extensions/browser/src/sdk-security-runtime.ts
+++ b/extensions/browser/src/sdk-security-runtime.ts
@@ -3,6 +3,7 @@ export {
   ensurePortAvailable,
   extractErrorCode,
   formatErrorMessage,
+  ensureAbsoluteDirectory,
   hasProxyEnvConfigured,
   isNotFoundPathError,
   isPathInside,

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -7,10 +7,13 @@ export { FsSafeError, type FsSafeErrorCode } from "@openclaw/fs-safe/errors";
 export {
   assertAbsolutePathInput,
   canonicalPathFromExistingAncestor,
+  ensureAbsoluteDirectory,
   findExistingAncestor,
   resolveAbsolutePathForRead,
   resolveAbsolutePathForWrite,
   type AbsolutePathSymlinkPolicy,
+  type EnsureAbsoluteDirectoryOptions,
+  type EnsureAbsoluteDirectoryResult,
   type ResolvedAbsolutePath,
   type ResolvedWritableAbsolutePath,
 } from "@openclaw/fs-safe/advanced";

--- a/src/plugin-sdk/security-runtime.ts
+++ b/src/plugin-sdk/security-runtime.ts
@@ -83,10 +83,13 @@ export { isNotFoundPathError, isPathInside } from "../infra/path-guards.js";
 export {
   assertAbsolutePathInput,
   canonicalPathFromExistingAncestor,
+  ensureAbsoluteDirectory,
   findExistingAncestor,
   resolveAbsolutePathForRead,
   resolveAbsolutePathForWrite,
   type AbsolutePathSymlinkPolicy,
+  type EnsureAbsoluteDirectoryOptions,
+  type EnsureAbsoluteDirectoryResult,
   type ResolvedAbsolutePath,
   type ResolvedWritableAbsolutePath,
 } from "../infra/fs-safe.js";


### PR DESCRIPTION
## Summary
- update `@openclaw/fs-safe` to the merged output writer SHA
- route browser downloads through `writeExternalFileWithinRoot` for private staging and finalization
- safely create managed output roots without accepting symlinked output directories

## Validation
- `fnm exec --using v22.20.0 pnpm exec oxfmt --check --threads=1 src/infra/fs-safe.ts src/plugin-sdk/security-runtime.ts extensions/browser/src/sdk-security-runtime.ts extensions/browser/src/browser/output-files.ts extensions/browser/src/browser/output-directories.ts extensions/browser/src/browser/pw-tools-core.downloads.ts extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts extensions/browser/src/browser/routes/output-paths.ts extensions/browser/src/browser/routes/agent.act.download.ts`
- `git diff --check`
- `fnm exec --using v22.20.0 pnpm test extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts`
- `fnm exec --using v22.20.0 pnpm test extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts`
- `fnm exec --using v22.20.0 pnpm test extensions/browser/src/browser/paths.test.ts`
- `fnm exec --using v22.20.0 pnpm tsgo:extensions:test`