### PR TITLE
[AI-assisted] fix(whatsapp): delta repeated tool preambles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: keep contributor diagnostics to a bounded top-three selection without sorting the full history. Thanks @shakkernerd.
 - Sessions/UI: avoid full-array sorting while selecting ACPX leases, Google Meet calendar events, and latest chat sessions. Thanks @shakkernerd.
 - Plugin SDK: mark direct `deliverOutboundPayloads` and legacy reply-dispatch bridges as deprecated compatibility substrate, enrich `sendDurableMessageBatch` with explicit durable send outcomes, migrate bundled send/turn paths off deprecated APIs, and enforce the split with `check:deprecated-api-usage`.
+- WhatsApp/streaming: send only the new suffix when text-end block replies repeat prior preambles across tool-call cycles, preventing cumulative WhatsApp preamble messages. Fixes #78946. Thanks @papawattu.
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Telegram/streaming: continue over-limit draft previews in a new message instead of stopping when rendered preview text crosses Telegram's message limit. (#74508) Thanks @anagnorisis2peripeteia.
 - Slack: route handled top-level channel turns in implicit-conversation channels to thread-scoped sessions when Slack reply threading is enabled, keeping the root turn and later thread replies on one OpenClaw session. (#78522) Thanks @zeroth-blip.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp: pass routing context into voice-note transcript echo preflight so echoed transcripts can deliver to the originating chat. Fixes #79778. (#79788) Thanks @hclsys.
 - Cron/failover: classify structured OpenAI-compatible `server_error` payloads as `server_error`, expose that reason in cron state, and let one-shot cron retry policy honor `retryOn: ["server_error"]` without requiring raw `5xx` text. (#45594) Thanks @clovericbot.
 - Slack: wake the resolved thread session after interactive reply button/select clicks and carry Slack delivery context through the queued interaction event, so clicks continue the visible conversation. Fixes #79676 and #61502. (#79836) Thanks @velvet-shark, @tianxiaochannel-oss88, and @Saicheg.
+- WhatsApp/streaming: send only the new suffix when text-end block replies repeat prior preambles across tool-call cycles, preventing cumulative WhatsApp preamble messages. Fixes #78946. (#79120) Thanks @brokemac79 and @papawattu.
 
 ## 2026.5.9
 
@@ -53,7 +54,6 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: keep contributor diagnostics to a bounded top-three selection without sorting the full history. Thanks @shakkernerd.
 - Sessions/UI: avoid full-array sorting while selecting ACPX leases, Google Meet calendar events, and latest chat sessions. Thanks @shakkernerd.
 - Plugin SDK: mark direct `deliverOutboundPayloads` and legacy reply-dispatch bridges as deprecated compatibility substrate, enrich `sendDurableMessageBatch` with explicit durable send outcomes, migrate bundled send/turn paths off deprecated APIs, and enforce the split with `check:deprecated-api-usage`.
-- WhatsApp/streaming: send only the new suffix when text-end block replies repeat prior preambles across tool-call cycles, preventing cumulative WhatsApp preamble messages. Fixes #78946. Thanks @papawattu.
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Telegram/streaming: continue over-limit draft previews in a new message instead of stopping when rendered preview text crosses Telegram's message limit. (#74508) Thanks @anagnorisis2peripeteia.
 - Slack: route handled top-level channel turns in implicit-conversation channels to thread-scoped sessions when Slack reply threading is enabled, keeping the root turn and later thread replies on one OpenClaw session. (#78522) Thanks @zeroth-blip.

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -871,6 +871,8 @@ export function handleMessageEnd(
           );
         } else {
           ctx.state.lastBlockReplyText = text;
+          ctx.state.lastDeliveredBlockReplyText = text;
+          ctx.state.toolExecutionSinceLastBlockReply = false;
           emitSplitResultAsBlockReply(ctx.consumeReplyDirectives(text, { final: true }));
         }
       }

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -61,6 +61,7 @@ function createTestContext(): {
       messagingToolSentTargets: [],
       successfulCronAdds: 0,
       deterministicApprovalPromptSent: false,
+      toolExecutionSinceLastBlockReply: false,
     },
     shouldEmitToolResult: () => false,
     shouldEmitToolOutput: () => false,

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -658,6 +658,7 @@ export function handleToolExecutionStart(
     const toolCallId = evt.toolCallId;
     const args = evt.args;
     const runId = ctx.params.runId;
+    ctx.state.toolExecutionSinceLastBlockReply = true;
 
     // Track start time and args for after_tool_call hook.
     const startedAt = Date.now();

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -64,6 +64,8 @@ export type EmbeddedPiSubscribeState = {
   emittedAssistantUpdate: boolean;
   lastStreamedReasoning?: string;
   lastBlockReplyText?: string;
+  lastDeliveredBlockReplyText?: string;
+  toolExecutionSinceLastBlockReply: boolean;
   reasoningStreamOpen: boolean;
   assistantMessageIndex: number;
   lastAssistantStreamItemId?: string;
@@ -216,6 +218,7 @@ type ToolHandlerState = Pick<
   | "heartbeatToolResponse"
   | "successfulCronAdds"
   | "deterministicApprovalPromptSent"
+  | "toolExecutionSinceLastBlockReply"
 >;
 
 export type ToolHandlerContext = {

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.does-not-append-text-end-content-is.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.does-not-append-text-end-content-is.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createTextEndBlockReplyHarness,
+  extractTextPayloads,
   emitAssistantTextDelta,
   emitAssistantTextEnd,
 } from "./pi-embedded-subscribe.e2e-harness.js";
@@ -51,5 +52,188 @@ describe("subscribeEmbeddedPiSession", () => {
       expect(onBlockReply).toHaveBeenCalledTimes(1);
     });
     expect(subscription.assistantTexts).toEqual([expected]);
+  });
+
+  it("sends only the suffix when text_end block replies grow across assistant messages", async () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    const emitAssistantSnapshot = (content: string) => {
+      emit({ type: "message_start", message: { role: "assistant" } });
+      emitAssistantTextEnd({ emit, content });
+    };
+    const emitToolStart = (toolCallId: string) => {
+      emit({
+        type: "tool_execution_start",
+        toolName: "browser",
+        toolCallId,
+        args: {},
+      });
+    };
+
+    emitAssistantSnapshot("Let me grab actual eBay prices:");
+    await vi.waitFor(() => {
+      expect(onBlockReply).toHaveBeenCalledTimes(1);
+    });
+
+    emitToolStart("tool-1");
+    await Promise.resolve();
+    emitAssistantSnapshot("Let me grab actual eBay prices:Let me grab actual prices from eBay:");
+    await vi.waitFor(() => {
+      expect(onBlockReply).toHaveBeenCalledTimes(2);
+    });
+
+    emitToolStart("tool-2");
+    await Promise.resolve();
+    emitAssistantSnapshot(
+      "Let me grab actual eBay prices:Let me grab actual prices from eBay:eBay blocks live pricing:",
+    );
+    await vi.waitFor(() => {
+      expect(onBlockReply).toHaveBeenCalledTimes(3);
+    });
+
+    expect(extractTextPayloads(onBlockReply.mock.calls)).toEqual([
+      "Let me grab actual eBay prices:",
+      "Let me grab actual prices from eBay:",
+      "eBay blocks live pricing:",
+    ]);
+    expect(subscription.assistantTexts).toEqual([
+      "Let me grab actual eBay prices:",
+      "Let me grab actual prices from eBay:",
+      "eBay blocks live pricing:",
+    ]);
+  });
+
+  it("keeps a full later reply that shares a prefix without an intervening tool call", async () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    const emitAssistantSnapshot = (content: string) => {
+      emit({ type: "message_start", message: { role: "assistant" } });
+      emitAssistantTextEnd({ emit, content });
+    };
+
+    emitAssistantSnapshot("OK");
+    await vi.waitFor(() => {
+      expect(onBlockReply).toHaveBeenCalledTimes(1);
+    });
+
+    emitAssistantSnapshot("OK, here's the detail");
+    await vi.waitFor(() => {
+      expect(onBlockReply).toHaveBeenCalledTimes(2);
+    });
+
+    expect(extractTextPayloads(onBlockReply.mock.calls)).toEqual(["OK", "OK, here's the detail"]);
+    expect(subscription.assistantTexts).toEqual(["OK", "OK, here's the detail"]);
+  });
+
+  it("keeps a full post-tool reply when the prior block is not a preamble", async () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    const emitAssistantSnapshot = (content: string) => {
+      emit({ type: "message_start", message: { role: "assistant" } });
+      emitAssistantTextEnd({ emit, content });
+    };
+
+    emitAssistantSnapshot("Checking...");
+    await vi.waitFor(() => {
+      expect(onBlockReply).toHaveBeenCalledTimes(1);
+    });
+
+    emit({
+      type: "tool_execution_start",
+      toolName: "browser",
+      toolCallId: "tool-post-check",
+      args: {},
+    });
+    await Promise.resolve();
+
+    emitAssistantSnapshot("Checking... found X");
+    await vi.waitFor(() => {
+      expect(onBlockReply).toHaveBeenCalledTimes(2);
+    });
+
+    expect(extractTextPayloads(onBlockReply.mock.calls)).toEqual([
+      "Checking...",
+      "Checking... found X",
+    ]);
+    expect(subscription.assistantTexts).toEqual(["Checking...", "Checking... found X"]);
+  });
+
+  it("keeps a full post-tool reply when the shared prefix is whitespace-separated", async () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    const emitAssistantSnapshot = (content: string) => {
+      emit({ type: "message_start", message: { role: "assistant" } });
+      emitAssistantTextEnd({ emit, content });
+    };
+
+    emitAssistantSnapshot("Checking:");
+    await vi.waitFor(() => {
+      expect(onBlockReply).toHaveBeenCalledTimes(1);
+    });
+
+    emit({
+      type: "tool_execution_start",
+      toolName: "browser",
+      toolCallId: "tool-post-check-colon",
+      args: {},
+    });
+    await Promise.resolve();
+
+    emitAssistantSnapshot("Checking: found X");
+    await vi.waitFor(() => {
+      expect(onBlockReply).toHaveBeenCalledTimes(2);
+    });
+
+    expect(extractTextPayloads(onBlockReply.mock.calls)).toEqual([
+      "Checking:",
+      "Checking: found X",
+    ]);
+    expect(subscription.assistantTexts).toEqual(["Checking:", "Checking: found X"]);
+  });
+
+  it("does not safety-send a cumulative text_end reply when the suffix was sent by a messaging tool", async () => {
+    const onBlockReply = vi.fn();
+    const { emit } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextEnd({ emit, content: "Checking:" });
+    await vi.waitFor(() => {
+      expect(onBlockReply).toHaveBeenCalledTimes(1);
+    });
+
+    emit({
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "message-tool-1",
+      args: { action: "send", to: "+1555", message: "Fetched prices" },
+    });
+    await Promise.resolve();
+    emit({
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "message-tool-1",
+      isError: false,
+      result: "ok",
+    });
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextEnd({ emit, content: "Checking: Fetched prices" });
+    await Promise.resolve();
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Checking: Fetched prices" }],
+      },
+    });
+    await Promise.resolve();
+
+    expect(extractTextPayloads(onBlockReply.mock.calls)).toEqual(["Checking:"]);
   });
 });

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -35,10 +35,7 @@ import type {
 import { isPromiseLike } from "./pi-embedded-subscribe.promise.js";
 import { filterToolResultMediaUrls } from "./pi-embedded-subscribe.tools.js";
 import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
-import {
-  stripDowngradedToolCallText,
-  THINKING_TAG_SCAN_RE,
-} from "./pi-embedded-utils.js";
+import { stripDowngradedToolCallText, THINKING_TAG_SCAN_RE } from "./pi-embedded-utils.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
 const FINAL_TAG_SCAN_RE = /<\s*(\/?)\s*final\s*>/gi;
@@ -146,6 +143,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     emittedAssistantUpdate: false,
     lastStreamedReasoning: undefined,
     lastBlockReplyText: undefined,
+    lastDeliveredBlockReplyText: undefined,
+    toolExecutionSinceLastBlockReply: false,
     reasoningStreamOpen: false,
     assistantMessageIndex: 0,
     lastAssistantStreamItemId: undefined,
@@ -710,34 +709,80 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     }
     // Strip <think> and <final> blocks across chunk boundaries to avoid leaking reasoning.
     // Also strip downgraded tool call text ([Tool Call: ...], [Historical context: ...], etc.).
-    const chunk = stripDowngradedToolCallText(
+    const blockReplyText = stripDowngradedToolCallText(
       stripBlockTags(text, state.blockState, { final: options?.final === true }),
     ).trimEnd();
-    if (!chunk) {
+    if (!blockReplyText) {
       return;
     }
-    if (chunk === state.lastBlockReplyText) {
+    if (blockReplyText === state.lastBlockReplyText) {
+      return;
+    }
+    const markBlockReplyTextHandled = () => {
+      state.lastBlockReplyText = blockReplyText;
+      state.lastDeliveredBlockReplyText = blockReplyText;
+      state.toolExecutionSinceLastBlockReply = false;
+    };
+    let chunk = blockReplyText;
+    let slicedPrefixReplay = false;
+    const lastDeliveredBlockReplyText = state.lastDeliveredBlockReplyText;
+    const blockReplySuffix = lastDeliveredBlockReplyText
+      ? blockReplyText.slice(lastDeliveredBlockReplyText.length)
+      : "";
+    const prefixReplayCandidate = Boolean(
+      state.blockReplyBreak === "text_end" &&
+      state.toolExecutionSinceLastBlockReply &&
+      lastDeliveredBlockReplyText &&
+      lastDeliveredBlockReplyText.trimEnd().endsWith(":") &&
+      blockReplyText.length > lastDeliveredBlockReplyText.length &&
+      blockReplyText.startsWith(lastDeliveredBlockReplyText),
+    );
+    if (prefixReplayCandidate && !/^\s/.test(blockReplySuffix)) {
+      chunk = blockReplySuffix;
+      slicedPrefixReplay = true;
+    }
+    if (!chunk) {
       return;
     }
 
     // Only check committed (successful) messaging tool texts - checking pending texts
     // is risky because if the tool fails after suppression, the user gets no response
     const normalizedChunk = normalizeTextForComparison(chunk);
-    if (isMessagingToolDuplicateNormalized(normalizedChunk, messagingToolSentTextsNormalized)) {
+    const normalizedReplaySuffix = prefixReplayCandidate
+      ? normalizeTextForComparison(blockReplySuffix.trimStart())
+      : "";
+    const isMessagingDuplicate =
+      isMessagingToolDuplicateNormalized(normalizedChunk, messagingToolSentTextsNormalized) ||
+      (prefixReplayCandidate &&
+        isMessagingToolDuplicateNormalized(
+          normalizedReplaySuffix,
+          messagingToolSentTextsNormalized,
+        ));
+    if (isMessagingDuplicate) {
       log.debug(`Skipping block reply - already sent via messaging tool: ${chunk.slice(0, 50)}...`);
+      if (prefixReplayCandidate) {
+        markBlockReplyTextHandled();
+      }
       return;
     }
 
     if (shouldSkipAssistantText(chunk)) {
+      if (slicedPrefixReplay) {
+        markBlockReplyTextHandled();
+      }
       return;
     }
 
     if (!params.onBlockReply) {
       pushAssistantText(chunk);
+      markBlockReplyTextHandled();
       return;
     }
     const splitResult = replyDirectiveAccumulator.consume(chunk);
     if (!splitResult) {
+      if (slicedPrefixReplay) {
+        markBlockReplyTextHandled();
+      }
       return;
     }
     const {
@@ -749,6 +794,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       replyToCurrent,
     } = splitResult;
     if (!cleanedText && (!mediaUrls || mediaUrls.length === 0) && !audioAsVoice) {
+      if (slicedPrefixReplay) {
+        markBlockReplyTextHandled();
+      }
       return;
     }
     pushAssistantText(chunk);
@@ -767,7 +815,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
           options?.final === true || Boolean(mediaUrls?.length || audioAsVoice),
       },
     );
-    state.lastBlockReplyText = chunk;
+    markBlockReplyTextHandled();
   };
 
   const consumeReplyDirectives = (text: string, options?: { final?: boolean }) =>
@@ -888,6 +936,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.pendingAssistantReplyDirectives = undefined;
     state.deterministicApprovalPromptPending = false;
     state.deterministicApprovalPromptSent = false;
+    state.lastDeliveredBlockReplyText = undefined;
+    state.toolExecutionSinceLastBlockReply = false;
     state.replayState = mergeEmbeddedRunReplayState(state.replayState, params.initialReplayState);
     state.livenessState = "working";
     resetAssistantMessageState(0);

--- a/src/agents/pi-tool-handler-state.test-helpers.ts
+++ b/src/agents/pi-tool-handler-state.test-helpers.ts
@@ -17,6 +17,7 @@ export function createBaseToolHandlerState() {
     pendingToolAudioAsVoice: false,
     pendingToolTrustedLocalMedia: false,
     deterministicApprovalPromptPending: false,
+    toolExecutionSinceLastBlockReply: false,
     messagingToolSentTexts: [] as string[],
     messagingToolSentTextsNormalized: [] as string[],
     messagingToolSentMediaUrls: [] as string[],


### PR DESCRIPTION
## Summary

- Problem: WhatsApp/text-end block replies could send cumulative, prefix-growing tool-call preambles as separate visible messages.
- Why it matters: WhatsApp cannot edit prior outbound messages, so every cumulative snapshot becomes user-visible noise.
- What changed: track the last delivered text-end block snapshot plus a tool-boundary signal, delta tight colon-joined preamble replays, and keep messaging-tool duplicate suppression from falling through to the message_end safety send.
- What did NOT change (scope boundary): no WhatsApp send-path rewrite, no channel config changes, and no live install behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78946
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: cumulative WhatsApp preambles are converted to suffix/delta block sends in the shared text_end block-reply path.
- Real environment tested: Windows 11 local OpenClaw repo using the real embedded block-reply subscriber path. No live WhatsApp account is configured on this machine.
- Exact steps or command run after this patch:
  - `corepack pnpm exec tsx -` with a local script that imports `subscribeEmbeddedPiSession`, emits a text_end assistant snapshot, two `tool_execution_start` events, and two later cumulative text_end snapshots matching the reported WhatsApp shape.
  - `corepack pnpm test src/agents/openclaw-owned-tool-runtime-contract.test.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.does-not-append-text-end-content-is.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-message-end-block-replies-message-tool.test.ts`
  - `corepack pnpm test extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts`
  - `corepack pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-subscribe.ts src/agents/pi-embedded-subscribe.handlers.messages.ts src/agents/pi-embedded-subscribe.handlers.tools.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts src/agents/pi-tool-handler-state.test-helpers.ts src/auto-reply/reply/block-reply-pipeline.ts extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts CHANGELOG.md`
  - `corepack pnpm check:changelog-attributions`
  - `corepack pnpm check:changed`
  - `git diff --check origin/main...HEAD`
  - `git diff --check`
  - `& "$env:APPDATA\npm\codex.cmd" review --base origin/main -c model_reasoning_effort='"medium"'`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied local console output from the real OpenClaw embedded block-reply subscriber, run outside Vitest:

```text
> corepack pnpm exec tsx -
{
  "delivered": [
    "Let me grab actual eBay prices:",
    "Let me grab actual prices from eBay:",
    "eBay blocks live pricing:"
  ]
}
```

Supplemental validation output: agent regression suite reported 4 files / 51 tests passed; WhatsApp inbound dispatch suite reported 35 tests passed; targeted formatter, changelog attribution, changed gate, whitespace checks, and final standalone Codex review all passed.
- Observed result after fix: the production subscriber delivered `["Let me grab actual eBay prices:", "Let me grab actual prices from eBay:", "eBay blocks live pricing:"]` instead of cumulative prefix-growing messages, and the messaging-tool duplicate case stays single-delivery rather than being safety-sent at `message_end`.
- What was not tested: live WhatsApp/vLLM outbound delivery; no real phone outbound send was available on this machine.
- Before evidence (optional but encouraged): ClawSweeper source-level review on #78946 identified the prior exact-only block dedupe and missing cross-tool prefix-superset suppression.

## Root Cause (if applicable)

- Root cause: text_end block reply dedupe only skipped exact repeats. Each assistant/tool cycle could emit a new non-identical prefix-growing snapshot, and WhatsApp treats each block as a separate outbound message.
- Missing detection / guardrail: no turn-level delivered block snapshot/tool-boundary guard, and no regression covering prefix-growing assistant text across tool calls.
- Contributing context (if known): WhatsApp uses the shared block-reply dispatcher for visible outbound text, where edit-style streaming is not available.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.does-not-append-text-end-content-is.test.ts`
- Scenario the test should lock in: across assistant/tool cycles, tight colon-joined cumulative text_end preambles emit only their new suffix, while normal prefix-sharing replies remain intact.
- Why this is the smallest reliable guardrail: it exercises the shared embedded block-reply path that WhatsApp consumes without requiring live channel credentials.
- Existing test that already covers this (if any): existing tests covered repeated text_end content within one assistant message, but not cross-tool prefix growth.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

WhatsApp/non-editable text_end block replies no longer emit cumulative duplicate preamble messages in the tight colon-joined tool-cycle replay shape; only the new suffix is sent.

## Diagram (if applicable)

```text
Before:
assistant preamble: -> tool -> assistant preamble:next: -> WhatsApp sends both full snapshots

After:
assistant preamble: -> tool -> assistant preamble:next: -> WhatsApp sends preamble:, then next:
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: local Node/pnpm workspace
- Model/provider: scripted local event replay; no live provider required for the tested path
- Integration/channel (if any): WhatsApp-facing shared block-reply path plus WhatsApp inbound dispatch tests
- Relevant config (redacted): no live WhatsApp credentials configured

### Steps

1. Emit a text_end assistant block reply ending in a colon.
2. Emit a tool execution cycle.
3. Emit a later assistant text_end block whose content starts with the previous block and appends the next tight preamble.

### Expected

- Only the newly appended suffix is delivered for the later block.

### Actual

- The local subscriber proof delivered only suffix messages; guard tests preserve full legitimate later replies.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: local real subscriber replay for cumulative text_end preambles, no-tool shared-prefix replies, post-tool non-preamble replies, whitespace-separated replies, and messaging-tool duplicate safety-send suppression.
- Edge cases checked: repeated text_end exact duplicate behavior, messaging-tool duplicate normalization, and targeted WhatsApp dispatch tests.
- What you did **not** verify: live WhatsApp account outbound delivery.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: over-suppressing legitimate later text that happens to share a prefix.
  - Mitigation: suffixing is limited to text_end, after a tool execution, prior delivered text ending in a colon, strict prefix growth, and no whitespace separator before the suffix; guard tests cover full legitimate replies.