### PR TITLE
fix(cli): canonicalize infer model refs safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/macOS: `openclaw gateway stop --disable` now persists the LaunchAgent disable bit even after a previous bootout left the service not loaded, keeping the explicit stay-down path reliable. (#78412) Thanks @wdeveloper16.
 - CLI/status: keep lean `openclaw status --json` off manifest-backed channel discovery so configured-channel checks do not repeatedly rescan plugin metadata. Fixes #79129.
 - Control UI/chat: hide retired and non-public Google Gemini model IDs from chat model catalogs and route the bare `gemini-3-pro` alias to Gemini 3.1 Pro Preview instead of the shut-down Gemini 3 Pro Preview. Thanks @BunsDev.
+- CLI/infer: canonicalize case-only catalog model refs in `infer model run --model` so mixed-case provider/model strings resolve to the canonical catalog entry instead of failing with `Unknown model`. (#78940) Thanks @ai-hpc.
 - CLI/install: refuse state-mutating OpenClaw CLI runs as root by default, keep an explicit `OPENCLAW_ALLOW_ROOT=1` escape hatch for intentional root/container use, and update DigitalOcean setup guidance to run OpenClaw as a non-root user. Fixes #67478. Thanks @Jerry-Xin and @natechicago.
 - Auto-reply/media: resolve `scp` from `PATH` when staging sandbox media so nonstandard OpenSSH installs can copy remote attachments.
 - Agents/PI: route PI-native OpenAI-compatible default streams through OpenClaw boundary-aware transports so local-compatible model runs keep API-key injection and transport policy.

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -14,7 +14,9 @@ import {
   resolveAgentModelFallbacksOverride,
 } from "./agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
+import { findModelInCatalog } from "./model-catalog-lookup.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
+import { splitTrailingAuthProfile } from "./model-ref-profile.js";
 export { resolveThinkingDefault } from "./model-thinking-default.js";
 import {
   type ModelRef,
@@ -234,6 +236,70 @@ export function resolveDefaultModelForAgent(params: {
     defaultModel: DEFAULT_MODEL,
     allowPluginNormalization: params.allowPluginNormalization,
   });
+}
+
+export async function canonicalizeCaseOnlyCatalogModelRef(params: {
+  raw: string | undefined;
+  cfg?: OpenClawConfig;
+  defaultProvider: string;
+  loadCatalog: () => Promise<ModelCatalogEntry[]>;
+  aliasIndex?: ModelAliasIndex;
+  allowManifestNormalization?: boolean;
+  allowPluginNormalization?: boolean;
+  preserveAuthProfile?: boolean;
+}): Promise<string | undefined> {
+  const rawModel = normalizeOptionalString(params.raw);
+  if (!rawModel) {
+    return undefined;
+  }
+  const split = splitTrailingAuthProfile(rawModel);
+  if (shouldKeepProfileQualifiedModelRefRaw(split.profile, params.preserveAuthProfile)) {
+    return rawModel;
+  }
+  if (!isCaseOnlyProviderModelRef(split.model)) {
+    return rawModel;
+  }
+  const resolved = resolveModelRefFromString({
+    cfg: params.cfg,
+    raw: split.model,
+    defaultProvider: params.defaultProvider,
+    aliasIndex: params.aliasIndex,
+    allowManifestNormalization: params.allowManifestNormalization,
+    allowPluginNormalization: params.allowPluginNormalization,
+  });
+  if (!resolved) {
+    return rawModel;
+  }
+  const entry = findModelInCatalog(
+    await params.loadCatalog(),
+    resolved.ref.provider,
+    resolved.ref.model,
+  );
+  return entry ? formatCatalogModelRef(entry, split.profile) : rawModel;
+}
+
+function hasExplicitProviderModelRef(raw: string): boolean {
+  const slash = raw.indexOf("/");
+  return slash > 0 && slash < raw.length - 1;
+}
+
+function isCaseOnlyProviderModelRef(raw: string): boolean {
+  return hasExplicitProviderModelRef(raw) && raw !== raw.toLowerCase();
+}
+
+function shouldKeepProfileQualifiedModelRefRaw(
+  profile: string | undefined,
+  preserveAuthProfile: boolean | undefined,
+): boolean {
+  return Boolean(profile && preserveAuthProfile === false);
+}
+
+function formatCatalogModelRef(entry: ModelCatalogEntry, profile: string | undefined): string {
+  return appendAuthProfileSuffix(`${entry.provider}/${entry.id}`, profile);
+}
+
+function appendAuthProfileSuffix(modelRef: string, profile: string | undefined): string {
+  return profile ? `${modelRef}@${profile}` : modelRef;
 }
 
 function resolveAllowedFallbacks(params: { cfg: OpenClawConfig; agentId?: string }): string[] {

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -154,6 +154,9 @@ vi.mock("../config/config.js", () => ({
 vi.mock("../agents/agent-scope.js", () => ({
   resolveDefaultAgentId: () => "main",
   resolveAgentDir: () => "/tmp/agent",
+  resolveAgentConfig: () => ({}),
+  resolveAgentEffectiveModelPrimary: () => undefined,
+  resolveAgentModelFallbacksOverride: () => [],
 }));
 
 vi.mock("../agents/model-catalog.js", () => ({
@@ -373,6 +376,42 @@ describe("capability cli", () => {
       return {};
     }) as never);
   });
+
+  async function runModelRunWithModel(model: string, transport: "local" | "gateway") {
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "model",
+        "run",
+        "--model",
+        model,
+        "--prompt",
+        "hello",
+        ...(transport === "gateway" ? ["--gateway"] : []),
+        "--json",
+      ],
+    });
+  }
+
+  function expectModelRunDispatch(transport: "local" | "gateway", modelRef: string) {
+    if (transport === "gateway") {
+      const slash = modelRef.indexOf("/");
+      expect(mocks.callGateway).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "agent",
+          params: expect.objectContaining({
+            provider: modelRef.slice(0, slash),
+            model: modelRef.slice(slash + 1),
+          }),
+        }),
+      );
+      return;
+    }
+    expect(mocks.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ modelRef }),
+    );
+  }
 
   it("lists canonical capabilities", async () => {
     await runRegisteredCli({
@@ -839,6 +878,50 @@ describe("capability cli", () => {
         }),
       }),
     );
+  });
+
+  it.each(["local", "gateway"] as const)(
+    "canonicalizes case-only catalog model refs before %s dispatch",
+    async (transport) => {
+      mocks.loadModelCatalog.mockResolvedValueOnce([
+        { id: "claude-opus-4-7", provider: "anthropic", name: "Claude Opus 4.7" },
+      ] as never);
+
+      await runModelRunWithModel("Anthropic/CLAUDE-OPUS-4-7", transport);
+
+      expect(mocks.loadModelCatalog).toHaveBeenCalledWith(
+        expect.objectContaining({ readOnly: true }),
+      );
+      expectModelRunDispatch(transport, "anthropic/claude-opus-4-7");
+    },
+  );
+
+  it("canonicalizes case-only catalog refs and preserves auth profiles before local dispatch", async () => {
+    mocks.loadModelCatalog.mockResolvedValueOnce([
+      { id: "claude-opus-4-7", provider: "anthropic", name: "Claude Opus 4.7" },
+    ] as never);
+
+    await runModelRunWithModel("Anthropic/CLAUDE-OPUS-4-7@work", "local");
+
+    expectModelRunDispatch("local", "anthropic/claude-opus-4-7@work");
+  });
+
+  it("leaves auth profile refs unchanged before gateway dispatch", async () => {
+    mocks.loadModelCatalog.mockResolvedValueOnce([
+      { id: "claude-opus-4-7", provider: "anthropic", name: "Claude Opus 4.7" },
+    ] as never);
+
+    await runModelRunWithModel("Anthropic/CLAUDE-OPUS-4-7@work", "gateway");
+
+    expectModelRunDispatch("gateway", "Anthropic/CLAUDE-OPUS-4-7@work");
+  });
+
+  it("preserves custom mixed-case profile refs before local dispatch when the catalog has no match", async () => {
+    mocks.loadModelCatalog.mockResolvedValueOnce([] as never);
+
+    await runModelRunWithModel("custom/MyModel@work", "local");
+
+    expectModelRunDispatch("local", "custom/MyModel@work");
   });
 
   it("rejects empty model run prompts before gateway dispatch", async () => {

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -10,8 +10,10 @@ import {
   loadAuthProfileStoreForRuntime,
 } from "../agents/auth-profiles.js";
 import { updateAuthProfileStoreWithLock } from "../agents/auth-profiles/store.js";
+import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
+import { canonicalizeCaseOnlyCatalogModelRef } from "../agents/model-selection.js";
 import {
   completeWithPreparedSimpleCompletionModel,
   prepareSimpleCompletionModelForAgent,
@@ -559,6 +561,20 @@ function resolveModelRefOverride(raw: string | undefined): { provider?: string; 
   };
 }
 
+async function canonicalizeModelRunRef(params: {
+  raw: string | undefined;
+  cfg: OpenClawConfig;
+  preserveAuthProfile: boolean;
+}): Promise<string | undefined> {
+  return await canonicalizeCaseOnlyCatalogModelRef({
+    cfg: params.cfg,
+    raw: params.raw,
+    defaultProvider: DEFAULT_PROVIDER,
+    loadCatalog: () => loadModelCatalog({ config: params.cfg, readOnly: true }),
+    preserveAuthProfile: params.preserveAuthProfile,
+  });
+}
+
 function requireProviderModelOverride(
   raw: string | undefined,
 ): { provider: string; model: string } | undefined {
@@ -642,6 +658,11 @@ async function runModelRun(params: {
 }) {
   const cfg = getRuntimeConfig();
   const agentId = resolveDefaultAgentId(cfg);
+  const modelRef = await canonicalizeModelRunRef({
+    raw: params.model,
+    cfg,
+    preserveAuthProfile: params.transport === "local",
+  });
   const imageFiles = await readModelRunImageFiles(params.files);
   const messageContent =
     imageFiles.length > 0
@@ -658,7 +679,7 @@ async function runModelRun(params: {
     const prepared = await prepareSimpleCompletionModelForAgent({
       cfg,
       agentId,
-      modelRef: params.model,
+      modelRef,
       allowMissingApiKeyModes: ["aws-sdk"],
       skipPiDiscovery: true,
     });
@@ -731,7 +752,7 @@ async function runModelRun(params: {
     } satisfies CapabilityEnvelope;
   }
 
-  const { provider, model } = resolveModelRefOverride(params.model);
+  const { provider, model } = resolveModelRefOverride(modelRef);
   // Provider/model overrides require trusted-operator scope. Use the backend
   // shared-secret lane so local gateway smokes do not depend on paired CLI device scopes.
   const hasModelOverride = Boolean(provider || model);


### PR DESCRIPTION
## Summary

This is a fresh follow-up to the review discussion on #73717. It is not the canonical fix for #73715; that Anthropic-specific bug is already fixed on current main by rejecting uppercase dynamic Anthropic model IDs before provider dispatch.

This PR addresses the remaining CLI consistency/UX concern: `infer model run --model` should not own a separate local model-ref parsing/canonicalization path that can drift from shared model-selection behavior.

What changed:

- Added shared `canonicalizeCaseOnlyCatalogModelRef` in `src/agents/model-selection.ts`.
- Splits trailing auth-profile suffixes before canonicalization.
- Parses the provider/model portion through shared model-ref parsing first.
- Applies catalog-based canonicalization only after parsing.
- Reattaches `@profile` suffixes unchanged for local model-run dispatch; Gateway `@profile` refs are left unchanged because the `agent` RPC has no explicit auth-profile field.
- Uses the shared helper from `src/cli/capability-cli.ts` with a read-only catalog lookup so model-run canonicalization does not trigger provider discovery or models.json writes.
- Adds local and Gateway regression coverage for plain refs, local `@profile` suffix preservation, and Gateway `@profile` non-canonicalization coverage.

## Verification

Unit/targeted proof:

- `pnpm test src/agents/model-selection.test.ts src/cli/capability-cli.test.ts -- --reporter=verbose`
- `pnpm exec oxfmt --check --threads=1 src/agents/model-selection.ts src/cli/capability-cli.ts src/cli/capability-cli.test.ts`
- `git diff --check`

## Real behavior proof

**Behavior or issue addressed:** `infer model run --model` now canonicalizes case-only catalog model refs through the shared model-ref path before local or Gateway dispatch. Local dispatch preserves auth-profile suffixes such as `provider/model@profile`; Gateway `@profile` refs are deliberately left unchanged because the Gateway `agent` RPC currently accepts only separate `provider` and `model` fields.

**Real environment tested:** Ubuntu 24.04.4 LTS VPS, Node 22.22.1, pnpm 10.33.2, OpenClaw source checkout at PR head `caea3bae13`, real OpenRouter provider credentials from the local OpenClaw config, with `OPENCLAW_TEST_ONLY_PROVIDER_PLUGIN_IDS=openrouter` to keep the live smoke focused.

**Exact steps or command run after this patch:** Ran a local transport smoke and a Gateway transport smoke using the mixed-case model input `OpenRouter/OPENROUTER/AUTO`. The local command used `pnpm --silent openclaw infer model run --model OpenRouter/OPENROUTER/AUTO --prompt 'Reply with OK only.' --json`. The Gateway command started a same-branch temporary Gateway on loopback port `19878` with token auth and a temporary config with WhatsApp disabled, then ran `OPENCLAW_GATEWAY_URL=ws://127.0.0.1:19878 pnpm --silent openclaw infer model run --gateway --model OpenRouter/OPENROUTER/AUTO --prompt 'Reply with OK only.' --json`.

**Evidence after fix:** Copied live terminal JSON output from the Ubuntu VPS after running the patched OpenClaw CLI against the real OpenRouter provider:

Local transport:

```json
{
  "ok": true,
  "capability": "model.run",
  "transport": "local",
  "provider": "openrouter",
  "model": "openrouter/auto",
  "attempts": [],
  "outputs": [
    {
      "text": "OK",
      "mediaUrl": null
    }
  ]
}
```

Gateway transport:

```json
{
  "ok": true,
  "capability": "model.run",
  "transport": "gateway",
  "provider": "openrouter",
  "model": "openrouter/auto",
  "attempts": [],
  "outputs": [
    {
      "text": "OK",
      "mediaUrl": null
    }
  ]
}
```

**Observed result after fix:** Both local and Gateway smokes accepted the mixed-case input `OpenRouter/OPENROUTER/AUTO`, dispatched successfully, and reported the canonical provider/model result as `provider=openrouter`, `model=openrouter/auto`, with output text `OK`.

**What was not tested:** I did not run a live `@profile` suffix call; local suffix preservation and Gateway suffix non-canonicalization are covered by targeted CLI regression tests. The live provider proof used OpenRouter because valid credentials were available on the VPS.

## Notes

No issue is closed by this PR. It is intentionally framed as a follow-up CLI consistency improvement from #73717 review feedback, not as the #73715 bug fix.








