### PR TITLE
perf: cache bundle MCP tool descriptors

### DIFF
--- a/src/agents/pi-bundle-mcp-materialize.ts
+++ b/src/agents/pi-bundle-mcp-materialize.ts
@@ -10,8 +10,162 @@ import {
   normalizeReservedToolNames,
   TOOL_NAME_SEPARATOR,
 } from "./pi-bundle-mcp-names.js";
-import type { BundleMcpToolRuntime, SessionMcpRuntime } from "./pi-bundle-mcp-types.js";
+import type {
+  BundleMcpToolRuntime,
+  McpToolCatalog,
+  SessionMcpRuntime,
+} from "./pi-bundle-mcp-types.js";
 import type { AnyAgentTool } from "./tools/common.js";
+
+type CachedBundleMcpToolDescriptor = {
+  name: string;
+  label: string;
+  description: string;
+  parameters: unknown;
+  serverName: string;
+  toolName: string;
+};
+
+type CachedBundleMcpToolMaterialization = {
+  descriptors: CachedBundleMcpToolDescriptor[];
+  warnings: string[];
+};
+
+type BundleMcpToolMaterializationCacheStats = {
+  bypass: number;
+  hit: number;
+  miss: number;
+  store: number;
+};
+
+let bundleMcpToolMaterializationCache = new WeakMap<
+  SessionMcpRuntime,
+  Map<string, CachedBundleMcpToolMaterialization>
+>();
+
+const bundleMcpToolMaterializationCacheStats: BundleMcpToolMaterializationCacheStats = {
+  bypass: 0,
+  hit: 0,
+  miss: 0,
+  store: 0,
+};
+
+function isBundleMcpToolMaterializationCacheEnabled(env: NodeJS.ProcessEnv): boolean {
+  return env.OPENCLAW_BUNDLE_MCP_TOOL_CACHE !== "0";
+}
+
+function buildReservedToolNamesCacheKey(reservedNames: ReadonlySet<string>): string {
+  return JSON.stringify([...reservedNames].toSorted());
+}
+
+function cloneSchemaValue(value: unknown): unknown {
+  if (value === undefined) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return value;
+  }
+}
+
+function readCachedBundleMcpToolMaterialization(params: {
+  runtime: SessionMcpRuntime;
+  cacheKey: string;
+}): CachedBundleMcpToolMaterialization | undefined {
+  return bundleMcpToolMaterializationCache.get(params.runtime)?.get(params.cacheKey);
+}
+
+function writeCachedBundleMcpToolMaterialization(params: {
+  runtime: SessionMcpRuntime;
+  cacheKey: string;
+  materialization: CachedBundleMcpToolMaterialization;
+}): void {
+  let runtimeCache = bundleMcpToolMaterializationCache.get(params.runtime);
+  if (!runtimeCache) {
+    runtimeCache = new Map();
+    bundleMcpToolMaterializationCache.set(params.runtime, runtimeCache);
+  }
+  runtimeCache.set(params.cacheKey, {
+    warnings: [...params.materialization.warnings],
+    descriptors: params.materialization.descriptors.map((descriptor) => ({
+      ...descriptor,
+      parameters: cloneSchemaValue(descriptor.parameters),
+    })),
+  });
+  bundleMcpToolMaterializationCacheStats.store += 1;
+}
+
+function createBundleMcpToolFromDescriptor(params: {
+  descriptor: CachedBundleMcpToolDescriptor;
+  runtime: SessionMcpRuntime;
+}): AnyAgentTool {
+  const { descriptor } = params;
+  const agentTool: AnyAgentTool = {
+    name: descriptor.name,
+    label: descriptor.label,
+    description: descriptor.description,
+    parameters: cloneSchemaValue(descriptor.parameters) as never,
+    execute: async (_toolCallId: string, input: unknown) => {
+      params.runtime.markUsed();
+      const result = await params.runtime.callTool(
+        descriptor.serverName,
+        descriptor.toolName,
+        input,
+      );
+      return toAgentToolResult({
+        serverName: descriptor.serverName,
+        toolName: descriptor.toolName,
+        result,
+      });
+    },
+  };
+  setPluginToolMeta(agentTool, {
+    pluginId: "bundle-mcp",
+    optional: false,
+  });
+  return agentTool;
+}
+
+function createBundleMcpRuntimeFromCachedMaterialization(params: {
+  materialization: CachedBundleMcpToolMaterialization;
+  runtime: SessionMcpRuntime;
+  releaseLease?: () => void;
+  disposeRuntime?: () => Promise<void>;
+}): BundleMcpToolRuntime {
+  let disposed = false;
+  for (const warning of params.materialization.warnings) {
+    logWarn(warning);
+  }
+  return {
+    tools: params.materialization.descriptors.map((descriptor) =>
+      createBundleMcpToolFromDescriptor({
+        descriptor,
+        runtime: params.runtime,
+      }),
+    ),
+    dispose: async () => {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      params.releaseLease?.();
+      await params.disposeRuntime?.();
+    },
+  };
+}
+
+export function resetBundleMcpToolMaterializationCacheForTest(): void {
+  bundleMcpToolMaterializationCache = new WeakMap();
+  bundleMcpToolMaterializationCacheStats.bypass = 0;
+  bundleMcpToolMaterializationCacheStats.hit = 0;
+  bundleMcpToolMaterializationCacheStats.miss = 0;
+  bundleMcpToolMaterializationCacheStats.store = 0;
+}
+
+export function getBundleMcpToolMaterializationCacheStatsForTest(): BundleMcpToolMaterializationCacheStats {
+  return { ...bundleMcpToolMaterializationCacheStats };
+}
 
 function toAgentToolResult(params: {
   serverName: string;
@@ -69,15 +223,38 @@ export async function materializeBundleMcpToolsForRun(params: {
   let disposed = false;
   const releaseLease = params.runtime.acquireLease?.();
   params.runtime.markUsed();
-  let catalog;
+  const reservedNames = normalizeReservedToolNames(params.reservedToolNames);
+  const cacheEnabled = isBundleMcpToolMaterializationCacheEnabled(process.env);
+  const cacheKey = buildReservedToolNamesCacheKey(reservedNames);
+  if (cacheEnabled) {
+    const cached = readCachedBundleMcpToolMaterialization({
+      runtime: params.runtime,
+      cacheKey,
+    });
+    if (cached) {
+      bundleMcpToolMaterializationCacheStats.hit += 1;
+      return createBundleMcpRuntimeFromCachedMaterialization({
+        materialization: cached,
+        runtime: params.runtime,
+        releaseLease,
+        disposeRuntime: params.disposeRuntime,
+      });
+    }
+    bundleMcpToolMaterializationCacheStats.miss += 1;
+  } else {
+    bundleMcpToolMaterializationCacheStats.bypass += 1;
+  }
+
+  let catalog: McpToolCatalog;
   try {
     catalog = await params.runtime.getCatalog();
   } catch (error) {
     releaseLease?.();
     throw error;
   }
-  const reservedNames = normalizeReservedToolNames(params.reservedToolNames);
-  const tools: BundleMcpToolRuntime["tools"] = [];
+
+  const descriptors: CachedBundleMcpToolDescriptor[] = [];
+  const warnings: string[] = [];
   const sortedCatalogTools = [...catalog.tools].toSorted((a, b) => {
     const serverOrder = a.safeServerName.localeCompare(b.safeServerName);
     if (serverOrder !== 0) {
@@ -101,40 +278,46 @@ export async function materializeBundleMcpToolsForRun(params: {
       reservedNames,
     });
     if (safeToolName !== `${tool.safeServerName}${TOOL_NAME_SEPARATOR}${originalName}`) {
-      logWarn(
+      warnings.push(
         `bundle-mcp: tool "${tool.toolName}" from server "${tool.serverName}" registered as "${safeToolName}" to keep the tool name provider-safe.`,
       );
     }
     reservedNames.add(normalizeLowercaseStringOrEmpty(safeToolName));
-    const agentTool: AnyAgentTool = {
+    descriptors.push({
       name: safeToolName,
       label: tool.title ?? tool.toolName,
       description: tool.description || tool.fallbackDescription,
-      parameters: tool.inputSchema,
-      execute: async (_toolCallId: string, input: unknown) => {
-        params.runtime.markUsed();
-        const result = await params.runtime.callTool(tool.serverName, tool.toolName, input);
-        return toAgentToolResult({
-          serverName: tool.serverName,
-          toolName: tool.toolName,
-          result,
-        });
-      },
-    };
-    setPluginToolMeta(agentTool, {
-      pluginId: "bundle-mcp",
-      optional: false,
+      parameters: cloneSchemaValue(tool.inputSchema),
+      serverName: tool.serverName,
+      toolName: tool.toolName,
     });
-    tools.push(agentTool);
   }
 
   // Sort tools deterministically by name so the tools block in API requests is stable across
   // turns (defensive — listTools() order is usually stable but not guaranteed).
   // Cannot fix name collisions: collision suffixes above are order-dependent.
-  tools.sort((a, b) => a.name.localeCompare(b.name));
+  descriptors.sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const warning of warnings) {
+    logWarn(warning);
+  }
+
+  const materialization = { descriptors, warnings };
+  if (cacheEnabled) {
+    writeCachedBundleMcpToolMaterialization({
+      runtime: params.runtime,
+      cacheKey,
+      materialization,
+    });
+  }
 
   return {
-    tools,
+    tools: descriptors.map((descriptor) =>
+      createBundleMcpToolFromDescriptor({
+        descriptor,
+        runtime: params.runtime,
+      }),
+    ),
     dispose: async () => {
       if (disposed) {
         return;

--- a/src/agents/pi-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/pi-bundle-mcp-tools.materialize.test.ts
@@ -1,14 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import {
   createBundleMcpToolRuntime,
+  getBundleMcpToolMaterializationCacheStatsForTest,
   materializeBundleMcpToolsForRun,
+  resetBundleMcpToolMaterializationCacheForTest,
 } from "./pi-bundle-mcp-materialize.js";
 import type { McpCatalogTool } from "./pi-bundle-mcp-types.js";
 import type { SessionMcpRuntime } from "./pi-bundle-mcp-types.js";
 
 function makeToolRuntime(
   params: {
+    onGetCatalog?: () => void;
     tools?: McpCatalogTool[];
     serverName?: string;
     resultText?: string;
@@ -32,18 +35,21 @@ function makeToolRuntime(
     createdAt: 0,
     lastUsedAt: 0,
     markUsed: () => {},
-    getCatalog: async () => ({
-      version: 1,
-      generatedAt: 0,
-      servers: {
-        [serverName]: {
-          serverName,
-          launchSummary: serverName,
-          toolCount: tools.length,
+    getCatalog: async () => {
+      params.onGetCatalog?.();
+      return {
+        version: 1,
+        generatedAt: 0,
+        servers: {
+          [serverName]: {
+            serverName,
+            launchSummary: serverName,
+            toolCount: tools.length,
+          },
         },
-      },
-      tools,
-    }),
+        tools,
+      };
+    },
     callTool: async () => ({
       content: [{ type: "text", text: params.resultText ?? "FROM-BUNDLE" }],
       isError: false,
@@ -51,6 +57,21 @@ function makeToolRuntime(
     dispose: async () => {},
   };
 }
+
+const previousBundleMcpToolCacheEnv = process.env.OPENCLAW_BUNDLE_MCP_TOOL_CACHE;
+
+beforeEach(() => {
+  delete process.env.OPENCLAW_BUNDLE_MCP_TOOL_CACHE;
+});
+
+afterEach(() => {
+  if (previousBundleMcpToolCacheEnv === undefined) {
+    delete process.env.OPENCLAW_BUNDLE_MCP_TOOL_CACHE;
+  } else {
+    process.env.OPENCLAW_BUNDLE_MCP_TOOL_CACHE = previousBundleMcpToolCacheEnv;
+  }
+  resetBundleMcpToolMaterializationCacheForTest();
+});
 
 describe("createBundleMcpToolRuntime", () => {
   it("materializes bundle MCP tools and executes them", async () => {
@@ -170,5 +191,68 @@ describe("createBundleMcpToolRuntime", () => {
       "multi__mu",
       "multi__zeta",
     ]);
+  });
+
+  it("reuses cached descriptors while creating fresh proxy tools per materialization", async () => {
+    let getCatalogCalls = 0;
+    const runtime = makeToolRuntime({
+      onGetCatalog: () => {
+        getCatalogCalls += 1;
+      },
+    });
+
+    const first = await materializeBundleMcpToolsForRun({ runtime });
+    const second = await materializeBundleMcpToolsForRun({ runtime });
+
+    expect(first.tools.map((tool) => tool.name)).toEqual(["bundleProbe__bundle_probe"]);
+    expect(second.tools.map((tool) => tool.name)).toEqual(["bundleProbe__bundle_probe"]);
+    expect(first.tools[0]).not.toBe(second.tools[0]);
+    expect(getCatalogCalls).toBe(1);
+    expect(getPluginToolMeta(second.tools[0])?.pluginId).toBe("bundle-mcp");
+    expect(getBundleMcpToolMaterializationCacheStatsForTest()).toEqual({
+      bypass: 0,
+      hit: 1,
+      miss: 1,
+      store: 1,
+    });
+  });
+
+  it("keeps reserved tool-name sets in separate materialization cache entries", async () => {
+    const runtime = makeToolRuntime();
+
+    const first = await materializeBundleMcpToolsForRun({ runtime });
+    const second = await materializeBundleMcpToolsForRun({
+      runtime,
+      reservedToolNames: ["bundleProbe__bundle_probe"],
+    });
+    const third = await materializeBundleMcpToolsForRun({
+      runtime,
+      reservedToolNames: ["bundleProbe__bundle_probe"],
+    });
+
+    expect(first.tools.map((tool) => tool.name)).toEqual(["bundleProbe__bundle_probe"]);
+    expect(second.tools.map((tool) => tool.name)).toEqual(["bundleProbe__bundle_probe-2"]);
+    expect(third.tools.map((tool) => tool.name)).toEqual(["bundleProbe__bundle_probe-2"]);
+    expect(getBundleMcpToolMaterializationCacheStatsForTest()).toEqual({
+      bypass: 0,
+      hit: 1,
+      miss: 2,
+      store: 2,
+    });
+  });
+
+  it("can disable bundle MCP materialization descriptor caching", async () => {
+    process.env.OPENCLAW_BUNDLE_MCP_TOOL_CACHE = "0";
+    const runtime = makeToolRuntime();
+
+    await materializeBundleMcpToolsForRun({ runtime });
+    await materializeBundleMcpToolsForRun({ runtime });
+
+    expect(getBundleMcpToolMaterializationCacheStatsForTest()).toEqual({
+      bypass: 2,
+      hit: 0,
+      miss: 0,
+      store: 0,
+    });
   });
 });

--- a/src/agents/pi-bundle-mcp-tools.ts
+++ b/src/agents/pi-bundle-mcp-tools.ts
@@ -18,5 +18,7 @@ export {
 } from "./pi-bundle-mcp-runtime.js";
 export {
   createBundleMcpToolRuntime,
+  getBundleMcpToolMaterializationCacheStatsForTest,
   materializeBundleMcpToolsForRun,
+  resetBundleMcpToolMaterializationCacheForTest,
 } from "./pi-bundle-mcp-materialize.js";

--- a/src/plugins/tool-descriptor-cache.test.ts
+++ b/src/plugins/tool-descriptor-cache.test.ts
@@ -17,7 +17,12 @@ vi.mock("../config/runtime-snapshot.js", () => ({
 import {
   buildPluginToolDescriptorCacheKey,
   createPluginToolDescriptorConfigCacheKeyMemo,
+  getPluginToolDescriptorCacheStatsForTest,
+  recordPluginToolDescriptorCacheHit,
+  recordPluginToolDescriptorCacheMiss,
+  recordPluginToolDescriptorCachePartial,
   resetPluginToolDescriptorCache,
+  writeCachedPluginToolDescriptors,
 } from "./tool-descriptor-cache.js";
 
 describe("plugin tool descriptor cache keys", () => {
@@ -135,5 +140,43 @@ describe("plugin tool descriptor cache keys", () => {
     });
 
     expect(firstKey).toBe(secondKey);
+  });
+
+  it("tracks descriptor cache hit/miss/store stats for diagnostics", () => {
+    writeCachedPluginToolDescriptors({
+      cacheKey: "demo",
+      descriptors: [
+        {
+          optional: false,
+          descriptor: {
+            name: "demo_tool",
+            description: "Demo tool",
+            inputSchema: { type: "object", properties: {} },
+            owner: { kind: "plugin", pluginId: "demo" },
+            executor: { kind: "plugin", pluginId: "demo", toolName: "demo_tool" },
+          },
+        },
+      ],
+    });
+    recordPluginToolDescriptorCacheHit();
+    recordPluginToolDescriptorCacheMiss();
+    recordPluginToolDescriptorCachePartial();
+
+    expect(getPluginToolDescriptorCacheStatsForTest()).toEqual({
+      hit: 1,
+      miss: 1,
+      partial: 1,
+      store: 1,
+      size: 1,
+    });
+
+    resetPluginToolDescriptorCache();
+    expect(getPluginToolDescriptorCacheStatsForTest()).toEqual({
+      hit: 0,
+      miss: 0,
+      partial: 0,
+      store: 0,
+      size: 0,
+    });
   });
 });

--- a/src/plugins/tool-descriptor-cache.ts
+++ b/src/plugins/tool-descriptor-cache.ts
@@ -19,6 +19,20 @@ const descriptorCache = new Map<string, CachedPluginToolDescriptor[]>();
 let descriptorCacheObjectIds = new WeakMap<object, number>();
 let nextDescriptorCacheObjectId = 1;
 
+type PluginToolDescriptorCacheStats = {
+  hit: number;
+  miss: number;
+  partial: number;
+  store: number;
+};
+
+const descriptorCacheStats: PluginToolDescriptorCacheStats = {
+  hit: 0,
+  miss: 0,
+  partial: 0,
+  store: 0,
+};
+
 export type PluginToolDescriptorConfigCacheKeyMemo = WeakMap<object, string | number | null>;
 
 export function createPluginToolDescriptorConfigCacheKeyMemo(): PluginToolDescriptorConfigCacheKeyMemo {
@@ -29,6 +43,31 @@ export function resetPluginToolDescriptorCache(): void {
   descriptorCache.clear();
   descriptorCacheObjectIds = new WeakMap();
   nextDescriptorCacheObjectId = 1;
+  descriptorCacheStats.hit = 0;
+  descriptorCacheStats.miss = 0;
+  descriptorCacheStats.partial = 0;
+  descriptorCacheStats.store = 0;
+}
+
+export function getPluginToolDescriptorCacheStatsForTest(): PluginToolDescriptorCacheStats & {
+  size: number;
+} {
+  return {
+    ...descriptorCacheStats,
+    size: descriptorCache.size,
+  };
+}
+
+export function recordPluginToolDescriptorCacheHit(): void {
+  descriptorCacheStats.hit += 1;
+}
+
+export function recordPluginToolDescriptorCacheMiss(): void {
+  descriptorCacheStats.miss += 1;
+}
+
+export function recordPluginToolDescriptorCachePartial(): void {
+  descriptorCacheStats.partial += 1;
 }
 
 function sourceFingerprint(source: string): string {
@@ -184,4 +223,5 @@ export function writeCachedPluginToolDescriptors(params: {
     }
   }
   descriptorCache.set(params.cacheKey, [...params.descriptors]);
+  descriptorCacheStats.store += 1;
 }

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -24,6 +24,9 @@ import {
   capturePluginToolDescriptor,
   createPluginToolDescriptorConfigCacheKeyMemo,
   readCachedPluginToolDescriptors,
+  recordPluginToolDescriptorCacheHit,
+  recordPluginToolDescriptorCacheMiss,
+  recordPluginToolDescriptorCachePartial,
   type CachedPluginToolDescriptor,
   type PluginToolDescriptorConfigCacheKeyMemo,
   writeCachedPluginToolDescriptors,
@@ -31,6 +34,7 @@ import {
 import type { OpenClawPluginToolContext } from "./types.js";
 
 export {
+  getPluginToolDescriptorCacheStatsForTest,
   resetPluginToolDescriptorCache,
   resetPluginToolDescriptorCache as resetPluginToolFactoryCache,
 } from "./tool-descriptor-cache.js";
@@ -662,15 +666,20 @@ function resolveCachedPluginTools(params: {
         configCacheKeyMemo: params.configCacheKeyMemo,
       }),
     );
+    if (!cached) {
+      recordPluginToolDescriptorCacheMiss();
+      continue;
+    }
     if (
-      !cached ||
       !cachedDescriptorsCoverToolNames({
         descriptors: cached,
         toolNames: availableToolNames,
       })
     ) {
+      recordPluginToolDescriptorCachePartial();
       continue;
     }
+    recordPluginToolDescriptorCacheHit();
     const pluginTools: AnyAgentTool[] = [];
     let hasNameConflict = false;
     const localNormalizedNames = new Set<string>();


### PR DESCRIPTION
Summary
- Add descriptor cache hit/miss/partial/store diagnostics for plugin tool descriptor cache tests.
- Cache bundle MCP materialized descriptors per session runtime and reserved tool-name set, while creating fresh proxy tools and live execute closures for each materialization.
- Add OPENCLAW_BUNDLE_MCP_TOOL_CACHE=0 kill switch and tests for hot hits, reserved-name cache partitioning, and bypass.

Verification
- pnpm test src/plugins/tool-descriptor-cache.test.ts src/agents/pi-bundle-mcp-tools.materialize.test.ts src/agents/pi-bundle-mcp-runtime.test.ts
- pnpm tsgo:core
- pnpm build
- pnpm exec oxfmt --check --threads=1 src/plugins/tool-descriptor-cache.ts src/plugins/tools.ts src/plugins/tool-descriptor-cache.test.ts src/agents/pi-bundle-mcp-materialize.ts src/agents/pi-bundle-mcp-tools.ts src/agents/pi-bundle-mcp-tools.materialize.test.ts
- pnpm check:changed --staged
- lightweight benchmark, 200 tools x 1000 materializations: cache disabled 0.5579s total / 0.5579ms mean / 1000 getCatalog calls; cache hot 0.2886s total / 0.2886ms mean / 1 getCatalog call