### PR TITLE
feat(realtime-voice): optional sendVideoFrame on bridge contract

### DIFF
--- a/src/plugin-sdk/realtime-voice.ts
+++ b/src/plugin-sdk/realtime-voice.ts
@@ -13,6 +13,8 @@ export type {
   RealtimeVoiceRole,
   RealtimeVoiceTool,
   RealtimeVoiceToolCallEvent,
+  RealtimeVoiceVideoFrameMimeType,
+  RealtimeVoiceVideoFrameOptions,
 } from "../realtime-voice/provider-types.js";
 export {
   REALTIME_VOICE_AGENT_CONSULT_TOOL,

--- a/src/realtime-voice/provider-types.ts
+++ b/src/realtime-voice/provider-types.ts
@@ -47,10 +47,39 @@ export type RealtimeVoiceProviderConfiguredContext = {
   providerConfig: RealtimeVoiceProviderConfig;
 };
 
+/**
+ * MIME types accepted by `sendVideoFrame` and `videoConfig.mimeType`.
+ *
+ * Providers that grow support for additional formats can extend the union
+ * upstream; clients should pass the format the provider advertised in the
+ * matching `videoConfig` slot when one was supplied.
+ */
+export type RealtimeVoiceVideoFrameMimeType = "image/jpeg" | "image/png";
+
+export type RealtimeVoiceVideoFrameOptions = {
+  mimeType: RealtimeVoiceVideoFrameMimeType;
+  /** Capture timestamp (ms since epoch). Optional; providers may ignore. */
+  ts?: number;
+};
+
 export type RealtimeVoiceBridgeCreateRequest = RealtimeVoiceBridgeCallbacks & {
   providerConfig: RealtimeVoiceProviderConfig;
   instructions?: string;
   tools?: RealtimeVoiceTool[];
+  /**
+   * Optional. Hint the provider about the video stream the client plans to
+   * push so it can pre-size buffers, configure the model, or surface a
+   * "vision unsupported" error early. Frames may still be sent without this,
+   * but providers may reject or downgrade quality.
+   */
+  videoConfig?: {
+    mimeType: RealtimeVoiceVideoFrameMimeType;
+    /** Approximate frame rate the client expects to push. */
+    fps?: number;
+    /** Width / height in pixels (informational only). */
+    width?: number;
+    height?: number;
+  };
 };
 
 export type RealtimeVoiceBrowserSessionCreateRequest = {
@@ -79,4 +108,11 @@ export type RealtimeVoiceBridge = {
   acknowledgeMark(): void;
   close(): void;
   isConnected(): boolean;
+  /**
+   * Optional. Send a single video frame (screen / camera capture) to the
+   * provider. Providers without vision support should leave this undefined;
+   * clients must check before calling. Use `videoConfig` on the create
+   * request to negotiate format and rate up front.
+   */
+  sendVideoFrame?(frame: Buffer, opts: RealtimeVoiceVideoFrameOptions): void;
 };


### PR DESCRIPTION
## Summary

Add an additive vision-input seam to `RealtimeVoiceBridge` so realtime voice providers can advertise screen / camera frame input behind a stable type. All new fields are optional; providers and host channels that do not implement vision compile unchanged.

- New `RealtimeVoiceVideoFrameMimeType = "image/jpeg" | "image/png"`
- New `RealtimeVoiceVideoFrameOptions { mimeType, ts? }`
- Optional `RealtimeVoiceBridgeCreateRequest.videoConfig { mimeType, fps?, width?, height? }` so providers can negotiate the stream shape up front
- Optional `RealtimeVoiceBridge.sendVideoFrame(frame, opts)`
- `src/plugin-sdk/realtime-voice.ts` re-exports the two new public types

## Motivation

I'm building a third-party RealtimeVoiceProvider plugin (jina-live, Gemini Live integration) that already ships `sendVideoFrame` on its own bridge as a forward-compat stub. Mac/Android clients consuming the bridge want to call it through the standard `RealtimeVoiceBridge` contract instead of typecasting to the concrete provider class. Promoting the method into the SDK keeps clients provider-neutral and gives future realtime endpoints (OpenAI Realtime image input, etc.) a place to opt in.

## Backwards compatibility

- All additions are optional. Existing OpenAI realtime voice provider compiles without changes (the method is `undefined`, satisfying the optional contract).
- Existing host channels (voice-call) compile unchanged because `videoConfig` is optional on the create request.
- Plugin SDK API baseline (`pnpm plugin-sdk:api:check`) stays clean — no removals or renames, only additive type exports.

## Test plan

- [x] `pnpm install`
- [x] `pnpm tsgo` (clean)
- [x] `pnpm plugin-sdk:api:check` (OK)
- [ ] Maintainer-side `pnpm check` + `pnpm test` if requested