### PR TITLE
[AI-assisted] fix(cron): clarify model allowlist rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/preflight: clarify disallowed `payload.model` diagnostics by showing the normalized rejected ref plus effective allowed refs and a provider-mismatch hint. Fixes #79058. Thanks @hypnotiq147.
 - Docs/Docker: document a local Compose override for Docker Desktop DNS failures in the shared-network `openclaw-cli` sidecar, keeping the default compose setup hardened while unblocking `openclaw plugins install` when users opt in. Fixes #79018. Thanks @Jason-Vaughan.
 - Compute plugin callback authorization dynamically [AI]. (#78866) Thanks @pgondhi987.
 - fix(active-memory): require admin scope for global toggles [AI]. (#78863) Thanks @pgondhi987.

--- a/src/cron/isolated-agent.model-formatting.test.ts
+++ b/src/cron/isolated-agent.model-formatting.test.ts
@@ -216,13 +216,26 @@ describe("cron model formatting and precedence edge cases", () => {
       });
     });
 
-    it("reports the cron allowlist path when payload.model is not allowed", async () => {
+    it("reports the cron allowlist keys when payload.model is not allowed", async () => {
       resolveAllowedModelRefMock.mockReturnValueOnce({
         error: "model not allowed: anthropic/claude-sonnet-4-6",
       });
 
       await expect(
         selectModel({
+          cfg: {
+            agents: {
+              defaults: {
+                model: {
+                  primary: "openai-codex/gpt-5.4",
+                  fallbacks: ["claude-cli/claude-sonnet-4-6"],
+                },
+                models: {
+                  "openai-codex/gpt-5.4": {},
+                },
+              },
+            },
+          },
           payload: {
             kind: "agentTurn",
             message: DEFAULT_MESSAGE,
@@ -232,7 +245,7 @@ describe("cron model formatting and precedence edge cases", () => {
       ).resolves.toEqual({
         ok: false,
         error:
-          "cron payload.model 'anthropic/claude-sonnet-4-6' rejected by agents.defaults.models allowlist: anthropic/claude-sonnet-4-6",
+          "cron payload.model 'anthropic/claude-sonnet-4-6' is not in the effective cron model allowlist (normalized: anthropic/claude-sonnet-4-6). Allowed: claude-cli/claude-sonnet-4-6, openai-codex/gpt-5.4. Did you mean 'claude-cli/claude-sonnet-4-6'?",
       });
     });
 

--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -1,3 +1,5 @@
+import { buildAllowedModelSetWithFallbacks } from "../../agents/model-selection-shared.js";
+import { resolveAgentModelFallbackValues } from "../../config/model-input.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CronJob } from "../types.js";
 import {
@@ -42,10 +44,38 @@ export type ResolveCronModelSelectionResult =
       error: string;
     };
 
-function formatCronPayloadModelRejection(modelOverride: string, error: string): string {
+function modelIdFromRef(ref: string): string {
+  const slash = ref.indexOf("/");
+  return slash >= 0 ? ref.slice(slash + 1) : ref;
+}
+
+function formatAllowedModelHint(
+  rejectedModelRef: string,
+  allowedModelRefs: ReadonlySet<string> | null,
+): string {
+  if (!allowedModelRefs || allowedModelRefs.size === 0) {
+    return "";
+  }
+
+  const allowed = [...allowedModelRefs].sort();
+  const rejectedModelId = modelIdFromRef(rejectedModelRef);
+  const suggested = allowed.find((ref) => modelIdFromRef(ref) === rejectedModelId);
+  const allowedText = ` Allowed: ${allowed.join(", ")}.`;
+  return suggested ? `${allowedText} Did you mean '${suggested}'?` : allowedText;
+}
+
+function formatCronPayloadModelRejection(
+  modelOverride: string,
+  error: string,
+  allowedModelRefs: ReadonlySet<string> | null,
+): string {
   if (error.startsWith("model not allowed:")) {
     const modelRef = error.slice("model not allowed:".length).trim();
-    return `cron payload.model '${modelOverride}' rejected by agents.defaults.models allowlist: ${modelRef}`;
+    const normalized = modelRef ? ` (normalized: ${modelRef})` : "";
+    return `cron payload.model '${modelOverride}' is not in the effective cron model allowlist${normalized}.${formatAllowedModelHint(
+      modelRef,
+      allowedModelRefs,
+    )}`;
   }
   return `cron payload.model '${modelOverride}' rejected: ${error}`;
 }
@@ -112,17 +142,31 @@ export async function resolveCronModelSelection(
   const modelOverrideRaw = params.payload.kind === "agentTurn" ? params.payload.model : undefined;
   const modelOverride = typeof modelOverrideRaw === "string" ? modelOverrideRaw.trim() : undefined;
   if (modelOverride !== undefined && modelOverride.length > 0) {
+    const overrideCatalog = await loadCatalogOnce();
     const resolvedOverride = resolveAllowedModelRef({
       cfg: params.cfgWithAgentDefaults,
-      catalog: await loadCatalogOnce(),
+      catalog: overrideCatalog,
       raw: modelOverride,
       defaultProvider: resolvedDefault.provider,
       defaultModel: resolvedDefault.model,
     });
     if ("error" in resolvedOverride) {
+      const allowedModels = buildAllowedModelSetWithFallbacks({
+        cfg: params.cfgWithAgentDefaults,
+        catalog: overrideCatalog,
+        defaultProvider: resolvedDefault.provider,
+        defaultModel: resolvedDefault.model,
+        fallbackModels: resolveAgentModelFallbackValues(
+          params.cfgWithAgentDefaults.agents?.defaults?.model,
+        ),
+      });
       return {
         ok: false,
-        error: formatCronPayloadModelRejection(modelOverride, resolvedOverride.error),
+        error: formatCronPayloadModelRejection(
+          modelOverride,
+          resolvedOverride.error,
+          allowedModels.allowAny ? null : allowedModels.allowedKeys,
+        ),
       };
     }
     provider = resolvedOverride.ref.provider;

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -212,6 +212,7 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
     });
 
     it("fails closed when payload.model is not allowed", async () => {
+      const fallbacksWithCliHint = ["claude-cli/claude-sonnet-4-6", ...defaultFallbacks];
       resolveAllowedModelRefMock.mockReturnValueOnce({
         error: "model not allowed: anthropic/claude-sonnet-4-6",
       });
@@ -221,7 +222,10 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
           cfg: {
             agents: {
               defaults: {
-                model: { primary: "openai-codex/gpt-5.4", fallbacks: defaultFallbacks },
+                model: { primary: "openai-codex/gpt-5.4", fallbacks: fallbacksWithCliHint },
+                models: {
+                  "openai-codex/gpt-5.4": {},
+                },
               },
             },
           },
@@ -237,7 +241,7 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
 
       expect(result.status).toBe("error");
       expect(result.error).toBe(
-        "cron payload.model 'anthropic/claude-sonnet-4-6' rejected by agents.defaults.models allowlist: anthropic/claude-sonnet-4-6",
+        "cron payload.model 'anthropic/claude-sonnet-4-6' is not in the effective cron model allowlist (normalized: anthropic/claude-sonnet-4-6). Allowed: anthropic/claude-opus-4-6, claude-cli/claude-sonnet-4-6, google-gemini-cli/gemini-3-pro-preview, nvidia/deepseek-ai/deepseek-v3.2, openai-codex/gpt-5.4, openai/gpt-5.4. Did you mean 'claude-cli/claude-sonnet-4-6'?",
       );
       expect(logWarnMock).not.toHaveBeenCalled();
       expect(runWithModelFallbackMock).not.toHaveBeenCalled();

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -150,7 +150,7 @@ describe("dispatchAgentHook trust handling", () => {
 
   it("prefers cron diagnostics for returned hook errors", async () => {
     const diagnosticSummary =
-      "cron payload.model 'anthropic/claude-sonnet-4-6' rejected by agents.defaults.models allowlist: anthropic/claude-sonnet-4-6";
+      "cron payload.model 'anthropic/claude-sonnet-4-6' is not in the effective cron model allowlist (normalized: anthropic/claude-sonnet-4-6). Allowed: claude-cli/claude-sonnet-4-6, openai-codex/gpt-5.4. Did you mean 'claude-cli/claude-sonnet-4-6'?";
     runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
       status: "error",
       summary: "generic failure",


### PR DESCRIPTION
## Summary

- Replace the tautological cron `payload.model` allowlist rejection with a clearer effective allowlist diagnostic.
- Build the displayed allowed refs from the same configured allowlist, default model, and fallback model path used by cron model resolution.
- Add coverage for provider-mismatch hints from fallback models and for gateway hook diagnostic passthrough.

Fixes #79058.

## Real behavior proof

The focused resolver-facing test now asserts the user-visible diagnostic for a rejected provider/model ref while the accepted ref exists as an effective fallback:

```text
cron payload.model 'anthropic/claude-sonnet-4-6' is not in the effective cron model allowlist (normalized: anthropic/claude-sonnet-4-6). Allowed: claude-cli/claude-sonnet-4-6, openai-codex/gpt-5.4. Did you mean 'claude-cli/claude-sonnet-4-6'?
```

That demonstrates the after-fix behavior no longer echoes the rejected model as the apparent allowlist value, and it points at the accepted provider-matched ref.

## Validation

- `corepack pnpm test src/cron/isolated-agent.model-formatting.test.ts src/cron/isolated-agent/run.skill-filter.test.ts src/gateway/server/hooks.agent-trust.test.ts`
- `corepack pnpm exec oxfmt --check --threads=1 src/cron/isolated-agent/model-selection.ts src/cron/isolated-agent.model-formatting.test.ts src/cron/isolated-agent/run.skill-filter.test.ts src/gateway/server/hooks.agent-trust.test.ts CHANGELOG.md`
- `corepack pnpm check:changelog-attributions`
- `git diff --check origin/main...HEAD`
- `corepack pnpm check:changed`
- `codex review --base origin/main -c model_reasoning_effort='"medium"'` returned: no actionable correctness issues.