### PR TITLE
Fix agent model override gateway scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/agent: let `openclaw agent --model` use the backend/admin Gateway scope without cached device-token scopes silently downscoping the request. (#78837) Thanks @VACInc.
 - Ollama: keep DeepSeek V4 cloud models thinking-capable even when Ollama Cloud `/api/show` omits the `thinking` capability, so `/think high` no longer rejects `ollama/deepseek-v4-*:cloud`.
 - ACP sessions: map canonical runtime options to backend-advertised ACP config keys like Claude's `effort` while keeping persisted OpenClaw state canonical. (#79926) Thanks @InTheCloudDan.
 - Gateway/watch: rebuild or restage missing bundled-plugin dist and runtime-postbuild outputs before launching the Gateway from a source checkout, preventing incomplete watch-mode runtime trees. (#70805) Thanks @rubencu.

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -172,6 +172,11 @@ describe("agentCliCommand", () => {
       const request = requireFirstCallArg(callGateway, "gateway") as {
         params?: Record<string, unknown>;
       };
+      expect(request).toMatchObject({
+        clientName: "cli",
+        mode: "cli",
+      });
+      expect(request).not.toHaveProperty("scopes");
       expect(request.params).not.toHaveProperty("cleanupBundleMcpOnRunEnd");
       expect(agentCommand).not.toHaveBeenCalled();
       expect(runtime.log).toHaveBeenCalledWith("hello");
@@ -222,6 +227,11 @@ describe("agentCliCommand", () => {
 
       expect(callGateway).toHaveBeenCalledTimes(1);
       const request = requireRecord(requireFirstCallArg(callGateway, "gateway"), "gateway request");
+      expect(request).toMatchObject({
+        clientName: "gateway-client",
+        mode: "backend",
+        scopes: ["operator.admin"],
+      });
       const params = requireRecord(request.params, "gateway request params");
       expect(params.model).toBe("ollama/qwen3.5:9b");
     });

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -7,6 +7,7 @@ import { withProgress } from "../cli/progress.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway, isGatewayTransportError, randomIdempotencyKey } from "../gateway/call.js";
+import { ADMIN_SCOPE } from "../gateway/operator-scopes.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../gateway/protocol/client-info.js";
 import { routeLogsToStderr } from "../logging/console.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -166,6 +167,8 @@ async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: RuntimeEnv) {
 
   const channel = normalizeMessageChannel(opts.channel);
   const idempotencyKey = normalizeOptionalString(opts.runId) || randomIdempotencyKey();
+  const modelOverride = normalizeOptionalString(opts.model);
+  const hasModelOverride = Boolean(modelOverride);
 
   const response: GatewayAgentResponse = await withProgress(
     {
@@ -179,7 +182,7 @@ async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: RuntimeEnv) {
         params: {
           message: body,
           agentId,
-          model: opts.model,
+          model: modelOverride,
           to: opts.to,
           replyTo: opts.replyTo,
           sessionId: opts.sessionId,
@@ -197,8 +200,11 @@ async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: RuntimeEnv) {
         },
         expectFinal: true,
         timeoutMs: gatewayTimeoutMs,
-        clientName: GATEWAY_CLIENT_NAMES.CLI,
-        mode: GATEWAY_CLIENT_MODES.CLI,
+        clientName: hasModelOverride
+          ? GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT
+          : GATEWAY_CLIENT_NAMES.CLI,
+        mode: hasModelOverride ? GATEWAY_CLIENT_MODES.BACKEND : GATEWAY_CLIENT_MODES.CLI,
+        ...(hasModelOverride ? { scopes: [ADMIN_SCOPE] } : {}),
       }),
   );
 

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -933,6 +933,29 @@ describe("GatewayClient connect auth payload", () => {
     client.stop();
   });
 
+  it("keeps requested scopes when reusing a stored device token", () => {
+    loadDeviceAuthTokenMock.mockReturnValue({
+      token: "stored-device-token",
+      scopes: ["operator.write"],
+    });
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      scopes: ["operator.admin"],
+    });
+
+    client.start();
+    const ws = getLatestWs();
+    ws.emitOpen();
+    emitConnectChallenge(ws);
+
+    expect(connectFrameFrom(ws)).toMatchObject({
+      token: "stored-device-token",
+      deviceToken: "stored-device-token",
+    });
+    expect(connectScopesFrom(ws)).toEqual(["operator.admin"]);
+    client.stop();
+  });
+
   it("loads stored device auth from the provided env", () => {
     loadDeviceAuthTokenMock.mockReturnValue({
       token: "stored-device-token",

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -648,7 +648,11 @@ export class GatewayClient {
     storedScopes?: string[];
   }): string[] {
     // Reuse cached scopes only when the client is reusing the cached device token.
-    // Explicit device tokens should keep the caller-requested scope set.
+    // Callers that ask for explicit scopes should keep that request so the
+    // server can authorize it or drive the normal scope-upgrade flow.
+    if (Array.isArray(this.opts.scopes)) {
+      return this.opts.scopes;
+    }
     if (
       params.usingStoredDeviceToken &&
       Array.isArray(params.storedScopes) &&


### PR DESCRIPTION
## Summary
- authorize `openclaw agent --model` through the backend/admin gateway path
- keep default agent calls on CLI gateway auth
- cover both paths in `agent-via-gateway` tests

## Root Cause
The CLI documented and forwarded per-run model overrides, but the gateway `agent` handler rejects provider/model overrides unless the caller has admin or internal override authorization. The default CLI gateway call used the least-privilege CLI path even when `--model` was present.

## Real behavior proof
- Behavior or issue addressed: `openclaw agent --model ...` should use the existing backend/admin gateway authorization path, while ordinary `openclaw agent` calls keep the default CLI gateway auth path.
- Real environment tested: isolated local command test harness for PR #78837 at `14ae07810f76`; each test creates a fresh temp session store; no existing Gateway service, channel account, or user session store was touched.
- Exact steps or command run after this patch: Ran the focused command-layer test file with verbose output so the model-override request construction is visible.
- Evidence after fix:

```text
✓ |commands| src/commands/agent-via-gateway.test.ts > agentCliCommand > uses gateway by default
✓ |commands| src/commands/agent-via-gateway.test.ts > agentCliCommand > passes model overrides through gateway requests

Test Files  1 passed (1)
Tests       13 passed (13)
```

- Observed result after fix: The default call still asserts `clientName: "cli"`, `mode: "cli"`, and no explicit scopes. The `--model` call asserts `clientName: "gateway-client"`, `mode: "backend"`, `scopes: ["operator.admin"]`, and forwards the requested model.
- What was not tested: A live model call through a running Gateway, because no usable model/provider credentials were present in the environment/profile on the proof host. The exercised path verifies the authorization-sensitive gateway request that previously caused the rejection.
- Before evidence: Current `main` sends `model: opts.model` using the CLI/write-scoped gateway call, and the gateway handler rejects provider/model overrides without admin/internal authorization with `provider/model overrides are not authorized for this caller.`

## Verification
- `pnpm exec oxfmt --check --threads=1 src/commands/agent-via-gateway.ts src/commands/agent-via-gateway.test.ts`
- `pnpm test src/commands/agent-via-gateway.test.ts -- --reporter=verbose`
- `git diff --check`