### PR TITLE
Use grammY inline keyboard helper

### DIFF
--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -58,7 +58,8 @@ vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => {
 vi.resetModules();
 const { deliverReplies } = await import("./delivery.js");
 
-vi.mock("grammy", () => ({
+vi.mock("grammy", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("grammy")>()),
   API_CONSTANTS: {
     DEFAULT_UPDATE_TYPES: ["message"],
     ALL_UPDATE_TYPES: ["message"],

--- a/extensions/telegram/src/inline-keyboard.ts
+++ b/extensions/telegram/src/inline-keyboard.ts
@@ -1,27 +1,21 @@
-import type { InlineKeyboardButton, InlineKeyboardMarkup } from "@grammyjs/types";
+import type { InlineKeyboardMarkup } from "@grammyjs/types";
+import { InlineKeyboard } from "grammy";
 import type { TelegramInlineButtons } from "./button-types.js";
 
 export function buildInlineKeyboard(
   buttons?: TelegramInlineButtons,
 ): InlineKeyboardMarkup | undefined {
-  if (!buttons?.length) {
-    return undefined;
-  }
-  const rows = buttons
+  const rows = (buttons ?? [])
     .map((row) =>
       row
-        .filter((button) => button?.text && button?.callback_data)
-        .map(
-          (button): InlineKeyboardButton =>
-            Object.assign(
-              { text: button.text, callback_data: button.callback_data },
-              button.style ? { style: button.style } : {},
-            ),
+        .filter((button) => button.text && button.callback_data)
+        .map((button) =>
+          InlineKeyboard.text(
+            button.style ? { text: button.text, style: button.style } : button.text,
+            button.callback_data,
+          ),
         ),
     )
     .filter((row) => row.length > 0);
-  if (rows.length === 0) {
-    return undefined;
-  }
-  return { inline_keyboard: rows };
+  return rows.length > 0 ? { inline_keyboard: rows } : undefined;
 }

--- a/extensions/telegram/src/send.proxy.test.ts
+++ b/extensions/telegram/src/send.proxy.test.ts
@@ -44,7 +44,8 @@ vi.mock("./fetch.js", () => ({
   resolveTelegramApiBase,
 }));
 
-vi.mock("grammy", () => ({
+vi.mock("grammy", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("grammy")>()),
   API_CONSTANTS: {
     DEFAULT_UPDATE_TYPES: ["message"],
     ALL_UPDATE_TYPES: ["message"],

--- a/extensions/telegram/src/send.test-harness.ts
+++ b/extensions/telegram/src/send.test-harness.ts
@@ -101,7 +101,8 @@ vi.mock("openclaw/plugin-sdk/web-media", () => ({
   loadWebMedia,
 }));
 
-vi.mock("grammy", () => ({
+vi.mock("grammy", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("grammy")>()),
   API_CONSTANTS: {
     DEFAULT_UPDATE_TYPES: ["message"],
     ALL_UPDATE_TYPES: ["message"],


### PR DESCRIPTION
## Summary
- Use grammY's inline keyboard button builder for Telegram callback buttons.
- Keep existing filtering and style behavior, with test mocks updated.

## Verification
- `node scripts/test-projects.mjs extensions/telegram/src/send.test.ts`
- `node scripts/test-projects.mjs extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/send.proxy.test.ts extensions/telegram/src/bot.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/telegram/src/inline-keyboard.ts extensions/telegram/src/send.test-harness.ts extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/send.proxy.test.ts`
- `git diff --check`
