### PR TITLE
Improve progress draft labels and tool details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Agents/failover: harden state-aware lane suspension by persisting quota resume transitions, restoring configured lane concurrency, preserving non-quota failure reasons, and exporting model failover events through diagnostics OTLP. Thanks @BunsDev.
+- Discord/streaming: make progress draft labels scroll away with other progress lines, render tool rows as compact emoji/details, and skip empty apply-patch starts until a patch summary exists. (#79146)
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: include a bounded one-line STT transcript preview in verbose voice logs so live voice debugging shows what speakers said before the agent reply.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Agents/failover: harden state-aware lane suspension by persisting quota resume transitions, restoring configured lane concurrency, preserving non-quota failure reasons, and exporting model failover events through diagnostics OTLP. Thanks @BunsDev.
-- Discord/streaming: make progress draft labels scroll away with other progress lines, render tool rows as compact emoji/details, and skip empty apply-patch starts until a patch summary exists. (#79146)
+- Channels/streaming: make progress draft labels scroll away with other progress lines, render structured tool rows as compact emoji/details, and skip empty Discord apply-patch starts until a patch summary exists. (#79146)
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: include a bounded one-line STT transcript preview in verbose voice logs so live voice debugging shows what speakers said before the agent reply.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Agents/failover: harden state-aware lane suspension by persisting quota resume transitions, restoring configured lane concurrency, preserving non-quota failure reasons, and exporting model failover events through diagnostics OTLP. Thanks @BunsDev.
-- Channels/streaming: make progress draft labels scroll away with other progress lines, render structured tool rows as compact emoji/details, and skip empty Discord apply-patch starts until a patch summary exists. (#79146)
+- Channels/streaming: make progress draft labels scroll away with other progress lines, render structured tool rows as compact emoji/details, show web-search queries from provider-native argument shapes, and skip empty Discord apply-patch starts until a patch summary exists. (#79146)
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: include a bounded one-line STT transcript preview in verbose voice logs so live voice debugging shows what speakers said before the agent reply.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Agents/failover: harden state-aware lane suspension by persisting quota resume transitions, restoring configured lane concurrency, preserving non-quota failure reasons, and exporting model failover events through diagnostics OTLP. Thanks @BunsDev.
-- Channels/streaming: make progress draft labels scroll away with other progress lines, render structured tool rows as compact emoji/details, show web-search queries from provider-native argument shapes, and skip empty Discord apply-patch starts until a patch summary exists. (#79146)
+- Channels/streaming: make progress draft labels scroll away with other progress lines, render structured tool rows as compact emoji/title/details, show web-search queries from provider-native argument shapes, and skip empty Discord apply-patch starts until a patch summary exists. (#79146)
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: include a bounded one-line STT transcript preview in verbose voice logs so live voice debugging shows what speakers said before the agent reply.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-973ce3342740726100f6f09d18c6802474f5f7eab255253cf6ea3e8d66c9a383  plugin-sdk-api-baseline.json
-f4cbbaaa129733216e1a566865d86b0832f5f35bc3db6c9ead1e2f937564dc68  plugin-sdk-api-baseline.jsonl
+0c69a93645885b5135fe4cb920b25aa24505cb2f818281a0185b2edc1966732d  plugin-sdk-api-baseline.json
+23d13fe064bb240d81a385c7fc02ca732c909b9cbdcae02fd45339dd3f74bd73  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-0c69a93645885b5135fe4cb920b25aa24505cb2f818281a0185b2edc1966732d  plugin-sdk-api-baseline.json
-23d13fe064bb240d81a385c7fc02ca732c909b9cbdcae02fd45339dd3f74bd73  plugin-sdk-api-baseline.jsonl
+887d2fee5f77f1de984bfb6ec0f001c0484c0367dbc8b5f42b62027df352c2e1  plugin-sdk-api-baseline.json
+8e2b4e64a801b47c4d45d5d4a2073180abcc1ecf7e677fae035799c6a68f7c82  plugin-sdk-api-baseline.jsonl

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -662,7 +662,7 @@ Default slash command settings:
   </Accordion>
 
   <Accordion title="Live stream preview">
-    OpenClaw can stream draft replies by sending a temporary message and editing it as text arrives. `channels.discord.streaming` takes `off` | `partial` | `block` | `progress` (default). `progress` keeps one editable status draft and updates it with tool progress until final delivery; the starter label is a rolling line, so it scrolls away like the rest once enough work appears. `streamMode` is a legacy runtime alias. Run `openclaw doctor --fix` to rewrite persisted config to the canonical key.
+    OpenClaw can stream draft replies by sending a temporary message and editing it as text arrives. `channels.discord.streaming` takes `off` | `partial` | `block` | `progress` (default). `progress` keeps one editable status draft and updates it with tool progress until final delivery; the shared starter label is a rolling line, so it scrolls away like the rest once enough work appears. `streamMode` is a legacy runtime alias. Run `openclaw doctor --fix` to rewrite persisted config to the canonical key.
 
     Set `channels.discord.streaming.mode` to `off` to disable Discord preview edits. If Discord block streaming is explicitly enabled, OpenClaw skips the preview stream to avoid double-streaming.
 

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -662,7 +662,7 @@ Default slash command settings:
   </Accordion>
 
   <Accordion title="Live stream preview">
-    OpenClaw can stream draft replies by sending a temporary message and editing it as text arrives. `channels.discord.streaming` takes `off` | `partial` | `block` | `progress` (default). `progress` keeps one editable status draft and updates it with tool progress until final delivery; `streamMode` is a legacy runtime alias. Run `openclaw doctor --fix` to rewrite persisted config to the canonical key.
+    OpenClaw can stream draft replies by sending a temporary message and editing it as text arrives. `channels.discord.streaming` takes `off` | `partial` | `block` | `progress` (default). `progress` keeps one editable status draft and updates it with tool progress until final delivery; the starter label is a rolling line, so it scrolls away like the rest once enough work appears. `streamMode` is a legacy runtime alias. Run `openclaw doctor --fix` to rewrite persisted config to the canonical key.
 
     Set `channels.discord.streaming.mode` to `off` to disable Discord preview edits. If Discord block streaming is explicitly enabled, OpenClaw skips the preview stream to avoid double-streaming.
 
@@ -687,6 +687,7 @@ Default slash command settings:
     - `block` emits draft-sized chunks (use `draftChunk` to tune size and breakpoints, clamped to `textChunkLimit`).
     - Media, error, and explicit-reply finals cancel pending preview edits.
     - `streaming.preview.toolProgress` (default `true`) controls whether tool/progress updates reuse the preview message.
+    - Tool/progress rows render as compact emoji + detail when available, for example `🛠️ run tests`, and omit repeated tool names unless no clearer detail exists.
     - `streaming.preview.commandText` / `streaming.progress.commandText` controls command/exec detail in compact progress lines: `raw` (default) or `status` (tool label only).
 
     Hide raw command/exec text while keeping compact progress lines:

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -687,7 +687,7 @@ Default slash command settings:
     - `block` emits draft-sized chunks (use `draftChunk` to tune size and breakpoints, clamped to `textChunkLimit`).
     - Media, error, and explicit-reply finals cancel pending preview edits.
     - `streaming.preview.toolProgress` (default `true`) controls whether tool/progress updates reuse the preview message.
-    - Tool/progress rows render as compact emoji + detail when available, for example `🛠️ run tests`, and omit repeated tool names unless no clearer detail exists.
+    - Tool/progress rows render as compact emoji + title + detail when available, for example `🛠️ Bash: run tests` or `🔎 Web Search: for "query"`.
     - `streaming.preview.commandText` / `streaming.progress.commandText` controls command/exec detail in compact progress lines: `raw` (default) or `status` (tool label only).
 
     Hide raw command/exec text while keeping compact progress lines:

--- a/docs/concepts/progress-drafts.md
+++ b/docs/concepts/progress-drafts.md
@@ -19,8 +19,8 @@ into the final answer when the channel can do that safely.
 ```text
 Shelling...
 📖 from docs/concepts/progress-drafts.md
-🔎 for "discord edit message"
-🛠️ run tests
+🔎 Web Search: for "discord edit message"
+🛠️ Bash: run tests
 ```
 
 Use progress drafts when you want one tidy status message during tool-heavy work
@@ -60,9 +60,9 @@ The label appears after the agent starts meaningful work and either remains busy
 for five seconds or emits a second work event. It is part of the rolling progress
 line list, so the starter status scrolls away once enough concrete work appears.
 Plain text-only replies do not show a progress draft. Progress lines are added
-only when the agent emits useful work updates, for example `🛠️ run tests`,
-`🔎 for "discord edit message"`, or `✍️ to /tmp/file`. By default they use the
-same compact explain mode as `/verbose`; set
+only when the agent emits useful work updates, for example `🛠️ Bash: run tests`,
+`🔎 Web Search: for "discord edit message"`, or `✍️ Write: to /tmp/file`.
+By default they use the same compact explain mode as `/verbose`; set
 `agents.defaults.toolProgressDetail: "raw"` when debugging and you also want raw
 commands/details appended.
 The final answer replaces the draft when possible; otherwise

--- a/docs/concepts/progress-drafts.md
+++ b/docs/concepts/progress-drafts.md
@@ -57,14 +57,14 @@ A progress draft has two parts:
 | Progress lines | Compact run updates using the same tool icons and detail formatter as verbose output. |
 
 The label appears after the agent starts meaningful work and either remains busy
-for five seconds or emits a second work event. Channels can render it as a fixed
-header or as the first rolling line; Discord uses a rolling line so the starter
-status scrolls away once enough concrete work appears. Plain text-only replies do
-not show a progress draft. Progress lines are added only when the agent emits
-useful work updates, for example `🛠️ run tests`, `🔎 for "discord edit message"`,
-or `✍️ to /tmp/file`. By default they use the same compact explain mode as
-`/verbose`; set `agents.defaults.toolProgressDetail: "raw"` when debugging and
-you also want raw commands/details appended.
+for five seconds or emits a second work event. It is part of the rolling progress
+line list, so the starter status scrolls away once enough concrete work appears.
+Plain text-only replies do not show a progress draft. Progress lines are added
+only when the agent emits useful work updates, for example `🛠️ run tests`,
+`🔎 for "discord edit message"`, or `✍️ to /tmp/file`. By default they use the
+same compact explain mode as `/verbose`; set
+`agents.defaults.toolProgressDetail: "raw"` when debugging and you also want raw
+commands/details appended.
 The final answer replaces the draft when possible; otherwise
 OpenClaw sends the final answer normally and cleans up or stops updating the
 draft according to the channel's transport.

--- a/docs/concepts/progress-drafts.md
+++ b/docs/concepts/progress-drafts.md
@@ -18,9 +18,9 @@ into the final answer when the channel can do that safely.
 
 ```text
 Shelling...
-📖 Read: from docs/concepts/progress-drafts.md
-🔎 Web Search: for "discord edit message"
-🛠️ Exec: run tests
+📖 from docs/concepts/progress-drafts.md
+🔎 for "discord edit message"
+🛠️ run tests
 ```
 
 Use progress drafts when you want one tidy status message during tool-heavy work
@@ -51,18 +51,20 @@ progress chatter for that turn.
 
 A progress draft has two parts:
 
-| Part           | Purpose                                                                     |
-| -------------- | --------------------------------------------------------------------------- |
-| Label          | A short title such as `Thinking...` or `Shelling...`.                       |
-| Progress lines | Compact run updates using the same tool labels and icons as verbose output. |
+| Part           | Purpose                                                                               |
+| -------------- | ------------------------------------------------------------------------------------- |
+| Label          | A short starter/status line such as `Thinking...` or `Shelling...`.                   |
+| Progress lines | Compact run updates using the same tool icons and detail formatter as verbose output. |
 
 The label appears after the agent starts meaningful work and either remains busy
-for five seconds or emits a second work event. Plain text-only replies do not
-show a progress draft. Progress lines are added only when the agent emits useful
-work updates, for example `🛠️ Exec`, `🔎 Web Search`, or `✍️ Write: to /tmp/file`.
-By default they use the same compact explain mode as `/verbose`; set
-`agents.defaults.toolProgressDetail: "raw"` when debugging and you also want raw
-commands/details appended.
+for five seconds or emits a second work event. Channels can render it as a fixed
+header or as the first rolling line; Discord uses a rolling line so the starter
+status scrolls away once enough concrete work appears. Plain text-only replies do
+not show a progress draft. Progress lines are added only when the agent emits
+useful work updates, for example `🛠️ run tests`, `🔎 for "discord edit message"`,
+or `✍️ to /tmp/file`. By default they use the same compact explain mode as
+`/verbose`; set `agents.defaults.toolProgressDetail: "raw"` when debugging and
+you also want raw commands/details appended.
 The final answer replaces the draft when possible; otherwise
 OpenClaw sends the final answer normally and cleans up or stops updating the
 draft according to the channel's transport.
@@ -189,16 +191,16 @@ OpenClaw uses the same formatter for progress drafts and `/verbose`:
 ```
 
 `"explain"` is the default and keeps drafts stable with concise labels like
-`🛠️ Exec: check JS syntax for /tmp/app.js`. `"raw"` appends the underlying
+`🛠️ check JS syntax for /tmp/app.js`. `"raw"` appends the underlying
 command/detail when available, which is useful while debugging but noisier in
 chat.
 
 For example, the same command appears differently depending on the detail mode:
 
-| Mode      | Progress line                                                        |
-| --------- | -------------------------------------------------------------------- |
-| `explain` | `🛠️ Exec: check JS syntax for /tmp/app.js`                           |
-| `raw`     | `🛠️ Exec: check JS syntax for /tmp/app.js, node --check /tmp/app.js` |
+| Mode      | Progress line                                                  |
+| --------- | -------------------------------------------------------------- |
+| `explain` | `🛠️ check JS syntax for /tmp/app.js`                           |
+| `raw`     | `🛠️ check JS syntax for /tmp/app.js, node --check /tmp/app.js` |
 
 Limit how many lines stay visible:
 

--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -1,6 +1,7 @@
 import { EmbeddedBlockChunker } from "openclaw/plugin-sdk/agent-runtime";
 import {
   createChannelProgressDraftGate,
+  type ChannelProgressDraftLine,
   formatChannelProgressDraftText,
   isChannelProgressDraftWorkToolName,
   resolveChannelProgressDraftMaxLines,
@@ -81,7 +82,7 @@ export function createDiscordDraftPreviewController(params: {
       previewToolProgressEnabled,
     });
   let previewToolProgressSuppressed = false;
-  let previewToolProgressLines: string[] = [];
+  let previewToolProgressLines: Array<string | ChannelProgressDraftLine> = [];
   let reasoningProgressRawText = "";
   let lastReasoningProgressLine: string | undefined;
   const progressSeed = `${params.accountId}:${params.deliverChannelId}`;
@@ -94,6 +95,8 @@ export function createDiscordDraftPreviewController(params: {
       entry: params.discordConfig,
       lines: previewToolProgressLines,
       seed: progressSeed,
+      labelPlacement: "line",
+      formatStructuredLine: formatDiscordProgressDraftLine,
     });
     if (!previewText || previewText === lastPartialText) {
       return;
@@ -156,7 +159,10 @@ export function createDiscordDraftPreviewController(params: {
       }
       await progressDraftGate.startNow();
     },
-    async pushToolProgress(line?: string, options?: { toolName?: string }) {
+    async pushToolProgress(
+      line?: string | ChannelProgressDraftLine,
+      options?: { toolName?: string },
+    ) {
       if (!draftStream) {
         return;
       }
@@ -166,25 +172,32 @@ export function createDiscordDraftPreviewController(params: {
       ) {
         return;
       }
-      const normalized = line?.replace(/\s+/g, " ").trim();
+      if (isEmptyDiscordProgressLine(line)) {
+        return;
+      }
+      const normalized = normalizeProgressLineIdentity(line);
       if (!normalized) {
         return;
       }
+      const progressLine: string | ChannelProgressDraftLine =
+        typeof line === "object" && line !== undefined ? line : normalized;
       if (discordStreamMode !== "progress") {
         if (!previewToolProgressEnabled || previewToolProgressSuppressed) {
           return;
         }
-        const previous = previewToolProgressLines.at(-1);
+        const previous = normalizeProgressLineIdentity(previewToolProgressLines.at(-1));
         if (previous === normalized) {
           return;
         }
-        previewToolProgressLines = [...previewToolProgressLines, normalized].slice(
+        previewToolProgressLines = [...previewToolProgressLines, progressLine].slice(
           -resolveChannelProgressDraftMaxLines(params.discordConfig),
         );
         const previewText = formatChannelProgressDraftText({
           entry: params.discordConfig,
           lines: previewToolProgressLines,
           seed: progressSeed,
+          labelPlacement: "line",
+          formatStructuredLine: formatDiscordProgressDraftLine,
         });
         lastPartialText = previewText;
         draftText = previewText;
@@ -194,15 +207,19 @@ export function createDiscordDraftPreviewController(params: {
         return;
       }
       if (previewToolProgressEnabled && !previewToolProgressSuppressed && normalized) {
-        const previous = previewToolProgressLines.at(-1);
+        const previous = normalizeProgressLineIdentity(previewToolProgressLines.at(-1));
         if (previous !== normalized) {
-          previewToolProgressLines = [...previewToolProgressLines, normalized].slice(
+          previewToolProgressLines = [...previewToolProgressLines, progressLine].slice(
             -resolveChannelProgressDraftMaxLines(params.discordConfig),
           );
         }
       }
       const alreadyStarted = progressDraftGate.hasStarted;
-      await progressDraftGate.noteWork();
+      if (shouldStartDiscordProgressDraftNow(line)) {
+        await progressDraftGate.startNow();
+      } else {
+        await progressDraftGate.noteWork();
+      }
       if (alreadyStarted && progressDraftGate.hasStarted) {
         await renderProgressDraft();
       }
@@ -391,4 +408,43 @@ function mergeReasoningProgressText(current: string, incoming: string): string {
 
 function isReasoningSnapshotText(text: string): boolean {
   return /^\s*(?:>\s*)?Reasoning:\s*/i.test(text);
+}
+
+function normalizeProgressLineIdentity(
+  line: string | ChannelProgressDraftLine | undefined,
+): string {
+  const text = typeof line === "string" ? line : line?.text;
+  return text?.replace(/\s+/g, " ").trim() ?? "";
+}
+
+function isEmptyDiscordProgressLine(line: string | ChannelProgressDraftLine | undefined): boolean {
+  if (!line || typeof line === "string") {
+    return false;
+  }
+  return line.toolName === "apply_patch" && !line.detail && !line.status;
+}
+
+function shouldStartDiscordProgressDraftNow(
+  line: string | ChannelProgressDraftLine | undefined,
+): boolean {
+  return typeof line === "object" && line?.kind === "patch" && Boolean(line.detail);
+}
+
+function formatDiscordProgressDraftLine(line: ChannelProgressDraftLine): string {
+  const icon = line.icon?.trim();
+  const prefix = icon ? `${icon} ` : "";
+  const detail = line.detail?.trim();
+  if (detail) {
+    return `${prefix}${detail}`;
+  }
+  const status = line.status?.trim();
+  if (status) {
+    return `${prefix}${status}`;
+  }
+  const text = line.text.trim();
+  const label = line.label.trim();
+  if (!icon && text && text !== label) {
+    return text;
+  }
+  return `${prefix}${label}`.trim();
 }

--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -95,8 +95,6 @@ export function createDiscordDraftPreviewController(params: {
       entry: params.discordConfig,
       lines: previewToolProgressLines,
       seed: progressSeed,
-      labelPlacement: "line",
-      formatStructuredLine: formatDiscordProgressDraftLine,
     });
     if (!previewText || previewText === lastPartialText) {
       return;
@@ -196,8 +194,6 @@ export function createDiscordDraftPreviewController(params: {
           entry: params.discordConfig,
           lines: previewToolProgressLines,
           seed: progressSeed,
-          labelPlacement: "line",
-          formatStructuredLine: formatDiscordProgressDraftLine,
         });
         lastPartialText = previewText;
         draftText = previewText;
@@ -428,23 +424,4 @@ function shouldStartDiscordProgressDraftNow(
   line: string | ChannelProgressDraftLine | undefined,
 ): boolean {
   return typeof line === "object" && line?.kind === "patch" && Boolean(line.detail);
-}
-
-function formatDiscordProgressDraftLine(line: ChannelProgressDraftLine): string {
-  const icon = line.icon?.trim();
-  const prefix = icon ? `${icon} ` : "";
-  const detail = line.detail?.trim();
-  if (detail) {
-    return `${prefix}${detail}`;
-  }
-  const status = line.status?.trim();
-  if (status) {
-    return `${prefix}${status}`;
-  }
-  const text = line.text.trim();
-  const label = line.label.trim();
-  if (!icon && text && text !== label) {
-    return text;
-  }
-  return `${prefix}${label}`.trim();
 }

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -127,6 +127,10 @@ type DispatchInboundParams = {
       phase?: string;
       summary?: string;
       title?: string;
+      name?: string;
+      added?: string[];
+      modified?: string[];
+      deleted?: string[];
     }) => Promise<void> | void;
     onReplyStart?: () => Promise<void> | void;
     sourceReplyDeliveryMode?: "automatic" | "message_tool_only";
@@ -1617,7 +1621,7 @@ describe("processDiscordMessage draft streaming", () => {
     await runProcessDiscordMessage(ctx);
 
     expect(draftStream.update).toHaveBeenCalledWith(
-      "Shelling\n🛠️ Exec: run tests, `pnpm test -- --watch=false`\n• done",
+      "Shelling\n🛠️ run tests, `pnpm test -- --watch=false`\n• done",
     );
   });
 
@@ -1650,6 +1654,66 @@ describe("processDiscordMessage draft streaming", () => {
     await runProcessDiscordMessage(ctx);
 
     expect(draftStream.update).toHaveBeenCalledWith("Shelling\n🛠️ Exec\n• done");
+  });
+
+  it("keeps Discord progress labels as rolling lines", async () => {
+    const draftStream = createMockDraftStreamForTest();
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onToolStart?.({ name: "first", phase: "start" });
+      await params?.replyOptions?.onToolStart?.({ name: "second", phase: "start" });
+      await params?.replyOptions?.onToolStart?.({ name: "third", phase: "start" });
+      return createNoQueuedDispatchResult();
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: {
+        streaming: {
+          mode: "progress",
+          progress: {
+            label: "Clawing...",
+            maxLines: 3,
+          },
+        },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(draftStream.update).toHaveBeenCalledWith("🧩 First\n🧩 Second\n🧩 Third");
+  });
+
+  it("skips empty apply_patch starts and renders the patch summary", async () => {
+    const draftStream = createMockDraftStreamForTest();
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onToolStart?.({ name: "apply_patch", phase: "start" });
+      await params?.replyOptions?.onPatchSummary?.({
+        phase: "end",
+        name: "apply_patch",
+        summary: "1 modified",
+        modified: ["extensions/discord/src/monitor/message-handler.draft-preview.ts"],
+      });
+      return createNoQueuedDispatchResult();
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: {
+        streaming: {
+          mode: "progress",
+          progress: {
+            label: "Clawing...",
+          },
+        },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(draftStream.update).toHaveBeenCalledWith(
+      "Clawing...\n🩹 1 modified; extensions/discord/src/monitor/message-handler.draft-prev…",
+    );
+    expect(draftStream.update).not.toHaveBeenCalledWith(expect.stringContaining("Apply Patch"));
   });
 
   it("shows reasoning text instead of a bare Reasoning progress line", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -1621,7 +1621,7 @@ describe("processDiscordMessage draft streaming", () => {
     await runProcessDiscordMessage(ctx);
 
     expect(draftStream.update).toHaveBeenCalledWith(
-      "Shelling\n🛠️ run tests, `pnpm test -- --watch=false`\n• done",
+      "Shelling\n🛠️ Exec: run tests, `pnpm test -- --watch=false`\n• done",
     );
   });
 

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -13,8 +13,8 @@ import {
   resolveChannelMessageSourceReplyDeliveryMode,
 } from "openclaw/plugin-sdk/channel-message";
 import {
-  formatChannelProgressDraftLine,
-  formatChannelProgressDraftLineForEntry,
+  buildChannelProgressDraftLine,
+  buildChannelProgressDraftLineForEntry,
   resolveChannelStreamingBlockEnabled,
 } from "openclaw/plugin-sdk/channel-streaming";
 import { recordInboundSession } from "openclaw/plugin-sdk/conversation-runtime";
@@ -674,7 +674,7 @@ export async function processDiscordMessage(
                   await maybeBindStatusReactionsToToolReaction(payload);
                   await statusReactions.setTool(payload.name);
                   await draftPreview.pushToolProgress(
-                    formatChannelProgressDraftLineForEntry(
+                    buildChannelProgressDraftLineForEntry(
                       discordConfig,
                       {
                         event: "tool",
@@ -689,7 +689,7 @@ export async function processDiscordMessage(
                 },
                 onItemEvent: async (payload) => {
                   await draftPreview.pushToolProgress(
-                    formatChannelProgressDraftLineForEntry(discordConfig, {
+                    buildChannelProgressDraftLineForEntry(discordConfig, {
                       event: "item",
                       itemKind: payload.kind,
                       title: payload.title,
@@ -707,7 +707,7 @@ export async function processDiscordMessage(
                     return;
                   }
                   await draftPreview.pushToolProgress(
-                    formatChannelProgressDraftLine({
+                    buildChannelProgressDraftLine({
                       event: "plan",
                       phase: payload.phase,
                       title: payload.title,
@@ -721,7 +721,7 @@ export async function processDiscordMessage(
                     return;
                   }
                   await draftPreview.pushToolProgress(
-                    formatChannelProgressDraftLine({
+                    buildChannelProgressDraftLine({
                       event: "approval",
                       phase: payload.phase,
                       title: payload.title,
@@ -736,7 +736,7 @@ export async function processDiscordMessage(
                     return;
                   }
                   await draftPreview.pushToolProgress(
-                    formatChannelProgressDraftLine({
+                    buildChannelProgressDraftLine({
                       event: "command-output",
                       phase: payload.phase,
                       title: payload.title,
@@ -751,7 +751,7 @@ export async function processDiscordMessage(
                     return;
                   }
                   await draftPreview.pushToolProgress(
-                    formatChannelProgressDraftLine({
+                    buildChannelProgressDraftLine({
                       event: "patch",
                       phase: payload.phase,
                       title: payload.title,

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -1,6 +1,6 @@
 import {
-  formatChannelProgressDraftLine,
-  formatChannelProgressDraftLineForEntry,
+  buildChannelProgressDraftLine,
+  buildChannelProgressDraftLineForEntry,
   resolveChannelPreviewStreamMode,
   resolveChannelStreamingBlockEnabled,
 } from "openclaw/plugin-sdk/channel-streaming";
@@ -385,7 +385,7 @@ export function createMSTeamsReplyDispatcher(params: {
               detailMode?: "explain" | "raw";
             }) => {
               await streamController.pushProgressLine(
-                formatChannelProgressDraftLineForEntry(
+                buildChannelProgressDraftLineForEntry(
                   msteamsCfg,
                   {
                     event: "tool",
@@ -409,7 +409,7 @@ export function createMSTeamsReplyDispatcher(params: {
               status?: string;
             }) => {
               await streamController.pushProgressLine(
-                formatChannelProgressDraftLineForEntry(msteamsCfg, {
+                buildChannelProgressDraftLineForEntry(msteamsCfg, {
                   event: "item",
                   itemKind: payload.kind,
                   title: payload.title,
@@ -432,7 +432,7 @@ export function createMSTeamsReplyDispatcher(params: {
                 return;
               }
               await streamController.pushProgressLine(
-                formatChannelProgressDraftLine({
+                buildChannelProgressDraftLine({
                   event: "plan",
                   phase: payload.phase,
                   title: payload.title,
@@ -452,7 +452,7 @@ export function createMSTeamsReplyDispatcher(params: {
                 return;
               }
               await streamController.pushProgressLine(
-                formatChannelProgressDraftLine({
+                buildChannelProgressDraftLine({
                   event: "approval",
                   phase: payload.phase,
                   title: payload.title,
@@ -473,7 +473,7 @@ export function createMSTeamsReplyDispatcher(params: {
                 return;
               }
               await streamController.pushProgressLine(
-                formatChannelProgressDraftLine({
+                buildChannelProgressDraftLine({
                   event: "command-output",
                   phase: payload.phase,
                   title: payload.title,
@@ -496,7 +496,7 @@ export function createMSTeamsReplyDispatcher(params: {
                 return;
               }
               await streamController.pushProgressLine(
-                formatChannelProgressDraftLine({
+                buildChannelProgressDraftLine({
                   event: "patch",
                   phase: payload.phase,
                   title: payload.title,

--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -320,9 +320,7 @@ describe("createTeamsReplyStreamController", () => {
 
     expect(ctrl.shouldSuppressDefaultToolProgressMessages()).toBe(true);
     expect(ctrl.shouldStreamPreviewToolProgress()).toBe(true);
-    expect(streamInstances[0]?.sendInformativeUpdate).toHaveBeenLastCalledWith(
-      "Working\n- tool: exec",
-    );
+    expect(streamInstances[0]?.sendInformativeUpdate).toHaveBeenLastCalledWith("- tool: exec");
   });
 
   it("suppresses Teams default progress messages without stream lines when tool progress is disabled", async () => {

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -8,6 +8,7 @@ import {
 } from "openclaw/plugin-sdk/channel-message";
 import {
   createChannelProgressDraftGate,
+  type ChannelProgressDraftLine,
   formatChannelProgressDraftText,
   isChannelProgressDraftWorkToolName,
   resolveChannelPreviewStreamMode,
@@ -70,7 +71,7 @@ export function createTeamsReplyStreamController(params: {
 
   let streamReceivedTokens = false;
   let informativeUpdateSent = false;
-  let progressLines: string[] = [];
+  let progressLines: Array<string | ChannelProgressDraftLine> = [];
   let lastInformativeText = "";
   let pendingFinalize: Promise<void> | undefined;
   let liveState: LiveMessageState<ReplyPayload> = createLiveMessageState({
@@ -125,7 +126,7 @@ export function createTeamsReplyStreamController(params: {
   };
 
   const pushProgressLine = async (
-    line?: string,
+    line?: string | ChannelProgressDraftLine,
     options?: { toolName?: string },
   ): Promise<void> => {
     if (!stream || streamMode !== "progress") {
@@ -135,11 +136,13 @@ export function createTeamsReplyStreamController(params: {
       return;
     }
     if (shouldStreamPreviewToolProgress) {
-      const normalized = line?.replace(/\s+/g, " ").trim();
+      const normalized = normalizeProgressLineIdentity(line);
       if (normalized) {
-        const previous = progressLines.at(-1);
+        const previous = normalizeProgressLineIdentity(progressLines.at(-1));
         if (previous !== normalized) {
-          progressLines = [...progressLines, normalized].slice(
+          const progressLine: string | ChannelProgressDraftLine =
+            typeof line === "object" && line !== undefined ? line : normalized;
+          progressLines = [...progressLines, progressLine].slice(
             -resolveChannelProgressDraftMaxLines(params.msteamsConfig),
           );
         }
@@ -230,7 +233,10 @@ export function createTeamsReplyStreamController(params: {
       stream.update(payload.text);
     },
 
-    async pushProgressLine(line?: string, options?: { toolName?: string }): Promise<void> {
+    async pushProgressLine(
+      line?: string | ChannelProgressDraftLine,
+      options?: { toolName?: string },
+    ): Promise<void> {
       await pushProgressLine(line, options);
     },
 
@@ -326,4 +332,11 @@ export function createTeamsReplyStreamController(params: {
       return streamReceivedTokens;
     },
   };
+}
+
+function normalizeProgressLineIdentity(
+  line: string | ChannelProgressDraftLine | undefined,
+): string {
+  const text = typeof line === "string" ? line : line?.text;
+  return text?.replace(/\s+/g, " ").trim() ?? "";
 }

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -331,17 +331,32 @@ vi.mock("openclaw/plugin-sdk/channel-streaming", () => ({
   },
   formatChannelProgressDraftText: (params: {
     entry?: { streaming?: { progress?: { label?: string | false; maxLines?: number } } };
-    lines: Array<string | { text: string }>;
+    lines: Array<
+      string | { text: string; icon?: string; detail?: string; status?: string; label: string }
+    >;
     formatLine?: (line: string) => string;
   }) => {
     const label = params.entry?.streaming?.progress?.label;
+    const maxLines = params.entry?.streaming?.progress?.maxLines ?? 8;
     const formatLine = params.formatLine ?? ((line: string) => line);
-    return [
+    const lines = [
       label === false ? undefined : (label ?? "Thinking"),
-      ...params.lines.map((line) => `• ${formatLine(typeof line === "string" ? line : line.text)}`),
+      ...params.lines.map((line) => {
+        const text =
+          typeof line === "string"
+            ? line
+            : line.detail
+              ? `${line.icon ?? ""} ${line.detail}`.trim()
+              : line.status
+                ? `${line.icon ?? ""} ${line.status}`.trim()
+                : line.text;
+        const formatted = formatLine(text);
+        return /^\p{Extended_Pictographic}/u.test(text) ? formatted : `• ${formatted}`;
+      }),
     ]
       .filter((line): line is string => Boolean(line))
-      .join("\n");
+      .slice(-maxLines);
+    return lines.join("\n");
   },
   formatChannelProgressDraftLine: (params: {
     progressText?: string;
@@ -797,7 +812,6 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
 
     expect(draftStream.update).toHaveBeenLastCalledWith(
       [
-        "Shelling",
         "• step 1",
         "• step 2",
         "• step 3",
@@ -859,7 +873,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       }),
     );
 
-    expect(draftStream.update).toHaveBeenCalledWith("Shelling\n• 🛠️ Exec\n• done");
+    expect(draftStream.update).toHaveBeenCalledWith("Shelling\n🛠️ Exec\n• done");
     expect(draftStream.update.mock.calls.flat().join("\n")).not.toContain("pnpm test");
   });
 

--- a/extensions/slack/src/progress-blocks.test.ts
+++ b/extensions/slack/src/progress-blocks.test.ts
@@ -72,11 +72,7 @@ describe("buildSlackProgressDraftBlocks", () => {
     expect(blocksWithLabel).toHaveLength(50);
     expect(blocksWithLabel?.[0]).toMatchObject({
       type: "section",
-      text: { text: "*Shelling...*" },
-    });
-    expect(blocksWithLabel?.[1]).toMatchObject({
-      type: "section",
-      fields: [{ text: "🛠️ *Exec 11*" }, { text: "run 11" }],
+      fields: [{ text: "🛠️ *Exec 10*" }, { text: "run 10" }],
     });
     expect(blocksWithLabel?.at(-1)).toMatchObject({
       type: "section",

--- a/extensions/slack/src/progress-blocks.ts
+++ b/extensions/slack/src/progress-blocks.ts
@@ -46,20 +46,21 @@ export function buildSlackProgressDraftBlocks(params: {
   label?: string;
   lines: readonly ChannelProgressDraftLine[];
 }): (Block | KnownBlock)[] | undefined {
-  const blocks: (Block | KnownBlock)[] = [];
   const label = params.label?.trim();
-  if (label) {
-    blocks.push({
-      type: "section",
-      text: field(`*${escapeSlackMrkdwn(label)}*`),
-    });
-  }
-  const availableLineBlocks = Math.max(0, SLACK_MAX_BLOCKS - blocks.length);
-  for (const line of params.lines.slice(-availableLineBlocks)) {
-    blocks.push({
+  const renderedBlocks: (Block | KnownBlock)[] = [
+    ...(label
+      ? [
+          {
+            type: "section" as const,
+            text: field(`*${escapeSlackMrkdwn(label)}*`),
+          },
+        ]
+      : []),
+    ...params.lines.map((line) => ({
       type: "section",
       fields: [field(lineTitle(line)), field(lineDetail(line))],
-    });
-  }
+    })),
+  ].slice(-SLACK_MAX_BLOCKS);
+  const blocks: (Block | KnownBlock)[] = renderedBlocks;
   return blocks.length ? blocks : undefined;
 }

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -280,19 +280,76 @@ function resolveWebSearchDetail(args: unknown): string | undefined {
     return undefined;
   }
 
-  const query = normalizeOptionalString(record.query);
+  const queries = collectWebSearchQueries(record);
   const count =
     typeof record.count === "number" && Number.isFinite(record.count) && record.count > 0
       ? Math.floor(record.count)
-      : undefined;
+      : typeof record.max_results === "number" &&
+          Number.isFinite(record.max_results) &&
+          record.max_results > 0
+        ? Math.floor(record.max_results)
+        : typeof record.num_results === "number" &&
+            Number.isFinite(record.num_results) &&
+            record.num_results > 0
+          ? Math.floor(record.num_results)
+          : typeof record.limit === "number" && Number.isFinite(record.limit) && record.limit > 0
+            ? Math.floor(record.limit)
+            : typeof record.top_k === "number" && Number.isFinite(record.top_k) && record.top_k > 0
+              ? Math.floor(record.top_k)
+              : undefined;
 
-  if (!query) {
+  if (queries.length === 0) {
     return undefined;
   }
 
-  return count !== undefined ? `for "${query}" (top ${count})` : `for "${query}"`;
+  const displayedQueries = queries.slice(0, 3).map((query) => `"${query}"`);
+  const queryText =
+    queries.length > displayedQueries.length
+      ? `${displayedQueries.join(", ")}…`
+      : displayedQueries.join(", ");
+
+  return count !== undefined ? `for ${queryText} (top ${count})` : `for ${queryText}`;
 }
 
+function collectWebSearchQueries(record: Record<string, unknown>): string[] {
+  const queries: string[] = [];
+  const seen = new Set<string>();
+  const add = (value: unknown) => {
+    const normalized = normalizeOptionalString(value);
+    if (!normalized || seen.has(normalized)) {
+      return;
+    }
+    seen.add(normalized);
+    queries.push(normalized);
+  };
+
+  add(record.query);
+  add(record.q);
+  add(record.search);
+  add(record.input);
+
+  for (const key of ["search_query", "image_query", "queries"]) {
+    const value = record[key];
+    if (!Array.isArray(value)) {
+      continue;
+    }
+    for (const entry of value) {
+      if (typeof entry === "string") {
+        add(entry);
+        continue;
+      }
+      const entryRecord = asRecord(entry);
+      if (!entryRecord) {
+        continue;
+      }
+      add(entryRecord.query);
+      add(entryRecord.q);
+      add(entryRecord.search);
+    }
+  }
+
+  return queries;
+}
 function resolveWebFetchDetail(args: unknown): string | undefined {
   const record = asRecord(args);
   if (!record) {

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -416,7 +416,7 @@ function resolveToolVerbAndDetail(params: {
   const verb = normalizeVerb(actionSpec?.label ?? params.action ?? fallbackVerb);
 
   let detail: string | undefined;
-  if (params.toolKey === "exec") {
+  if (params.toolKey === "exec" || params.toolKey === "bash") {
     detail = resolveExecDetail(params.args, { detailMode: params.toolDetailMode });
   }
   if (!detail && params.toolKey === "read") {

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -104,6 +104,18 @@ describe("tool display details", () => {
     expect(detail).toContain(".openclaw/workspace)");
   });
 
+  it("summarizes bash commands with the same command explainer", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "bash",
+        args: { command: "sed -n '1,80p' extensions/discord/src/draft-stream.ts" },
+        detailMode: "explain",
+      }),
+    );
+
+    expect(detail).toBe("print lines 1-80 from extensions/discord/src/draft-stream.ts");
+  });
+
   it("moves cd path to context suffix and appends raw command", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -88,6 +88,33 @@ describe("tool display details", () => {
     expect(detail).toBe('for "OpenClaw docs" (top 3)');
   });
 
+  it("formats web_search provider query shapes", () => {
+    expect(
+      formatToolDetail(
+        resolveToolDisplay({
+          name: "web_search",
+          args: { q: "Codex OAuth API key", max_results: 5 },
+        }),
+      ),
+    ).toBe('for "Codex OAuth API key" (top 5)');
+
+    expect(
+      formatToolDetail(
+        resolveToolDisplay({
+          name: "web_search",
+          args: {
+            search_query: [
+              { q: "latest Kimi model" },
+              { q: "latest Gemini model" },
+              { q: "latest Claude model" },
+              { q: "latest OpenAI model" },
+            ],
+          },
+        }),
+      ),
+    ).toBe('for "latest Kimi model", "latest Gemini model", "latest Claude model"…');
+  });
+
   it("summarizes exec commands with context", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({

--- a/src/plugin-sdk/channel-streaming.test.ts
+++ b/src/plugin-sdk/channel-streaming.test.ts
@@ -210,28 +210,27 @@ describe("channel-streaming", () => {
         lines: [" tool: read ", "patch applied", "tests done"],
         formatLine: (line) => `\`${line}\``,
       }),
-    ).toBe("Shelling\n• `patch applied`\n• `tests done`");
+    ).toBe("• `patch applied`\n• `tests done`");
     expect(
       formatChannelProgressDraftText({
         entry,
         lines: ["🛠️ Exec", "plain update"],
       }),
-    ).toBe("Shelling\n🛠️ Exec\n• plain update");
+    ).toBe("🛠️ Exec\n• plain update");
   });
 
-  it("can render progress labels as rolling lines", () => {
+  it("renders progress labels as rolling lines", () => {
     const entry = { streaming: { progress: { label: "Shelling", maxLines: 3 } } };
 
     expect(
       formatChannelProgressDraftText({
         entry,
-        labelPlacement: "line",
         lines: ["🛠️ Exec", "📖 Read", "🩹 Patch"],
       }),
     ).toBe("🛠️ Exec\n📖 Read\n🩹 Patch");
   });
 
-  it("lets channels render structured progress lines", () => {
+  it("renders structured progress lines with compact details", () => {
     const line = buildChannelProgressDraftLine({
       event: "patch",
       summary: "1 modified",
@@ -242,8 +241,6 @@ describe("channel-streaming", () => {
       formatChannelProgressDraftText({
         entry: { streaming: { progress: { label: false } } },
         lines: line ? [line] : [],
-        formatStructuredLine: (entry) =>
-          entry.detail ? `${entry.icon ?? ""} ${entry.detail}`.trim() : entry.text,
       }),
     ).toBe("🩹 1 modified; extensions/discord/src/monitor/message-handler.draft-prev…");
   });
@@ -259,7 +256,7 @@ describe("channel-streaming", () => {
   });
 
   it("keeps compacted raw progress lines from leaking unmatched markdown backticks", () => {
-    const line = formatChannelProgressDraftLine(
+    const line = buildChannelProgressDraftLine(
       {
         event: "tool",
         name: "exec",
@@ -273,10 +270,12 @@ describe("channel-streaming", () => {
 
     const text = formatChannelProgressDraftText({
       entry: { streaming: { progress: { label: "Shelling" } } },
-      lines: [line ?? ""],
+      lines: line ? [line] : [],
     });
 
-    expect(text).toBe("Shelling\n🛠️ Exec: run node script…that/keeps/going/and/going/index…");
+    expect(text).toBe(
+      "Shelling\n🛠️ run node script scripts/check-something-with-a-very-long-path, node…",
+    );
     expect(text.match(/`/g) ?? []).toHaveLength(0);
   });
 

--- a/src/plugin-sdk/channel-streaming.test.ts
+++ b/src/plugin-sdk/channel-streaming.test.ts
@@ -334,6 +334,13 @@ describe("channel-streaming", () => {
     ).toBe("🛠️ Bash: print lines 1-80 from extensions/discord/src/draft-stream.ts");
     expect(
       formatChannelProgressDraftLine({
+        event: "tool",
+        name: "web_search",
+        args: { search_query: [{ q: "Codex OAuth API key" }], response_length: "short" },
+      }),
+    ).toBe('🔎 Web Search: for "Codex OAuth API key"');
+    expect(
+      formatChannelProgressDraftLine({
         event: "item",
         itemKind: "command",
         name: "exec",

--- a/src/plugin-sdk/channel-streaming.test.ts
+++ b/src/plugin-sdk/channel-streaming.test.ts
@@ -273,9 +273,7 @@ describe("channel-streaming", () => {
       lines: line ? [line] : [],
     });
 
-    expect(text).toBe(
-      "Shelling\n🛠️ run node script scripts/check-something-with-a-very-long-path, node…",
-    );
+    expect(text).toBe("Shelling\n🛠️ Exec: run node script…that/keeps/going/and/going/index…");
     expect(text.match(/`/g) ?? []).toHaveLength(0);
   });
 

--- a/src/plugin-sdk/channel-streaming.test.ts
+++ b/src/plugin-sdk/channel-streaming.test.ts
@@ -219,6 +219,35 @@ describe("channel-streaming", () => {
     ).toBe("Shelling\n🛠️ Exec\n• plain update");
   });
 
+  it("can render progress labels as rolling lines", () => {
+    const entry = { streaming: { progress: { label: "Shelling", maxLines: 3 } } };
+
+    expect(
+      formatChannelProgressDraftText({
+        entry,
+        labelPlacement: "line",
+        lines: ["🛠️ Exec", "📖 Read", "🩹 Patch"],
+      }),
+    ).toBe("🛠️ Exec\n📖 Read\n🩹 Patch");
+  });
+
+  it("lets channels render structured progress lines", () => {
+    const line = buildChannelProgressDraftLine({
+      event: "patch",
+      summary: "1 modified",
+      modified: ["extensions/discord/src/monitor/message-handler.draft-preview.ts"],
+    });
+
+    expect(
+      formatChannelProgressDraftText({
+        entry: { streaming: { progress: { label: false } } },
+        lines: line ? [line] : [],
+        formatStructuredLine: (entry) =>
+          entry.detail ? `${entry.icon ?? ""} ${entry.detail}`.trim() : entry.text,
+      }),
+    ).toBe("🩹 1 modified; extensions/discord/src/monitor/message-handler.draft-prev…");
+  });
+
   it("bounds progress draft line length to reduce edit reflow", () => {
     expect(
       formatChannelProgressDraftText({
@@ -297,6 +326,13 @@ describe("channel-streaming", () => {
         { detailMode: "raw" },
       ),
     ).toBe("🛠️ Exec: run tests, `pnpm test -- --watch=false`");
+    expect(
+      formatChannelProgressDraftLine({
+        event: "tool",
+        name: "bash",
+        args: { command: "sed -n '1,80p' extensions/discord/src/draft-stream.ts" },
+      }),
+    ).toBe("🛠️ Bash: print lines 1-80 from extensions/discord/src/draft-stream.ts");
     expect(
       formatChannelProgressDraftLine({
         event: "item",

--- a/src/plugin-sdk/channel-streaming.ts
+++ b/src/plugin-sdk/channel-streaming.ts
@@ -754,16 +754,22 @@ function getProgressDraftLineText(line: string | ChannelProgressDraftLine): stri
   }
   const icon = line.icon?.trim();
   const prefix = icon ? `${icon} ` : "";
+  const label = line.label.trim();
   const detail = line.detail?.trim();
   if (detail) {
+    if (line.kind !== "patch" && label) {
+      return `${prefix}${label}: ${detail}`;
+    }
     return `${prefix}${detail}`;
   }
   const status = line.status?.trim();
   if (status) {
+    if (label) {
+      return `${prefix}${label}: ${status}`;
+    }
     return `${prefix}${status}`;
   }
   const text = line.text.trim();
-  const label = line.label.trim();
   if (!icon && text && text !== label) {
     return text;
   }

--- a/src/plugin-sdk/channel-streaming.ts
+++ b/src/plugin-sdk/channel-streaming.ts
@@ -758,6 +758,8 @@ export function formatChannelProgressDraftText(params: {
   seed?: string;
   random?: () => number;
   formatLine?: (line: string) => string;
+  formatStructuredLine?: (line: ChannelProgressDraftLine) => string;
+  labelPlacement?: "header" | "line";
   bullet?: string;
 }): string {
   const label = resolveChannelProgressDraftLabel({
@@ -768,17 +770,27 @@ export function formatChannelProgressDraftText(params: {
   const maxLines = resolveChannelProgressDraftMaxLines(params.entry);
   const formatLine = params.formatLine ?? ((line: string) => line);
   const bullet = params.bullet ?? "•";
-  const lines = params.lines
-    .map((line) =>
-      compactChannelProgressDraftLine(
-        getProgressDraftLineText(line),
-        DEFAULT_PROGRESS_DRAFT_MAX_LINE_CHARS,
-      ),
-    )
-    .filter((line) => line.length > 0)
+  const labelPlacement = params.labelPlacement ?? "header";
+  const rawLines: Array<string | ChannelProgressDraftLine | { draftLabel: string }> =
+    labelPlacement === "line" && label ? [{ draftLabel: label }, ...params.lines] : params.lines;
+  const lines = rawLines
+    .map((line) => {
+      const isLabelLine = typeof line === "object" && line !== null && "draftLabel" in line;
+      const rawText = isLabelLine
+        ? line.draftLabel
+        : typeof line === "string"
+          ? line
+          : (params.formatStructuredLine?.(line) ?? getProgressDraftLineText(line));
+      const text = compactChannelProgressDraftLine(rawText, DEFAULT_PROGRESS_DRAFT_MAX_LINE_CHARS);
+      return text ? { text, isLabelLine } : undefined;
+    })
+    .filter((line): line is { text: string; isLabelLine: boolean } => Boolean(line))
     .slice(-maxLines)
-    .map((line) =>
-      shouldPrefixProgressLine(line) ? `${bullet} ${formatLine(line)}` : formatLine(line),
-    );
-  return [label, ...lines].filter((line): line is string => Boolean(line)).join("\n");
+    .map(({ text, isLabelLine }) => {
+      const formatted = formatLine(text);
+      return !isLabelLine && shouldPrefixProgressLine(text) ? `${bullet} ${formatted}` : formatted;
+    });
+  return [labelPlacement === "header" ? label : undefined, ...lines]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
 }

--- a/src/plugin-sdk/channel-streaming.ts
+++ b/src/plugin-sdk/channel-streaming.ts
@@ -749,7 +749,25 @@ function compactChannelProgressDraftLine(line: string, maxChars: number): string
 }
 
 function getProgressDraftLineText(line: string | ChannelProgressDraftLine): string {
-  return typeof line === "string" ? line : line.text;
+  if (typeof line === "string") {
+    return line;
+  }
+  const icon = line.icon?.trim();
+  const prefix = icon ? `${icon} ` : "";
+  const detail = line.detail?.trim();
+  if (detail) {
+    return `${prefix}${detail}`;
+  }
+  const status = line.status?.trim();
+  if (status) {
+    return `${prefix}${status}`;
+  }
+  const text = line.text.trim();
+  const label = line.label.trim();
+  if (!icon && text && text !== label) {
+    return text;
+  }
+  return `${prefix}${label}`.trim();
 }
 
 export function formatChannelProgressDraftText(params: {
@@ -758,8 +776,6 @@ export function formatChannelProgressDraftText(params: {
   seed?: string;
   random?: () => number;
   formatLine?: (line: string) => string;
-  formatStructuredLine?: (line: ChannelProgressDraftLine) => string;
-  labelPlacement?: "header" | "line";
   bullet?: string;
 }): string {
   const label = resolveChannelProgressDraftLabel({
@@ -770,9 +786,9 @@ export function formatChannelProgressDraftText(params: {
   const maxLines = resolveChannelProgressDraftMaxLines(params.entry);
   const formatLine = params.formatLine ?? ((line: string) => line);
   const bullet = params.bullet ?? "•";
-  const labelPlacement = params.labelPlacement ?? "header";
-  const rawLines: Array<string | ChannelProgressDraftLine | { draftLabel: string }> =
-    labelPlacement === "line" && label ? [{ draftLabel: label }, ...params.lines] : params.lines;
+  const rawLines: Array<string | ChannelProgressDraftLine | { draftLabel: string }> = label
+    ? [{ draftLabel: label }, ...params.lines]
+    : params.lines;
   const lines = rawLines
     .map((line) => {
       const isLabelLine = typeof line === "object" && line !== null && "draftLabel" in line;
@@ -780,17 +796,15 @@ export function formatChannelProgressDraftText(params: {
         ? line.draftLabel
         : typeof line === "string"
           ? line
-          : (params.formatStructuredLine?.(line) ?? getProgressDraftLineText(line));
+          : getProgressDraftLineText(line);
       const text = compactChannelProgressDraftLine(rawText, DEFAULT_PROGRESS_DRAFT_MAX_LINE_CHARS);
       return text ? { text, isLabelLine } : undefined;
     })
     .filter((line): line is { text: string; isLabelLine: boolean } => Boolean(line))
     .slice(-maxLines)
     .map(({ text, isLabelLine }) => {
-      const formatted = formatLine(text);
+      const formatted = isLabelLine ? text : formatLine(text);
       return !isLabelLine && shouldPrefixProgressLine(text) ? `${bullet} ${formatted}` : formatted;
     });
-  return [labelPlacement === "header" ? label : undefined, ...lines]
-    .filter((line): line is string => Boolean(line))
-    .join("\n");
+  return lines.filter((line): line is string => Boolean(line)).join("\n");
 }


### PR DESCRIPTION
## Summary

- make shared progress draft labels render as rolling lines so starter text scrolls away instead of staying sticky
- render structured progress rows through the shared formatter as compact emoji + title + details; Discord, Slack, and Teams now use that path
- show web-search query text for provider/native argument shapes like `q`, `search_query`, and batched query arrays instead of falling back to bare `Web Search`
- skip empty Discord apply-patch starts until a patch summary exists and summarize bash commands with the shared exec explainer

## Real behavior proof

- Behavior addressed: Discord/Teams/Slack progress draft rows should keep rolling labels, preserve readable tool titles for structured rows, and show web-search query details instead of bare `Web Search`.
- Real environment tested: local OpenClaw checkout on macOS, Node 22+/tsx runtime, PR head `70233f8037`.
- Exact steps or command run after this patch: `node --import tsx -e 'import { buildChannelProgressDraftLine, formatChannelProgressDraftText } from "./src/plugin-sdk/channel-streaming.ts"; const lines = [buildChannelProgressDraftLine({event:"tool", name:"web_search", args:{search_query:[{q:"Codex OAuth API key"}], response_length:"short"}}), buildChannelProgressDraftLine({event:"tool", name:"bash", args:{command:"pnpm test"}})].filter(Boolean); console.log(formatChannelProgressDraftText({entry:{streaming:{progress:{label:"Shelling", maxLines:4}}}, lines}));'`
- Evidence after fix: console output from the real shared progress-draft formatter:

```text
Shelling
🔎 Web Search: for "Codex OAuth API key"
🛠️ Bash: run tests
```

- Observed result after fix: the draft text keeps the starter label as the first rolling line, renders the web-search row with the `Web Search` title plus query detail, and renders the bash row with the `Bash` title plus command summary.
- What was not tested: live Discord/Slack/Teams network delivery; covered the shared formatter plus channel controller tests locally.

## Verification

- `pnpm install`
- `pnpm test src/plugin-sdk/channel-streaming.test.ts extensions/discord/src/monitor/message-handler.process.test.ts src/agents/tool-display.test.ts`
- `pnpm test src/plugin-sdk/channel-streaming.test.ts extensions/discord/src/monitor/message-handler.process.test.ts extensions/slack/src/progress-blocks.test.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts extensions/msteams/src/reply-stream-controller.test.ts extensions/msteams/src/reply-dispatcher.test.ts src/agents/tool-display.test.ts`
- `pnpm plugin-sdk:api:check`
- `pnpm tsgo:extensions`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/concepts/progress-drafts.md docs/channels/discord.md src/plugin-sdk/channel-streaming.ts src/plugin-sdk/channel-streaming.test.ts extensions/discord/src/monitor/message-handler.process.test.ts`
- `pnpm build`
