### PR TITLE
fix(gateway): break plugin node capability type cycle

### DIFF
--- a/src/gateway/plugin-node-capability-types.ts
+++ b/src/gateway/plugin-node-capability-types.ts
@@ -1,0 +1,11 @@
+export type PluginNodeCapabilitySurface = {
+  surface: string;
+  ttlMs?: number;
+  scopeKey?: string;
+};
+
+export type PluginNodeCapabilityClient = {
+  pluginSurfaceUrls?: Record<string, string>;
+  pluginNodeCapabilitySurfaces?: Record<string, PluginNodeCapabilitySurface>;
+  pluginNodeCapabilities?: Record<string, { capability: string; expiresAtMs: number }>;
+};

--- a/src/gateway/plugin-node-capability.ts
+++ b/src/gateway/plugin-node-capability.ts
@@ -1,21 +1,17 @@
 import { randomBytes } from "node:crypto";
 import { safeEqualSecret } from "../security/secret-equal.js";
+import type {
+  PluginNodeCapabilityClient,
+  PluginNodeCapabilitySurface,
+} from "./plugin-node-capability-types.js";
 
 export const PLUGIN_NODE_CAPABILITY_PATH_PREFIX = "/__openclaw__/cap";
 const PLUGIN_NODE_CAPABILITY_QUERY_PARAM = "oc_cap";
 export const DEFAULT_PLUGIN_NODE_CAPABILITY_TTL_MS = 10 * 60_000;
-
-export type PluginNodeCapabilitySurface = {
-  surface: string;
-  ttlMs?: number;
-  scopeKey?: string;
-};
-
-export type PluginNodeCapabilityClient = {
-  pluginSurfaceUrls?: Record<string, string>;
-  pluginNodeCapabilitySurfaces?: Record<string, PluginNodeCapabilitySurface>;
-  pluginNodeCapabilities?: Record<string, { capability: string; expiresAtMs: number }>;
-};
+export type {
+  PluginNodeCapabilityClient,
+  PluginNodeCapabilitySurface,
+} from "./plugin-node-capability-types.js";
 
 export function indexPluginNodeCapabilitySurfaces(
   surfaces: readonly PluginNodeCapabilitySurface[],

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -1,5 +1,5 @@
 import type { WebSocket } from "ws";
-import type { PluginNodeCapabilityClient } from "../plugin-node-capability.js";
+import type { PluginNodeCapabilityClient } from "../plugin-node-capability-types.js";
 import type { ConnectParams } from "../protocol/index.js";
 
 export type GatewayWsClient = PluginNodeCapabilityClient & {


### PR DESCRIPTION
## Summary

- Split Gateway plugin-node capability client/surface types into a leaf type-only module.
- Keep `src/gateway/plugin-node-capability.ts` exporting the same public types while avoiding a type import from `server/ws-types.ts` back through the runtime module.
- Point `GatewayWsClient` at the leaf type module so `check:architecture` no longer sees the plugin-node capability import cycle.

This PR has been rebased onto current `main`; the earlier UI, Canvas, and Knip unused-file CI fixes are now already present upstream, so this branch is narrowed to the remaining Gateway cycle unblock.

## Real behavior proof

- **Behavior or issue addressed:** Main validation still needed the Gateway plugin-node capability type-only import cycle removed so architecture checks can stay green after the related CI fixes on `main`.
- **Real environment tested:** Real local OpenClaw source checkout on macOS, branch `ci-unblock-main-checks`, rebased on `origin/main` at `56636dfe578f7bbef5eb2484414f3e4cf4b07436`.
- **Exact steps or command run after this patch:** Ran the targeted OpenClaw repo commands listed in Verification, including the boundary invariant test, core typechecks, deadcode checks, and architecture cycle checks.
- **Evidence after fix:** Copied terminal output from the local checkout:

```text
$ pnpm test src/plugins/contracts/boundary-invariants.test.ts
Test Files 1 passed (1)
Tests 13 passed (13)

$ pnpm check:architecture
Import cycle check: 0 runtime value cycle(s).
Madge import cycle check: 0 cycle(s).
deprecated internal config API guard passed
deprecated JSDoc guard passed

$ pnpm deadcode:unused-files
[deadcode] Knip unused-file allowlist matched 30 intentional entries.
```

- **Observed result after fix:** The Gateway capability runtime module no longer needs to import the WebSocket client type, and the server WebSocket type imports only the leaf type module. The targeted architecture and boundary checks pass locally.
- **What was not tested:** I did not run the full `pnpm check` sweep locally; this is a narrow CI unblock PR and the local proof covers the touched Gateway cycle surface.

## Verification

- `pnpm exec oxfmt --check --threads=1 src/gateway/plugin-node-capability-types.ts src/gateway/plugin-node-capability.ts src/gateway/server/ws-types.ts`
- `git diff --check`
- `pnpm deadcode:dependencies`
- `pnpm deadcode:unused-files`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm test src/plugins/contracts/boundary-invariants.test.ts`
- `pnpm check:architecture`
