### PR TITLE
fix(doctor): preserve agentRuntime-specific model expressions during --fix normalization (#78499)

### DIFF
--- a/src/commands/doctor/shared/legacy-config-core-normalizers-codex-runtime.test.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers-codex-runtime.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { normalizeLegacyRuntimeModelRefs } from "./legacy-config-core-normalizers.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+
+describe("normalizeLegacyRuntimeModelRefs - codex runtime preservation (#78499)", () => {
+  it("should NOT rewrite model refs when agent already has agentRuntime.id: codex", () => {
+    const cfg = {
+      agents: {
+        list: [
+          {
+            id: "my-codex-agent",
+            agentRuntime: { id: "codex" },
+            model: { primary: "codex/gpt-5.5" },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const changes: string[] = [];
+    const result = normalizeLegacyRuntimeModelRefs(cfg, changes);
+
+    // Model should remain untouched
+    const agent = (result.agents as any).list[0];
+    expect(agent.model.primary).toBe("codex/gpt-5.5");
+    expect(changes).toHaveLength(0);
+  });
+
+  it("should NOT rewrite model refs when agent has agentRuntime.id: claude-cli", () => {
+    const cfg = {
+      agents: {
+        list: [
+          {
+            id: "my-claude-agent",
+            agentRuntime: { id: "claude-cli" },
+            model: { primary: "claude-cli/claude-sonnet-4-20250514" },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const changes: string[] = [];
+    const result = normalizeLegacyRuntimeModelRefs(cfg, changes);
+
+    const agent = (result.agents as any).list[0];
+    expect(agent.model.primary).toBe("claude-cli/claude-sonnet-4-20250514");
+    expect(changes).toHaveLength(0);
+  });
+
+  it("should still rewrite model refs when agent has NO agentRuntime set", () => {
+    const cfg = {
+      agents: {
+        list: [
+          {
+            id: "legacy-agent",
+            model: { primary: "codex/gpt-5.5" },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const changes: string[] = [];
+    const result = normalizeLegacyRuntimeModelRefs(cfg, changes);
+
+    const agent = (result.agents as any).list[0];
+    expect(agent.model.primary).toBe("openai/gpt-5.5");
+    expect(agent.agentRuntime.id).toBe("codex");
+    expect(changes.length).toBeGreaterThan(0);
+  });
+
+  it("should still rewrite when agentRuntime.id is auto", () => {
+    const cfg = {
+      agents: {
+        list: [
+          {
+            id: "auto-agent",
+            agentRuntime: { id: "auto" },
+            model: { primary: "codex/gpt-5.5" },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    const changes: string[] = [];
+    const result = normalizeLegacyRuntimeModelRefs(cfg, changes);
+
+    const agent = (result.agents as any).list[0];
+    expect(agent.model.primary).toBe("openai/gpt-5.5");
+  });
+});

--- a/src/commands/doctor/shared/legacy-config-core-normalizers.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers.ts
@@ -1,4 +1,7 @@
-import { migrateLegacyRuntimeModelRef } from "../../../agents/model-runtime-aliases.js";
+import {
+  migrateLegacyRuntimeModelRef,
+  isLegacyRuntimeModelProvider,
+} from "../../../agents/model-runtime-aliases.js";
 import { normalizeProviderId } from "../../../agents/provider-id.js";
 import { resolveSingleAccountKeysToMove } from "../../../channels/plugins/setup-promotion-helpers.js";
 import { resolveNormalizedProviderModelMaxTokens } from "../../../config/defaults.js";
@@ -338,7 +341,21 @@ function normalizeLegacyRuntimeAgentContainer(
   let changed = false;
   const next: Record<string, unknown> = { ...raw };
 
-  const model = normalizeLegacyRuntimeAgentModelConfig(raw.model);
+  // If the agent already has an explicit agentRuntime.id that corresponds to a
+  // known non-default runtime (codex, codex-cli, claude-cli, etc.), skip model
+  // prefix normalization — those runtimes use their own model ref format and
+  // rewriting e.g. "codex/gpt-5.5" → "openai/gpt-5.5" breaks auth profile
+  // selection. See #78499.
+  const existingRuntimeId =
+    isRecord(raw.agentRuntime) && typeof raw.agentRuntime.id === "string"
+      ? raw.agentRuntime.id.trim().toLowerCase()
+      : undefined;
+  const hasExplicitNonDefaultRuntime =
+    existingRuntimeId && existingRuntimeId !== "auto" && isLegacyRuntimeModelProvider(existingRuntimeId);
+
+  const model = hasExplicitNonDefaultRuntime
+    ? { value: raw.model, changed: false, selectedRuntime: undefined }
+    : normalizeLegacyRuntimeAgentModelConfig(raw.model);
   if (model.changed) {
     next.model = model.value;
     changed = true;


### PR DESCRIPTION
## Summary

`openclaw doctor --fix` was incorrectly rewriting model references for agents that already have an explicit `agentRuntime.id` set to a non-default runtime (e.g. `codex`, `claude-cli`).

For example, an agent configured with:
```yaml
agentRuntime:
  id: codex
model:
  primary: codex/gpt-5.5
```

Would have its model rewritten to `openai/gpt-5.5`, which then breaks the Codex app-server auth profile selection (it expects models under the `openai-codex` provider, not `openai:default`).

## Fix

Before applying legacy model prefix normalization, check if the agent already has an explicit `agentRuntime.id` that corresponds to a known non-default runtime. If so, skip the model rewrite entirely — the model ref is already in the correct format for that runtime.

## Test

Added unit tests covering:
- Codex runtime agent model preserved
- Claude-cli runtime agent model preserved  
- Agent without agentRuntime still gets migrated (legacy path)
- Agent with `agentRuntime.id: auto` still gets migrated

Fixes #78499