### PR TITLE
Surface billing stream errors

### DIFF
--- a/src/agents/stream-message-shared.test.ts
+++ b/src/agents/stream-message-shared.test.ts
@@ -41,4 +41,25 @@ describe("buildStreamErrorAssistantMessage", () => {
     // Original errorMessage is preserved verbatim for clients that surface it.
     expect(message.errorMessage).toBe("   ");
   });
+
+  it("surfaces a safe billing hint when the provider rejects the token budget", () => {
+    const message = buildStreamErrorAssistantMessage({
+      model: {
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "moonshotai/kimi-k2.6",
+      },
+      errorMessage:
+        "402 This request requires more credits, or fewer max_tokens. You requested up to 4096 tokens, but can only afford 643. To increase, visit https://openrouter.ai/settings/credits",
+    });
+
+    expect(message.content).toEqual([
+      {
+        type: "text",
+        text: "[model unavailable: billing/credits] openrouter (moonshotai/kimi-k2.6) cannot run with the current API key balance. Requested up to 4096 tokens, but the account can only afford 643. Add credits, lower maxTokens, or switch models.",
+      },
+    ]);
+    expect(JSON.stringify(message.content)).not.toContain("settings/credits");
+    expect(message.errorMessage).toContain("settings/credits");
+  });
 });

--- a/src/agents/stream-message-shared.ts
+++ b/src/agents/stream-message-shared.ts
@@ -80,24 +80,50 @@ export function buildAssistantMessageWithZeroUsage(params: {
 // raw provider error text is intentionally NOT placed in `content` because that
 // array is replayed back to the model on the next turn — provider error strings
 // can carry hostnames or upstream metadata, and replaying them as assistant
-// content opens a prompt-injection surface (CWE-200). The detailed error stays
-// in the peer `errorMessage` field, which clients/UIs read directly and
-// providers do not include in their wire payloads.
+// content opens a prompt-injection surface (CWE-200). A small allowlisted
+// billing message is the exception: it is built from model metadata plus
+// numeric token-budget details only, so clients that render content without
+// reading `errorMessage` can still tell the operator what is wrong. The detailed
+// error stays in the peer `errorMessage` field, which clients/UIs read directly
+// and providers do not include in their wire payloads.
 //
 // This constant is the single source of truth used by replay normalization and
 // session-file repair as well, so a session repaired offline reads identically
 // to a live stream-error turn (and the repair pass remains idempotent).
 export const STREAM_ERROR_FALLBACK_TEXT = "[assistant turn failed before producing content]";
 
+const BILLING_ERROR_HINT_RE =
+  /\b(?:billing|credits?|credit|insufficient balance|run out of credits|fewer max_tokens|can only afford)\b/i;
+const AFFORDABLE_TOKEN_RE =
+  /requested up to\s+([\d,]+)\s+tokens?,?\s+but can only afford\s+([\d,]+)/i;
+
+function buildBillingStreamErrorText(params: {
+  model: StreamModelDescriptor;
+  errorMessage: string;
+}): string | undefined {
+  const raw = params.errorMessage.trim();
+  if (!raw || !BILLING_ERROR_HINT_RE.test(raw)) {
+    return undefined;
+  }
+
+  const affordMatch = raw.match(AFFORDABLE_TOKEN_RE);
+  const affordText = affordMatch
+    ? ` Requested up to ${affordMatch[1]} tokens, but the account can only afford ${affordMatch[2]}.`
+    : "";
+
+  return `[model unavailable: billing/credits] ${params.model.provider} (${params.model.id}) cannot run with the current API key balance.${affordText} Add credits, lower maxTokens, or switch models.`;
+}
+
 export function buildStreamErrorAssistantMessage(params: {
   model: StreamModelDescriptor;
   errorMessage: string;
   timestamp?: number;
 }): AssistantMessage & { stopReason: "error"; errorMessage: string } {
+  const visibleText = buildBillingStreamErrorText(params) ?? STREAM_ERROR_FALLBACK_TEXT;
   return {
     ...buildAssistantMessageWithZeroUsage({
       model: params.model,
-      content: [{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }],
+      content: [{ type: "text", text: visibleText }],
       stopReason: "error",
       timestamp: params.timestamp,
     }),


### PR DESCRIPTION
## Summary
- show a safe, actionable chat message when a stream turn fails because of billing, credits, or token-budget limits
- keep raw upstream provider errors in errorMessage instead of replaying them as assistant content
- add regression coverage for OpenRouter-style insufficient-credits errors

## Verification
- pnpm exec vitest run src/agents/stream-message-shared.test.ts
- pnpm tsgo:core
- pnpm exec oxlint src/agents/stream-message-shared.ts src/agents/stream-message-shared.test.ts
- pnpm exec oxfmt --check --threads=1 src/agents/stream-message-shared.ts src/agents/stream-message-shared.test.ts