### PR TITLE
fix(whatsapp): ignore outbound echoes for inbound activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -598,6 +598,7 @@ Docs: https://docs.openclaw.ai
 - Hooks/cron: log returned `/hooks/agent` isolated-run errors and failed cron jobs with cron diagnostic summaries, so rejected `payload.model` values are visible instead of looking like accepted-but-missing runs. Fixes #78597. (#78655) Thanks @kevinslin.
 - Managed proxy/security: classify raw socket callsites and proxy runtime mutations in boundary checks so new direct egress or unmanaged proxy-state changes cannot land without explicit review. (#77126) Thanks @jesse-merhi.
 - Channels/iMessage: surface the silent group-allowlist drop at default log level by emitting a one-time `warn` per account at monitor startup when `channels.imessage.groupPolicy: "allowlist"` is set without a `channels.imessage.groups` block, plus a one-time `warn` per `chat_id` when the runtime gate drops a specific group, naming the exact `channels.imessage.groups[...]` key to add to allow it. Fixes #78749. (#79190) Thanks @omarshahine.
+- WhatsApp: stop Gateway-originated outbound echoes from advancing inbound activity in `openclaw channels status`, so outbound self-sends no longer look like handled inbound messages. Fixes #79056. (#79057) Thanks @ai-hpc and @bittoby.
 
 ## 2026.5.3-1
 

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -113,6 +113,14 @@ function isGroupJid(jid: string): boolean {
   return (typeof isJidGroup === "function" ? isJidGroup(jid) : jid.endsWith("@g.us")) === true;
 }
 
+function recordAcceptedInboundActivity(accountId: string): void {
+  recordChannelActivity({
+    channel: "whatsapp",
+    accountId,
+    direction: "inbound",
+  });
+}
+
 function isRetryableSendDisconnectError(err: unknown): boolean {
   return /closed|reset|timed\s*out|disconnect|no active socket/i.test(formatError(err));
 }
@@ -799,11 +807,6 @@ export async function attachWebInboxToSocket(
       return;
     }
     for (const msg of upsert.messages ?? []) {
-      recordChannelActivity({
-        channel: "whatsapp",
-        accountId: options.accountId,
-        direction: "inbound",
-      });
       const inbound = await normalizeInboundMessage(msg);
       if (!inbound) {
         continue;
@@ -832,6 +835,7 @@ export async function attachWebInboxToSocket(
         continue;
       }
 
+      recordAcceptedInboundActivity(options.accountId);
       await enqueueInboundMessage(msg, inbound, enriched);
     }
   };

--- a/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test-support.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildNotifyMessageUpsert,
   expectPairingPromptSent,
+  getRecordChannelActivityMock,
   installWebMonitorInboxUnitTestHooks,
   mockLoadConfig,
   settleInboundWork,
@@ -31,6 +32,20 @@ function createAllowListConfig(allowFrom: string[]) {
 async function openInboxMonitor(onMessage = vi.fn()) {
   const { listener, sock } = await startInboxMonitor(onMessage);
   return { onMessage, listener, sock };
+}
+
+function expectOnlyOutboundChannelActivity(accountId = "default") {
+  const recordChannelActivityMock = getRecordChannelActivityMock();
+  expect(recordChannelActivityMock).toHaveBeenCalledWith({
+    channel: "whatsapp",
+    accountId,
+    direction: "outbound",
+  });
+  expect(recordChannelActivityMock).not.toHaveBeenCalledWith({
+    channel: "whatsapp",
+    accountId,
+    direction: "inbound",
+  });
 }
 
 async function expectOutboundDmSkipsPairing(params: {
@@ -294,6 +309,7 @@ describe("web monitor inbox", () => {
     await settleInboundWork();
 
     expect(onMessage).not.toHaveBeenCalled();
+    expectOnlyOutboundChannelActivity();
 
     await listener.close();
   });
@@ -333,6 +349,7 @@ describe("web monitor inbox", () => {
     await settleInboundWork();
 
     expect(onMessage).not.toHaveBeenCalled();
+    expectOnlyOutboundChannelActivity();
 
     await listener.close();
   });

--- a/extensions/whatsapp/src/monitor-inbox.test-harness.ts
+++ b/extensions/whatsapp/src/monitor-inbox.test-harness.ts
@@ -55,6 +55,25 @@ const sessionState = vi.hoisted(() => ({
   sock: undefined as MockSock | undefined,
 }));
 
+const channelActivityMocks = vi.hoisted(() => ({
+  recordChannelActivity: vi.fn(),
+}));
+
+export function getRecordChannelActivityMock(): AnyMockFn {
+  return channelActivityMocks.recordChannelActivity;
+}
+
+vi.mock("openclaw/plugin-sdk/channel-activity-runtime", async () => {
+  const actual = await vi.importActual<
+    typeof import("openclaw/plugin-sdk/channel-activity-runtime")
+  >("openclaw/plugin-sdk/channel-activity-runtime");
+  return {
+    ...actual,
+    recordChannelActivity: (...args: unknown[]) =>
+      channelActivityMocks.recordChannelActivity(...args),
+  };
+});
+
 const inboundRuntimeMocks = vi.hoisted(() => {
   const wrapperKeys = [
     "ephemeralMessage",
@@ -277,6 +296,7 @@ export function installWebMonitorInboxUnitTestHooks(opts?: { authDir?: boolean }
   beforeEach(async () => {
     vi.useRealTimers();
     vi.clearAllMocks();
+    channelActivityMocks.recordChannelActivity.mockClear();
     sessionState.sock = createMockSock();
     resetPairingSecurityMocks(DEFAULT_WEB_INBOX_CONFIG);
     if (!monitorWebInbox || !resetWebInboundDedupe) {


### PR DESCRIPTION
## Summary

- Problem: WhatsApp Web outbound echo events could update channel inbound activity before the message was filtered out as an outbound echo.
- Why it matters: `openclaw channels status --probe` could report fresh inbound activity after a Gateway-originated self-send even though no real inbound WhatsApp message was handled.
- What changed: WhatsApp now records inbound channel activity only after the message survives normalization, append-history filtering, enrichment, and recent-inbound dedupe, immediately before enqueueing the inbound message.
- What did NOT change: Outbound activity recording, WhatsApp send behavior, self-chat filtering, group handling, and auto-reply dispatch are otherwise unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #79056
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: WhatsApp self-sends should advance outbound activity but should not make channel status look like a fresh inbound message arrived.
- Real environment tested: Ubuntu VPS, Node 22, managed systemd user Gateway, live linked WhatsApp Web account.
- Exact steps or command run after this patch: rebuilt the local checkout, restarted the managed Gateway, captured `openclaw channels status --json`, sent one WhatsApp message to the linked account's own E.164 number through `openclaw message send --channel whatsapp --account default`, waited, then captured `channels status --json` and redacted Gateway logs.
- Evidence after fix:

```json
{
  "sendMessageId": "3EB0FE70141FB96653FA7A",
  "before": {
    "lastInboundAt": null,
    "lastOutboundAt": null,
    "connected": true,
    "healthState": "healthy"
  },
  "after": {
    "lastInboundAt": null,
    "lastOutboundAt": "2026-05-07T17:55:58.765Z",
    "connected": true,
    "healthState": "healthy"
  },
  "inboundAdvanced": false,
  "outboundAdvanced": true
}
```

Redacted matching logs after fix only showed the outbound send:

```text
[whatsapp] Sending message -> sha256:<redacted>
[whatsapp] Sent message 3EB0FE70141FB96653FA7A -> sha256:<redacted> (138ms)
[ws] res send channel=whatsapp
```

- Observed result after fix: outbound activity advanced and inbound activity did not advance.
- What was not tested: every WhatsApp deployment mode, multi-account WhatsApp, and full repository test suite.
- Before evidence: current main advanced both status timestamps for the same Gateway-originated self-send path:

```json
{
  "sendMessageId": "3EB03B031C04B624AAEA9B",
  "before": {
    "lastInboundAt": "2026-05-07T17:18:40.619Z",
    "lastOutboundAt": "2026-05-07T17:18:40.517Z"
  },
  "after": {
    "lastInboundAt": "2026-05-07T17:41:18.191Z",
    "lastOutboundAt": "2026-05-07T17:41:18.145Z"
  },
  "inboundAdvanced": true,
  "outboundAdvanced": true
}
```

## Root Cause (if applicable)

- Root cause: `attachWebInboxToSocket` recorded inbound channel activity at the top of each WhatsApp `messages.upsert` item, before `normalizeInboundMessage` could reject Gateway-originated outbound echoes via the recent outbound-message filter.
- Missing detection / guardrail: Existing outbound echo tests asserted no inbound message was delivered, but did not assert that inbound channel activity was not recorded.
- Contributing context (if known): `channels status` uses channel activity as fallback status metadata, so pre-filter raw WhatsApp Web events can leak into user-visible status even when the inbound message is later dropped.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/monitor-inbox.behavior.test.ts`
- Scenario the test should lock in: Gateway-originated WhatsApp fromMe echoes are filtered without recording inbound channel activity.
- Why this is the smallest reliable guardrail: The bug is local to the WhatsApp inbox monitor's ordering around echo filtering and enqueueing.
- Existing test that already covers this (if any): Existing echo-filter tests covered no inbound delivery; this PR extends them to cover channel activity accounting.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`openclaw channels status --probe` no longer reports fresh WhatsApp inbound activity from a Gateway-originated outbound echo/self-send.

## Diagram (if applicable)

```text
Before:
WhatsApp Web upsert -> record inbound activity -> echo filter drops message -> status still shows inbound activity

After:
WhatsApp Web upsert -> echo/history/enrichment/dedupe filters -> record inbound activity only for accepted inbound -> enqueue
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Node 22, systemd user Gateway
- Model/provider: N/A
- Integration/channel (if any): WhatsApp Web, account `default`
- Relevant config (redacted): live linked WhatsApp account, loopback Gateway

### Steps

1. Start a linked WhatsApp Gateway account.
2. Capture `openclaw channels status --json`.
3. Send a Gateway-originated WhatsApp message to the linked account's own E.164 number.
4. Capture `openclaw channels status --json` again.
5. Compare `lastInboundAt` and `lastOutboundAt`.

### Expected

- `lastOutboundAt` advances.
- `lastInboundAt` does not advance unless a real inbound WhatsApp message is handled.

### Actual

- Before this patch, both `lastInboundAt` and `lastOutboundAt` advanced for the self-send echo.
- After this patch, only `lastOutboundAt` advances.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: outbound self-send status accounting on a live linked WhatsApp Gateway; focused WhatsApp inbox echo tests; broader WhatsApp send/inbound/status/session tests.
- Edge cases checked: outbound DM echo, self-chat DM echo, append history filtering, inbound dedupe, media/status/session neighboring tests.
- What you did **not** verify: full repository suite, every WhatsApp account topology, and long-lived multi-day runtime behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Moving activity accounting later could miss activity for messages that are normalized but intentionally skipped before enqueueing.
- Mitigation: That is the intended boundary for user-visible inbound activity; skipped echoes, stale append history, failed enrichment, and duplicate redeliveries should not make status report fresh inbound handling.
