### PR TITLE
feat(ui): 刷新页面时恢复上次使用的助手

### DIFF
--- a/ui/src/ui/controllers/agents.ts
+++ b/ui/src/ui/controllers/agents.ts
@@ -68,7 +68,22 @@ export async function loadAgents(state: AgentsState) {
     if (res) {
       state.agentsList = res;
       const selected = state.agentsSelectedId;
-      if (!selected || !res.agents.some((entry) => entry.id === selected)) {
+      const known = res.agents.some((entry) => entry.id === selected);
+      if (selected && known) {
+        // 已有有效选中助手，保持不变
+        return;
+      }
+      // 尝试从 sessionKey 中恢复助手 ID
+      const sessionAgentId = state.sessionKey
+        ? resolveAgentIdFromSessionKey(state.sessionKey)
+        : null;
+      const sessionAgentKnown =
+        sessionAgentId && res.agents.some((entry) => entry.id === sessionAgentId);
+      if (sessionAgentKnown) {
+        // sessionKey 中的助手在列表中存在，恢复该助手选择
+        state.agentsSelectedId = sessionAgentId;
+      } else {
+        // 默认选择：defaultId 或第一个助手
         state.agentsSelectedId = res.defaultId ?? res.agents[0]?.id ?? null;
       }
     }


### PR DESCRIPTION
## Summary

- 在 `loadAgents()` 中增加从 `sessionKey` 恢复助手选择的逻辑
- `sessionKey` 格式为 `agent:<agentId>:<rest>`，通过 `resolveAgentIdFromSessionKey` 提取助手 ID
- 如果提取的助手 ID 在列表中存在，则恢复该选择

## 问题描述

刷新页面时，未关闭会话对应的助手选择丢失，被重置为默认助手。用户选择了一个非默认助手后刷新页面，助手选择会被重置。

## 解决方案

修改 `loadAgents()` 函数，在加载助手列表后选择助手时，优先从 `sessionKey` 中恢复对应的 `agentId`。

## 测试计划

- [x] 单元测试通过 (`pnpm test -- src/ui/controllers/agents.test.ts`)
- [x] TypeScript 类型检查通过 (`pnpm tsgo`)
- [ ] 手动测试：选择非默认助手 → 刷新页面 → 验证助手选择保持不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)