### PR TITLE
fix(sessions): resolve parentId so user messages don't orphan trailing assistant text

### DIFF
--- a/src/config/sessions/transcript-append.test.ts
+++ b/src/config/sessions/transcript-append.test.ts
@@ -1,0 +1,287 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { useTempSessionsFixture } from "./test-helpers.js";
+import { appendSessionTranscriptMessage } from "./transcript-append.js";
+
+/**
+ * Regression coverage for the "double reply" bug:
+ * https://github.com/openclaw/openclaw/issues (root cause described in
+ * murmur-ops/notes/double-reply-bug-2026-05-07.md and the corresponding fix
+ * brief).
+ *
+ * Symptom: when a turn ends with `assistant{toolCall} -> toolResult ->
+ * assistant{text}` and an inbound user message arrives shortly after (or the
+ * trailing assistant text has not yet landed on disk via a non-canonical
+ * write path), the user message was historically appended with
+ * `parentId = <toolResult.id>` instead of the most-recent conversational
+ * (assistant/user) message. On the next normalisation pass the assistant text
+ * branch is dropped and the model re-emits the same content, producing a
+ * duplicated reply to the user.
+ */
+describe("appendSessionTranscriptMessage parentId resolution", () => {
+  const fixture = useTempSessionsFixture("transcript-append-parent-test-");
+
+  function transcriptPath(): string {
+    return path.join(fixture.sessionsDir(), "session.jsonl");
+  }
+
+  function writeHeader(): string {
+    const file = transcriptPath();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        type: "session",
+        version: 1,
+        id: "test-session",
+        timestamp: new Date().toISOString(),
+        cwd: process.cwd(),
+      }) + "\n",
+      "utf-8",
+    );
+    return file;
+  }
+
+  function appendRaw(file: string, entry: Record<string, unknown>): void {
+    fs.appendFileSync(file, JSON.stringify(entry) + "\n", "utf-8");
+  }
+
+  it("attaches an inbound user message to the assistant text leaf, not the toolResult", async () => {
+    const file = writeHeader();
+    appendRaw(file, {
+      type: "message",
+      id: "user-1",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: { role: "user", content: [{ type: "text", text: "hi" }] },
+    });
+    appendRaw(file, {
+      type: "message",
+      id: "assistant-toolcall-1",
+      parentId: "user-1",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "t1", name: "exec", arguments: {} }],
+      },
+    });
+    appendRaw(file, {
+      type: "message",
+      id: "tool-result-1",
+      parentId: "assistant-toolcall-1",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "toolResult",
+        toolCallId: "t1",
+        toolName: "exec",
+        content: [{ type: "text", text: "ok" }],
+      },
+    });
+    appendRaw(file, {
+      type: "message",
+      id: "assistant-text-1",
+      parentId: "tool-result-1",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Done." }],
+      },
+    });
+
+    const { messageId } = await appendSessionTranscriptMessage({
+      transcriptPath: file,
+      message: { role: "user", content: [{ type: "text", text: "thanks!" }] },
+    });
+
+    const lines = fs
+      .readFileSync(file, "utf-8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    const appended = lines.find((entry: { id?: string }) => entry.id === messageId);
+    expect(appended).toBeDefined();
+    expect(appended.parentId).toBe("assistant-text-1");
+  });
+
+  it("attaches an inbound user message to the most-recent assistant message even when the leaf is a toolResult (orphan-pattern repro)", async () => {
+    // This is the bug shape: the trailing assistant-text never lands (e.g. an
+    // idempotency / delivery-mirror short-circuit returned without writing,
+    // or the streaming-final write hasn't completed yet) and the on-disk leaf
+    // is a toolResult. The user message must still attach to the assistant
+    // turn so that on linearisation the conversational branch is preserved.
+    const file = writeHeader();
+    appendRaw(file, {
+      type: "message",
+      id: "user-1",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: { role: "user", content: [{ type: "text", text: "search" }] },
+    });
+    appendRaw(file, {
+      type: "message",
+      id: "assistant-1",
+      parentId: "user-1",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "t1", name: "search", arguments: {} }],
+      },
+    });
+    appendRaw(file, {
+      type: "message",
+      id: "tool-result-1",
+      parentId: "assistant-1",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "toolResult",
+        toolCallId: "t1",
+        toolName: "search",
+        content: [{ type: "text", text: "result" }],
+      },
+    });
+
+    const { messageId } = await appendSessionTranscriptMessage({
+      transcriptPath: file,
+      message: { role: "user", content: [{ type: "text", text: "next" }] },
+    });
+
+    const lines = fs
+      .readFileSync(file, "utf-8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    const appended = lines.find((entry: { id?: string }) => entry.id === messageId);
+    expect(appended).toBeDefined();
+    // Before the fix: parentId === "tool-result-1" (sibling-orphan).
+    // After the fix: parentId === "assistant-1" (the most-recent conversational entry).
+    expect(appended.parentId).toBe("assistant-1");
+  });
+
+  it("non-user (e.g. assistant) appends preserve historical behaviour and use the trailing leaf", async () => {
+    const file = writeHeader();
+    appendRaw(file, {
+      type: "message",
+      id: "user-1",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: { role: "user", content: [{ type: "text", text: "search" }] },
+    });
+    appendRaw(file, {
+      type: "message",
+      id: "assistant-1",
+      parentId: "user-1",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "t1", name: "search", arguments: {} }],
+      },
+    });
+    appendRaw(file, {
+      type: "message",
+      id: "tool-result-1",
+      parentId: "assistant-1",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "toolResult",
+        toolCallId: "t1",
+        toolName: "search",
+        content: [{ type: "text", text: "result" }],
+      },
+    });
+
+    const { messageId } = await appendSessionTranscriptMessage({
+      transcriptPath: file,
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Here is the answer." }],
+      },
+    });
+
+    const lines = fs
+      .readFileSync(file, "utf-8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    const appended = lines.find((entry: { id?: string }) => entry.id === messageId);
+    expect(appended).toBeDefined();
+    // Assistant follow-up to a tool result must remain a child of the toolResult
+    // so the tool-call/tool-result chain stays intact within its turn.
+    expect(appended.parentId).toBe("tool-result-1");
+  });
+
+  it("falls back to the trailing leaf when no conversational ancestor exists", async () => {
+    const file = writeHeader();
+    appendRaw(file, {
+      type: "message",
+      id: "tool-result-only",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "toolResult",
+        toolCallId: "t-orphan",
+        toolName: "exec",
+        content: [{ type: "text", text: "ok" }],
+      },
+    });
+
+    const { messageId } = await appendSessionTranscriptMessage({
+      transcriptPath: file,
+      message: { role: "user", content: [{ type: "text", text: "hi" }] },
+    });
+
+    const lines = fs
+      .readFileSync(file, "utf-8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    const appended = lines.find((entry: { id?: string }) => entry.id === messageId);
+    expect(appended).toBeDefined();
+    expect(appended.parentId).toBe("tool-result-only");
+  });
+
+  it("serializes concurrent appenders so each entry parents on the most-recent on-disk leaf", async () => {
+    // Belt-and-suspenders: even with the per-path queue the cross-process write
+    // lock must serialise read+append within a single function, so two
+    // concurrent appenders never both compute parentId from the same stale leaf.
+    const file = writeHeader();
+    appendRaw(file, {
+      type: "message",
+      id: "seed",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: { role: "assistant", content: [{ type: "text", text: "seed" }] },
+    });
+
+    const results = await Promise.all([
+      appendSessionTranscriptMessage({
+        transcriptPath: file,
+        message: { role: "user", content: [{ type: "text", text: "a" }] },
+      }),
+      appendSessionTranscriptMessage({
+        transcriptPath: file,
+        message: { role: "user", content: [{ type: "text", text: "b" }] },
+      }),
+      appendSessionTranscriptMessage({
+        transcriptPath: file,
+        message: { role: "user", content: [{ type: "text", text: "c" }] },
+      }),
+    ]);
+
+    const lines = fs
+      .readFileSync(file, "utf-8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    // Header + seed + three appended entries.
+    expect(lines.length).toBe(5);
+    const ids = new Set(lines.map((entry: { id?: string }) => entry.id));
+    for (const r of results) {
+      expect(ids.has(r.messageId)).toBe(true);
+    }
+    // Each appended entry's parentId must point at the previous on-disk entry.
+    for (let i = 2; i < lines.length; i += 1) {
+      expect(lines[i].parentId).toBe(lines[i - 1].id);
+    }
+  });
+});

--- a/src/config/sessions/transcript-append.ts
+++ b/src/config/sessions/transcript-append.ts
@@ -22,6 +22,7 @@ async function loadCurrentSessionVersion(): Promise<number> {
 
 type TranscriptLeafInfo = {
   leafId?: string;
+  leafConversationalId?: string;
   hasParentLinkedEntries: boolean;
   nonSessionEntryCount: number;
 };
@@ -30,19 +31,53 @@ async function yieldTranscriptAppendScan(): Promise<void> {
   await new Promise<void>((resolve) => setImmediate(resolve));
 }
 
-function lineParentLinkedEntryId(line: string): string | undefined {
+type ParentLinkedEntryInfo = {
+  id: string;
+  /**
+   * The `role` field of the embedded message, when present. Used to discriminate
+   * tool-result intermediates from conversational messages so that incoming user
+   * messages can attach to the most-recent assistant/user turn rather than to a
+   * tool-result intermediate. See appendSessionTranscriptMessageLocked.
+   */
+  role?: string;
+};
+
+function lineParentLinkedEntryInfo(line: string): ParentLinkedEntryInfo | undefined {
   if (!line.trim()) {
     return undefined;
   }
   try {
-    const parsed = JSON.parse(line) as { type?: unknown; id?: unknown; parentId?: unknown };
-    return parsed.type !== "session" && typeof parsed.id === "string" && "parentId" in parsed
-      ? parsed.id
+    const parsed = JSON.parse(line) as {
+      type?: unknown;
+      id?: unknown;
+      parentId?: unknown;
+      message?: { role?: unknown } | null;
+    };
+    if (parsed.type === "session" || typeof parsed.id !== "string" || !("parentId" in parsed)) {
+      return undefined;
+    }
+    const role = parsed.message && typeof parsed.message === "object"
+      ? (parsed.message as { role?: unknown }).role
       : undefined;
+    return {
+      id: parsed.id,
+      ...(typeof role === "string" ? { role } : {}),
+    };
   } catch {
     return undefined;
   }
 }
+
+function lineParentLinkedEntryId(line: string): string | undefined {
+  return lineParentLinkedEntryInfo(line)?.id;
+}
+
+/**
+ * Roles whose entries represent intermediate tool exchange records rather than
+ * conversational turns. When choosing the parent for an incoming `user` message
+ * we walk past these to find the most-recent assistant/user message instead.
+ */
+const TOOL_INTERMEDIATE_ROLES: ReadonlySet<string> = new Set(["toolResult", "tool_result"]);
 
 function normalizeEntryId(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
@@ -68,8 +103,22 @@ async function readTranscriptLeafInfo(transcriptPath: string): Promise<Transcrip
     const buffer = Buffer.allocUnsafe(TRANSCRIPT_APPEND_SCAN_CHUNK_BYTES);
     let carry = "";
     let leafId: string | undefined;
+    let leafConversationalId: string | undefined;
     let hasParentLinkedEntries = false;
     let nonSessionEntryCount = 0;
+    const consumeLine = (line: string): void => {
+      if (lineHasNonSessionEntry(line)) {
+        nonSessionEntryCount += 1;
+      }
+      const info = lineParentLinkedEntryInfo(line);
+      if (info) {
+        leafId = info.id;
+        hasParentLinkedEntries = true;
+        if (!info.role || !TOOL_INTERMEDIATE_ROLES.has(info.role)) {
+          leafConversationalId = info.id;
+        }
+      }
+    };
     while (true) {
       const { bytesRead } = await handle.read(buffer, 0, buffer.length, null);
       if (bytesRead <= 0) {
@@ -79,34 +128,51 @@ async function readTranscriptLeafInfo(transcriptPath: string): Promise<Transcrip
       const lines = text.split(/\r?\n/);
       carry = lines.pop() ?? "";
       for (const line of lines) {
-        if (lineHasNonSessionEntry(line)) {
-          nonSessionEntryCount += 1;
-        }
-        const id = lineParentLinkedEntryId(line);
-        if (id) {
-          leafId = id;
-          hasParentLinkedEntries = true;
-        }
+        consumeLine(line);
       }
       await yieldTranscriptAppendScan();
     }
     const tail = carry + decoder.end();
-    if (lineHasNonSessionEntry(tail)) {
-      nonSessionEntryCount += 1;
-    }
-    const id = lineParentLinkedEntryId(tail);
-    if (id) {
-      leafId = id;
-      hasParentLinkedEntries = true;
-    }
+    consumeLine(tail);
     return {
       ...(leafId ? { leafId } : {}),
+      ...(leafConversationalId ? { leafConversationalId } : {}),
       hasParentLinkedEntries,
       nonSessionEntryCount,
     };
   } finally {
     await handle.close();
   }
+}
+
+function extractIncomingMessageRole(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const role = (message as { role?: unknown }).role;
+  return typeof role === "string" ? role : undefined;
+}
+
+/**
+ * Choose the parentId for a freshly-appended entry. For incoming `user` messages
+ * we prefer the most-recent conversational entry (assistant/user) over any
+ * trailing tool-result intermediate, so an inbound user message after a turn
+ * that ended with `assistant{toolCall} → toolResult → assistant{text}` does not
+ * become a sibling of the toolResult and orphan the assistant text on the next
+ * normalisation pass.
+ *
+ * If the incoming role is not `user`, or the leaf is already conversational, we
+ * fall through to the historical behaviour (use the trailing entry).
+ */
+function resolveParentIdForIncomingMessage(
+  leafInfo: TranscriptLeafInfo,
+  incomingMessage: unknown,
+): string | null {
+  const incomingRole = extractIncomingMessageRole(incomingMessage);
+  if (incomingRole === "user" && leafInfo.leafConversationalId) {
+    return leafInfo.leafConversationalId;
+  }
+  return leafInfo.leafId ?? null;
 }
 
 function lineHasNonSessionEntry(line: string): boolean {
@@ -288,7 +354,9 @@ async function appendSessionTranscriptMessageLocked(params: {
     const entry = {
       type: "message",
       id: messageId,
-      ...(shouldRawAppend ? {} : { parentId: leafInfo.leafId ?? null }),
+      ...(shouldRawAppend
+        ? {}
+        : { parentId: resolveParentIdForIncomingMessage(leafInfo, params.message) }),
       timestamp: new Date(now).toISOString(),
       message: params.message,
     };


### PR DESCRIPTION
## Summary

Fixes a bug in session transcript jsonl append where, after a turn that ended with `assistant{toolCall} → toolResult → assistant{text}`, an inbound user message could be appended with `parentId = <toolResult.id>` instead of the most-recent conversational entry. On the next normalisation/linearisation pass the assistant-text branch was dropped — so the model was re-prompted without its own prior reply in context and emitted essentially the same response again. Users saw their assistant repeat itself ("double reply").

## Root cause

`readTranscriptLeafInfo` in `src/config/sessions/transcript-append.ts` walks the file and reports the trailing `parentId`-linked entry's id as the leaf. `appendSessionTranscriptMessage` then sets `parentId = leafInfo.leafId ?? null` regardless of the incoming message's role.

That works for the happy path. It breaks when:

1. The trailing assistant text never lands on disk (a delivery-mirror / `idempotencyKey` / `isRedundantDeliveryMirror` short-circuit in `appendExactAssistantMessageToSessionTranscript` returns early without appending), so the on-disk leaf stays at the toolResult.
2. A streaming-final assistant text and an inbound user message race, and the user message wins to disk first.

In both cases the user message becomes a sibling of the toolResult, then the assistant text branch (the tool exchange + the model's reply) is pruned by linearisation and the model re-emits the same answer.

(`acquireSessionWriteLock` and the new `withTranscriptAppendQueue` already serialise concurrent appenders within a process; this PR is the belt-and-suspenders fix that makes parent resolution correct even when the trailing on-disk entry is a tool intermediate.)

## Fix shape

Track a `leafConversationalId` alongside `leafId` during the leaf scan — the most-recent entry whose `message.role` is not `toolResult` / `tool_result`. When the incoming message has `role: "user"`, prefer `leafConversationalId` as the parent; otherwise fall through to the historical trailing-leaf behaviour. Non-user appends (assistant follow-ups, tool exchanges within an assistant turn) keep their existing parent so the tool-call/tool-result chain stays intact.

The change is localised to `src/config/sessions/transcript-append.ts`; the only existing call site is `appendSessionTranscriptMessage`. No call signatures change.

## Tests

`src/config/sessions/transcript-append.test.ts` (new) covers:

- Inbound `user` message after `assistant{toolCall} → toolResult → assistant{text}` parents on the assistant text leaf (happy path stays correct).
- Inbound `user` message when the on-disk leaf is a `toolResult` parents on the most-recent assistant message — the regression repro.
- Non-user (assistant) appends still parent on the trailing entry, preserving the tool-call/tool-result chain.
- Fallback to the trailing leaf when no conversational ancestor exists.
- Concurrent appenders serialise so each entry parents on the previous on-disk entry.

Existing `src/config/sessions/transcript.test.ts` (12 tests) continues to pass. Full `runtime-config` Vitest project (138 files, 1270 tests) passes locally.

## Forensics

Originally diagnosed from a Telegram operator's session transcripts where the user observed the same assistant reply twice in succession after a turn that ended in a tool exchange. Forensic notes (private repo, will be linked once pushed): `mibb-ops/notes/double-reply-bug-2026-05-07.md`. Fix brief: `murmur-ops/notes/double-reply-bug-fix-brief.md`.

## Risk

Behavioural change is scoped to entries where `message.role === "user"` *and* the on-disk leaf is a tool-result intermediate — i.e. the broken case. All other appends keep historical behaviour.
