### PR TITLE
fix(infra/net): prefer bundled undici 8 fetch in fetchWithSsrFGuard to fix dispatcher mismatch on Node 25+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Agents/failover: harden state-aware lane suspension by persisting quota resume transitions, restoring configured lane concurrency, preserving non-quota failure reasons, and exporting model failover events through diagnostics OTLP. Thanks @BunsDev.
+- Infra/net: fix `fetchWithSsrFGuard` falling back to `globalThis.fetch` (built-in undici ~7.x on Node 25+) when no explicit `fetchImpl` is supplied, which caused dispatchers from the bundled undici 8.x to be rejected with `TypeError: fetch failed` during private-IP fetches such as `memory_search` Ollama embeddings. Now prefers the bundled undici 8.x `fetch` over the built-in global, while still honoring `globalThis.fetch` when it is replaced by a test mock. (#79132) Thanks @colmbrogan.
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: include a bounded one-line STT transcript preview in verbose voice logs so live voice debugging shows what speakers said before the agent reply.

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -27,6 +27,7 @@ import {
   createHttp1Agent,
   createHttp1EnvHttpProxyAgent,
   createHttp1ProxyAgent,
+  loadUndiciRuntimeDeps,
 } from "./undici-runtime.js";
 
 function resolveDispatcherTimeoutMs(fromParams: number | undefined): number | undefined {
@@ -342,7 +343,13 @@ function rewriteRedirectInitForCrossOrigin(params: {
 export { fetchWithRuntimeDispatcher } from "./runtime-fetch.js";
 
 export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<GuardedFetchResult> {
-  const defaultFetch: FetchLike | undefined = params.fetchImpl ?? globalThis.fetch;
+  // When tests mock globalThis.fetch, honour the mock so test stubs are observed.
+  // Otherwise prefer the bundled undici fetch: on Node 25+ globalThis.fetch resolves
+  // to built-in undici ~7.x which rejects undici 8.x dispatchers (#79132).
+  const bundledOrGlobal: FetchLike | undefined = isMockedFetch(globalThis.fetch)
+    ? (globalThis.fetch as unknown as FetchLike)
+    : ((loadUndiciRuntimeDeps().fetch as unknown as FetchLike) ?? globalThis.fetch);
+  const defaultFetch: FetchLike | undefined = params.fetchImpl ?? bundledOrGlobal;
   if (!defaultFetch) {
     throw new Error("fetch is not available");
   }


### PR DESCRIPTION
## Problem

`fetchWithSsrFGuard` falls back to `globalThis.fetch` when no `fetchImpl` is supplied:

```ts
// src/infra/net/fetch-guard.ts:345 (before fix)
const defaultFetch = params.fetchImpl ?? globalThis.fetch;
```

On Node 25, `globalThis.fetch` is the **built-in** undici ~7.x. When `createPinnedDispatcher` constructs an undici 8.x `Agent` (the bundled version) and passes it as a `dispatcher` in `RequestInit`, the built-in fetch rejects it:

```
TypeError: fetch failed
  cause: TypeError: Expected an instance of Dispatcher
```

This hits any private-IP fetch that goes through `fetchWithSsrFGuard` without a caller-provided `fetchImpl` — notably `memory_search` Ollama embedding calls in gateway deployments running as a macOS LaunchDaemon on Node 25 / aarch64. Public-IP calls (Telegram, OpenRouter) bypass the SSRF guard path and are unaffected.

Reported in #79132; originally acknowledged in #46685 as Bug 2 but not addressed before that issue was closed.

Closes #79132.

## Fix

Resolve the bundled undici 8.x `fetch` via `loadUndiciRuntimeDeps()` as the preferred fallback:

```diff
-const defaultFetch = params.fetchImpl ?? globalThis.fetch;
+const bundledOrGlobal = isMockedFetch(globalThis.fetch)
+  ? globalThis.fetch          // honour test mocks
+  : loadUndiciRuntimeDeps().fetch ?? globalThis.fetch;  // prefer bundled undici 8
+const defaultFetch = params.fetchImpl ?? bundledOrGlobal;
```

`isMockedFetch()` is already used in `runtime-fetch.ts` for the same purpose — it detects vitest spy stubs (`.mock` property) so test code that replaces `globalThis.fetch` with a mock continues to work.

## Real behavior proof

**Behavior or issue addressed:** `TypeError: fetch failed` from bundled undici 8.x dispatchers being passed to the built-in undici 7.x `globalThis.fetch`.

**Real environment tested:** DGX Spark, Node v22.16 (bundled undici is the same version mismatch path). Verified via `loadUndiciRuntimeDeps().fetch` returning the bundled undici 8.x fetch. Full Node 25 aarch64-darwin reproduction is the reporter's setup (#79132).

**Exact steps or command run after this patch:**
```bash
pnpm vitest run src/infra/net/fetch-guard.ssrf.test.ts
```

**Evidence after fix:**
```
Test Files  1 passed (1)
Tests  53 passed (53)
```
Includes the existing "uses mocked global fetch when tests stub it" regression test (line 372) which verifies `isMockedFetch()` guard is correct.

**Observed result after fix:** All 53 fetch-guard SSRF tests pass. The existing test that sets `TEST_UNDICI_RUNTIME_DEPS_KEY.fetch` to a throwing mock and `globalThis.fetch` to a recording mock confirms that mocked global fetch is still honoured in test contexts.

**What was not tested:** Live Node 25 / aarch64-darwin LaunchDaemon Ollama `memory_search` call (reporter's environment). The fix is a fallback resolution change with no network or dispatcher logic changes.