### PR TITLE
fix(telegram): suppress 'no extra answer' placeholder when reply is in flight (#78929)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,6 +286,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/pairing: preserve deliberately narrowed role-token scopes when approving device scope upgrades instead of regranting the whole approved baseline.
 - Telegram/ACP: keep chat-bound ACP replies durable by delivering final-only ACP output as final text instead of transient Telegram preview blocks. Thanks @shakkernerd.
 - Telegram: hydrate replied-to messages as a persisted nearest-first reply chain so agents can see observed parent text, media refs, captions, senders, timestamps, and nested replies instead of guessing from a shallow reply id.
+- Telegram: skip the rewritten silent-reply fallback when the dispatcher reports a final reply was queued in the same turn so a "No extra answer from me." filler cannot race ahead of the actual reply when lane delivery state never observes the send. Fixes #78929.
 - Gateway/watch: leave `OPENCLAW_TRACE_SYNC_IO` disabled by default in `pnpm gateway:watch:raw` so watch mode avoids noisy Node sync-I/O stack traces unless explicitly requested.
 - Codex app-server: close stdio stdin before force-killing the managed app-server, matching Codex single-client shutdown behavior and avoiding unsettled CLI exits after successful runs.
 - CLI/Codex: dispose registered agent harnesses during short-lived CLI shutdown so successful Codex-backed `agent --local` runs do not leave app-server child processes alive.

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -365,6 +365,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
     };
   }
 
+  function createDirectSessionPayload(): TelegramMessageContext["ctxPayload"] {
+    return {
+      SessionKey: "agent:test:telegram:direct:123",
+      ChatType: "direct",
+    } as TelegramMessageContext["ctxPayload"];
+  }
+
   function observeDeliveredReply(text: string): Promise<void> {
     return new Promise((resolve) => {
       deliverReplies.mockImplementation(async (params: { replies?: Array<{ text?: string }> }) => {
@@ -1643,5 +1650,42 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(generateTopicLabel).not.toHaveBeenCalled();
     expect(bot.api.editForumTopic).not.toHaveBeenCalled();
+  });
+
+  it("does not emit a silent-reply fallback when the dispatcher reports a queued final reply", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: true,
+      counts: { block: 0, final: 1, tool: 0 },
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      streamMode: "off",
+    });
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("emits a silent-reply fallback when no final reply was queued and nothing was delivered", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+      counts: { block: 0, final: 0, tool: 0 },
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      streamMode: "off",
+    });
+
+    expect(deliverReplies).toHaveBeenCalledTimes(1);
+    const replies = deliverReplies.mock.calls[0]?.[0]?.replies as
+      | Array<{ text?: string }>
+      | undefined;
+    expect(replies?.[0]?.text?.trim()).toBeTruthy();
+    expect(replies?.[0]?.text).not.toBe("NO_REPLY");
   });
 });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1543,7 +1543,8 @@ export const dispatchTelegramMessage = async ({
     !sentFallback &&
     !dispatchError &&
     !deliverySummary.delivered &&
-    !suppressSilentReplyFallback
+    !suppressSilentReplyFallback &&
+    !queuedFinal
   ) {
     const policySessionKey =
       ctxPayload.CommandSource === "native"
@@ -1573,7 +1574,8 @@ export const dispatchTelegramMessage = async ({
     });
   }
 
-  const hasFinalResponse = deliverySummary.delivered || sentFallback || suppressSilentReplyFallback;
+  const hasFinalResponse =
+    deliverySummary.delivered || sentFallback || suppressSilentReplyFallback || queuedFinal;
 
   if (statusReactionController && !hasFinalResponse) {
     void finalizeTelegramStatusReaction({ outcome: "error", hasFinalResponse: false }).catch(


### PR DESCRIPTION
## Summary

Closes #78929.

When a Telegram inbound turn ends without `deliveryState.markDelivered()` being recorded — but the reply dispatcher reports `queuedFinal=true` — the existing fallback path constructed a synthetic `NO_REPLY` payload and pushed it through `createOutboundPayloadPlan`, which rewrites it to `"No extra answer from me."` for direct sessions. That filler raced ahead of the real reply, producing the user-visible `"No extra answer from me."` message that arrives just before the actual answer.

This change adds `!queuedFinal` to the silent-reply fallback gate (alongside the existing `!sentFallback / !dispatchError / !deliverySummary.delivered / !suppressSilentReplyFallback` checks). When the dispatcher reports a final reply was queued and dispatched in this turn, we trust that signal and skip the rewritten silent-reply rewrite, mirroring the existing `suppressSilentReplyFallback` (`message_tool_only`) suppression. `queuedFinal` is also folded into `hasFinalResponse` so the status reaction outcome stays `done` rather than being misreported as `error`.

## Real behavior proof

- Behavior or issue addressed: Telegram should deliver the actual agent reply without a preceding `No extra answer from me.` placeholder when a final reply is already queued in the same turn.
- Real environment tested: Real Telegram bot-to-bot group using the PR head gateway (`646fabea6117a095a2659d5a72ccc796c805843e`) and a local OpenAI-compatible test server for deterministic model output.
- Exact steps or command run after this patch: `node ~/.codex/skills/custom/telegram-e2e-bot-to-bot/scripts/run-mock-sut-e2e.mjs --text '@{sut} Please answer with OPENCLAW_E2E_OK only. Do not send any extra answer placeholder.' --expect OPENCLAW_E2E_OK --timeout-ms 90000 --output /tmp/openclaw-pr-79142-telegram-e2e-proof-a9c1448.json`
- Evidence after fix: Copied live output from the Telegram bot-to-bot probe, with bot identifiers redacted:

```json
{
  "ok": true,
  "sent": {
    "messageId": 6022,
    "text": "@<sut-bot> Please answer with OPENCLAW_E2E_OK only. Do not send any extra answer placeholder."
  },
  "reply": {
    "messageId": 6023,
    "fromUsername": "<sut-bot>",
    "replyToMessageId": 6022,
    "text": "OPENCLAW_E2E_OK"
  },
  "observedCount": 1,
  "rttMs": 5061,
  "modelRequests": 1
}
```

- Observed result after fix: The SUT bot sent one threaded reply (`6023` replying to `6022`) with `OPENCLAW_E2E_OK`; no `No extra answer from me.` placeholder appeared in the observed Telegram replies.
- What was not tested: No broad Telegram QA suite or live third-party model provider was run; this proof used real Telegram transport with deterministic local model output.

## Verification

- `pnpm test extensions/telegram/src/bot-message-dispatch.test.ts` — 41 passed.
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts` — passed.
- `git diff --check origin/main...HEAD` — passed.
- `pnpm check:changed` — passed (extensions, extensionTests, docs lanes).
- `node ~/.codex/skills/custom/telegram-e2e-bot-to-bot/scripts/run-mock-sut-e2e.mjs --text '@{sut} Please answer with OPENCLAW_E2E_OK only. Do not send any extra answer placeholder.' --expect OPENCLAW_E2E_OK --timeout-ms 90000 --output /tmp/openclaw-pr-79142-telegram-e2e-proof-a9c1448.json` — passed (real Telegram bot-to-bot probe; one threaded SUT reply; no placeholder observed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

