### PR TITLE
fix(approvals): interpolate request id into "Reply with:" line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Approvals: interpolate the request id into the chat fallback `Reply with: /approve <id> ...` line in both the exec and plugin approval forwarders so owners can copy-paste the command directly instead of seeing a literal `<id>` placeholder. (#78782) Thanks @itsuzef.
 - Exec approvals/node: let trusted backend node invokes complete no-device Control UI approvals after the original request connection changes, while keeping node, command, cwd, env, and allow-once replay bindings enforced. Fixes #78569. Thanks @naturedogdog.
 - Agents/subagents: keep background completion delivery on the requester-agent handoff/queue-retry path instead of raw-sending child results directly, and strip child-result wrapper or OpenClaw runtime-context scaffolding from queued outbound retries. Fixes #78531. Thanks @EthanSK.
 - CLI/completion: guard the shell-profile source line written by `openclaw completion --install` with a file existence check (`[ -f ... ] && source ...` for bash/zsh, `test -f ...; and source ...` for fish) so uninstalling OpenClaw no longer makes new login shells error on a missing completion cache. (#78659) Thanks @sjf.

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -571,7 +571,7 @@ describe("exec approval forwarder", () => {
     expect(text).toContain("🔒 Exec approval required");
     expect(text).toContain("Command: `echo hello`");
     expect(text).toContain("Expires in: 5s");
-    expect(text).toContain("Reply with: /approve <id> allow-once|allow-always|deny");
+    expect(text).toContain("Reply with: /approve req-1 allow-once|allow-always|deny");
   });
 
   it("includes command analysis warnings in fallback delivery text", async () => {
@@ -608,7 +608,7 @@ describe("exec approval forwarder", () => {
     ).resolves.toBe(true);
     await Promise.resolve();
     const text = getFirstDeliveryText(deliver);
-    expect(text).toContain("Reply with: /approve <id> allow-once|deny");
+    expect(text).toContain("Reply with: /approve req-1 allow-once|deny");
     expect(text).not.toContain("allow-once|allow-always|deny");
     expect(text).toContain("Allow Always is unavailable");
   });

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -285,7 +285,7 @@ export function buildExecApprovalRequestMessage(request: ExecApprovalRequest, no
       ? "Background mode note: non-interactive runs cannot wait for chat approvals; use pre-approved policy (allow-always or ask=off)."
       : "Background mode note: non-interactive runs cannot wait for chat approvals; the effective policy still requires per-run approval unless ask=off.",
   );
-  lines.push(`Reply with: /approve <id> ${decisionText}`);
+  lines.push(`Reply with: /approve ${request.id} ${decisionText}`);
   if (!allowedDecisions.includes("allow-always")) {
     lines.push(
       "Allow Always is unavailable because the effective policy requires approval every time.",

--- a/src/infra/plugin-approval-forwarder.test.ts
+++ b/src/infra/plugin-approval-forwarder.test.ts
@@ -171,7 +171,7 @@ describe("plugin approval forwarding", () => {
         | { payloads?: Array<{ text?: string; interactive?: unknown }> }
         | undefined;
       const payload = deliveryArgs?.payloads?.[0];
-      expect(payload?.text).toContain("Reply with: /approve <id> allow-once|deny");
+      expect(payload?.text).toContain("Reply with: /approve plugin-req-1 allow-once|deny");
       expect(payload?.text).not.toContain("allow-always");
       expect(payload?.interactive).toEqual({
         blocks: [

--- a/src/infra/plugin-approvals.ts
+++ b/src/infra/plugin-approvals.ts
@@ -91,9 +91,9 @@ export function buildPluginApprovalRequestMessage(
   const expiresIn = Math.max(0, Math.round((request.expiresAtMs - nowMsValue) / 1000));
   lines.push(`Expires in: ${expiresIn}s`);
   lines.push(
-    `Reply with: /approve <id> ${resolvePluginApprovalRequestAllowedDecisions(request.request).join(
-      "|",
-    )}`,
+    `Reply with: /approve ${request.id} ${resolvePluginApprovalRequestAllowedDecisions(
+      request.request,
+    ).join("|")}`,
   );
   return lines.join("\n");
 }

--- a/src/plugin-sdk/approval-renderers.test.ts
+++ b/src/plugin-sdk/approval-renderers.test.ts
@@ -118,7 +118,7 @@ describe("plugin-sdk/approval-renderers", () => {
         nowMs: 1_000,
       }),
       textExpected: (text: string) =>
-        expect(text).toContain("Reply with: /approve <id> allow-once|deny"),
+        expect(text).toContain("Reply with: /approve plugin-approval-123 allow-once|deny"),
       interactiveExpected: {
         blocks: [
           {


### PR DESCRIPTION
## What

`buildExecApprovalRequestMessage` (in `src/infra/exec-approval-forwarder.ts`) and `buildPluginApprovalRequestMessage` (in `src/infra/plugin-approvals.ts`) emit the chat-fallback `Reply with: /approve <id> ...` line with a literal `<id>` placeholder instead of the actual request id.

That makes the line useless for its stated purpose: owners cannot copy-paste it into chat. They have to manually splice the ID from the `ID: ...` line two lines above.

## Why

Other approval surfaces in the same codebase already interpolate the id correctly:

- `src/agents/bash-tools.exec-runtime.ts:397` uses `${params.approvalSlug}`
- `src/infra/approval-native-route-notice.ts:44` uses `${commandId}`

So this is just a missed spot. The system prompt at `src/agents/system-prompt.ts:192-194` even instructs models to *"copy the exact /approve command from the tool output's Reply with: line"* — which silently degrades when the line literally contains `<id>`.

## Fix

Interpolate `request.id` at the two call sites and update the four test assertions that pinned the broken literal.

## Scope

- 2 production files: `src/infra/exec-approval-forwarder.ts`, `src/infra/plugin-approvals.ts`
- 3 test files updated: `src/infra/exec-approval-forwarder.test.ts`, `src/infra/plugin-approval-forwarder.test.ts`, `src/plugin-sdk/approval-renderers.test.ts`
- 5 files, 8 insertions, 8 deletions. No new files. No behavior change beyond the bug fix.

## Real behavior proof

**Behavior or issue addressed:** `buildExecApprovalRequestMessage` and `buildPluginApprovalRequestMessage` rendered the literal string `Reply with: /approve <id> ...` into outbound chat fallback text. Owners reading the message in their channel could not copy-paste that line — `<id>` is not a real id, it is a placeholder.

**Real environment tested:** Local checkout of `openclaw/openclaw` at `upstream/main` (sha `b680360fde`) on macOS 26.4 / Node 22.14, with this patch applied as commit `8a8f91e1a8`. Exercised by importing the two builder functions directly and rendering the assembled chat strings against constructed `ExecApprovalRequest` and `PluginApprovalRequest` payloads — the same code path used by the gateway when it composes outbound approval-request messages. Not run inside a connected channel session; see *What was not tested* below.

**Exact steps or command run after this patch:** From the worktree at the patched HEAD (`8a8f91e1a8`, one commit above `upstream/main`), I dropped a small ESM script `proof-render.mjs` next to the package root that imports the two builder functions and prints what the gateway would actually emit on the wire for two synthetic requests with ids `req-7f3a9c2e` and `plugin-req-9b1d8c4a`. I then ran it directly with the node binary using the tsx loader so the TypeScript sources resolve without a build step:

```text
node --import tsx proof-render.mjs
```

**Evidence after fix:** Console output captured directly from the `node` invocation above. The output is the live string returned by the patched `buildExecApprovalRequestMessage` / `buildPluginApprovalRequestMessage` — the exact bytes the gateway would deliver to a channel. Stdout, fenced verbatim:

```text
===== buildExecApprovalRequestMessage =====
🔒 Exec approval required
ID: req-7f3a9c2e
Command: `echo hello`
CWD: /tmp
Host: host-a
Agent: main
Security: trusted
Ask: on-failure
Expires in: 1m
Mode: foreground (interactive approvals available in this chat).
Background mode note: non-interactive runs cannot wait for chat approvals; use pre-approved policy (allow-always or ask=off).
Reply with: /approve req-7f3a9c2e allow-once|allow-always|deny

===== buildPluginApprovalRequestMessage =====
🛡️ Plugin approval required
Title: Send funds via x-pay
Description: Approval needed before transferring 250.00 USD
Tool: x_pay.transfer
Plugin: x-pay
Agent: main
ID: plugin-req-9b1d8c4a
Expires in: 60s
Reply with: /approve plugin-req-9b1d8c4a allow-once|allow-always|deny
```

**Observed result after fix:** The exec-approval `Reply with:` line now reads `Reply with: /approve req-7f3a9c2e allow-once|allow-always|deny` — the actual request id, copy-pasteable as-is. The plugin-approval `Reply with:` line now reads `Reply with: /approve plugin-req-9b1d8c4a allow-once|allow-always|deny` — same fix, same shape. Neither line contains the literal substring `<id>` anywhere. Before the patch, both lines emitted `/approve <id> ...` regardless of `request.id`.

**What was not tested:** I did not stand up a connected Slack/Telegram/WhatsApp channel and trigger an exec approval through a real agent turn end-to-end — my local environment is not provisioned for any of those channels. The proof exercises the same builder functions the gateway calls in `outbound/deliver.ts`; what is not directly demonstrated is the channel adapter's serialization step. Given the change is a string interpolation in the builder output and the channel adapters consume that string opaquely, I do not expect channel-side surprises, but a maintainer with a live channel setup could confirm the rendered text shows up unchanged in chat.

## Notes for reviewer

- This was the only literal-`<id>` regression I found — all other `Reply with:` call sites in `src/` already interpolate. Grep used: `git grep -n "Reply with:" -- 'src/**/*.ts'`.
- AI-assisted (Claude). The model identified the bug location, wrote the surgical fix, and updated the test assertions. Author reviewed the diff line-by-line and confirms understanding. Degree of testing: lightly tested locally (touched-file unit tests + the live render above).
- Targeted unit run that also passed (supplemental, not the proof of behavior): `pnpm test src/infra/exec-approval-forwarder.test.ts src/infra/plugin-approval-forwarder.test.ts src/plugin-sdk/approval-renderers.test.ts` → 37 tests across 2 vitest shards, all green.
