### PR TITLE
feat(memory): pre-warm QMD embedder during gateway boot sync

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1272,6 +1272,31 @@ export class QmdMemoryManager implements MemorySearchManager {
     return this.clampResultsByInjectedChars(this.diversifyResultsBySource(ranked, resultLimit));
   }
 
+  /**
+   * Pay the embedder cold-start cost off the user-facing path. The
+   * GGUF embedding model is mmap'd from disk on first use and the
+   * first inference takes longer than the per-query timeout on
+   * resource-constrained pods, surfacing as `qmd query … timed out
+   * after 4000ms` and a fallback to the builtin index.
+   *
+   * Best-effort. Failures are swallowed — if QMD is genuinely
+   * unhealthy the next real query falls through to the existing
+   * fallback path, same as before. The 30s ceiling is generous enough
+   * to cover model load on slow disks without blocking gateway-ready
+   * indefinitely.
+   */
+  async prewarmEmbedder(): Promise<void> {
+    if (!qmdUsesVectors(this.qmd.searchMode)) return;
+    try {
+      await this.runQmd(["vsearch", "warmup", "--json", "-n", "1"], {
+        timeoutMs: 30_000,
+        discardOutput: true,
+      });
+    } catch (err) {
+      log.debug(`qmd prewarmEmbedder failed (non-fatal): ${String(err)}`);
+    }
+  }
+
   async sync(params?: {
     reason?: string;
     force?: boolean;

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -106,5 +106,17 @@ export interface MemorySearchManager {
   probeEmbeddingAvailability(): Promise<MemoryEmbeddingProbeResult>;
   probeVectorStoreAvailability?(): Promise<boolean>;
   probeVectorAvailability(): Promise<boolean>;
+  /**
+   * Optional: force the search backend to load any heavy artefacts
+   * (embedding models, vector indexes) it would otherwise lazy-load on
+   * the first user query. Best-effort — implementations should swallow
+   * failures so the next real query can fall back to default behaviour.
+   *
+   * Called by the gateway boot path right after `sync(...)` so the cold
+   * mmap + first-inference cost is paid off the user-facing path. The
+   * QMD backend's first `vsearch` can exceed the per-query 4s timeout
+   * on cold pods (the embedder GGUF is mmap'd from disk on first use).
+   */
+  prewarmEmbedder?(): Promise<void>;
   close?(): Promise<void>;
 }

--- a/src/gateway/server-startup-memory.test.ts
+++ b/src/gateway/server-startup-memory.test.ts
@@ -30,6 +30,7 @@ function createQmdManagerMock() {
   return {
     search: vi.fn(),
     sync: vi.fn(async () => undefined),
+    prewarmEmbedder: vi.fn(async () => undefined),
     close: vi.fn(async () => undefined),
   };
 }
@@ -98,6 +99,34 @@ describe("startGatewayMemoryBackend", () => {
       'qmd memory startup initialization deferred for 1 agent: "lazy"',
     );
     expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("calls prewarmEmbedder once per qmd-enabled agent right after sync", async () => {
+    const cfg = createQmdConfig({
+      list: [
+        { id: "ops", default: true },
+        { id: "main", memorySearch: { enabled: true } },
+      ],
+    });
+    const log = createGatewayLogMock();
+    const opsManager = createQmdManagerMock();
+    const mainManager = createQmdManagerMock();
+    getMemorySearchManagerMock
+      .mockResolvedValueOnce({ manager: opsManager })
+      .mockResolvedValueOnce({ manager: mainManager });
+
+    await startGatewayMemoryBackend({ cfg, log });
+
+    expect(opsManager.sync).toHaveBeenCalledTimes(1);
+    expect(opsManager.prewarmEmbedder).toHaveBeenCalledTimes(1);
+    expect(mainManager.sync).toHaveBeenCalledTimes(1);
+    expect(mainManager.prewarmEmbedder).toHaveBeenCalledTimes(1);
+    // prewarmEmbedder must run after sync — sync writes the index it
+    // will then mmap, and a hard order avoids racing the embedder
+    // load against an in-flight index write.
+    expect(opsManager.sync.mock.invocationCallOrder[0]).toBeLessThan(
+      opsManager.prewarmEmbedder.mock.invocationCallOrder[0],
+    );
   });
 
   it("initializes all qmd agents when memory search is explicitly enabled in defaults", async () => {

--- a/src/gateway/server-startup-memory.ts
+++ b/src/gateway/server-startup-memory.ts
@@ -80,6 +80,11 @@ export async function startGatewayMemoryBackend(params: {
     }
     try {
       await manager.sync?.({ reason: "boot", force: true });
+      // Pay the embedder cold-start cost here so the first user query
+      // doesn't time out against the per-query limit waiting for the
+      // GGUF mmap + first inference. Best-effort; failures are logged
+      // by the manager and do not block the boot sequence.
+      await manager.prewarmEmbedder?.();
     } catch (err) {
       params.log.warn(`qmd memory startup boot sync failed for agent "${agentId}": ${String(err)}`);
       continue;


### PR DESCRIPTION
## Summary

The first `qmd vsearch …` query on a freshly booted pod has to mmap the embedding GGUF (~600 MB) and run cold inference. On resource-constrained hosts that exceeds the per-query 4 s timeout, producing:

```
[memory] qmd query failed: Error: qmd query … timed out after 4000ms
[memory] qmd memory failed; switching to builtin index: …
```

The fallback is graceful, but it degrades the first turn after every pod boot.

## Approach

The gateway already runs an opt-in boot sync (`memory.qmd.update.startup` = `"immediate"` | `"idle"`) that calls `manager.sync({ reason: "boot" })` to refresh the index. Add a sibling step right after the sync that pays the embedder cold-start cost off the user-facing path:

- New optional `prewarmEmbedder?(): Promise<void>` on the `MemorySearchManager` host SDK interface — best-effort, no-op default.
- `QmdMemoryManager.prewarmEmbedder()` fires `qmd vsearch warmup --json -n 1` with a 30 s timeout. Failures are swallowed (and logged at debug) — if QMD is genuinely broken the first real query still falls through to the existing builtin-index path.
- `startGatewayMemoryBackend` calls it after a successful sync, before closing the manager. Test enforces the sync→prewarm order so we never race the embedder load against an in-flight index write.

## Cost / benefit

~2–3 s of post-attach background time once per pod boot, in exchange for a guaranteed-warm first user query. Matches the existing pattern of paying boot-time costs for steady-state predictability (cf. `server-startup-plugins` prestaging bundled-plugin runtime deps).

No behaviour change for non-QMD backends or when the boot-sync policy is disabled (default).

## Test plan

- New unit test in `src/gateway/server-startup-memory.test.ts`:
  - asserts `prewarmEmbedder` is called once per QMD-enabled agent
  - asserts it runs strictly after `sync` (invocationCallOrder)
- Existing tests for the deferred / disabled / failing-init paths continue to pass — `prewarmEmbedder` is optional on the interface and the mock now provides a no-op stub.

## Related

Surfaces the issue described under `memory.qmd.update.startup` in the gateway docs — the existing policy warms the index but not the model. Pancake-claw runs into this on every pod boot at ~03:00 UTC when the wiki-audit cron fires before any user traffic has triggered a lazy embedder load.