### PR TITLE
fix(agents): route embedded default streams through OpenClaw transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/OpenAI-compatible: route embedded-session default stream wrappers through OpenClaw's boundary-aware transport so custom `openai-completions` backends receive streaming usage data again. Fixes #78661. Thanks @khaney64.
 - fix(active-memory): require admin scope for global toggles [AI]. (#78863) Thanks @pgondhi987.
 - Honor owner enforcement for native commands [AI]. (#78864) Thanks @pgondhi987.
 - Config/BlueBubbles: remove the duplicate core-owned BlueBubbles config schema while preserving plugin-owned `dmPolicy` allowFrom validation for channel and account configs. Fixes #69238. Thanks @omarshahine.

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -201,6 +201,7 @@ function prepareCompactionSessionAgent(params: {
 }) {
   params.session.agent.streamFn = resolveEmbeddedAgentStreamFn({
     currentStreamFn: resolveEmbeddedAgentBaseStreamFn({ session: params.session as never }),
+    currentStreamFnOrigin: "embedded-session-default",
     providerStreamFn: params.providerStreamFn as never,
     shouldUseWebSocketTransport: params.shouldUseWebSocketTransport,
     wsApiKey: params.wsApiKey,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1912,6 +1912,7 @@ export async function runEmbeddedAttempt(
       }
       const streamStrategy = describeEmbeddedAgentStreamStrategy({
         currentStreamFn: defaultSessionStreamFn,
+        currentStreamFnOrigin: "embedded-session-default",
         providerStreamFn,
         shouldUseWebSocketTransport,
         wsApiKey,
@@ -1919,6 +1920,7 @@ export async function runEmbeddedAttempt(
       });
       activeSession.agent.streamFn = resolveEmbeddedAgentStreamFn({
         currentStreamFn: defaultSessionStreamFn,
+        currentStreamFnOrigin: "embedded-session-default",
         providerStreamFn,
         shouldUseWebSocketTransport,
         wsApiKey,

--- a/src/agents/pi-embedded-runner/stream-resolution.test.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.test.ts
@@ -1,5 +1,6 @@
+import { createServer } from "node:http";
 import type { StreamFn } from "@mariozechner/pi-agent-core";
-import { streamSimple } from "@mariozechner/pi-ai";
+import { streamSimple, type Model } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import * as providerTransportStream from "../provider-transport-stream.js";
 import {
@@ -84,6 +85,21 @@ describe("describeEmbeddedAgentStreamStrategy", () => {
       }),
     ).toBe("session-custom");
   });
+
+  it("describes embedded-session default wrappers as default fallbacks", () => {
+    expect(
+      describeEmbeddedAgentStreamStrategy({
+        currentStreamFn: vi.fn() as never,
+        currentStreamFnOrigin: "embedded-session-default",
+        shouldUseWebSocketTransport: false,
+        model: {
+          api: "openai-completions",
+          provider: "llama",
+          id: "qwen3",
+        } as never,
+      }),
+    ).toBe("boundary-aware:openai-completions");
+  });
 });
 
 describe("resolveEmbeddedAgentStreamFn", () => {
@@ -145,6 +161,176 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     });
 
     expect(streamFn).not.toBe(streamSimple);
+  });
+
+  it("routes embedded-session default OpenAI-compatible wrappers through boundary-aware transports", async () => {
+    const defaultSessionStreamFn = vi.fn(async (model, context, options) =>
+      streamSimple(model, context, { ...options, apiKey: "session-default-key" }),
+    );
+    const innerStreamFn = vi.fn(async (_model, _context, options) => options);
+    overrideBoundaryAwareStreamFnOnce(innerStreamFn as never);
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: defaultSessionStreamFn as never,
+      currentStreamFnOrigin: "embedded-session-default",
+      shouldUseWebSocketTransport: false,
+      sessionId: "session-1",
+      model: {
+        api: "openai-completions",
+        provider: "llama",
+        id: "qwen3",
+      } as never,
+      resolvedApiKey: "local-token",
+    });
+
+    expect(streamFn).not.toBe(defaultSessionStreamFn);
+    await expect(
+      streamFn({ provider: "llama", id: "qwen3" } as never, {} as never, {}),
+    ).resolves.toMatchObject({ apiKey: "local-token" });
+    expect(innerStreamFn).toHaveBeenCalledTimes(1);
+    expect(defaultSessionStreamFn).not.toHaveBeenCalled();
+  });
+
+  it("keeps unmarked custom currentStreamFn wrappers unchanged", () => {
+    const currentStreamFn = vi.fn(async (model, context, options) =>
+      streamSimple(model, context, { ...options, apiKey: "custom-key" }),
+    );
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: currentStreamFn as never,
+      shouldUseWebSocketTransport: false,
+      sessionId: "session-1",
+      model: {
+        api: "openai-completions",
+        provider: "llama",
+        id: "qwen3",
+      } as never,
+    });
+
+    expect(streamFn).toBe(currentStreamFn);
+  });
+
+  it("sends streaming usage through OpenClaw transport for PI auth-wrapped defaults", async () => {
+    let captured:
+      | {
+          authorization?: string;
+          path?: string;
+          streamOptions?: unknown;
+        }
+      | undefined;
+    const server = createServer((req, res) => {
+      let body = "";
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        const parsed = JSON.parse(body) as { stream_options?: unknown };
+        captured = {
+          authorization: Array.isArray(req.headers.authorization)
+            ? req.headers.authorization[0]
+            : req.headers.authorization,
+          path: req.url,
+          streamOptions: parsed.stream_options,
+        };
+        res.writeHead(200, {
+          "content-type": "text/event-stream; charset=utf-8",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        const created = Math.floor(Date.now() / 1000);
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-usage-proof",
+            object: "chat.completion.chunk",
+            created,
+            model: "qwen3",
+            choices: [
+              {
+                index: 0,
+                delta: { role: "assistant", content: "OK" },
+                finish_reason: null,
+              },
+            ],
+          })}\n\n`,
+        );
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-usage-proof",
+            object: "chat.completion.chunk",
+            created,
+            model: "qwen3",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 7, completion_tokens: 2, total_tokens: 9 },
+          })}\n\n`,
+        );
+        res.write("data: [DONE]\n\n");
+        res.end();
+      });
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback server address");
+      }
+      const model = {
+        id: "qwen3",
+        name: "Qwen3",
+        api: "openai-completions",
+        provider: "llama",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 4096,
+        maxTokens: 256,
+      } satisfies Model<"openai-completions">;
+      const defaultSessionStreamFn = vi.fn(async (m, context, options) =>
+        streamSimple(m as never, context, { ...options, apiKey: "session-default-key" }),
+      );
+      const streamFn = resolveEmbeddedAgentStreamFn({
+        currentStreamFn: defaultSessionStreamFn as never,
+        currentStreamFnOrigin: "embedded-session-default",
+        shouldUseWebSocketTransport: false,
+        sessionId: "session-1",
+        model: model as never,
+        resolvedApiKey: "runtime-key",
+      });
+
+      let doneMessage: { usage?: unknown } | undefined;
+      const stream = await streamFn(
+        model as never,
+        {
+          messages: [{ role: "user", content: "Reply OK", timestamp: Date.now() }],
+          tools: [],
+        } as never,
+        {},
+      );
+      for await (const event of stream as AsyncIterable<{
+        type: string;
+        message?: { usage?: unknown };
+      }>) {
+        if (event.type === "done") {
+          doneMessage = event.message;
+        }
+      }
+
+      expect(defaultSessionStreamFn).not.toHaveBeenCalled();
+      expect(captured).toMatchObject({
+        authorization: "Bearer runtime-key",
+        path: "/v1/chat/completions",
+        streamOptions: { include_usage: true },
+      });
+      expect(doneMessage?.usage).toMatchObject({
+        input: 7,
+        output: 2,
+        totalTokens: 9,
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 
   it("injects the resolved run api key into provider-owned stream functions", async () => {

--- a/src/agents/pi-embedded-runner/stream-resolution.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.ts
@@ -9,6 +9,8 @@ import type { EmbeddedRunAttemptParams } from "./run/types.js";
 
 let embeddedAgentBaseStreamFnCache = new WeakMap<object, StreamFn | undefined>();
 
+type EmbeddedAgentCurrentStreamFnOrigin = "embedded-session-default";
+
 export function resolveEmbeddedAgentBaseStreamFn(params: {
   session: { agent: { streamFn?: StreamFn } };
 }): StreamFn | undefined {
@@ -27,6 +29,7 @@ export function resetEmbeddedAgentBaseStreamFnCacheForTest(): void {
 
 export function describeEmbeddedAgentStreamStrategy(params: {
   currentStreamFn: StreamFn | undefined;
+  currentStreamFnOrigin?: EmbeddedAgentCurrentStreamFnOrigin;
   providerStreamFn?: StreamFn;
   shouldUseWebSocketTransport: boolean;
   wsApiKey?: string;
@@ -41,7 +44,7 @@ export function describeEmbeddedAgentStreamStrategy(params: {
   if (params.model.provider === "anthropic-vertex") {
     return "anthropic-vertex";
   }
-  if (params.currentStreamFn === undefined || params.currentStreamFn === streamSimple) {
+  if (isEmbeddedAgentDefaultStreamFn(params)) {
     return createBoundaryAwareStreamFnForModel(params.model)
       ? `boundary-aware:${params.model.api}`
       : "stream-simple";
@@ -63,6 +66,7 @@ export async function resolveEmbeddedAgentApiKey(params: {
 
 export function resolveEmbeddedAgentStreamFn(params: {
   currentStreamFn: StreamFn | undefined;
+  currentStreamFnOrigin?: EmbeddedAgentCurrentStreamFnOrigin;
   providerStreamFn?: StreamFn;
   shouldUseWebSocketTransport: boolean;
   wsApiKey?: string;
@@ -104,7 +108,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
     return createAnthropicVertexStreamFnForModel(params.model);
   }
 
-  if (params.currentStreamFn === undefined || params.currentStreamFn === streamSimple) {
+  if (isEmbeddedAgentDefaultStreamFn(params)) {
     const boundaryAwareStreamFn = createBoundaryAwareStreamFnForModel(params.model);
     if (boundaryAwareStreamFn) {
       // Boundary-aware transports read credentials from options.apiKey just
@@ -122,6 +126,19 @@ export function resolveEmbeddedAgentStreamFn(params: {
   }
 
   return currentStreamFn;
+}
+
+function isEmbeddedAgentDefaultStreamFn(params: {
+  currentStreamFn: StreamFn | undefined;
+  currentStreamFnOrigin?: EmbeddedAgentCurrentStreamFnOrigin;
+}): boolean {
+  // PI createAgentSession installs an auth-wrapped default stream, so the
+  // session-default path cannot rely on streamSimple identity alone.
+  return (
+    params.currentStreamFn === undefined ||
+    params.currentStreamFn === streamSimple ||
+    params.currentStreamFnOrigin === "embedded-session-default"
+  );
 }
 
 function wrapEmbeddedAgentStreamFn(


### PR DESCRIPTION
## Summary

Fixes #78661 by routing PI's embedded-session default stream wrapper through OpenClaw's boundary-aware transport for supported APIs, including custom `openai-completions` providers. This restores `stream_options.include_usage: true` without requiring every local/custom backend to set `compat.supportsUsageInStreaming`.

This is related to the existing candidates #78679 and #78705:

- #78679 recognizes registered PI provider streams, but ClawSweeper noted it misses the actual `createAgentSession` auth-wrapper path.
- #78705 targets the same auth-wrapper class, but is currently conflicted/proof-blocked.
- This branch is rebased on current `origin/main` (`7ad53cef`) and keeps true custom `currentStreamFn` values untouched unless the caller marks the stream as the embedded-session default.

## Root Cause

`createAgentSession` installs a session default `streamFn` wrapper that resolves auth and then calls `streamSimple`. That wrapper is not identity-equal to the module-level `streamSimple`, so `resolveEmbeddedAgentStreamFn()` treated it as `session-custom` and returned it unchanged. For custom `openai-completions` providers, that bypassed OpenClaw's completions transport, which is the path that unconditionally sends streaming usage options.

## Changes

- Adds an explicit `currentStreamFnOrigin: "embedded-session-default"` marker to embedded stream strategy/resolution.
- Passes that marker from normal embedded attempts and compaction, where the stream comes from the cached base session default.
- Keeps provider-owned streams, WebSocket transport, Anthropic Vertex transport, and unmarked custom session streams unchanged.
- Adds regression coverage for:
  - Strategy labels for embedded-session default wrappers.
  - Routing auth-wrapped defaults through boundary-aware transport.
  - Preserving unmarked custom wrappers.
  - A loopback OpenAI-compatible endpoint proving the outgoing request includes `stream_options.include_usage: true`, uses the runtime API key, and records nonzero usage.
- Adds a changelog entry.

## Real behavior proof

Behavior or issue addressed: Embedded sessions using PI auth-wrapped default streams bypassed OpenClaw's boundary-aware `openai-completions` transport, so custom OpenAI-compatible providers omitted `stream_options.include_usage` and recorded zero usage. This patch routes only marked embedded-session defaults through OpenClaw transport while preserving unmarked custom streams.

Real environment tested: Local OpenClaw source checkout on macOS, rebased on current upstream `origin/main` (`7ad53cef`), with a refreshed pnpm workspace install. The after-fix proof used a real loopback HTTP server implementing the OpenAI-compatible `/v1/chat/completions` streaming endpoint and the actual OpenClaw `createOpenAICompletionsTransportStreamFn()` path selected through `resolveEmbeddedAgentStreamFn()`.

Exact steps or command run after this patch: Ran a standalone live Node command from the source checkout: `node --import tsx --input-type=module`, which started a loopback OpenAI-compatible SSE server, constructed a PI-style auth-wrapped default stream, called `resolveEmbeddedAgentStreamFn({ currentStreamFnOrigin: "embedded-session-default", model: { api: "openai-completions", provider: "llama" } })`, streamed one request through the resolved function, and printed the captured request body plus final usage.

Evidence after fix: Copied live output from the standalone loopback command shows the real outgoing request and final streamed usage:

```json
{
  "defaultWrapperCalls": 0,
  "captured": {
    "path": "/v1/chat/completions",
    "authorization": "Bearer runtime-key-redacted",
    "model": "qwen3",
    "stream": true,
    "stream_options": {
      "include_usage": true
    }
  },
  "doneUsage": {
    "input": 7,
    "output": 2,
    "cacheRead": 0,
    "cacheWrite": 0,
    "totalTokens": 9,
    "cost": {
      "input": 0,
      "output": 0,
      "cacheRead": 0,
      "cacheWrite": 0,
      "total": 0
    }
  }
}
```

Observed result after fix: The PI-style default wrapper was not called (`defaultWrapperCalls: 0`), proving the session-default path was replaced by OpenClaw transport. The captured live HTTP request went to `/v1/chat/completions`, used the runtime key, included `stream_options.include_usage: true`, and the streamed usage block produced nonzero usage (`input: 7`, `output: 2`, `totalTokens: 9`).

What was not tested: I did not run against an external llama.cpp host. The loopback server exercised the same real outgoing HTTP request path and captured the request/usage behavior without exposing private network details.

## Verification

```bash
pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/pi-embedded-runner/compact.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/stream-resolution.ts src/agents/pi-embedded-runner/stream-resolution.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/stream-resolution.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/run/attempt.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/compact.hooks.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/openai-transport-stream.test.ts
pnpm check:changed
git diff --check
```

Results:

- `stream-resolution.test.ts`: 21 passed
- `run/attempt.test.ts`: 128 passed
- `compact.hooks.test.ts`: 39 passed
- `openai-transport-stream.test.ts`: 104 passed
- `pnpm check:changed`: passed
- `git diff --check`: passed