### PR TITLE
fix(slack): preserve mention source metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Agents/failover: harden state-aware lane suspension by persisting quota resume transitions, restoring configured lane concurrency, preserving non-quota failure reasons, and exporting model failover events through diagnostics OTLP. Thanks @BunsDev.
+- Slack: preserve explicit Slack mention targets, user-group ids, implicit thread wake reasons, and mention source metadata in inbound prompt context while keeping existing mention-gating behavior unchanged. Fixes #79025. Thanks @bek91.
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: include a bounded one-line STT transcript preview in verbose voice logs so live voice debugging shows what speakers said before the agent reply.

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -907,6 +907,8 @@ Current Slack message actions include `send`, `upload-file`, `download-file`, `r
     - mention regex patterns (`agents.list[].groupChat.mentionPatterns`, fallback `messages.groupChat.mentionPatterns`)
     - implicit reply-to-bot thread behavior (disabled when `thread.requireExplicitMention` is `true`)
 
+    Slack prompt metadata preserves the collapsed wake decision (`was_mentioned`) plus provider-native mention detail for the current turn: `explicitly_mentioned_bot`, `mentioned_user_ids`, `mentioned_subteam_ids`, `implicit_mention_kinds`, and `mention_source`. Agents can distinguish a direct bot mention from an implicit thread wake where the message explicitly mentions another Slack user.
+
     Per-channel controls (`channels.slack.channels.<id>`; names only via startup resolution or `dangerouslyAllowNameMatching`):
 
     - `requireMention`

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -1388,6 +1388,43 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(new Set([root!.ctxPayload.SessionKey, followUp!.ctxPayload.SessionKey]).size).toBe(1);
   });
 
+  it("preserves explicit Slack mention targets when an implicit thread wake mentions someone else", async () => {
+    const { storePath } = storeFixture.makeTmpStorePath();
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        session: { store: storePath },
+        channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
+      } as OpenClawConfig,
+      defaultRequireMention: true,
+      replyToMode: "all",
+    });
+    slackCtx.resolveChannelName = async () => ({ name: "proj-openclaw", type: "channel" });
+    slackCtx.resolveUserName = async () => ({ name: "Bek" });
+
+    const prepared = await prepareSlackMessage({
+      ctx: slackCtx,
+      account: createSlackAccount({ replyToMode: "all" }),
+      message: {
+        type: "message",
+        channel: "C0AHZFCAS1K",
+        channel_type: "channel",
+        user: "U_BEK",
+        text: "<@UOTHER> can you check this?",
+        ts: "1777244714.000100",
+        thread_ts: "1777244692.409919",
+        parent_user_id: "B1",
+      } as SlackMessageEvent,
+      opts: { source: "message" },
+    });
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.ctxPayload.WasMentioned).toBe(true);
+    expect(prepared!.ctxPayload.ExplicitlyMentionedBot).toBe(false);
+    expect(prepared!.ctxPayload.MentionedUserIds).toEqual(["UOTHER"]);
+    expect(prepared!.ctxPayload.ImplicitMentionKinds).toEqual(["reply_to_bot"]);
+    expect(prepared!.ctxPayload.MentionSource).toBe("implicit_thread");
+  });
+
   it("treats Slack user-group mentions as explicit mentions when the bot is a member", async () => {
     const usergroupsUsersList = vi.fn().mockResolvedValue({
       ok: true,
@@ -1431,6 +1468,9 @@ describe("slack prepareSlackMessage inbound contract", () => {
     });
     expect(prepared).toBeTruthy();
     expect(prepared!.ctxPayload.WasMentioned).toBe(true);
+    expect(prepared!.ctxPayload.ExplicitlyMentionedBot).toBe(true);
+    expect(prepared!.ctxPayload.MentionedSubteamIds).toEqual(["S0AGENTS"]);
+    expect(prepared!.ctxPayload.MentionSource).toBe("subteam");
   });
 
   it("drops Slack user-group mentions when the bot is not a member", async () => {

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -68,6 +68,8 @@ import type { PreparedSlackMessage } from "./types.js";
 
 const mentionRegexCache = new WeakMap<SlackMonitorContext, Map<string, RegExp[]>>();
 const SLACK_ANY_MENTION_RE = /<@[^>]+>|<!subteam\^[^>]+>/;
+const SLACK_USER_MENTION_RE = /<@([A-Z0-9]+)(?:\|[^>]+)?>/gi;
+const SLACK_SUBTEAM_MENTION_RE = /<!subteam\^([A-Z0-9]+)(?:\|[^>]+)?>/gi;
 const SLACK_SUBTEAM_MENTION_MARKER = "<!subteam^";
 
 function resolveCachedMentionRegexes(
@@ -111,6 +113,43 @@ type SlackAuthorizationContext = {
   senderId: string;
   allowFromLower: string[];
 };
+
+function collectUniqueSlackMentionIds(text: string, regex: RegExp): string[] {
+  const ids: string[] = [];
+  regex.lastIndex = 0;
+  for (const match of text.matchAll(regex)) {
+    const id = normalizeOptionalString(match[1]);
+    if (id && !ids.includes(id)) {
+      ids.push(id);
+    }
+  }
+  return ids;
+}
+
+function resolveSlackMentionSource(params: {
+  explicitlyMentionedBotUser: boolean;
+  explicitlyMentionedBotSubteam: boolean;
+  matchedImplicitMentionKinds: readonly string[];
+  shouldBypassMention: boolean;
+  wasMentioned: boolean;
+}): NonNullable<FinalizedMsgContext["MentionSource"]> {
+  if (params.explicitlyMentionedBotUser) {
+    return "explicit_bot";
+  }
+  if (params.explicitlyMentionedBotSubteam) {
+    return "subteam";
+  }
+  if (params.matchedImplicitMentionKinds.length > 0) {
+    return "implicit_thread";
+  }
+  if (params.shouldBypassMention) {
+    return "command_bypass";
+  }
+  if (params.wasMentioned) {
+    return "mention_pattern";
+  }
+  return "none";
+}
 
 async function resolveSlackConversationContext(params: {
   ctx: SlackMonitorContext;
@@ -289,20 +328,24 @@ export async function prepareSlackMessage(params: {
   }
   const { senderId, allowFromLower } = authorization;
   const messageText = message.text ?? "";
+  const mentionedUserIds = collectUniqueSlackMentionIds(messageText, SLACK_USER_MENTION_RE);
+  const mentionedSubteamIds = collectUniqueSlackMentionIds(messageText, SLACK_SUBTEAM_MENTION_RE);
   const hasAnyMention = SLACK_ANY_MENTION_RE.test(messageText);
   const hasSubteamMention = messageText.includes(SLACK_SUBTEAM_MENTION_MARKER);
-  const explicitlyMentioned = Boolean(
-    ctx.botUserId &&
-    (messageText.includes(`<@${ctx.botUserId}>`) ||
-      (hasSubteamMention &&
-        (await isSlackSubteamMentionForBot({
-          client: ctx.app.client,
-          text: messageText,
-          botUserId: ctx.botUserId,
-          teamId: ctx.teamId,
-          log: logVerbose,
-        })))),
+  const explicitlyMentionedBotUser = Boolean(
+    ctx.botUserId && mentionedUserIds.includes(ctx.botUserId),
   );
+  const explicitlyMentionedBotSubteam =
+    Boolean(ctx.botUserId && hasSubteamMention) &&
+    (await isSlackSubteamMentionForBot({
+      client: ctx.app.client,
+      text: messageText,
+      botUserId: ctx.botUserId,
+      teamId: ctx.teamId,
+      log: logVerbose,
+    }));
+  const explicitlyMentioned =
+    explicitlyMentionedBotUser || explicitlyMentionedBotSubteam || opts.source === "app_mention";
   const seedTopLevelRoomThreadBySource =
     opts.source === "app_mention" || opts.wasMentioned === true || explicitlyMentioned;
   let routing = resolveSlackRoutingContext({
@@ -524,6 +567,14 @@ export async function prepareSlackMessage(params: {
     },
   });
   const effectiveWasMentioned = mentionDecision.effectiveWasMentioned;
+  const matchedImplicitMentionKinds = mentionDecision.matchedImplicitMentionKinds;
+  const mentionSource = resolveSlackMentionSource({
+    explicitlyMentionedBotUser: explicitlyMentionedBotUser || opts.source === "app_mention",
+    explicitlyMentionedBotSubteam,
+    matchedImplicitMentionKinds,
+    shouldBypassMention: mentionDecision.shouldBypassMention,
+    wasMentioned,
+  });
   if (isRoom && shouldRequireMention && mentionDecision.shouldSkip) {
     ctx.logger.info({ channel: message.channel, reason: "no-mention" }, "skipping channel message");
     const pendingText = (message.text ?? "").trim();
@@ -792,6 +843,13 @@ export async function prepareSlackMessage(params: {
     ThreadLabel: threadLabel,
     Timestamp: message.ts ? Math.round(Number(message.ts) * 1000) : undefined,
     WasMentioned: isRoomish ? effectiveWasMentioned : undefined,
+    ExplicitlyMentionedBot: isRoomish ? explicitlyMentioned : undefined,
+    MentionedUserIds: isRoomish && mentionedUserIds.length > 0 ? mentionedUserIds : undefined,
+    MentionedSubteamIds:
+      isRoomish && mentionedSubteamIds.length > 0 ? mentionedSubteamIds : undefined,
+    ImplicitMentionKinds:
+      isRoomish && matchedImplicitMentionKinds.length > 0 ? matchedImplicitMentionKinds : undefined,
+    MentionSource: isRoomish ? mentionSource : undefined,
     MediaPath: firstMedia?.path,
     MediaType: firstMedia?.contentType,
     MediaUrl: firstMedia?.path,

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -494,6 +494,11 @@ describe("buildInboundUserContextPrefix", () => {
     const text = buildInboundUserContextPrefix({
       ChatType: "group",
       WasMentioned: true,
+      ExplicitlyMentionedBot: false,
+      MentionedUserIds: [" U_OTHER ", "", "U_HELPER"],
+      MentionedSubteamIds: [" S_ONCALL "],
+      ImplicitMentionKinds: ["bot_thread_participant"],
+      MentionSource: "implicit_thread",
       ReplyToBody: "quoted",
       ForwardedFrom: "sender",
       ThreadStarterBody: "starter",
@@ -503,6 +508,11 @@ describe("buildInboundUserContextPrefix", () => {
     const conversationInfo = parseConversationInfoPayload(text);
     expect(conversationInfo["is_group_chat"]).toBe(true);
     expect(conversationInfo["was_mentioned"]).toBe(true);
+    expect(conversationInfo["explicitly_mentioned_bot"]).toBe(false);
+    expect(conversationInfo["mentioned_user_ids"]).toEqual(["U_OTHER", "U_HELPER"]);
+    expect(conversationInfo["mentioned_subteam_ids"]).toEqual(["S_ONCALL"]);
+    expect(conversationInfo["implicit_mention_kinds"]).toEqual(["bot_thread_participant"]);
+    expect(conversationInfo["mention_source"]).toBe("implicit_thread");
     expect(conversationInfo["has_reply_context"]).toBe(true);
     expect(conversationInfo["has_forwarded_context"]).toBe(true);
     expect(conversationInfo["has_thread_starter"]).toBe(true);

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -25,6 +25,16 @@ function normalizePromptMetadataString(value: unknown): string | undefined {
   return sanitized || undefined;
 }
 
+function normalizePromptMetadataStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const normalized = value
+    .map((entry) => normalizePromptMetadataString(entry))
+    .filter((entry): entry is string => Boolean(entry));
+  return normalized.length > 0 ? normalized : undefined;
+}
+
 function sanitizePromptBody(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
@@ -227,6 +237,12 @@ export function buildInboundUserContextPrefix(
     is_forum: ctx.IsForum === true ? true : undefined,
     is_group_chat: !isDirect ? true : undefined,
     was_mentioned: ctx.WasMentioned === true ? true : undefined,
+    explicitly_mentioned_bot:
+      typeof ctx.ExplicitlyMentionedBot === "boolean" ? ctx.ExplicitlyMentionedBot : undefined,
+    mentioned_user_ids: normalizePromptMetadataStringArray(ctx.MentionedUserIds),
+    mentioned_subteam_ids: normalizePromptMetadataStringArray(ctx.MentionedSubteamIds),
+    implicit_mention_kinds: normalizePromptMetadataStringArray(ctx.ImplicitMentionKinds),
+    mention_source: normalizePromptMetadataString(ctx.MentionSource),
     has_reply_context: sanitizePromptBody(ctx.ReplyToBody) ? true : undefined,
     has_forwarded_context: normalizePromptMetadataString(ctx.ForwardedFrom) ? true : undefined,
     has_thread_starter: sanitizePromptBody(ctx.ThreadStarterBody) ? true : undefined,

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -188,6 +188,22 @@ export type MsgContext = {
   /** Platform bot username when command mentions should be normalized. */
   BotUsername?: string;
   WasMentioned?: boolean;
+  /** True when this turn explicitly mentioned the current bot target. */
+  ExplicitlyMentionedBot?: boolean;
+  /** Provider-native explicit user mention ids present on this turn. */
+  MentionedUserIds?: string[];
+  /** Provider-native explicit user-group/subteam mention ids present on this turn. */
+  MentionedSubteamIds?: string[];
+  /** Provider-native implicit mention wake reasons present on this turn. */
+  ImplicitMentionKinds?: string[];
+  /** Provider-native source that caused the current mention decision. */
+  MentionSource?:
+    | "explicit_bot"
+    | "subteam"
+    | "mention_pattern"
+    | "implicit_thread"
+    | "command_bypass"
+    | "none";
   CommandAuthorized?: boolean;
   CommandSource?: "text" | "native";
   CommandTargetSessionKey?: string;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: Slack thread replies can be marked `was_mentioned: true` from implicit thread participation even when the only explicit Slack mention targets another user, leaving agents with no prompt-visible distinction.
- Why it matters: the old context collapsed explicit bot mentions, explicit other-user mentions, user-group mentions, mention-pattern wakes, command bypass, and implicit thread wakes into one boolean.
- What changed: preserve Slack explicit user ids, user-group ids, implicit wake kinds, and mention source through Slack prepare -> finalized context -> prompt conversation metadata.
- What did NOT change (scope boundary): existing mention-gating and wake behavior remain compatible; this PR adds metadata rather than suppressing implicit thread wakes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #79025
- Related #79046
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Slack implicit thread wake metadata now shows that the bot was not explicitly mentioned and that another Slack user id was explicitly mentioned.
- Real environment tested: local OpenClaw checkout on Ubuntu, Node v24.15.0 via nvm, pnpm 10.33.2.
- Exact steps or command run after this patch: ran the local OpenClaw prompt metadata renderer with Slack context containing `WasMentioned: true`, `ExplicitlyMentionedBot: false`, `MentionedUserIds: ["UOTHER"]`, `ImplicitMentionKinds: ["reply_to_bot"]`, and `MentionSource: "implicit_thread"`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): console output from the local OpenClaw prompt metadata renderer after this patch:

  ```json
  {
    "chat_id": "channel:C0AHZFCAS1K",
    "message_id": "1777244714.000100",
    "sender_id": "U_BEK",
    "sender": "U_BEK",
    "is_group_chat": true,
    "was_mentioned": true,
    "explicitly_mentioned_bot": false,
    "mentioned_user_ids": [
      "UOTHER"
    ],
    "implicit_mention_kinds": [
      "reply_to_bot"
    ],
    "mention_source": "implicit_thread"
  }
  ```

- Observed result after fix: the prompt metadata keeps the compatible `was_mentioned: true` flag while also exposing `explicitly_mentioned_bot: false`, explicit target `UOTHER`, `implicit_mention_kinds: ["reply_to_bot"]`, and `mention_source: "implicit_thread"`.
- What was not tested: a live Slack Socket Mode workspace event; the Slack prepare path is covered by the added regression test and the prompt rendering was exercised locally.
- Before evidence (optional but encouraged): #79025 includes a real incident where the prompt showed only `was_mentioned: true` after a thread message explicitly mentioned another user.

## Root Cause (if applicable)

- Root cause: Slack message preparation computed explicit mention facts and implicit thread wake kinds, but only carried the collapsed `WasMentioned` boolean into the inbound context and prompt metadata.
- Missing detection / guardrail: tests asserted that implicit thread replies stayed routed/mentioned, but did not assert that explicit mention targets or source details survived into prompt metadata.
- Contributing context (if known): `thread.requireExplicitMention=true` can suppress implicit Slack thread wakes, but the metadata loss exists even when current implicit behavior is intentionally enabled.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/slack/src/monitor/message-handler/prepare.test.ts`; `src/auto-reply/reply/inbound-meta.test.ts`.
- Scenario the test should lock in: implicit Slack thread wake with an explicit mention of another user keeps `WasMentioned=true` but also carries `ExplicitlyMentionedBot=false`, `MentionedUserIds`, `ImplicitMentionKinds`, and `MentionSource` into prompt metadata.
- Why this is the smallest reliable guardrail: the bug is metadata preservation across Slack prepare and prompt rendering, not live Slack transport delivery.
- Existing test that already covers this (if any): existing thread and subteam mention tests covered wake behavior but not source metadata.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Slack agents now receive additional untrusted conversation metadata fields: `explicitly_mentioned_bot`, `mentioned_user_ids`, `mentioned_subteam_ids`, `implicit_mention_kinds`, and `mention_source`. Existing `was_mentioned` behavior remains compatible.

## Diagram (if applicable)

```text
Before:
Slack text <@UOTHER> in bot thread -> implicit wake -> was_mentioned: true

After:
Slack text <@UOTHER> in bot thread -> implicit wake -> was_mentioned: true
                                                        -> explicitly_mentioned_bot: false
                                                        -> mentioned_user_ids: ["UOTHER"]
                                                        -> mention_source: "implicit_thread"
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu
- Runtime/container: local Node v24.15.0 via nvm, pnpm 10.33.2
- Model/provider: N/A
- Integration/channel (if any): Slack
- Relevant config (redacted): implicit thread wake behavior enabled, equivalent to Slack thread participation/reply-to-bot flow in #79025

### Steps

1. Prepare a Slack room/thread message that explicitly mentions another user id while the thread wake is implicit.
2. Verify Slack prepare preserves explicit mention targets and implicit wake kind.
3. Render inbound prompt metadata and verify the new fields are present beside the compatible `was_mentioned` flag.

### Expected

- Prompt metadata distinguishes explicit bot mention, explicit other-user mention targets, implicit wake kind, and mention source.

### Actual

- Prompt metadata includes `explicitly_mentioned_bot: false`, `mentioned_user_ids: ["UOTHER"]`, `implicit_mention_kinds: ["reply_to_bot"]`, and `mention_source: "implicit_thread"`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Slack implicit thread wake with another-user mention; Slack user-group mention metadata; prompt metadata rendering and normalization.
- Edge cases checked: explicit mention target arrays are trimmed and empty entries are omitted; existing `WasMentioned` compatibility remains.
- What you did **not** verify: live Slack Socket Mode event delivery in a real workspace.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: additional Slack ids appear in the prompt metadata block.
  - Mitigation: these are provider-native ids from the current Slack message, rendered in the existing untrusted conversation metadata block; tests cover the new fields.

## Validation

- `pnpm test extensions/slack/src/monitor/message-handler/prepare.test.ts src/auto-reply/reply/inbound-meta.test.ts` passed.
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/channels/slack.md extensions/slack/src/monitor/message-handler/prepare.ts extensions/slack/src/monitor/message-handler/prepare.test.ts src/auto-reply/reply/inbound-meta.ts src/auto-reply/reply/inbound-meta.test.ts src/auto-reply/templating.ts` passed.
- `pnpm lint:extensions -- extensions/slack/src/monitor/message-handler/prepare.ts` passed.
- `git diff --check` passed.
- `pnpm tsgo:extensions`, `pnpm tsgo:core`, and `pnpm tsgo:extensions:test` passed as part of `pnpm tsgo:extensions && pnpm tsgo:core && pnpm tsgo:extensions:test && pnpm tsgo:core:test`.
- `pnpm tsgo:core:test` failed on unrelated pre-existing OpenAI test fixture type errors in `src/agents/openai-transport-stream.test.ts` and `src/agents/pi-embedded-runner/openai-stream-wrappers.test.ts`; no touched Slack/prompt files were implicated.
