### PR TITLE
fix: keep gateway watch sync tracing opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/performance: avoid resolving plugin auto-enable metadata twice in one runtime config pass, reducing repeated dashboard turn metadata scans. Thanks @shakkernerd.
 - Auth/providers: pass `config` and `workspaceDir` lookup context through to provider-id resolution so workspace-scoped auth aliases resolve correctly when no explicit alias map is supplied. Thanks @shakkernerd.
 - Gateway/performance: avoid importing `jiti` on native-loadable plugin startup paths, so compiled bundled plugin surfaces do not pay source-transform loader cost unless fallback loading is actually needed.
-- Gateway/diagnostics: add startup phase spans, active work labels, stale terminal bridge markers, and default sync-I/O tracing in `pnpm gateway:watch` so slow Gateway turns are easier to attribute from logs and stability diagnostics.
+- Gateway/diagnostics: add startup phase spans, active work labels, stale terminal bridge markers, and opt-in sync-I/O tracing in `pnpm gateway:watch` so slow Gateway turns are easier to attribute from logs and stability diagnostics.
 - Plugins/loader: preserve real compiled plugin module evaluation errors on the native fast path instead of treating every thrown `.js` module as a source-transform fallback miss. Thanks @vincentkoc.
 - QA/Mantis: add `pnpm openclaw qa mantis slack-desktop-smoke` to run Slack live QA inside a Crabbox VNC desktop, open Slack Web, and capture desktop screenshots beside the Slack QA artifacts.
 - QA/Mantis: add an opt-in Discord thread attachment before/after scenario that creates a real thread, calls `message.thread-reply` with `filePath`, and captures baseline/candidate screenshot evidence.
@@ -126,7 +126,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/runtime state: add `registerIfAbsent` for atomic keyed-store dedupe claims that return whether a plugin successfully claimed a key without overwriting an existing live value. Thanks @amknight.
 - Exec approvals: add a tree-sitter-backed shell command explainer for future approval and command-review surfaces. (#75004) Thanks @jesse-merhi.
 - Control UI/performance: record browser long animation frame or long task entries in the debug event log when supported, making slow dashboard renders easier to attribute from the UI.
-- Gateway/diagnostics: add startup phase spans, active work labels, stale terminal bridge markers, and default sync-I/O tracing in `pnpm gateway:watch` so slow Gateway turns are easier to attribute from logs and stability diagnostics.
+- Gateway/diagnostics: add startup phase spans, active work labels, stale terminal bridge markers, and opt-in sync-I/O tracing in `pnpm gateway:watch` so slow Gateway turns are easier to attribute from logs and stability diagnostics.
 - QA/Codex harness: add targeted live Docker/Testbox diagnostics, auth preflight checks, cache mount fixes, and app-server protocol checkout discovery so maintainer harness failures are easier to reproduce. Thanks @vincentkoc.
 - QA/Mantis: add `pnpm openclaw qa mantis slack-desktop-smoke` to run Slack live QA inside a Crabbox VNC desktop, open Slack Web, and capture desktop screenshots beside the Slack QA artifacts.
 - QA/Mantis: add visual desktop tasks with Crabbox MP4 recording, screenshot capture, and optional image-understanding assertions, and preserve video artifacts in Mantis before/after reports.
@@ -155,6 +155,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/watch: leave `OPENCLAW_TRACE_SYNC_IO` disabled by default in `pnpm gateway:watch:raw` so watch mode avoids noisy Node sync-I/O stack traces unless explicitly requested.
 - Providers: preserve non-OK `text/event-stream` response bodies so provider HTTP errors keep their JSON detail instead of collapsing to generic streaming failures. Fixes #78180.
 - Chat commands: make `/model default` reset the session model override instead of treating it as a literal model name. Fixes #78182.
 - Cron: make rejected `payload.model` errors show the configured `agents.defaults.models` allowlist instead of echoing the rejected model twice. Fixes #79058.

--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -96,9 +96,9 @@ add Node's sync I/O trace flag through the source runner:
 OPENCLAW_TRACE_SYNC_IO=1 pnpm openclaw gateway --force
 ```
 
-`pnpm gateway:watch` enables this flag by default for the watched Gateway child.
-Set `OPENCLAW_TRACE_SYNC_IO=0` to suppress Node sync I/O trace output in watch
-mode.
+`pnpm gateway:watch` leaves this flag disabled by default for the watched
+Gateway child. Set `OPENCLAW_TRACE_SYNC_IO=1` when you explicitly want Node
+sync I/O trace output in watch mode.
 
 ## Gateway watch mode
 

--- a/scripts/watch-node.mjs
+++ b/scripts/watch-node.mjs
@@ -277,9 +277,6 @@ export async function runWatchMain(params = {}) {
   // The watcher owns process restarts; keep SIGUSR1/config reloads in-process
   // so inherited launchd/systemd markers do not make the child exit and stall.
   childEnv.OPENCLAW_NO_RESPAWN = "1";
-  if (isGatewayWatchCommand(deps.args) && childEnv.OPENCLAW_TRACE_SYNC_IO === undefined) {
-    childEnv.OPENCLAW_TRACE_SYNC_IO = "1";
-  }
   if (deps.args.length > 0) {
     childEnv.OPENCLAW_WATCH_COMMAND = deps.args.join(" ");
   }

--- a/src/infra/watch-node.test.ts
+++ b/src/infra/watch-node.test.ts
@@ -143,8 +143,16 @@ describe("watch-node script", () => {
             OPENCLAW_WATCH_MODE: "1",
             OPENCLAW_WATCH_SESSION: "1700000000000-4242",
             OPENCLAW_NO_RESPAWN: "1",
-            OPENCLAW_TRACE_SYNC_IO: "1",
             OPENCLAW_WATCH_COMMAND: "gateway --force",
+          }),
+        }),
+      );
+      expect(spawn).toHaveBeenCalledWith(
+        "/usr/local/bin/node",
+        ["scripts/run-node.mjs", "gateway", "--force"],
+        expect.objectContaining({
+          env: expect.not.objectContaining({
+            OPENCLAW_TRACE_SYNC_IO: expect.any(String),
           }),
         }),
       );


### PR DESCRIPTION
## Context
`pnpm gateway:watch:raw` was still defaulting the watched Gateway child to `OPENCLAW_TRACE_SYNC_IO=1`, which made Node sync-I/O diagnostics noisy unless operators explicitly disabled them.

This changes watch mode so sync-I/O tracing is opt-in: the watcher preserves explicit `OPENCLAW_TRACE_SYNC_IO` values but no longer injects `1` by default. The debugging docs and changelog now describe the opt-in behavior.

## Real behavior proof

- Behavior or issue addressed: `pnpm gateway:watch:raw` should not show Node sync-I/O trace output by default.
- Real environment tested: local OpenClaw source worktree on macOS, using isolated temp OpenClaw home/state/config and a non-default Gateway port; Node `v22.22.2` was used for the raw-watch probe because the default shell Node is `v22.15.1` and the repo now requires `>=22.16.0`.
- Exact steps or command run after this patch: bounded `pnpm gateway:watch:raw` probe with `OPENCLAW_TRACE_SYNC_IO` unset, isolated temp paths, and output scanned for `trace-sync-io`, `WARNING: Detected use of sync API`, `OPENCLAW_TRACE_SYNC_IO=1`, and `Enabling Node --trace-sync-io`.
- Evidence after fix: copied live terminal output from the after-fix raw-watch probe:

```text
node=v22.22.2
tmp=/var/folders/tq/q602_jgs7x768t74ks6q_b0m0000gp/T/openclaw-watch-raw-mmI8Nv
port=31167
exit_code=1
exit_signal=null
trace-sync-io=0
sync-api-warning=0
env-one=0
runner-enabled=0
--- output head ---

> openclaw@2026.5.6 gateway:watch:raw /Users/kevinlin/.codex/worktrees/f176/openclaw
> node scripts/watch-node.mjs gateway --force

ELIFECYCLE Command failed with exit code 1.
```

- Observed result after fix: raw watch no longer emits sync-I/O trace markers by default; the unit coverage also asserts the spawned watched child env does not contain `OPENCLAW_TRACE_SYNC_IO` unless explicitly supplied.
- What was not tested: a long-running fully configured Gateway session; the isolated raw-watch probe exited before producing normal Gateway logs in this sandbox, but the default trace markers were absent from captured output and the focused watch-node test covers the spawned child environment directly.

## Verification

- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/help/debugging.md scripts/watch-node.mjs src/infra/watch-node.test.ts`
- `pnpm test src/infra/watch-node.test.ts -- --reporter=verbose`
- `pnpm changed:lanes --json`
- `pnpm check:changed`
- `git diff --check`

Note: local commands print the existing Node engine warning when using the default shell Node `v22.15.1`; OpenClaw requires `>=22.16.0`.
