### PR TITLE
[AI-assisted] fix(providers): honor CIDR NO_PROXY entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/proxy: honor IPv4 CIDR and trailing wildcard `NO_PROXY` entries such as `100.64.0.0/10`, `100.64.*`, and `10.*` before routing private model-provider requests through an environment proxy. Fixes #79030. Thanks @briqt.
 - Docs/Docker: document a local Compose override for Docker Desktop DNS failures in the shared-network `openclaw-cli` sidecar, keeping the default compose setup hardened while unblocking `openclaw plugins install` when users opt in. Fixes #79018. Thanks @Jason-Vaughan.
 - Compute plugin callback authorization dynamically [AI]. (#78866) Thanks @pgondhi987.
 - fix(active-memory): require admin scope for global toggles [AI]. (#78863) Thanks @pgondhi987.

--- a/src/infra/net/proxy-env.test.ts
+++ b/src/infra/net/proxy-env.test.ts
@@ -294,6 +294,54 @@ describe("matchesNoProxy", () => {
       expected: true,
     },
     {
+      name: "matches IPv4 CIDR entries",
+      url: "http://100.64.0.3:8990/v1/messages",
+      env: { NO_PROXY: "100.64.0.0/10" } as NodeJS.ProcessEnv,
+      expected: true,
+    },
+    {
+      name: "matches IPv4 CIDR entries with port constraints",
+      url: "http://100.64.0.3:8990/v1/messages",
+      env: { NO_PROXY: "100.64.0.0/10:8990" } as NodeJS.ProcessEnv,
+      expected: true,
+    },
+    {
+      name: "does not match IPv4 CIDR entries when target is outside the range",
+      url: "http://100.128.0.3:8990/v1/messages",
+      env: { NO_PROXY: "100.64.0.0/10" } as NodeJS.ProcessEnv,
+      expected: false,
+    },
+    {
+      name: "matches trailing IPv4 wildcard entries",
+      url: "http://100.64.0.3:8990/v1/messages",
+      env: { NO_PROXY: "100.64.*" } as NodeJS.ProcessEnv,
+      expected: true,
+    },
+    {
+      name: "matches single-octet IPv4 wildcard entries",
+      url: "http://10.42.1.2:11434/api/chat",
+      env: { NO_PROXY: "10.*" } as NodeJS.ProcessEnv,
+      expected: true,
+    },
+    {
+      name: "matches trailing IPv4 wildcard entries with port constraints",
+      url: "http://100.64.0.3:8990/v1/messages",
+      env: { NO_PROXY: "100.64.*:8990" } as NodeJS.ProcessEnv,
+      expected: true,
+    },
+    {
+      name: "does not match trailing IPv4 wildcard entries when port differs",
+      url: "http://100.64.0.3:8991/v1/messages",
+      env: { NO_PROXY: "100.64.*:8990" } as NodeJS.ProcessEnv,
+      expected: false,
+    },
+    {
+      name: "does not treat mid-host IPv4 wildcard entries as supported",
+      url: "http://100.64.0.3:8990/v1/messages",
+      env: { NO_PROXY: "100.*.0.3" } as NodeJS.ProcessEnv,
+      expected: false,
+    },
+    {
       name: "returns false for malformed target URL",
       url: "not-a-url",
       env: { NO_PROXY: "*" } as NodeJS.ProcessEnv,
@@ -336,6 +384,24 @@ describe("shouldUseEnvHttpProxyForUrl", () => {
       env: {
         HTTPS_PROXY: "http://proxy.test:8080",
         NO_PROXY: "corp.example",
+      } as NodeJS.ProcessEnv,
+      expected: false,
+    },
+    {
+      name: "keeps strict mode for IPv4 CIDR NO_PROXY matches",
+      url: "http://100.64.0.3:8990/v1/messages",
+      env: {
+        HTTP_PROXY: "http://proxy.test:8080",
+        NO_PROXY: "100.64.0.0/10",
+      } as NodeJS.ProcessEnv,
+      expected: false,
+    },
+    {
+      name: "keeps strict mode for IPv4 wildcard NO_PROXY matches",
+      url: "http://100.64.0.3:8990/v1/messages",
+      env: {
+        HTTP_PROXY: "http://proxy.test:8080",
+        NO_PROXY: "100.64.*",
       } as NodeJS.ProcessEnv,
       expected: false,
     },

--- a/src/infra/net/proxy-env.ts
+++ b/src/infra/net/proxy-env.ts
@@ -1,3 +1,5 @@
+import { isIP } from "node:net";
+
 export const PROXY_ENV_KEYS = [
   "HTTP_PROXY",
   "HTTPS_PROXY",
@@ -114,7 +116,9 @@ export function shouldUseEnvHttpProxyForUrl(
 /**
  * Check whether a target URL should bypass the HTTP proxy per NO_PROXY env var.
  *
- * Mirrors undici EnvHttpProxyAgent semantics
+ * Mirrors undici EnvHttpProxyAgent semantics, plus OpenClaw's target-aware
+ * IPv4 CIDR and trailing-octet wildcard extensions for private provider
+ * endpoints
  * (`undici/lib/dispatcher/env-http-proxy-agent.js`):
  * - Entries separated by commas OR whitespace (undici splits on `/[,\s]/`)
  * - Case-insensitive
@@ -128,9 +132,11 @@ export function shouldUseEnvHttpProxyForUrl(
  * - Subdomain suffix match (`openai.com` matches `api.openai.com`)
  * - Optional `:port` suffix; when present, must match target port
  * - IPv6 literals in bracketed form (`[::1]`)
+ * - IPv4 CIDR entries (`100.64.0.0/10`)
+ * - IPv4 trailing-octet wildcard entries (`100.64.*`, `10.*`)
  *
  * Undici does not export its matcher, so this is a targeted reimplementation
- * kept in sync with the upstream file above. Paired with
+ * kept in sync with the upstream file above where behavior overlaps. Paired with
  * `hasEnvHttpProxyConfigured` this gates the trusted-env-proxy auto-upgrade
  * in provider HTTP helpers; see openclaw#64974 review thread on NO_PROXY
  * SSRF bypass.
@@ -205,6 +211,10 @@ export function matchesNoProxy(targetUrl: string, env: NodeJS.ProcessEnv = proce
       continue;
     }
 
+    if (matchesIpv4NoProxyExtension(targetHost, normalizedEntry)) {
+      return true;
+    }
+
     if (targetHost === normalizedEntry) {
       return true;
     }
@@ -213,4 +223,87 @@ export function matchesNoProxy(targetUrl: string, env: NodeJS.ProcessEnv = proce
     }
   }
   return false;
+}
+
+function matchesIpv4NoProxyExtension(targetHost: string, entryHost: string): boolean {
+  if (isIP(targetHost) !== 4) {
+    return false;
+  }
+
+  if (entryHost.includes("/")) {
+    return matchesIpv4Cidr(targetHost, entryHost);
+  }
+
+  if (entryHost.includes("*")) {
+    return matchesIpv4TrailingWildcard(targetHost, entryHost);
+  }
+
+  return false;
+}
+
+function parseIpv4Address(value: string): number | undefined {
+  if (isIP(value) !== 4) {
+    return undefined;
+  }
+
+  const octets = value.split(".").map((octet) => Number.parseInt(octet, 10));
+  if (octets.length !== 4 || octets.some((octet) => !Number.isInteger(octet))) {
+    return undefined;
+  }
+
+  return (((octets[0] << 24) >>> 0) | (octets[1] << 16) | (octets[2] << 8) | octets[3]) >>> 0;
+}
+
+function matchesIpv4Cidr(targetHost: string, entryHost: string): boolean {
+  const parts = entryHost.split("/");
+  if (parts.length !== 2) {
+    return false;
+  }
+
+  const [networkHost, prefixRaw] = parts;
+  if (!networkHost || !/^\d{1,2}$/.test(prefixRaw)) {
+    return false;
+  }
+
+  const prefix = Number.parseInt(prefixRaw, 10);
+  if (prefix < 0 || prefix > 32) {
+    return false;
+  }
+
+  const target = parseIpv4Address(targetHost);
+  const network = parseIpv4Address(networkHost);
+  if (target === undefined || network === undefined) {
+    return false;
+  }
+
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+  return (target & mask) === (network & mask);
+}
+
+function matchesIpv4TrailingWildcard(targetHost: string, entryHost: string): boolean {
+  const targetOctets = targetHost.split(".");
+  const patternOctets = entryHost.split(".");
+  if (
+    patternOctets.length < 2 ||
+    patternOctets.length > 4 ||
+    patternOctets[patternOctets.length - 1] !== "*"
+  ) {
+    return false;
+  }
+
+  const fixedOctets = patternOctets.slice(0, -1);
+  if (
+    fixedOctets.length === 0 ||
+    fixedOctets.some((octet) => {
+      if (!/^\d{1,3}$/.test(octet)) {
+        return true;
+      }
+      const value = Number.parseInt(octet, 10);
+      return value < 0 || value > 255;
+    })
+  ) {
+    return false;
+  }
+
+  return fixedOctets.every((octet, index) => targetOctets[index] === String(Number(octet)));
 }


### PR DESCRIPTION
## Summary

- Extend the env-proxy `NO_PROXY` matcher with IPv4 CIDR entries such as `100.64.0.0/10` and trailing IPv4 wildcard entries such as `100.64.*` / `10.*`.
- Keep existing Undici-style hostname, suffix, wildcard-dot, port, and IPv6 literal behavior intact.
- Add regression coverage for the reported private provider URL and for CIDR/wildcard port constraints.

Fixes #79030.

## Verification

- `corepack pnpm test src/infra/net/proxy-env.test.ts src/agents/provider-transport-fetch.test.ts src/infra/net/fetch-guard.ssrf.test.ts`
- `corepack pnpm exec oxfmt --check --threads=1 src/infra/net/proxy-env.ts src/infra/net/proxy-env.test.ts src/agents/provider-transport-fetch.test.ts CHANGELOG.md`
- `corepack pnpm check:changelog-attributions`
- `git diff --check origin/main...HEAD`
- `corepack pnpm check:changed`
- `& "$env:APPDATA\npm\codex.cmd" review --base origin/main -c model_reasoning_effort='"medium"'` completed with no findings.

## Real behavior proof

Behavior or issue addressed: private model-provider URLs covered only by CIDR or IPv4 wildcard `NO_PROXY` entries were still eligible for trusted env-proxy routing.

Real environment tested: local OpenClaw checkout on Windows, branch `fix-provider-no-proxy-cidr-79030`, commit `eca45b80a5`, using the production `src/infra/net/proxy-env.ts` helper directly.

Exact steps or command run after this patch:

```powershell
corepack pnpm tsx -e "import { matchesNoProxy, shouldUseEnvHttpProxyForUrl } from './src/infra/net/proxy-env.ts'; const url = 'http://100.64.0.3:8990/v1/messages'; const env = { HTTP_PROXY: 'http://127.0.0.1:3067', HTTPS_PROXY: 'http://127.0.0.1:3067', NO_PROXY: '100.64.*,100.64.0.0/10' }; console.log(JSON.stringify({ matchesNoProxy: matchesNoProxy(url, env), shouldUseEnvHttpProxyForUrl: shouldUseEnvHttpProxyForUrl(url, env) }));"
```

Evidence after fix:

```json
{"matchesNoProxy":true,"shouldUseEnvHttpProxyForUrl":false}
```

Observed result after fix: the reported `100.64.0.3` provider URL now matches the `NO_PROXY` entries and is not selected for environment proxy routing.

What was not tested: I did not run a live Tailscale/Headscale provider endpoint or capture traffic through a real local proxy; the proof uses OpenClaw's production proxy decision helper plus focused regression tests.