### PR TITLE
[codex] Fix Telegram model status Codex auth label

### DIFF
--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -3,7 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const authProfilesStoreMock = vi.hoisted(() => ({
-  profiles: {} as Record<string, { type: "api_key"; provider: string; key: string }>,
+  profiles: {} as Record<
+    string,
+    | { type: "api_key"; provider: string; key: string }
+    | { type: "oauth"; provider: string; access: string; refresh: string; expires: number }
+  >,
 }));
 
 vi.mock("../../agents/auth-profiles.js", () => ({
@@ -25,7 +29,7 @@ vi.mock("../../agents/auth-profiles.js", () => ({
       .map(([profileId, profile]) => ({ profileId, profile })),
   replaceRuntimeAuthProfileStoreSnapshots: (
     snapshots: Array<{
-      store?: { profiles?: Record<string, { type: "api_key"; provider: string; key: string }> };
+      store?: { profiles?: Record<string, AuthProfileForTest> };
     }>,
   ) => {
     authProfilesStoreMock.profiles = snapshots[0]?.store?.profiles ?? {};
@@ -55,7 +59,7 @@ vi.mock("../../agents/auth-profiles/store.js", () => {
     loadAuthProfileStoreWithoutExternalProfiles: store,
     replaceRuntimeAuthProfileStoreSnapshots: (
       snapshots: Array<{
-        store?: { profiles?: Record<string, { type: "api_key"; provider: string; key: string }> };
+        store?: { profiles?: Record<string, AuthProfileForTest> };
       }>,
     ) => {
       authProfilesStoreMock.profiles = snapshots[0]?.store?.profiles ?? {};
@@ -132,11 +136,13 @@ const queueMocks = vi.hoisted(() => ({
 
 // Mock dependencies for directive handling persistence.
 vi.mock("../../agents/agent-scope.js", () => ({
+  listAgentEntries: () => [],
   resolveAgentConfig: vi.fn(() => ({})),
   resolveAgentDir: vi.fn(() => "/tmp/agent"),
   resolveAgentEffectiveModelPrimary: vi.fn(() => undefined),
   resolveAgentModelFallbacksOverride: vi.fn(() => undefined),
   resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
+  resolveSessionAgentIds: () => ({ sessionAgentId: "main" }),
   resolveSessionAgentId: vi.fn(() => "main"),
 }));
 
@@ -173,6 +179,14 @@ const TEST_AGENT_DIR = "/tmp/agent";
 const OPENAI_DATE_PROFILE_ID = "20251001";
 
 type ApiKeyProfile = { type: "api_key"; provider: string; key: string };
+type OAuthProfileForTest = {
+  type: "oauth";
+  provider: string;
+  access: string;
+  refresh: string;
+  expires: number;
+};
+type AuthProfileForTest = ApiKeyProfile | OAuthProfileForTest;
 
 function baseAliasIndex(): ModelAliasIndex {
   return { byAlias: new Map(), byKey: new Map() };
@@ -224,7 +238,7 @@ afterEach(() => {
   clearRuntimeAuthProfileStoreSnapshots();
 });
 
-function setAuthProfiles(profiles: Record<string, ApiKeyProfile>) {
+function setAuthProfiles(profiles: Record<string, AuthProfileForTest>) {
   replaceRuntimeAuthProfileStoreSnapshots([
     {
       agentDir: TEST_AGENT_DIR,
@@ -501,6 +515,124 @@ describe("/model chat UX", () => {
     expect(reply?.text).not.toContain("claude-sonnet-4-1");
     expect(reply?.text).toContain("auth:");
     expect(reply?.text).not.toContain("missing (missing)");
+  });
+
+  it("reports Codex runtime auth for OpenAI status rows", async () => {
+    setAuthProfiles({
+      "openai-codex:patrick@example.test": {
+        type: "oauth",
+        provider: "openai-codex",
+        access: "access-token",
+        refresh: "refresh-token",
+        expires: Date.now() + 60_000,
+      },
+    });
+
+    const reply = await resolveModelInfoReply({
+      directives: parseInlineDirectives("/model status"),
+      provider: "openai",
+      model: "gpt-5.5",
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      cfg: {
+        commands: { text: true },
+        agents: {
+          defaults: {
+            agentRuntime: { id: "codex" },
+            model: { primary: "openai/gpt-5.5" },
+            models: {
+              "codex/gpt-5.5": {},
+              "openai/gpt-5.5": {},
+            },
+          },
+        },
+      } as OpenClawConfig,
+      allowedModelCatalog: [{ provider: "openai", id: "gpt-5.5", name: "GPT-5.5" }],
+    });
+
+    expect(reply?.text).toContain("[openai] endpoint: default auth:");
+    expect(reply?.text).not.toContain("[openai] endpoint: default auth: missing");
+    expect(reply?.text).toContain("via codex runtime / openai-codex");
+    expect(reply?.text).toContain("openai-codex:patrick@example.test=OAuth");
+  });
+
+  it("keeps direct provider auth labels when OpenAI API key auth exists", async () => {
+    setAuthProfiles({
+      "openai:api-key": {
+        type: "api_key",
+        provider: "openai",
+        key: "sk-openai-direct",
+      },
+      "openai-codex:patrick@example.test": {
+        type: "oauth",
+        provider: "openai-codex",
+        access: "access-token",
+        refresh: "refresh-token",
+        expires: Date.now() + 60_000,
+      },
+    });
+
+    const reply = await resolveModelInfoReply({
+      directives: parseInlineDirectives("/model status"),
+      provider: "openai",
+      model: "gpt-5.5",
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      cfg: {
+        commands: { text: true },
+        agents: {
+          defaults: {
+            agentRuntime: { id: "codex" },
+            model: { primary: "openai/gpt-5.5" },
+            models: {
+              "openai/gpt-5.5": {},
+            },
+          },
+        },
+      } as OpenClawConfig,
+      allowedModelCatalog: [{ provider: "openai", id: "gpt-5.5", name: "GPT-5.5" }],
+    });
+
+    expect(reply?.text).toContain("[openai] endpoint: default auth:");
+    expect(reply?.text).toContain("openai:api-key=");
+    expect(reply?.text).not.toContain("via codex runtime");
+  });
+
+  it("does not borrow Codex auth when OpenAI is pinned to PI runtime", async () => {
+    setAuthProfiles({
+      "openai-codex:patrick@example.test": {
+        type: "oauth",
+        provider: "openai-codex",
+        access: "access-token",
+        refresh: "refresh-token",
+        expires: Date.now() + 60_000,
+      },
+    });
+
+    const reply = await resolveModelInfoReply({
+      directives: parseInlineDirectives("/model status"),
+      provider: "openai",
+      model: "gpt-5.5",
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      cfg: {
+        commands: { text: true },
+        agents: {
+          defaults: {
+            agentRuntime: { id: "pi" },
+            model: { primary: "openai/gpt-5.5" },
+            models: {
+              "openai/gpt-5.5": {},
+            },
+          },
+        },
+      } as OpenClawConfig,
+      allowedModelCatalog: [{ provider: "openai", id: "gpt-5.5", name: "GPT-5.5" }],
+    });
+
+    expect(reply?.text).toContain("[openai] endpoint: default auth: missing");
+    expect(reply?.text).not.toContain("via codex runtime");
+    expect(reply?.text).not.toContain("openai-codex:patrick@example.test=OAuth");
   });
 
   it("uses workspace-scoped auth evidence in /model status labels", async () => {

--- a/src/auto-reply/reply/directive-handling.model.ts
+++ b/src/auto-reply/reply/directive-handling.model.ts
@@ -1,4 +1,5 @@
 import { resolveAuthStorePathForDisplay } from "../../agents/auth-profiles.js";
+import { resolveAgentHarnessPolicy } from "../../agents/harness/selection.js";
 import {
   type ModelAliasIndex,
   modelKey,
@@ -6,6 +7,7 @@ import {
   resolveConfiguredModelRef,
   resolveModelRefFromString,
 } from "../../agents/model-selection.js";
+import { buildAgentRuntimeAuthPlan } from "../../agents/runtime-plan/auth.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -28,6 +30,81 @@ import {
 } from "./directive-handling.model-picker.js";
 export { resolveModelSelectionFromDirective } from "./directive-handling.model-selection.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
+
+function isMissingAuthLabel(auth: { label: string; source: string }): boolean {
+  return auth.label === "missing" && auth.source === "missing";
+}
+
+function resolveStatusHarnessRuntime(params: {
+  sessionEntry?: Pick<SessionEntry, "agentHarnessId" | "agentRuntimeOverride">;
+  defaultRuntime: string;
+}): string {
+  const sessionRuntime = normalizeOptionalString(
+    params.sessionEntry?.agentRuntimeOverride ?? params.sessionEntry?.agentHarnessId,
+  );
+  return sessionRuntime && sessionRuntime !== "auto" && sessionRuntime !== "default"
+    ? sessionRuntime
+    : params.defaultRuntime;
+}
+
+async function resolveStatusAuthLabel(params: {
+  provider: string;
+  modelId: string;
+  cfg: OpenClawConfig;
+  modelsPath: string;
+  agentDir: string;
+  activeAgentId: string;
+  authMode: ModelAuthDetailMode;
+  workspaceDir?: string;
+  sessionEntry?: Pick<SessionEntry, "agentHarnessId" | "agentRuntimeOverride">;
+}): Promise<string> {
+  const auth = await resolveAuthLabel(
+    params.provider,
+    params.cfg,
+    params.modelsPath,
+    params.agentDir,
+    params.authMode,
+    params.workspaceDir,
+  );
+  if (!isMissingAuthLabel(auth)) {
+    return formatAuthLabel(auth);
+  }
+
+  const provider = normalizeProviderId(params.provider);
+  const harnessPolicy = resolveAgentHarnessPolicy({
+    provider,
+    modelId: params.modelId,
+    config: params.cfg,
+    agentId: params.activeAgentId,
+  });
+  const harnessRuntime = resolveStatusHarnessRuntime({
+    sessionEntry: params.sessionEntry,
+    defaultRuntime: harnessPolicy.runtime,
+  });
+  const runtimeAuthPlan = buildAgentRuntimeAuthPlan({
+    provider,
+    config: params.cfg,
+    workspaceDir: params.workspaceDir,
+    harnessRuntime,
+  });
+  const effectiveAuthProvider = runtimeAuthPlan.harnessAuthProvider;
+  if (!effectiveAuthProvider || effectiveAuthProvider === provider) {
+    return formatAuthLabel(auth);
+  }
+
+  const runtimeAuth = await resolveAuthLabel(
+    effectiveAuthProvider,
+    params.cfg,
+    params.modelsPath,
+    params.agentDir,
+    params.authMode,
+    params.workspaceDir,
+  );
+  if (isMissingAuthLabel(runtimeAuth)) {
+    return formatAuthLabel(auth);
+  }
+  return `via ${harnessRuntime} runtime / ${effectiveAuthProvider} ${formatAuthLabel(runtimeAuth)}`;
+}
 
 function pushUniqueCatalogEntry(params: {
   keys: Set<string>;
@@ -204,7 +281,8 @@ export async function maybeHandleModelDirectiveInfo(params: {
   resetModelOverride: boolean;
   workspaceDir?: string;
   surface?: string;
-  sessionEntry?: Pick<SessionEntry, "modelProvider" | "model">;
+  sessionEntry?: Pick<SessionEntry, "modelProvider" | "model"> &
+    Partial<Pick<SessionEntry, "agentHarnessId" | "agentRuntimeOverride">>;
 }): Promise<ReplyPayload | undefined> {
   if (!params.directives.hasModelDirective) {
     return undefined;
@@ -302,15 +380,18 @@ export async function maybeHandleModelDirectiveInfo(params: {
     if (authByProvider.has(provider)) {
       continue;
     }
-    const auth = await resolveAuthLabel(
+    const authLabel = await resolveStatusAuthLabel({
       provider,
-      params.cfg,
+      modelId: entry.id,
+      cfg: params.cfg,
       modelsPath,
-      params.agentDir,
+      agentDir: params.agentDir,
+      activeAgentId: params.activeAgentId,
       authMode,
-      params.workspaceDir,
-    );
-    authByProvider.set(provider, formatAuthLabel(auth));
+      workspaceDir: params.workspaceDir,
+      sessionEntry: params.sessionEntry,
+    });
+    authByProvider.set(provider, authLabel);
   }
 
   const modelRefs = resolveSelectedAndActiveModel({


### PR DESCRIPTION
Fixes #79133

## Summary

- make Telegram `/model status` derive effective auth from the shared agent harness/runtime auth plan before formatting provider rows
- preserve direct provider auth labels when API-key, env, custom, or workspace-scoped auth exists
- add regressions for Codex runtime OAuth, direct OpenAI API-key auth, and PI runtime not borrowing Codex auth

## Root cause

Telegram `/model status` is a read model, but it recomputed auth availability from the literal picker provider instead of using the runtime auth plan that execution uses. For `agentRuntime.id = codex` and `openai/gpt-5.5`, execution authenticates through the Codex harness auth provider (`openai-codex`), while the status row checked only direct `openai` auth and printed `missing`.

## Fix

The status row still asks `resolveAuthLabel(provider, ...)` first and returns direct provider auth unchanged. Only when that direct label is missing does it resolve the effective harness policy and call `buildAgentRuntimeAuthPlan(...)`; if the plan exposes a distinct `harnessAuthProvider`, the row formats that provider's auth as the effective runtime auth.

## Expected output examples

Codex runtime with OpenAI model and `openai-codex` OAuth, no direct OpenAI API key:

```text
Current: openai/gpt-5.5
Default: openai/gpt-5.5
[openai] endpoint: default auth: via codex runtime / openai-codex openai-codex:patrick@example.test=OAuth
  • openai/gpt-5.5
```

Direct OpenAI API-key auth present:

```text
Current: openai/gpt-5.5
Default: openai/gpt-5.5
[openai] endpoint: default auth: openai:api-key=sk...ct
  • openai/gpt-5.5
```

PI runtime pinned with only `openai-codex` OAuth and no direct OpenAI auth:

```text
Current: openai/gpt-5.5
Default: openai/gpt-5.5
[openai] endpoint: default auth: missing
  • openai/gpt-5.5
```

## Validation

- Temp local state: `HOME=/tmp/.../home OPENCLAW_STATE_DIR=/tmp/.../state OPENCLAW_CONFIG_DIR=/tmp/.../config CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 pnpm test src/auto-reply/reply/directive-handling.model.test.ts`
- `pnpm test src/auto-reply/reply/directive-handling.model.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/directive-handling.model.ts src/auto-reply/reply/directive-handling.model.test.ts`
- `pnpm exec oxlint src/auto-reply/reply/directive-handling.model.ts src/auto-reply/reply/directive-handling.model.test.ts`
- `pnpm tsgo:core:test`
- Crabbox Blacksmith Testbox `tbx_01kr2dp0d58zsx15vg9h448wd8`: `env CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 pnpm test src/auto-reply/reply/directive-handling.model.test.ts`