### PR TITLE
docs(security): document filesystem capability model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Docs/security: add the filesystem capability model that separates agent runtime isolation, scratch storage, and `fs-safe` host mutations for #78096.
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: stream ElevenLabs TTS directly into Discord playback and send ElevenLabs latency optimization as the documented query parameter so spoken replies can start sooner.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1502,6 +1502,7 @@
                     "pages": [
                       "gateway/security/index",
                       "gateway/security/secure-file-operations",
+                      "gateway/security/filesystem-capability-model",
                       "gateway/security/audit-checks",
                       "gateway/operator-scopes",
                       "gateway/sandboxing",

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -36,6 +36,8 @@ Not sandboxed:
   - **Elevated exec bypasses sandboxing and uses the configured escape path (`gateway` by default, or `node` when the exec target is `node`).**
   - If sandboxing is off, `tools.elevated` does not change execution (already on host). See [Elevated Mode](/tools/elevated).
 
+Sandboxing is one layer of the filesystem safety model. It controls where tools run, while rooted host file mutation still goes through `@openclaw/fs-safe` and future scratch-only storage may use a separate virtual filesystem. See [Filesystem capability model](/gateway/security/filesystem-capability-model).
+
 ## Modes
 
 `agents.defaults.sandbox.mode` controls **when** sandboxing is used:

--- a/docs/gateway/security/filesystem-capability-model.md
+++ b/docs/gateway/security/filesystem-capability-model.md
@@ -1,0 +1,84 @@
+---
+summary: "Layered filesystem capability model for agent isolation, scratch storage, and safe host file operations"
+read_when:
+  - Designing agent filesystem isolation, scratch storage, sandbox behavior, or host file mutation APIs
+title: "Filesystem capability model"
+---
+
+OpenClaw uses several filesystem controls that solve different problems. Treat them as layers, not replacements for each other:
+
+| Layer                      | Purpose                                                                                                     | Current fit                                   |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| Runtime boundary           | Keep tool execution away from the host with Docker, SSH, OpenShell, or future worker and process boundaries | Defense in depth around tool execution        |
+| Agent scratch storage      | Store agent-local temporary state that does not need to be a real host path                                 | Candidate for a virtual filesystem experiment |
+| Host filesystem capability | Mutate real workspaces, media, archives, and state files safely under a rooted capability                   | `@openclaw/fs-safe`                           |
+
+The important distinction is that virtual or sandbox-local storage can reduce how often OpenClaw touches the host filesystem, but it cannot replace safe real-host mutation for repo edits, archive extraction, media staging, exported session data, or any integration that must write a real path.
+
+## Current model
+
+OpenClaw is a long-lived Gateway with one or more agents. Agents can have different workspaces, sandbox settings, tool policies, auth stores, and channel bindings.
+
+The workspace is the default current directory and memory anchor, not a hard security boundary by itself. When tools run on the host, absolute paths and host permissions still define what the process can reach. Use [Sandboxing](/gateway/sandboxing), per-agent tool policy, and separate OS users or hosts when you need a stronger boundary.
+
+For trusted Gateway code that receives untrusted path names, OpenClaw uses [`@openclaw/fs-safe`](https://github.com/openclaw/fs-safe). That package provides rooted file operations, atomic replacement helpers, archive extraction limits, temp workspace helpers, JSON state helpers, and secret-file helpers. See [Secure file operations](/gateway/security/secure-file-operations).
+
+## Why Node permissions are only an outer guard
+
+Node's [permission model](https://nodejs.org/api/permissions.html) can restrict process or worker access with launch flags such as `--permission`, `--allow-fs-read`, `--allow-fs-write`, and `--allow-worker`.
+
+That can be useful around a worker or subprocess, but it is not the same abstraction as an object-capability filesystem API:
+
+- It is launch policy for a process or worker, not a value like `workspaceRoot.write("src/index.ts")`.
+- It is coarse for one long-lived Gateway that hosts many agents with different roots.
+- Every worker needs correctly configured `execArgv` and environment policy.
+- Worker creation and subprocess creation must stay controlled so inner code cannot weaken the model.
+- Node documents important constraints, including non-inheritance to worker threads, existing file descriptors, and symlink behavior.
+- It does not provide portable `openat` or dirfd-style mutation APIs for traversal-resistant real-host writes.
+
+Use Node permissions, worker isolation, or process isolation as defense in depth. Keep rooted filesystem APIs for host path mutation.
+
+## Virtual filesystem role
+
+A virtual filesystem can be useful for agent scratch or state that does not need to appear on the host:
+
+- intermediate tool outputs;
+- agent-local notes, caches, or resumable task state;
+- generated artifacts that will be explicitly exported later;
+- provider or workflow scratch paths where user-visible semantics do not require a host path.
+
+This can narrow the host filesystem surface and make per-agent cleanup easier. It should not become the default location for real workspace edits unless the user explicitly opts into a virtual workspace model with clear export and sync semantics.
+
+## Host filesystem capability role
+
+Real host paths are still required when OpenClaw edits a repository, stages local media for a channel, extracts archives into a workspace, exports session data, writes Gateway state, or updates plugin-owned local state that intentionally lives on disk.
+
+For these operations, prefer a rooted capability object over ad hoc string checks:
+
+- Core code should use the local fs-safe wrappers under `src/infra/*`.
+- Plugin-facing APIs should expose SDK helpers or capabilities instead of raw host paths where feasible.
+- Archive, copy, rename, remove, and write paths need tests for traversal, symlink, hardlink, and race-shaped cases.
+- If hostile local-user isolation matters, run separate gateways under separate OS users or hosts. `fs-safe` is a library guardrail, not a multi-tenant sandbox.
+
+## Experiment checklist
+
+Use this checklist for future implementation PRs:
+
+- Inventory which file operations require real host paths and which are scratch-only.
+- Prototype one agent running in a worker with explicit filesystem permission flags, then compare with a process-mode prototype.
+- Add a per-agent scratch filesystem experiment without changing real workspace edit behavior.
+- Measure startup cost, memory, debugging complexity, and failure recovery for each runtime boundary.
+- Keep workspace edits on `fs-safe` while measuring how much Python helper usage remains after scratch-only paths move away from host writes.
+- Evaluate optional Linux `openat2` acceleration only as a portable `fs-safe` implementation detail, not as the whole OpenClaw model.
+- Document any new plugin API boundary that passes capabilities instead of raw host paths.
+- Add regression tests for traversal, symlink, hardlink, rename, copy, remove, archive extraction, and time-of-check to time-of-use races.
+
+## Non-goals
+
+- Do not replace `fs-safe` with Node permissions.
+- Do not migrate all agent execution to workers, processes, or a third-party orchestrator without measured product and operations proof.
+- Do not make virtual filesystems the only storage model for workspace edits.
+- Do not remove Python helper paths until an equally safe portable alternative exists for the covered operations.
+- Do not add large runtime dependencies to core without install size, startup, security, and ownership review.
+
+Related: [Security](/gateway/security), [Secure file operations](/gateway/security/secure-file-operations), [Sandboxing](/gateway/sandboxing), [Multi-agent sandbox and tools](/tools/multi-agent-sandbox-tools), [Agent workspace](/concepts/agent-workspace).

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -71,6 +71,8 @@ OpenClaw uses `@openclaw/fs-safe` for root-bounded file access, atomic writes, a
 
 Details: [Secure file operations](/gateway/security/secure-file-operations).
 
+For the design model that separates tool runtime boundaries, agent scratch storage, and real-host path capabilities, see [Filesystem capability model](/gateway/security/filesystem-capability-model).
+
 ### Shared Slack workspace: real risk
 
 If "everyone in Slack can message the bot," the core risk is delegated tool authority:

--- a/docs/gateway/security/secure-file-operations.md
+++ b/docs/gateway/security/secure-file-operations.md
@@ -9,6 +9,8 @@ OpenClaw uses [`@openclaw/fs-safe`](https://github.com/openclaw/fs-safe) for sec
 
 The goal is a consistent **library guardrail** for trusted OpenClaw code that receives untrusted path names. It is not a sandbox. Host filesystem permissions, OS users, containers, and the agent/tool policy still define the real blast radius.
 
+For the broader layered model that separates runtime isolation, agent scratch storage, and real-host filesystem capabilities, see [Filesystem capability model](/gateway/security/filesystem-capability-model).
+
 ## Default: no Python helper
 
 OpenClaw defaults the fs-safe POSIX Python helper to **off**.
@@ -73,4 +75,4 @@ Use `require` rather than `auto` when the helper is part of your security postur
 - Secrets should use OpenClaw secret helpers or fs-safe secret/private-state helpers; do not hand-roll mode checks around `fs.writeFile`.
 - If you need hostile local-user isolation, do not rely on fs-safe alone. Run separate gateways under separate OS users/hosts or use sandboxing.
 
-Related: [Security](/gateway/security), [Sandboxing](/gateway/sandboxing), [Exec approvals](/tools/exec-approvals), [Secrets](/gateway/secrets).
+Related: [Security](/gateway/security), [Filesystem capability model](/gateway/security/filesystem-capability-model), [Sandboxing](/gateway/sandboxing), [Exec approvals](/tools/exec-approvals), [Secrets](/gateway/secrets).


### PR DESCRIPTION
## Summary

- Problem: #78096 tracks a long-term architecture question across per-agent runtime isolation, scratch storage, and safe real-host filesystem mutation.
- Why it matters: those layers solve different security and product problems, and blending them risks treating Node permissions or VFS scratch storage as replacements for `fs-safe` host mutation.
- What changed: added a dedicated filesystem capability model doc, linked it from secure file operations, sandboxing, and security docs, and added it to Mintlify navigation.
- What did NOT change (scope boundary): no runtime behavior, dependency, sandbox backend, or plugin API changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78096
- Related #
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: converts the architecture tracking note into durable docs and navigation.
- Real environment tested: local docs checkout on Linux with Node 24.15.0 and pnpm 10.33.2.
- Exact steps or command run after this patch: `pnpm exec oxfmt --check --threads=1 docs/gateway/security/filesystem-capability-model.md docs/gateway/security/secure-file-operations.md docs/gateway/sandboxing.md docs/gateway/security/index.md CHANGELOG.md docs/docs.json`; `node scripts/check-docs-mdx.mjs docs`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied terminal output: `Docs MDX check passed (620 files, 13827ms). All matched files use the correct format. Finished in 11760ms on 5 files using 1 threads.`
- Observed result after fix: the new page passes docs validation and is present in `docs/docs.json` navigation under Security and sandboxing.
- What was not tested: live Mintlify deployment.
- Before evidence (optional but encouraged): #78096 existed only as an issue note with no docs page.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: N/A.
- Missing detection / guardrail: N/A.
- Contributing context (if known): N/A.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `scripts/check-docs-mdx.mjs`, `oxfmt`.
- Scenario the test should lock in: docs front matter, links, MDX syntax, docs navigation JSON, and formatting stay valid.
- Why this is the smallest reliable guardrail: this is docs-only with no runtime behavior.
- Existing test that already covers this (if any): docs MDX check and formatter.
- If no new test is added, why not: docs-only architecture guidance does not need runtime test coverage.

## User-visible / Behavior Changes

Adds a new docs page: `https://docs.openclaw.ai/gateway/security/filesystem-capability-model`.

## Diagram (if applicable)

```text
Before:
[issue note] -> [no durable docs page]

After:
[issue note] -> [filesystem capability model docs] -> [linked from security/sandboxing navigation]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 24.15.0, pnpm 10.33.2
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Open `docs/gateway/security/filesystem-capability-model.md`.
2. Confirm `docs/docs.json` includes `gateway/security/filesystem-capability-model` under Security and sandboxing.
3. Run the docs formatter and MDX checks.

### Expected

- Docs page exists, links resolve, navigation includes the page, and checks pass.

### Actual

- Formatter passed and docs MDX check passed for 620 files.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: docs page content, security/sandboxing links, docs navigation entry, changelog entry, formatter, MDX docs check.
- Edge cases checked: Node permission wording checked against official Node permissions docs; scope states this is not a runtime implementation.
- What you did **not** verify: live docs deployment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: readers mistake the model page for implemented VFS or worker isolation.
  - Mitigation: the page explicitly labels those as future experiments and says no runtime behavior changed.