### PR TITLE
fix: respect OPENCLAW_HOME env var in update command (#78371)

### DIFF
--- a/src/infra/package-update-steps.ts
+++ b/src/infra/package-update-steps.ts
@@ -17,6 +17,16 @@ import {
   type ResolvedGlobalInstallTarget,
 } from "./update-global.js";
 
+/**
+ * If OPENCLAW_HOME is set, return it as the pnpm --global-dir value.
+ * This supports custom pnpm global installs where the standard layout
+ * heuristic (versioned subdirectory) does not apply.
+ */
+function resolveOpenclawHomeAsGlobalDir(): string | null {
+  const value = process.env.OPENCLAW_HOME?.trim();
+  return value ? path.resolve(value) : null;
+}
+
 export type PackageUpdateStepResult = {
   name: string;
   command: string;
@@ -376,7 +386,8 @@ export async function runGlobalPackageUpdateSteps(params: {
     const installLocation =
       stagedInstall?.prefix ??
       (installCommandTarget.manager === "pnpm"
-        ? resolvePnpmGlobalDirFromGlobalRoot(installCommandTarget.globalRoot)
+        ? resolvePnpmGlobalDirFromGlobalRoot(installCommandTarget.globalRoot) ??
+          resolveOpenclawHomeAsGlobalDir()
         : null);
     const updateStep = await params.runStep({
       name: "global update",

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -1,5 +1,6 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { bundledDistPluginFile } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -560,6 +561,30 @@ describe("update global helpers", () => {
         packageRoot: path.join(defaultPnpmRoot, "openclaw"),
       });
     });
+  });
+
+  it("detects pnpm via OPENCLAW_HOME when standard heuristics fail", async () => {
+    const customHome = path.join(os.tmpdir(), "openclaw-home-test");
+    const pkgRoot = path.join(customHome, "node_modules", "openclaw");
+    process.env.OPENCLAW_HOME = customHome;
+    try {
+      const runCommand: CommandRunner = async (argv) => {
+        // Both npm root -g and pnpm root -g return paths that don't match pkgRoot
+        if (argv.includes("root") && argv.includes("-g")) {
+          return { stdout: "/some/other/path/node_modules\n", stderr: "", code: 0 };
+        }
+        // pnpm --version succeeds
+        if (argv[0] === "pnpm" && argv[1] === "--version") {
+          return { stdout: "9.0.0\n", stderr: "", code: 0 };
+        }
+        return { stdout: "", stderr: "", code: 1 };
+      };
+      await expect(
+        detectGlobalInstallManagerForRoot(runCommand, pkgRoot, 1000),
+      ).resolves.toBe("pnpm");
+    } finally {
+      delete process.env.OPENCLAW_HOME;
+    }
   });
 
   it("builds install argv and npm fallback argv", () => {

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -473,6 +473,29 @@ function inferGlobalRootFromPackageRoot(pkgRoot?: string | null): string | null 
   return path.basename(globalRoot) === "node_modules" ? globalRoot : null;
 }
 
+/**
+ * When OPENCLAW_HOME is set and the package root resides under it, infer the
+ * global node_modules root.  This covers custom pnpm --global-dir installs
+ * where the standard heuristics (pnpm root -g, .modules.yaml) don't match.
+ */
+function inferGlobalRootFromOpenclawHome(pkgRoot?: string | null): string | null {
+  const openclawHome = process.env.OPENCLAW_HOME?.trim();
+  if (!openclawHome || !pkgRoot) {
+    return null;
+  }
+  const resolvedHome = path.resolve(openclawHome);
+  const resolvedPkgRoot = path.resolve(pkgRoot);
+  if (!resolvedPkgRoot.startsWith(resolvedHome + path.sep)) {
+    return null;
+  }
+  // The package root is <global-root>/openclaw — so the global root is the parent
+  const candidate = path.dirname(resolvedPkgRoot);
+  if (path.basename(candidate) === "node_modules") {
+    return candidate;
+  }
+  return null;
+}
+
 function inferPnpmGlobalRootFromPackageRoot(pkgRoot?: string | null): string | null {
   const directGlobalRoot = inferGlobalRootFromPackageRoot(pkgRoot);
   if (resolvePnpmGlobalDirFromGlobalRoot(directGlobalRoot)) {
@@ -604,7 +627,11 @@ export async function resolveGlobalInstallTarget(params: {
     command.manager === "pnpm" && (await isPnpmGlobalPackageRoot(params.pkgRoot))
       ? inferPnpmGlobalRootFromPackageRoot(params.pkgRoot)
       : null;
-  const targetGlobalRoot = pkgRootGlobalRoot ?? globalRoot;
+  const openclawHomeGlobalRoot =
+    !pkgRootGlobalRoot && command.manager === "pnpm"
+      ? inferGlobalRootFromOpenclawHome(params.pkgRoot)
+      : null;
+  const targetGlobalRoot = pkgRootGlobalRoot ?? openclawHomeGlobalRoot ?? globalRoot;
   return {
     ...command,
     globalRoot: targetGlobalRoot,
@@ -662,6 +689,25 @@ export async function detectGlobalInstallManagerForRoot(
 
   if (resolvePreferredNpmCommand(pkgRoot)) {
     return "npm";
+  }
+
+  // If OPENCLAW_HOME is set and the package root resides under it,
+  // detect the package manager by checking which one is available.
+  const openclawHome = process.env.OPENCLAW_HOME?.trim();
+  if (openclawHome) {
+    const resolvedHome = path.resolve(openclawHome);
+    if (pkgReal.startsWith(resolvedHome + path.sep) || pkgReal === resolvedHome) {
+      // Check if pnpm is available (common for OPENCLAW_HOME custom installs)
+      const pnpmCheck = await runCommand(["pnpm", "--version"], { timeoutMs }).catch(() => null);
+      if (pnpmCheck && pnpmCheck.code === 0) {
+        return "pnpm";
+      }
+      // Fall back to npm
+      const npmCheck = await runCommand(["npm", "--version"], { timeoutMs }).catch(() => null);
+      if (npmCheck && npmCheck.code === 0) {
+        return "npm";
+      }
+    }
   }
 
   return null;

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -221,6 +222,25 @@ function buildStartDirs(opts: UpdateRunnerOptions): string[] {
     const packageRoot = resolveNodeModulesBinPackageRoot(argv1);
     if (packageRoot) {
       dirs.push(packageRoot);
+    }
+  }
+  const openclawHome = normalizeDir(process.env.OPENCLAW_HOME);
+  if (openclawHome) {
+    dirs.push(openclawHome);
+    // Add common package locations under OPENCLAW_HOME so that
+    // findPackageRoot can locate the openclaw package.json.
+    // Direct node_modules layout (npm-style)
+    dirs.push(path.join(openclawHome, "node_modules", "openclaw"));
+    // pnpm global layout: <global-dir>/<version>/node_modules/<pkg>
+    try {
+      const entries = fsSync.readdirSync(openclawHome, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory() && /^\d+$/u.test(entry.name)) {
+          dirs.push(path.join(openclawHome, entry.name, "node_modules", "openclaw"));
+        }
+      }
+    } catch {
+      // ignore - directory may not exist or not be readable
     }
   }
   const proc = normalizeDir(process.cwd());


### PR DESCRIPTION
## Summary

When `OPENCLAW_HOME` is set to a custom installation directory (e.g., `D:\openclaw`), `openclaw update` now correctly installs the update there instead of falling through to the npm/pnpm default global prefix.

## Root Cause

The update flow discovers the package root by walking up from `process.cwd()` and `argv[1]`. For custom installs where `OPENCLAW_HOME` points to the installation directory, neither of those paths necessarily leads to the correct package root. Additionally, `detectGlobalInstallManagerForRoot` relies on `pnpm root -g` matching the actual install location, which fails for custom `--global-dir` installs.

## Changes

- **`buildStartDirs`**: Include `OPENCLAW_HOME` and its `node_modules` subdirectories (both npm-style and pnpm versioned layout) as candidate directories for package root discovery.
- **`detectGlobalInstallManagerForRoot`**: Fall back to checking if the package root is under `OPENCLAW_HOME` and detect the available package manager.
- **`resolveGlobalInstallTarget`**: Use `OPENCLAW_HOME` to infer the correct pnpm global root for `--global-dir`.
- **`package-update-steps`**: Pass `OPENCLAW_HOME` as `--global-dir` fallback for pnpm when the standard versioned-directory heuristic doesn't apply.

## Test

Added unit test verifying pnpm detection via `OPENCLAW_HOME` when standard heuristics fail.

Fixes #78371