### PR TITLE
fix: doctor model ref warning should check auth profile before suggesting openai-codex/* → openai/* rewrite (#78533)

### DIFF
--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -106,6 +106,29 @@ describe("collectCodexRouteWarnings", () => {
     expect(warnings).toEqual([expect.stringContaining('runtime is "codex"')]);
   });
 
+  it("suppresses warning when openai-codex OAuth auth profile exists", () => {
+    const warnings = collectCodexRouteWarnings({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai-codex/gpt-5.5",
+          },
+        },
+        auth: {
+          profiles: {
+            "openai-codex:user@example.com": {
+              provider: "openai-codex",
+              mode: "oauth",
+              email: "user@example.com",
+            },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
   it("does not warn for canonical OpenAI refs", () => {
     const warnings = collectCodexRouteWarnings({
       cfg: {

--- a/src/commands/doctor/shared/codex-route-warnings.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.ts
@@ -564,12 +564,25 @@ function formatCodexRouteChange(hit: CodexRouteHit, runtime: CodexRepairRuntime)
   return `${hit.path}: ${hit.model} -> ${hit.canonicalModel}${suffix}.`;
 }
 
+function hasCodexOAuthProfile(cfg: OpenClawConfig): boolean {
+  const profiles = cfg.auth?.profiles;
+  if (!profiles) {
+    return false;
+  }
+  return Object.values(profiles).some(
+    (profile) => profile.provider === "openai-codex" && profile.mode === "oauth",
+  );
+}
+
 export function collectCodexRouteWarnings(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }): string[] {
   const hits = collectConfigModelRefs(params.cfg, params.env);
   if (hits.length === 0) {
+    return [];
+  }
+  if (hasCodexOAuthProfile(params.cfg)) {
     return [];
   }
   return [


### PR DESCRIPTION
## Summary

The read-only `openclaw doctor` warning about legacy `openai-codex/*` model refs now checks `auth.profiles` for a configured openai-codex OAuth entry before emitting. Users who intentionally use Codex OAuth routing will no longer see a misleading "should become" warning.

## Root cause

`collectCodexRouteWarnings` unconditionally emitted warnings for any `openai-codex/*` model ref in config, without checking whether the user has an active openai-codex OAuth auth profile that makes those refs intentional and correct. The `--fix` path already had auth-profile awareness; the read-only warning path did not.

## Fix

Added `hasCodexOAuthProfile(cfg)` check that inspects `cfg.auth.profiles` for any profile with `provider === "openai-codex"  && mode === "oauth"`. When such a profile exists, the warning is suppressed.

Fixes #78533