### PR TITLE
Keep Control UI refresh responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/runtime state: add `registerIfAbsent` for atomic keyed-store dedupe claims that return whether a plugin successfully claimed a key without overwriting an existing live value. Thanks @amknight.
 - Exec approvals: add a tree-sitter-backed shell command explainer for future approval and command-review surfaces. (#75004) Thanks @jesse-merhi.
 - Control UI/performance: record browser long animation frame or long task entries in the debug event log when supported, making slow dashboard renders easier to attribute from the UI.
+- Control UI/performance: keep chat, config, and channel refreshes responsive by decoupling slow history/schema/status work, reducing the client history window, and logging over-budget chat/config renders. Refs #77060, #45698, #47979, #44107. Thanks @BunsDev.
 - Gateway/diagnostics: add startup phase spans, active work labels, stale terminal bridge markers, and opt-in sync-I/O tracing in `pnpm gateway:watch` so slow Gateway turns are easier to attribute from logs and stability diagnostics.
 - QA/Codex harness: add targeted live Docker/Testbox diagnostics, auth preflight checks, cache mount fixes, and app-server protocol checkout discovery so maintainer harness failures are easier to reproduce. Thanks @vincentkoc.
 - QA/Mantis: add `pnpm openclaw qa mantis slack-desktop-smoke` to run Slack live QA inside a Crabbox VNC desktop, open Slack Web, and capture desktop screenshots beside the Slack QA artifacts.

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -177,6 +177,40 @@ describe("refreshChat", () => {
     });
     expect(requestUpdate).not.toHaveBeenCalled();
   });
+
+  it("can wait for history without waiting for secondary metadata refreshes", async () => {
+    const history = createDeferred<unknown>();
+    const requestUpdate = vi.fn();
+    const request = vi.fn((method: string) => {
+      if (method === "chat.history") {
+        return history.promise;
+      }
+      return new Promise<unknown>(() => undefined);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      sessionKey: "main",
+      requestUpdate,
+    });
+
+    const refresh = refreshChat(host, { awaitHistory: true, scheduleScroll: false });
+    const pendingOutcome = await Promise.race([
+      refresh.then(() => "resolved" as const),
+      new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 0)),
+    ]);
+
+    expect(pendingOutcome).toBe("pending");
+    history.resolve({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "ready" }] }],
+    });
+
+    await expect(refresh).resolves.toBeUndefined();
+    expect(host.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "ready" }] },
+    ]);
+    expect(request).toHaveBeenCalledWith("models.list", { view: "configured" });
+    expect(requestUpdate).toHaveBeenCalled();
+  });
 });
 
 describe("refreshChatAvatar", () => {

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -142,6 +142,43 @@ function createDeferred<T>() {
   return { promise, resolve, reject };
 }
 
+describe("refreshChat", () => {
+  beforeAll(async () => {
+    await loadChatHelpers();
+  });
+
+  it("dispatches chat refresh work without waiting for slow history or secondary RPCs", async () => {
+    const request = vi.fn(() => new Promise<unknown>(() => undefined));
+    const requestUpdate = vi.fn();
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      sessionKey: "main",
+      requestUpdate,
+    });
+
+    const refresh = refreshChat(host);
+    const outcome = await Promise.race([
+      refresh.then(() => "resolved" as const),
+      new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 0)),
+    ]);
+
+    expect(outcome).toBe("resolved");
+    expect(host.chatLoading).toBe(true);
+    expect(request).toHaveBeenCalledWith("chat.history", {
+      sessionKey: "main",
+      limit: 100,
+      maxChars: 4000,
+    });
+    expect(request).toHaveBeenCalledWith("models.list", { view: "configured" });
+    expect(request).toHaveBeenCalledWith("commands.list", {
+      agentId: "main",
+      includeArgs: true,
+      scope: "text",
+    });
+    expect(requestUpdate).not.toHaveBeenCalled();
+  });
+});
+
 describe("refreshChatAvatar", () => {
   beforeAll(async () => {
     await loadChatHelpers();

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -746,7 +746,10 @@ function injectCommandResult(host: ChatHost, content: string) {
   ];
 }
 
-export async function refreshChat(host: ChatHost, opts?: { scheduleScroll?: boolean }) {
+export async function refreshChat(
+  host: ChatHost,
+  opts?: { scheduleScroll?: boolean; awaitHistory?: boolean },
+) {
   const requestUpdate = () => host.requestUpdate?.();
   const historyRefresh = loadChatHistory(host as unknown as ChatState).finally(() => {
     if (opts?.scheduleScroll !== false) {
@@ -767,6 +770,10 @@ export async function refreshChat(host: ChatHost, opts?: { scheduleScroll?: bool
   ]).finally(requestUpdate);
   void historyRefresh;
   void secondaryRefresh;
+  if (opts?.awaitHistory === true) {
+    await historyRefresh;
+    return;
+  }
   await Promise.resolve();
 }
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -66,6 +66,7 @@ export type ChatHost = ChatInputHistoryState & {
   chatModelCatalog: ModelCatalogEntry[];
   sessionsResult?: SessionsListResult | null;
   updateComplete?: Promise<unknown>;
+  requestUpdate?: () => void;
   refreshSessionsAfterChat: Set<string>;
   pendingAbort?: { runId?: string | null; sessionKey: string } | null;
   chatSubmitGuards?: Map<string, Promise<void>>;
@@ -746,7 +747,14 @@ function injectCommandResult(host: ChatHost, content: string) {
 }
 
 export async function refreshChat(host: ChatHost, opts?: { scheduleScroll?: boolean }) {
-  void Promise.allSettled([
+  const requestUpdate = () => host.requestUpdate?.();
+  const historyRefresh = loadChatHistory(host as unknown as ChatState).finally(() => {
+    if (opts?.scheduleScroll !== false) {
+      scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0]);
+    }
+    requestUpdate();
+  });
+  const secondaryRefresh = Promise.allSettled([
     loadSessions(host as unknown as SessionsState, {
       activeMinutes: 0,
       limit: 0,
@@ -756,11 +764,10 @@ export async function refreshChat(host: ChatHost, opts?: { scheduleScroll?: bool
     refreshChatAvatar(host),
     refreshChatModels(host),
     refreshChatCommands(host),
-  ]);
-  await loadChatHistory(host as unknown as ChatState);
-  if (opts?.scheduleScroll !== false) {
-    scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0]);
-  }
+  ]).finally(requestUpdate);
+  void historyRefresh;
+  void secondaryRefresh;
+  await Promise.resolve();
 }
 
 async function refreshChatModels(host: ChatHost) {

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -37,6 +37,7 @@ vi.mock("./controllers/sessions.ts", () => ({
 import {
   createChatSession,
   dismissChatError,
+  handleChatManualRefresh,
   isCronSessionKey,
   parseSessionKey,
   resolveAssistantAttachmentAuthToken,
@@ -644,6 +645,57 @@ describe("resolveSessionOptionGroups", () => {
     });
 
     expect(labels).toEqual(["Beta main"]);
+  });
+});
+
+describe("handleChatManualRefresh", () => {
+  it("waits for chat history before scrolling and clearing refresh state", async () => {
+    let animationFrameCallback: FrameRequestCallback | null = null;
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    Object.defineProperty(globalThis, "requestAnimationFrame", {
+      configurable: true,
+      value: vi.fn((callback: FrameRequestCallback) => {
+        animationFrameCallback = callback;
+        return 1;
+      }),
+    });
+    let resolveRefresh!: () => void;
+    refreshChatMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveRefresh = resolve;
+      }),
+    );
+    const state = {
+      chatManualRefreshInFlight: false,
+      chatNewMessagesBelow: true,
+      updateComplete: Promise.resolve(),
+      resetToolStream: vi.fn(),
+      scrollToBottom: vi.fn(),
+    } as unknown as Parameters<typeof handleChatManualRefresh>[0];
+
+    const run = handleChatManualRefresh(state);
+    await Promise.resolve();
+
+    expect(state.scrollToBottom).not.toHaveBeenCalled();
+    resolveRefresh();
+    await run;
+
+    expect(refreshChatMock).toHaveBeenCalledWith(state, {
+      awaitHistory: true,
+      scheduleScroll: false,
+    });
+    expect(state.scrollToBottom).toHaveBeenCalledWith({ smooth: true });
+    expect(state.chatManualRefreshInFlight).toBe(true);
+    expect(animationFrameCallback).toBeTypeOf("function");
+
+    animationFrameCallback?.(0);
+
+    expect(state.chatManualRefreshInFlight).toBe(false);
+    expect(state.chatNewMessagesBelow).toBe(false);
+    Object.defineProperty(globalThis, "requestAnimationFrame", {
+      configurable: true,
+      value: previousRequestAnimationFrame,
+    });
   });
 });
 

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -650,52 +650,59 @@ describe("resolveSessionOptionGroups", () => {
 
 describe("handleChatManualRefresh", () => {
   it("waits for chat history before scrolling and clearing refresh state", async () => {
-    let animationFrameCallback: FrameRequestCallback | null = null;
+    const animationFrame = { callback: undefined as FrameRequestCallback | undefined };
     const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
     Object.defineProperty(globalThis, "requestAnimationFrame", {
       configurable: true,
       value: vi.fn((callback: FrameRequestCallback) => {
-        animationFrameCallback = callback;
+        animationFrame.callback = callback;
         return 1;
       }),
     });
-    let resolveRefresh!: () => void;
-    refreshChatMock.mockReturnValueOnce(
-      new Promise<void>((resolve) => {
-        resolveRefresh = resolve;
-      }),
-    );
-    const state = {
-      chatManualRefreshInFlight: false,
-      chatNewMessagesBelow: true,
-      updateComplete: Promise.resolve(),
-      resetToolStream: vi.fn(),
-      scrollToBottom: vi.fn(),
-    } as unknown as Parameters<typeof handleChatManualRefresh>[0];
+    try {
+      let resolveRefresh!: () => void;
+      refreshChatMock.mockReturnValueOnce(
+        new Promise<void>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+      );
+      const state = {
+        chatManualRefreshInFlight: false,
+        chatNewMessagesBelow: true,
+        updateComplete: Promise.resolve(),
+        resetToolStream: vi.fn(),
+        scrollToBottom: vi.fn(),
+      } as unknown as Parameters<typeof handleChatManualRefresh>[0];
 
-    const run = handleChatManualRefresh(state);
-    await Promise.resolve();
+      const run = handleChatManualRefresh(state);
+      await Promise.resolve();
 
-    expect(state.scrollToBottom).not.toHaveBeenCalled();
-    resolveRefresh();
-    await run;
+      expect(state.scrollToBottom).not.toHaveBeenCalled();
+      resolveRefresh();
+      await run;
 
-    expect(refreshChatMock).toHaveBeenCalledWith(state, {
-      awaitHistory: true,
-      scheduleScroll: false,
-    });
-    expect(state.scrollToBottom).toHaveBeenCalledWith({ smooth: true });
-    expect(state.chatManualRefreshInFlight).toBe(true);
-    expect(animationFrameCallback).toBeTypeOf("function");
+      expect(refreshChatMock).toHaveBeenCalledWith(state, {
+        awaitHistory: true,
+        scheduleScroll: false,
+      });
+      expect(state.scrollToBottom).toHaveBeenCalledWith({ smooth: true });
+      expect(state.chatManualRefreshInFlight).toBe(true);
+      expect(animationFrame.callback).toBeTypeOf("function");
 
-    animationFrameCallback?.(0);
+      const callback = animationFrame.callback;
+      if (!callback) {
+        throw new Error("expected manual refresh to schedule a frame callback");
+      }
+      callback(0);
 
-    expect(state.chatManualRefreshInFlight).toBe(false);
-    expect(state.chatNewMessagesBelow).toBe(false);
-    Object.defineProperty(globalThis, "requestAnimationFrame", {
-      configurable: true,
-      value: previousRequestAnimationFrame,
-    });
+      expect(state.chatManualRefreshInFlight).toBe(false);
+      expect(state.chatNewMessagesBelow).toBe(false);
+    } finally {
+      Object.defineProperty(globalThis, "requestAnimationFrame", {
+        configurable: true,
+        value: previousRequestAnimationFrame,
+      });
+    }
   });
 });
 

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -49,6 +49,25 @@ type ChatRefreshHost = AppViewState & {
   updateComplete?: Promise<unknown>;
 };
 
+export async function handleChatManualRefresh(state: ChatRefreshHost): Promise<void> {
+  state.chatManualRefreshInFlight = true;
+  state.chatNewMessagesBelow = false;
+  await state.updateComplete;
+  state.resetToolStream();
+  try {
+    await refreshChat(state as unknown as Parameters<typeof refreshChat>[0], {
+      awaitHistory: true,
+      scheduleScroll: false,
+    });
+    state.scrollToBottom({ smooth: true });
+  } finally {
+    requestAnimationFrame(() => {
+      state.chatManualRefreshInFlight = false;
+      state.chatNewMessagesBelow = false;
+    });
+  }
+}
+
 export function resolveAssistantAttachmentAuthToken(
   state: Pick<AppViewState, "hello" | "settings" | "password">,
 ) {
@@ -315,24 +334,7 @@ export function renderChatControls(state: AppViewState) {
       <button
         class="btn btn--sm btn--icon"
         ?disabled=${refreshDisabled}
-        @click=${async () => {
-          const app = state as unknown as ChatRefreshHost;
-          app.chatManualRefreshInFlight = true;
-          app.chatNewMessagesBelow = false;
-          await app.updateComplete;
-          app.resetToolStream();
-          try {
-            await refreshChat(state as unknown as Parameters<typeof refreshChat>[0], {
-              scheduleScroll: false,
-            });
-            app.scrollToBottom({ smooth: true });
-          } finally {
-            requestAnimationFrame(() => {
-              app.chatManualRefreshInFlight = false;
-              app.chatNewMessagesBelow = false;
-            });
-          }
-        }}
+        @click=${() => handleChatManualRefresh(state as unknown as ChatRefreshHost)}
         title=${refreshLabel}
         aria-label=${refreshLabel}
         data-tooltip=${refreshLabel}

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2458,7 +2458,7 @@ export function renderApp(state: AppViewState) {
                   onRefresh: () => {
                     state.chatSideResult = null;
                     state.resetToolStream();
-                    return refreshChat(state, { scheduleScroll: false });
+                    return refreshChat(state, { awaitHistory: true, scheduleScroll: false });
                   },
                   onToggleFocusMode: () => {
                     if (state.onboarding) {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -981,7 +981,9 @@ export function renderApp(state: AppViewState) {
       "config",
       {
         tab: state.tab,
+        formMode: overrides.formMode,
         activeSection: overrides.activeSection,
+        activeSubsection: overrides.activeSubsection,
         schemaSectionCount: countTopLevelSchemaProperties(commonConfigProps.schema),
         hasSearch: Boolean(overrides.searchQuery?.trim()),
       },

--- a/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
+++ b/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
@@ -244,7 +244,12 @@ describe("refreshActiveTab", () => {
   it("does not wait for config schema before resolving config tab refresh", async () => {
     const host = createHost();
     host.tab = "config";
-    mocks.loadConfigSchemaMock.mockReturnValueOnce(new Promise<void>(() => undefined));
+    let resolveSchema!: () => void;
+    mocks.loadConfigSchemaMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveSchema = resolve;
+      }),
+    );
 
     const refresh = refreshActiveTab(host as never);
     const outcome = await Promise.race([
@@ -255,15 +260,30 @@ describe("refreshActiveTab", () => {
     expect(outcome).toBe("resolved");
     expect(mocks.loadConfigSchemaMock).toHaveBeenCalledOnce();
     expect(mocks.loadConfigMock).toHaveBeenCalledOnce();
+    expect(host.requestUpdate).not.toHaveBeenCalled();
+
+    resolveSchema();
+
+    await vi.waitFor(() => {
+      expect(host.requestUpdate).toHaveBeenCalledOnce();
+    });
   });
 
   it("renders channels from the cheap snapshot before starting slow probes", async () => {
     const host = createHost();
     host.tab = "channels";
-    mocks.loadConfigSchemaMock.mockReturnValueOnce(new Promise<void>(() => undefined));
+    let resolveSchema!: () => void;
+    let resolveProbe!: () => void;
+    mocks.loadConfigSchemaMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveSchema = resolve;
+      }),
+    );
     mocks.loadChannelsMock.mockImplementation(async (_host, probe) => {
       if (probe) {
-        await new Promise<void>(() => undefined);
+        await new Promise<void>((resolve) => {
+          resolveProbe = resolve;
+        });
       }
     });
 
@@ -276,6 +296,14 @@ describe("refreshActiveTab", () => {
     expect(outcome).toBe("resolved");
     expect(mocks.loadChannelsMock.mock.calls.map(([, probe]) => probe)).toEqual([false, true]);
     expect(mocks.loadConfigMock).toHaveBeenCalledOnce();
+    expect(host.requestUpdate).not.toHaveBeenCalled();
+
+    resolveSchema();
+    resolveProbe();
+
+    await vi.waitFor(() => {
+      expect(host.requestUpdate).toHaveBeenCalledTimes(2);
+    });
   });
 
   it("records overview secondary refresh duration and aggregate status", async () => {

--- a/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
+++ b/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
   loadAgentIdentityMock: vi.fn(async () => {}),
   loadAgentSkillsMock: vi.fn(async () => {}),
   loadAgentsMock: vi.fn(async () => {}),
-  loadChannelsMock: vi.fn(async () => {}),
+  loadChannelsMock: vi.fn<(_host: unknown, _probe: boolean) => Promise<void>>(async () => {}),
   loadConfigMock: vi.fn(async () => {}),
   loadConfigSchemaMock: vi.fn(async () => {}),
   loadCronStatusMock: vi.fn(async () => {}),
@@ -239,6 +239,43 @@ describe("refreshActiveTab", () => {
     expect(mocks.loadChannelsMock).toHaveBeenCalled();
     expect(mocks.loadSessionsMock).toHaveBeenCalled();
     expect(mocks.loadUsageMock).toHaveBeenCalled();
+  });
+
+  it("does not wait for config schema before resolving config tab refresh", async () => {
+    const host = createHost();
+    host.tab = "config";
+    mocks.loadConfigSchemaMock.mockReturnValueOnce(new Promise<void>(() => undefined));
+
+    const refresh = refreshActiveTab(host as never);
+    const outcome = await Promise.race([
+      refresh.then(() => "resolved" as const),
+      new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 0)),
+    ]);
+
+    expect(outcome).toBe("resolved");
+    expect(mocks.loadConfigSchemaMock).toHaveBeenCalledOnce();
+    expect(mocks.loadConfigMock).toHaveBeenCalledOnce();
+  });
+
+  it("renders channels from the cheap snapshot before starting slow probes", async () => {
+    const host = createHost();
+    host.tab = "channels";
+    mocks.loadConfigSchemaMock.mockReturnValueOnce(new Promise<void>(() => undefined));
+    mocks.loadChannelsMock.mockImplementation(async (_host, probe) => {
+      if (probe) {
+        await new Promise<void>(() => undefined);
+      }
+    });
+
+    const refresh = refreshActiveTab(host as never);
+    const outcome = await Promise.race([
+      refresh.then(() => "resolved" as const),
+      new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 0)),
+    ]);
+
+    expect(outcome).toBe("resolved");
+    expect(mocks.loadChannelsMock.mock.calls.map(([, probe]) => probe)).toEqual([false, true]);
+    expect(mocks.loadConfigMock).toHaveBeenCalledOnce();
   });
 
   it("records overview secondary refresh duration and aggregate status", async () => {

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -357,7 +357,7 @@ export async function refreshActiveTab(host: SettingsHost) {
       case "automation":
       case "infrastructure":
       case "aiAgents":
-        await loadConfigSchema(app);
+        void loadConfigSchema(app).finally(() => host.requestUpdate?.());
         await loadConfig(app);
         break;
       case "overview":
@@ -837,11 +837,9 @@ function buildAttentionItems(host: SettingsAppHost) {
 
 export async function loadChannelsTab(host: SettingsHost) {
   const app = host as unknown as SettingsAppHost;
-  await Promise.all([
-    loadChannels(app, true, { softTimeoutMs: 750 }),
-    loadConfigSchema(app),
-    loadConfig(app),
-  ]);
+  void loadConfigSchema(app).finally(() => host.requestUpdate?.());
+  await Promise.all([loadChannels(app, false), loadConfig(app)]);
+  void loadChannels(app, true).finally(() => host.requestUpdate?.());
 }
 
 export async function loadCron(host: SettingsHost) {

--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -151,6 +151,39 @@ describe("buildChatItems", () => {
     expect(items).toEqual([]);
   });
 
+  it("renders only the last 100 history messages and shows a hidden-count notice", () => {
+    const items = buildChatItems(
+      createProps({
+        messages: Array.from({ length: 105 }, (_, index) => ({
+          role: index % 2 === 0 ? "user" : "assistant",
+          content: `message ${index}`,
+          timestamp: index,
+        })),
+      }),
+    );
+
+    const groups = items.filter((item) => item.kind === "group");
+
+    expect(items[0]).toMatchObject({
+      kind: "group",
+      messages: [
+        expect.objectContaining({
+          message: expect.objectContaining({
+            role: "system",
+            content: "Showing last 100 messages (5 hidden).",
+          }),
+        }),
+      ],
+    });
+    expect(groups).toHaveLength(101);
+    expect(groups[1].messages[0].message).toMatchObject({
+      content: "message 5",
+    });
+    expect(groups.at(-1)?.messages[0].message).toMatchObject({
+      content: "message 104",
+    });
+  });
+
   it("does not collapse duplicate text messages separated by another message", () => {
     const groups = messageGroups({
       messages: [

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -3,13 +3,12 @@ import {
   isAssistantHeartbeatAckForDisplay,
   stripHeartbeatTokenForDisplay,
 } from "./heartbeat-display.ts";
+import { CHAT_HISTORY_RENDER_LIMIT } from "./history-limits.ts";
 import { extractTextCached } from "./message-extract.ts";
 import { normalizeMessage } from "./message-normalizer.ts";
 import { normalizeRoleForGrouping } from "./role-normalizer.ts";
 import { messageMatchesSearchQuery } from "./search-match.ts";
 import { extractToolCards, extractToolPreview } from "./tool-cards.ts";
-
-const CHAT_HISTORY_RENDER_LIMIT = 200;
 
 export type BuildChatItemsProps = {
   sessionKey: string;

--- a/ui/src/ui/chat/history-limits.ts
+++ b/ui/src/ui/chat/history-limits.ts
@@ -1,1 +1,1 @@
-export const CHAT_HISTORY_RENDER_LIMIT = 200;
+export const CHAT_HISTORY_RENDER_LIMIT = 100;


### PR DESCRIPTION
## Summary

- Decouple Control UI chat refresh so slow history, sessions, avatar, model, or command RPCs do not block the operator surface.
- Load config/schema and channel status in smaller steps so config-heavy tabs and channel probes can render stale/partial state before slow work finishes.
- Align the chat render window with the bounded history request and keep render timing visible through the existing Control UI performance log.

Refs #77060, #45698, #47979, #44107.

## Verification

- `pnpm test ui/src/ui/app-chat.test.ts ui/src/ui/app-settings.refresh-active-tab.node.test.ts ui/src/ui/control-ui-performance.test.ts ui/src/ui/controllers/chat.test.ts`
- `pnpm exec oxfmt --check --threads=1 ui/src/ui/app-chat.ts ui/src/ui/app-chat.test.ts ui/src/ui/app-settings.ts ui/src/ui/app-settings.refresh-active-tab.node.test.ts ui/src/ui/app-render.ts ui/src/ui/chat/build-chat-items.ts ui/src/ui/chat/history-limits.ts`
- `git diff --check origin/main..HEAD`

## Notes

- Testbox was attempted before rebasing, but install was blocked by pnpm `minimumReleaseAge` for `@anthropic-ai/sdk`.
- After rebasing onto current `origin/main`, `OPENCLAW_LOCAL_CHECK=1 pnpm check:changed` reaches core typecheck and fails on existing unrelated strictness errors outside this PR (`packages/memory-host-sdk`, `src/agents`, `src/infra`, `src/media`, `src/plugins`, etc.). The focused UI tests above pass.
- Draft until the remote/main typecheck situation is clean enough to rerun the full changed gate on this branch.
