### PR TITLE
fix BTW usage placeholder visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Commands/BTW: show the `/btw` missing-question usage placeholder with brackets so outbound channel sanitization keeps it visible. Fixes #62877. Thanks @RajvardhanPatil07.
 - CLI backends: keep versioned OAuth identity matches reusable when auth profile ids rotate, so Claude CLI sessions do not reset and lose continuity during same-account OAuth refresh/profile alias changes. Fixes #78541.
 - Model providers: normalize APNG sniffed PNG uploads, preserve Gemini 3 tool-call thought-signature replay with documented fallback signatures, accept legacy `__env__:VAR` custom-provider keys, and repair snake_case tool-call transcript sanitization. Fixes #51881, #48915, #77566, and #42858.
 - Telegram/models: parse provider ids containing dots in `/models` callback buttons so `hf.co` model lists render as inline keyboard buttons. Fixes #38745.

--- a/src/auto-reply/reply/commands-btw.test.ts
+++ b/src/auto-reply/reply/commands-btw.test.ts
@@ -39,7 +39,7 @@ describe("handleBtwCommand", () => {
 
     expect(result).toEqual({
       shouldContinue: false,
-      reply: { text: "Usage: /btw <side question>" },
+      reply: { text: "Usage: /btw [side question]" },
     });
   });
 

--- a/src/auto-reply/reply/commands-btw.ts
+++ b/src/auto-reply/reply/commands-btw.ts
@@ -4,7 +4,7 @@ import { extractBtwQuestion } from "./btw-command.js";
 import { rejectUnauthorizedCommand } from "./command-gates.js";
 import type { CommandHandler } from "./commands-types.js";
 
-const BTW_USAGE = "Usage: /btw <side question>";
+const BTW_USAGE = "Usage: /btw [side question]";
 
 export const handleBtwCommand: CommandHandler = async (params, allowTextCommands) => {
   if (!allowTextCommands) {

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -93,6 +93,10 @@ describe("sanitizeForPlainText", () => {
     expect(sanitizeForPlainText("hello world")).toBe("hello world");
   });
 
+  it("preserves bracketed command placeholders", () => {
+    expect(sanitizeForPlainText("Usage: /btw [side question]")).toBe("Usage: /btw [side question]");
+  });
+
   it("does not corrupt angle brackets in prose", () => {
     // `a < b` does not match `<tag>` pattern because there is no closing `>`
     // immediately after a tag-like sequence.


### PR DESCRIPTION
## Summary

- Problem: `/btw` without a side question returns `Usage: /btw <side question>`, and plain-text channel sanitization treats `<side question>` as an HTML-like tag.
- Why it matters: users on sanitized outbound channels can see only `Usage: /btw `, losing the helpful placeholder.
- What changed: changed the producer string to `Usage: /btw [side question]`, updated the `/btw` command test, added a sanitizer regression, and added a changelog entry.
- What did NOT change (scope boundary): no sanitizer rules, command parsing, `/side` alias behavior, or live channel delivery plumbing changed.

AI-assisted: yes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62877
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: the `/btw` missing-question usage placeholder must remain visible after outbound plain-text sanitization.
- Real environment tested: local OpenClaw source checkout on macOS with Node v25.9.0 and pnpm 10.33.2 via `npx`; actual `sanitizeForPlainText` implementation imported with `tsx`.
- Exact steps or command run after this patch:
  - `npx pnpm@10.33.2 exec tsx -e 'import { sanitizeForPlainText } from "./src/infra/outbound/sanitize-text.ts"; console.log("old:", JSON.stringify(sanitizeForPlainText("Usage: /btw <side question>"))); console.log("new:", JSON.stringify(sanitizeForPlainText("Usage: /btw [side question]")));'`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
old: "Usage: /btw "
new: "Usage: /btw [side question]"
```

- Observed result after fix: the old tag-shaped placeholder is still stripped by the sanitizer, while the new bracketed placeholder remains visible exactly as delivered to plain-text channels.
- What was not tested: a live WhatsApp/Telegram/Signal send; this patch is isolated to the command producer text plus the shared sanitizer behavior.
- Before evidence (optional but encouraged): the same terminal capture above includes the pre-fix string shape as `old: "Usage: /btw "`.

## Root Cause (if applicable)

- Root cause: the usage placeholder was written with angle brackets, so the outbound sanitizer's remaining-HTML stripping pattern interpreted `<side question>` as a tag.
- Missing detection / guardrail: no regression asserted that command usage examples with placeholders survive the plain-text sanitizer.
- Contributing context (if known): inline code/backticks would not be enough if the inner placeholder remains tag-shaped before the final stripping pass.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/commands-btw.test.ts` and `src/infra/outbound/sanitize-text.test.ts`.
- Scenario the test should lock in: `/btw` with no question returns the bracketed usage string, and that usage string survives `sanitizeForPlainText` unchanged.
- Why this is the smallest reliable guardrail: the regression is caused by the specific producer text plus the shared plain-text sanitizer, so focused coverage locks both sides without requiring a live channel.
- Existing test that already covers this (if any): the existing `/btw` missing-question test covered the producer output, but expected the unsafe placeholder.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`/btw` with no side question now replies with `Usage: /btw [side question]` instead of `Usage: /btw <side question>`.

## Diagram (if applicable)

```text
Before:
/btw -> Usage: /btw <side question> -> sanitizer strips placeholder -> Usage: /btw 

After:
/btw -> Usage: /btw [side question] -> sanitizer preserves placeholder -> Usage: /btw [side question]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v25.9.0, pnpm 10.33.2 via `npx`
- Model/provider: N/A
- Integration/channel (if any): shared plain-text outbound sanitizer path; no live channel credentials used
- Relevant config (redacted): N/A

### Steps

1. Run the live sanitizer command from the real behavior proof section.
2. Run `npx pnpm@10.33.2 test src/auto-reply/reply/commands-btw.test.ts src/infra/outbound/sanitize-text.test.ts`.
3. Run `npx pnpm@10.33.2 exec oxfmt --check --threads=1 src/auto-reply/reply/commands-btw.ts src/auto-reply/reply/commands-btw.test.ts src/infra/outbound/sanitize-text.test.ts CHANGELOG.md`.
4. Run `npx pnpm@10.33.2 check:changed`.

### Expected

- The bracketed usage placeholder stays visible after sanitization.
- Focused tests, formatting, and changed-file checks pass.

### Actual

- `old: "Usage: /btw "`
- `new: "Usage: /btw [side question]"`
- Focused tests passed 2 Vitest shards: 39 tests total.
- `oxfmt --check` reported all matched files use the correct format.
- `check:changed` completed successfully.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: old placeholder shape strips in the actual sanitizer, new placeholder shape survives; `/btw` missing-question command now returns the bracketed usage string; focused sanitizer and command tests pass.
- Edge cases checked: formatting, whitespace, and repo changed-file checks.
- What you did **not** verify: live external-channel delivery with real credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
