### PR TITLE
fix(gateway): clear reset skills snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/sessions: clear cached skills snapshots during `/new` and `sessions.reset` so long-lived channel sessions rebuild the visible skill list after skills change. (#78873) Thanks @Evizero.
 - fix(auto-reply): gate inline skill tool dispatch [AI]. (#78517) Thanks @pgondhi987.
 - Canvas plugin: keep legacy root `canvasHost` configs valid until `openclaw doctor --fix` migrates them into `plugins.entries.canvas.config.host`, move Canvas/A2UI clients to gateway protocol v4 plugin surfaces, and refresh the generated A2UI bundle hash so normal builds stay clean.
 - feishu: honor config write policy for dynamic agents [AI]. (#78520) Thanks @pgondhi987.

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -729,6 +729,54 @@ describe("initSessionState RawBody", () => {
     expect(result.triggerBodyNormalized).toBe("/NEW KeepThisCase");
   });
 
+  it("drops cached skills snapshot when /new rotates an existing session", async () => {
+    const root = await makeCaseDir("openclaw-rawbody-reset-skills-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:signal:direct:uuid:reset-skills";
+    const existingSessionId = "session-with-stale-skills";
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: Date.now(),
+        systemSent: true,
+        skillsSnapshot: {
+          prompt: "<available_skills><skill><name>stale</name></skill></available_skills>",
+          skills: [{ name: "stale" }],
+          version: 0,
+        },
+      },
+    });
+
+    const cfg = {
+      session: {
+        store: storePath,
+        resetTriggers: ["/new"],
+      },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        RawBody: "/new continue",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(true);
+    expect(result.sessionId).not.toBe(existingSessionId);
+    expect(result.sessionEntry.skillsSnapshot).toBeUndefined();
+
+    const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      { skillsSnapshot?: unknown }
+    >;
+    expect(store[sessionKey]?.skillsSnapshot).toBeUndefined();
+  });
+
   it("drains stale system events when /new rotates an existing session", async () => {
     const root = await makeCaseDir("openclaw-rawbody-reset-system-events-");
     const storePath = path.join(root, "sessions.json");

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -768,6 +768,9 @@ export async function initSessionState(params: {
     sessionEntry.outputTokens = undefined;
     sessionEntry.estimatedCostUsd = undefined;
     sessionEntry.contextTokens = undefined;
+    // Skills snapshots are prompt/runtime caches. Do not preserve a stale
+    // snapshot through /new; the next turn must rebuild the visible skill list.
+    sessionEntry.skillsSnapshot = undefined;
   }
   // Preserve per-session overrides while resetting compaction state on /new.
   sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };

--- a/src/gateway/server.sessions.reset-models.test.ts
+++ b/src/gateway/server.sessions.reset-models.test.ts
@@ -50,6 +50,46 @@ test("sessions.reset recomputes model from defaults instead of stale runtime mod
   await expect(fs.stat(reset.payload?.entry.sessionFile as string)).resolves.toBeTruthy();
 });
 
+test("sessions.reset drops cached skills snapshot so /new rebuilds visible skills", async () => {
+  const { storePath } = await createSessionStoreDir();
+  testState.agentConfig = {
+    model: {
+      primary: "openai/gpt-test-a",
+    },
+  };
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-stale-skills", {
+        skillsSnapshot: {
+          prompt: "<available_skills><skill><name>stale</name></skill></available_skills>",
+          skills: [{ name: "stale" }],
+          version: 0,
+        },
+      }),
+    },
+  });
+
+  const reset = await directSessionReq<{
+    ok: true;
+    key: string;
+    entry: {
+      sessionId: string;
+      skillsSnapshot?: unknown;
+    };
+  }>("sessions.reset", { key: "main" });
+
+  expect(reset.ok).toBe(true);
+  expect(reset.payload?.entry.sessionId).not.toBe("sess-stale-skills");
+  expect(reset.payload?.entry.skillsSnapshot).toBeUndefined();
+
+  const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+    string,
+    { skillsSnapshot?: unknown }
+  >;
+  expect(store["agent:main:main"]?.skillsSnapshot).toBeUndefined();
+});
+
 test("sessions.reset preserves legacy explicit model overrides without modelOverrideSource", async () => {
   const { storePath } = await createSessionStoreDir();
   testState.agentConfig = {

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -623,7 +623,10 @@ export async function performGatewaySessionReset(params: {
       lastTo: currentEntry?.lastTo,
       lastAccountId: currentEntry?.lastAccountId,
       lastThreadId: currentEntry?.lastThreadId,
-      skillsSnapshot: currentEntry?.skillsSnapshot,
+      // Do not carry the cached skills catalog across /new. Long-lived channel
+      // sessions (Signal DMs/groups in particular) otherwise keep advertising a
+      // stale <available_skills> block even after reset/restart, because the
+      // skills snapshot version is runtime-local and may reset to 0.
       acp: currentEntry?.acp,
       inputTokens: 0,
       outputTokens: 0,


### PR DESCRIPTION
## Summary

- Problem: `/new`/`sessions.reset` preserved the cached `skillsSnapshot` from the previous session entry.
- Why it matters: long-lived channel sessions could keep advertising stale `<available_skills>` content after skills changed or after a Gateway restart reset the runtime-local skills snapshot version.
- What changed: reset entries now omit `skillsSnapshot`, forcing the next agent run to rebuild the visible skills catalog; added regression coverage for the session reset RPC path.
- What did NOT change (scope boundary): session identity/channel metadata, model reset behavior, and other preserved session settings remain unchanged.

AI-assisted: yes. I used an AI coding agent to prepare the branch/PR and I reviewed the diff and validation output.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: session reset should not carry a stale cached skills snapshot into the new session entry.
- Real environment tested: local OpenClaw checkout on Linux, Node/pnpm repo environment.
- Exact steps or command run after this patch: `pnpm test src/gateway/server.sessions.reset-models.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): command passed with `Test Files 1 passed (1)` and `Tests 6 passed (6)`.
- Observed result after fix: the regression test verifies `sessions.reset` returns a new session entry without `skillsSnapshot` and the persisted store no longer contains `skillsSnapshot` for the reset session key.
- What was not tested: live Signal/Telegram/Discord channel `/new` roundtrip with an installed/removed skill; no screenshot/recording captured.
- Before evidence (optional but encouraged): the previous implementation explicitly copied `currentEntry?.skillsSnapshot` into the reset entry.

## Root Cause (if applicable)

- Root cause: `performGatewaySessionReset` copied `currentEntry?.skillsSnapshot` into the new reset session entry along with durable session metadata.
- Missing detection / guardrail: there was no reset regression test asserting cached skills snapshots are ephemeral across `/new`.
- Contributing context (if known): skills snapshot versions are runtime-local, so a Gateway restart can make a stale persisted snapshot look current again.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server.sessions.reset-models.test.ts`
- Scenario the test should lock in: reset a session entry containing a `skillsSnapshot` and assert the returned/persisted reset entry drops it.
- Why this is the smallest reliable guardrail: the bug is in the gateway session reset persistence path, and the direct session RPC test exercises that path without needing a live channel.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`/new`/session reset rebuilds visible skills instead of preserving a stale cached skills list.

## Diagram (if applicable)

```text
Before:
/user runs /new -> reset entry copies old skillsSnapshot -> next run may show stale skills

After:
/user runs /new -> reset entry omits skillsSnapshot -> next run rebuilds skills catalog
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm checkout
- Model/provider: test config uses `openai/gpt-test-a`
- Integration/channel (if any): Gateway sessions RPC test harness
- Relevant config (redacted): test-local session store fixture only

### Steps

1. Create a session store entry with `skillsSnapshot`.
2. Call `sessions.reset` for the session key.
3. Read the returned entry and persisted session store.

### Expected

- The reset entry has a fresh session id and no `skillsSnapshot`.

### Actual

- After this patch, the reset entry has a fresh session id and no `skillsSnapshot`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run:

```text
pnpm test src/gateway/server.sessions.reset-models.test.ts
Test Files 1 passed (1)
Tests 6 passed (6)
```

Also run:

```text
git diff --check
pnpm check:changed
```

`pnpm check:changed` completed the selected core/coreTests/docs lanes without errors.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted Gateway session reset regression test and changed-lane checks.
- Edge cases checked: persisted reset entry drops `skillsSnapshot`; existing reset model override tests still pass.
- What you did **not** verify: live channel `/new` behavior in Signal/Telegram/Discord with real skill install/removal.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: dropping the cached snapshot means the next run must rebuild skills context.
  - Mitigation: that rebuild is desired after reset and avoids stale skill prompts; durable session metadata remains preserved.
