### PR TITLE
fix(feishu): fix topic session splitting for both native topic_group and normal groups with topic message format

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2644,6 +2644,110 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("hydrates topic thread_id from rootId for normal groups with topic message format", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    // When querying the rootId (replied-to message), Feishu returns its threadId
+    mockGetMessageFeishu.mockResolvedValueOnce({
+      messageId: "om_bot_reply_001",
+      chatId: "oc-group",
+      chatType: "group",
+      content: "bot reply",
+      contentType: "text",
+      threadId: "omt_normal_group_topic",
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group_topic",
+              replyInThread: "enabled",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    // Normal group (chat_type="group") with topic message format.
+    // User replies to bot's message (root_id=om_*), event has thread_id=omt_*
+    const replyEvent: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-user" } },
+      message: {
+        message_id: "msg-user-reply",
+        chat_id: "oc-group",
+        chat_type: "group",
+        root_id: "om_bot_reply_001",
+        thread_id: "omt_normal_group_topic",
+        message_type: "text",
+        content: JSON.stringify({ text: "reply in normal group topic" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event: replyEvent });
+
+    expect(mockResolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        peer: { kind: "group", id: "oc-group:topic:omt_normal_group_topic" },
+      }),
+    );
+  });
+
+  it("hydrates topic thread_id via rootId when threadId is missing in normal group", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    // The replied-to message has a threadId that can be retrieved via API
+    mockGetMessageFeishu.mockResolvedValueOnce({
+      messageId: "om_bot_reply_002",
+      chatId: "oc-group",
+      chatType: "group",
+      content: "bot reply",
+      contentType: "text",
+      threadId: "omt_hydrated_topic",
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group_topic",
+              replyInThread: "enabled",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    // Normal group reply where event does NOT carry thread_id but has root_id
+    const replyEvent: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-user" } },
+      message: {
+        message_id: "msg-user-reply-2",
+        chat_id: "oc-group",
+        chat_type: "group",
+        root_id: "om_bot_reply_002",
+        message_type: "text",
+        content: JSON.stringify({ text: "reply without thread_id" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event: replyEvent });
+
+    // Should hydrate via rootId
+    expect(mockGetMessageFeishu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "om_bot_reply_002",
+      }),
+    );
+    expect(mockResolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        peer: { kind: "group", id: "oc-group:topic:omt_hydrated_topic" },
+      }),
+    );
+  });
+
   it("replies to the topic root when handling a message inside an existing topic", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -533,30 +533,44 @@ export async function handleFeishuMessage(params: {
     ? resolveConfiguredFeishuGroupSessionScope({ groupConfig, feishuCfg })
     : null;
   let effectiveThreadId = ctx.threadId;
-  if (
-    isGroup &&
-    ctx.chatType === "topic_group" &&
-    !effectiveThreadId &&
-    isFeishuTopicSessionScope(groupSessionScope ?? "group")
-  ) {
-    try {
-      const messageInfo = await getMessageFeishu({
-        cfg,
-        accountId: account.accountId,
-        messageId: ctx.messageId,
-      });
-      const hydratedThreadId = messageInfo?.threadId?.trim();
-      if (hydratedThreadId) {
-        ctx = { ...ctx, threadId: hydratedThreadId };
-        effectiveThreadId = hydratedThreadId;
+  // Track whether we hydrated to a native Feishu topic ID so we can suppress
+  // rootId in session routing (rootId would otherwise take priority and split the session).
+  let hydratedToNativeTopic = false;
+  if (isGroup && isFeishuTopicSessionScope(groupSessionScope ?? "group")) {
+    const hasValidTopicThreadId = effectiveThreadId && effectiveThreadId.startsWith("omt_");
+    // Only attempt hydration when rootId looks like a real Feishu message ID (om_*)
+    // but is not already a native topic ID (omt_*). This avoids hydrating for
+    // OpenClaw-created threads where rootId is the initiating message.
+    const hasFeishuRootIdToHydrate =
+      ctx.rootId && ctx.rootId.startsWith("om_") && !ctx.rootId.startsWith("omt_");
+    if (!hasValidTopicThreadId && (ctx.chatType === "topic_group" || hasFeishuRootIdToHydrate)) {
+      try {
+        // Prefer querying rootId (the replied-to message already in the topic)
+        // over messageId (the newly sent message which may not have threadId yet).
+        const hydrateMessageId = ctx.rootId || ctx.messageId;
+        const messageInfo = await getMessageFeishu({
+          cfg,
+          accountId: account.accountId,
+          messageId: hydrateMessageId,
+        });
+        const hydratedThreadId = messageInfo?.threadId?.trim();
+        if (hydratedThreadId && hydratedThreadId.startsWith("omt_")) {
+          ctx = { ...ctx, threadId: hydratedThreadId };
+          effectiveThreadId = hydratedThreadId;
+          hydratedToNativeTopic = true;
+          log(
+            `feishu[${account.accountId}]: hydrated topic thread_id=${hydratedThreadId} for message=${ctx.messageId} (via ${hydrateMessageId})`,
+          );
+        }
+      } catch (err) {
         log(
-          `feishu[${account.accountId}]: hydrated topic thread_id=${hydratedThreadId} for message=${ctx.messageId}`,
+          `feishu[${account.accountId}]: failed to hydrate topic thread_id for message=${ctx.messageId}: ${String(err)}`,
         );
       }
-    } catch (err) {
-      log(
-        `feishu[${account.accountId}]: failed to hydrate topic thread_id for message=${ctx.messageId}: ${String(err)}`,
-      );
+    } else if (hasValidTopicThreadId && hasFeishuRootIdToHydrate) {
+      // Event already carries omt_* threadId AND a Feishu rootId (om_*) — this means
+      // we're in a Feishu native topic with a quote-reply. Suppress rootId so threadId wins.
+      hydratedToNativeTopic = true;
     }
   }
   const effectiveGroupSenderAllowFrom = isGroup
@@ -569,7 +583,10 @@ export async function handleFeishuMessage(params: {
         chatId: ctx.chatId,
         senderOpenId: ctx.senderOpenId,
         messageId: ctx.messageId,
-        rootId: ctx.rootId,
+        // When we hydrated to a native Feishu topic (omt_*), suppress rootId so the
+        // topicScope fallback chain uses threadId instead of the stale om_* rootId.
+        // For OpenClaw-created threads (non-hydrated), rootId is preserved as-is.
+        rootId: hydratedToNativeTopic ? undefined : ctx.rootId,
         threadId: effectiveThreadId,
         chatType: ctx.chatType,
         groupConfig,


### PR DESCRIPTION
## Summary

- **Problem**: Feishu topic session splitting persists after #78310 — affects **both** native `topic_group` and normal groups with topic message format.
- **Why it matters**: With `groupSessionScope: "group_topic"`, the first turn routes by `rootId` (om_*) and follow-ups by `threadId` (omt_*), splitting one Feishu topic into multiple OpenClaw sessions.
- **What changed**: 
  1. Hydrate condition expanded to cover normal groups (chat_type="group") with topic message format
  2. Hydrate now queries `rootId` (replied-to message) instead of `messageId` (newly sent message)
  3. `topicScope` prioritizes valid `omt_*` threadId over `rootId` fallback

### Two types of Feishu "topic groups"

| Type | `chat_type` | How to create |
|------|-------------|---------------|
| Native Topic Group | `"topic_group"` | Create group → select "Topic" mode |
| Normal Group + Topic Message Format | `"group"` | Group Settings → Message Format → Topic Messages |

PR #78310 only partially fixed the first type and completely missed the second. **This PR fixes both.**

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations (Feishu plugin)

## Linked Issue/PR

- Fixes remaining issues from #78262
- Extends #78310

## Root Cause

1. **Hydrate queries wrong message**: `ctx.messageId` (newly sent) may not have `threadId` yet in Feishu's API. Should query `ctx.rootId` (replied-to message already in the topic).

2. **Hydrate condition too narrow**: `ctx.chatType === "topic_group"` excludes normal groups that use topic message format (where `chat_type === "group"` but threads still use `omt_*` IDs).

3. **topicScope priority wrong**: When `chatType !== "topic_group"`, the fallback chain `?? normalizedRootId ?? normalizedThreadId` puts `rootId` (om_*) ahead of `threadId` (omt_*).

## Real behavior proof

- **Environment**: OpenClaw 2026.5.6, Azure VM, Feishu WebSocket mode
- **Tested on**: Both native topic_group AND normal group with topic message format
- **Steps**: 
  1. Reverted to official 5.6 code → both group types show session splitting
  2. Applied patch → both group types route all turns to same `omt_*` session
- **Evidence**: Gateway logs confirm `peer=oc_xxx:topic:omt_*` for all turns after fix

## Regression Test Plan

- Added 2 new test cases in `bot.test.ts`:
  - `hydrates topic thread_id from rootId for normal groups with topic message format`
  - `hydrates topic thread_id via rootId when threadId is missing in normal group`

## User-visible Changes

Feishu topic-mode sessions are stable for both native topic groups and normal groups using topic message format.

## Compatibility

- Backward compatible: Yes
- Config changes: No
- Migration needed: No
