### PR TITLE
Fix Codex plugin migration selection UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Docs: https://docs.openclaw.ai
 - Google Meet: preserve `realtime.introMessage: ""` so realtime Chrome joins can stay silent instead of restoring the default spoken intro. Thanks @vincentkoc.
 - CLI/migrate: add bulk on/off and skip controls to interactive Codex skill migration, leaving conflicting skill copies unchecked by default. (#77597) Thanks @kevinslin.
 - CLI/migrate: show native Codex plugin names before truncated plan items and prompt for plugin activation explicitly during interactive Codex migration instead of silently keeping every planned plugin. Thanks @kevinslin.
+- CLI/migrate: put migrated native Codex plugin activation behind guardian app-server mode when a usable built-in Codex auth profile exists and no app-server settings have been customized. Thanks @kevinslin.
 - OpenAI/Codex media: advertise Codex audio transcription in runtime and manifest metadata and route active Codex chat models to the OpenAI transcription default instead of sending chat model ids to audio transcription. Thanks @vincentkoc.
 - Models/auth: add `openclaw models auth list [--provider <id>] [--json]` so users can inspect saved per-agent auth profiles without dumping secrets or hitting the old “too many arguments” path. Thanks @vincentkoc.
 - Cron CLI: add `openclaw cron list --agent <id>`, normalize the requested agent id, and include jobs without a stored agent id under the configured default agent while keeping `cron list` unfiltered when no agent is supplied. Fixes #77118. Thanks @zhanggttry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Docs: https://docs.openclaw.ai
 - Voice Call/realtime: bound the paced Twilio audio queue and close overloaded realtime streams before provider audio can pile up behind the websocket backpressure guard. Thanks @vincentkoc.
 - Google Meet: preserve `realtime.introMessage: ""` so realtime Chrome joins can stay silent instead of restoring the default spoken intro. Thanks @vincentkoc.
 - CLI/migrate: add bulk on/off and skip controls to interactive Codex skill migration, leaving conflicting skill copies unchecked by default. (#77597) Thanks @kevinslin.
+- CLI/migrate: show native Codex plugin names before truncated plan items and prompt for plugin activation explicitly during interactive Codex migration instead of silently keeping every planned plugin. Thanks @kevinslin.
 - OpenAI/Codex media: advertise Codex audio transcription in runtime and manifest metadata and route active Codex chat models to the OpenAI transcription default instead of sending chat model ids to audio transcription. Thanks @vincentkoc.
 - Models/auth: add `openclaw models auth list [--provider <id>] [--json]` so users can inspect saved per-agent auth profiles without dumping secrets or hitting the old “too many arguments” path. Thanks @vincentkoc.
 - Cron CLI: add `openclaw cron list --agent <id>`, normalize the requested agent id, and include jobs without a stored agent id under the configured default agent while keeping `cron list` unfiltered when no agent is supplied. Fixes #77118. Thanks @zhanggttry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,6 @@ Docs: https://docs.openclaw.ai
 - Google Meet: preserve `realtime.introMessage: ""` so realtime Chrome joins can stay silent instead of restoring the default spoken intro. Thanks @vincentkoc.
 - CLI/migrate: add bulk on/off and skip controls to interactive Codex skill migration, leaving conflicting skill copies unchecked by default. (#77597) Thanks @kevinslin.
 - CLI/migrate: show native Codex plugin names before truncated plan items and prompt for plugin activation explicitly during interactive Codex migration instead of silently keeping every planned plugin. Thanks @kevinslin.
-- CLI/migrate: put migrated native Codex plugin activation behind guardian app-server mode when a usable built-in Codex auth profile exists and no app-server settings have been customized. Thanks @kevinslin.
 - CLI/migrate: leave already configured target Codex plugins unchecked in the interactive plugin selector and show a `plugin exists` conflict hint while keeping new plugin activations selected by default. Thanks @kevinslin.
 - OpenAI/Codex media: advertise Codex audio transcription in runtime and manifest metadata and route active Codex chat models to the OpenAI transcription default instead of sending chat model ids to audio transcription. Thanks @vincentkoc.
 - Models/auth: add `openclaw models auth list [--provider <id>] [--json]` so users can inspect saved per-agent auth profiles without dumping secrets or hitting the old “too many arguments” path. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Docs: https://docs.openclaw.ai
 - CLI/migrate: add bulk on/off and skip controls to interactive Codex skill migration, leaving conflicting skill copies unchecked by default. (#77597) Thanks @kevinslin.
 - CLI/migrate: show native Codex plugin names before truncated plan items and prompt for plugin activation explicitly during interactive Codex migration instead of silently keeping every planned plugin. Thanks @kevinslin.
 - CLI/migrate: leave already configured target Codex plugins unchecked in the interactive plugin selector and show a `plugin exists` conflict hint while keeping new plugin activations selected by default. Thanks @kevinslin.
+- CLI/migrate: return cleanly without apply confirmation when interactive Codex migration leaves both skill copies and native plugin activations unselected. Thanks @kevinslin.
 - OpenAI/Codex media: advertise Codex audio transcription in runtime and manifest metadata and route active Codex chat models to the OpenAI transcription default instead of sending chat model ids to audio transcription. Thanks @vincentkoc.
 - Models/auth: add `openclaw models auth list [--provider <id>] [--json]` so users can inspect saved per-agent auth profiles without dumping secrets or hitting the old “too many arguments” path. Thanks @vincentkoc.
 - Cron CLI: add `openclaw cron list --agent <id>`, normalize the requested agent id, and include jobs without a stored agent id under the configured default agent while keeping `cron list` unfiltered when no agent is supplied. Fixes #77118. Thanks @zhanggttry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Docs: https://docs.openclaw.ai
 - CLI/migrate: add bulk on/off and skip controls to interactive Codex skill migration, leaving conflicting skill copies unchecked by default. (#77597) Thanks @kevinslin.
 - CLI/migrate: show native Codex plugin names before truncated plan items and prompt for plugin activation explicitly during interactive Codex migration instead of silently keeping every planned plugin. Thanks @kevinslin.
 - CLI/migrate: put migrated native Codex plugin activation behind guardian app-server mode when a usable built-in Codex auth profile exists and no app-server settings have been customized. Thanks @kevinslin.
+- CLI/migrate: leave already configured target Codex plugins unchecked in the interactive plugin selector and show a `plugin exists` conflict hint while keeping new plugin activations selected by default. Thanks @kevinslin.
 - OpenAI/Codex media: advertise Codex audio transcription in runtime and manifest metadata and route active Codex chat models to the OpenAI transcription default instead of sending chat model ids to audio transcription. Thanks @vincentkoc.
 - Models/auth: add `openclaw models auth list [--provider <id>] [--json]` so users can inspect saved per-agent auth profiles without dumping secrets or hitting the old “too many arguments” path. Thanks @vincentkoc.
 - Cron CLI: add `openclaw cron list --agent <id>`, normalize the requested agent id, and include jobs without a stored agent id under the configured default agent while keeping `cron list` unfiltered when no agent is supplied. Fixes #77118. Thanks @zhanggttry.

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -57,7 +57,7 @@ openclaw onboard --import-from hermes --import-source ~/.hermes
   Select one skill copy item by skill name or item id. Repeat the flag to migrate multiple skills. When omitted, interactive Codex migrations show a checkbox selector and non-interactive migrations keep all planned skills.
 </ParamField>
 <ParamField path="--plugin <name>" type="string">
-  Select one Codex plugin install item by plugin name or item id. Repeat the flag to migrate multiple Codex plugins. This only applies to source-installed `openai-curated` Codex plugins discovered by the Codex app-server inventory.
+  Select one Codex plugin install item by plugin name or item id. Repeat the flag to migrate multiple Codex plugins. When omitted, interactive Codex migrations show a native Codex plugin checkbox selector and non-interactive migrations keep all planned plugins. This only applies to source-installed `openai-curated` Codex plugins discovered by the Codex app-server inventory.
 </ParamField>
 <ParamField path="--no-backup" type="boolean">
   Skip the pre-apply backup. Requires `--force` when local OpenClaw state exists.
@@ -123,19 +123,23 @@ launches use per-agent `CODEX_HOME` and `HOME` directories, so they do not read
 your personal Codex CLI state by default.
 
 Running `openclaw migrate codex` in an interactive terminal previews the full
-plan, then opens a checkbox selector for skill copy items before the final
-apply confirmation. Use `Toggle all on` or `Toggle all off` for bulk selection;
-planned skills start checked, conflict skills start unchecked, and `Skip for now`
-leaves skills unchanged without applying. For scripted or exact runs, pass
-`--skill <name>` once per skill, for example:
+plan, then opens checkbox selectors before the final apply confirmation. Skill
+copy items are prompted first. Use `Toggle all on` or `Toggle all off` for bulk
+selection; planned skills start checked, conflict skills start unchecked, and
+`Skip for now` leaves skills unchanged without applying. When source-installed
+curated Codex plugins are migratable and `--plugin` was not supplied, migration
+then prompts for native Codex plugin activation by plugin name. Plugin items
+start checked; choose `Toggle all off` to migrate no native Codex plugins in
+that run, or `Skip for now` to stop before applying. For scripted or exact runs,
+pass `--skill <name>` once per skill, for example:
 
 ```bash
 openclaw migrate codex --dry-run --skill gog-vault77-google-workspace
 openclaw migrate apply codex --yes --skill gog-vault77-google-workspace
 ```
 
-Use `--plugin <name>` to limit native Codex plugin migration to one or more
-source-installed curated plugins:
+Use `--plugin <name>` to limit native Codex plugin migration non-interactively
+to one or more source-installed curated plugins:
 
 ```bash
 openclaw migrate codex --dry-run --plugin google-calendar

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -172,9 +172,6 @@ manual review.
 For migrated source-installed curated plugins, apply writes:
 
 - `plugins.entries.codex.enabled: true`
-- `plugins.entries.codex.config.appServer.mode: "guardian"` when a usable
-  `openai-codex` auth profile is available and no app-server settings already
-  exist
 - `plugins.entries.codex.config.codexPlugins.enabled: true`
 - `plugins.entries.codex.config.codexPlugins.allow_destructive_actions: false`
 - one explicit plugin entry with `marketplaceName: "openai-curated"` and

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -126,12 +126,15 @@ Running `openclaw migrate codex` in an interactive terminal previews the full
 plan, then opens checkbox selectors before the final apply confirmation. Skill
 copy items are prompted first. Use `Toggle all on` or `Toggle all off` for bulk
 selection; planned skills start checked, conflict skills start unchecked, and
-`Skip for now` leaves skills unchanged without applying. When source-installed
-curated Codex plugins are migratable and `--plugin` was not supplied, migration
-then prompts for native Codex plugin activation by plugin name. Plugin items
-start checked; choose `Toggle all off` to migrate no native Codex plugins in
-that run, or `Skip for now` to stop before applying. For scripted or exact runs,
-pass `--skill <name>` once per skill, for example:
+`Skip for now` skips skill copies for this run while still continuing to plugin
+selection. When source-installed curated Codex plugins are migratable and
+`--plugin` was not supplied, migration then prompts for native Codex plugin
+activation by plugin name. Plugin items
+start checked unless the target OpenClaw Codex plugin config already has that
+plugin. Existing target plugins start unchecked and show a conflict hint such as
+`conflict: plugin exists`; choose `Toggle all off` to migrate no native Codex
+plugins in that run, or `Skip for now` to stop before applying. For scripted or
+exact runs, pass `--skill <name>` once per skill, for example:
 
 ```bash
 openclaw migrate codex --dry-run --skill gog-vault77-google-workspace

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -169,6 +169,9 @@ manual review.
 For migrated source-installed curated plugins, apply writes:
 
 - `plugins.entries.codex.enabled: true`
+- `plugins.entries.codex.config.appServer.mode: "guardian"` when a usable
+  `openai-codex` auth profile is available and no app-server settings already
+  exist
 - `plugins.entries.codex.config.codexPlugins.enabled: true`
 - `plugins.entries.codex.config.codexPlugins.allow_destructive_actions: false`
 - one explicit plugin entry with `marketplaceName: "openai-curated"` and

--- a/extensions/codex/src/migration/apply.ts
+++ b/extensions/codex/src/migration/apply.ts
@@ -33,14 +33,13 @@ import type { v2 } from "../app-server/protocol.js";
 import { requestCodexAppServerJson } from "../app-server/request.js";
 import { buildCodexMigrationPlan } from "./plan.js";
 import {
-  buildCodexPluginsConfigValueForContext,
+  buildCodexPluginsConfigValue,
   CODEX_PLUGIN_CONFIG_ITEM_ID,
   CODEX_PLUGIN_CONFIG_PATH,
   hasCodexPluginConfigConflict,
   readCodexPluginMigrationConfigEntry,
   type CodexPluginMigrationConfigEntry,
 } from "./plan.js";
-import { resolveCodexMigrationTargets } from "./targets.js";
 
 const CODEX_PLUGIN_AUTH_REQUIRED_REASON = "auth_required";
 const CODEX_PLUGIN_NOT_SELECTED_REASON = "not selected for migration";
@@ -179,9 +178,7 @@ async function applyCodexPluginConfigItem(
     return markMigrationItemError(item, "config runtime unavailable");
   }
   const currentConfig = configApi.current() as MigrationProviderContext["config"];
-  const value = buildCodexPluginsConfigValueForContext({ ...ctx, config: currentConfig }, entries, {
-    agentDir: resolveCodexMigrationTargets({ ...ctx, config: currentConfig }).agentDir,
-  });
+  const value = buildCodexPluginsConfigValue(entries, { config: currentConfig });
   if (!ctx.overwrite && hasCodexPluginConfigConflict(currentConfig, value)) {
     return markMigrationItemConflict(item, MIGRATION_REASON_TARGET_EXISTS);
   }

--- a/extensions/codex/src/migration/apply.ts
+++ b/extensions/codex/src/migration/apply.ts
@@ -33,13 +33,14 @@ import type { v2 } from "../app-server/protocol.js";
 import { requestCodexAppServerJson } from "../app-server/request.js";
 import { buildCodexMigrationPlan } from "./plan.js";
 import {
-  buildCodexPluginsConfigValue,
+  buildCodexPluginsConfigValueForContext,
   CODEX_PLUGIN_CONFIG_ITEM_ID,
   CODEX_PLUGIN_CONFIG_PATH,
   hasCodexPluginConfigConflict,
   readCodexPluginMigrationConfigEntry,
   type CodexPluginMigrationConfigEntry,
 } from "./plan.js";
+import { resolveCodexMigrationTargets } from "./targets.js";
 
 const CODEX_PLUGIN_AUTH_REQUIRED_REASON = "auth_required";
 const CODEX_PLUGIN_NOT_SELECTED_REASON = "not selected for migration";
@@ -178,7 +179,9 @@ async function applyCodexPluginConfigItem(
     return markMigrationItemError(item, "config runtime unavailable");
   }
   const currentConfig = configApi.current() as MigrationProviderContext["config"];
-  const value = buildCodexPluginsConfigValue(entries, { config: currentConfig });
+  const value = buildCodexPluginsConfigValueForContext({ ...ctx, config: currentConfig }, entries, {
+    agentDir: resolveCodexMigrationTargets({ ...ctx, config: currentConfig }).agentDir,
+  });
   if (!ctx.overwrite && hasCodexPluginConfigConflict(currentConfig, value)) {
     return markMigrationItemConflict(item, MIGRATION_REASON_TARGET_EXISTS);
   }

--- a/extensions/codex/src/migration/plan.ts
+++ b/extensions/codex/src/migration/plan.ts
@@ -12,6 +12,7 @@ import type {
   MigrationPlan,
   MigrationProviderContext,
 } from "openclaw/plugin-sdk/plugin-entry";
+import { isProviderAuthProfileConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { CODEX_PLUGINS_MARKETPLACE_NAME } from "../app-server/config.js";
 import { exists, sanitizeName } from "./helpers.js";
 import {
@@ -31,6 +32,13 @@ const CODEX_PLUGIN_NATIVE_CONFIG_PATH = [
   "codex",
   "config",
   "codexPlugins",
+] as const;
+const CODEX_APP_SERVER_CONFIG_PATH = [
+  "plugins",
+  "entries",
+  "codex",
+  "config",
+  "appServer",
 ] as const;
 
 export type CodexPluginMigrationConfigEntry = {
@@ -188,9 +196,44 @@ function readExistingAllowDestructiveActions(
   return typeof value === "boolean" ? value : undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function hasCustomAppServerConfig(config: MigrationProviderContext["config"]): boolean {
+  const value = readMigrationConfigPath(
+    config as Record<string, unknown>,
+    CODEX_APP_SERVER_CONFIG_PATH,
+  );
+  if (value === undefined) {
+    return false;
+  }
+  if (!isRecord(value)) {
+    return true;
+  }
+  return Object.keys(value).length > 0;
+}
+
+function shouldEnableGuardianAppServerMode(params: {
+  ctx: MigrationProviderContext;
+  agentDir: string;
+}): boolean {
+  if (hasCustomAppServerConfig(params.ctx.config)) {
+    return false;
+  }
+  return isProviderAuthProfileConfigured({
+    provider: "openai-codex",
+    cfg: params.ctx.config,
+    agentDir: params.agentDir,
+  });
+}
+
 export function buildCodexPluginsConfigValue(
   entries: readonly CodexPluginMigrationConfigEntry[],
-  params: { config?: MigrationProviderContext["config"] } = {},
+  params: {
+    config?: MigrationProviderContext["config"];
+    guardianAppServerMode?: boolean;
+  } = {},
 ): Record<string, unknown> {
   const plugins = Object.fromEntries(
     entries
@@ -204,19 +247,37 @@ export function buildCodexPluginsConfigValue(
         },
       ]),
   );
-  return {
-    enabled: true,
-    config: {
-      codexPlugins: {
-        enabled: true,
-        allow_destructive_actions:
-          params.config === undefined
-            ? false
-            : (readExistingAllowDestructiveActions(params.config) ?? false),
-        plugins,
-      },
+  const config: Record<string, unknown> = {
+    codexPlugins: {
+      enabled: true,
+      allow_destructive_actions:
+        params.config === undefined
+          ? false
+          : (readExistingAllowDestructiveActions(params.config) ?? false),
+      plugins,
     },
   };
+  if (params.guardianAppServerMode === true) {
+    config.appServer = { mode: "guardian" };
+  }
+  return {
+    enabled: true,
+    config,
+  };
+}
+
+export function buildCodexPluginsConfigValueForContext(
+  ctx: MigrationProviderContext,
+  entries: readonly CodexPluginMigrationConfigEntry[],
+  params: { agentDir: string },
+): Record<string, unknown> {
+  return buildCodexPluginsConfigValue(entries, {
+    config: ctx.config,
+    guardianAppServerMode: shouldEnableGuardianAppServerMode({
+      ctx,
+      agentDir: params.agentDir,
+    }),
+  });
 }
 
 export function hasCodexPluginConfigConflict(
@@ -237,6 +298,7 @@ export function hasCodexPluginConfigConflict(
 function buildPluginConfigItem(
   ctx: MigrationProviderContext,
   pluginItems: readonly MigrationItem[],
+  params: { agentDir: string },
 ): MigrationItem | undefined {
   const entries = pluginItems
     .map((item) => readCodexPluginMigrationConfigEntry(item, true))
@@ -244,7 +306,9 @@ function buildPluginConfigItem(
   if (entries.length === 0) {
     return undefined;
   }
-  const value = buildCodexPluginsConfigValue(entries, { config: ctx.config });
+  const value = buildCodexPluginsConfigValueForContext(ctx, entries, {
+    agentDir: params.agentDir,
+  });
   const conflict = !ctx.overwrite && hasCodexPluginConfigConflict(ctx.config, value);
   return createMigrationItem({
     id: CODEX_PLUGIN_CONFIG_ITEM_ID,
@@ -282,7 +346,9 @@ export async function buildCodexMigrationPlan(
   );
   const pluginItems = buildPluginItems(source.plugins);
   items.push(...pluginItems);
-  const pluginConfigItem = buildPluginConfigItem(ctx, pluginItems);
+  const pluginConfigItem = buildPluginConfigItem(ctx, pluginItems, {
+    agentDir: targets.agentDir,
+  });
   if (pluginConfigItem) {
     items.push(pluginConfigItem);
   }

--- a/extensions/codex/src/migration/plan.ts
+++ b/extensions/codex/src/migration/plan.ts
@@ -33,6 +33,7 @@ const CODEX_PLUGIN_NATIVE_CONFIG_PATH = [
   "config",
   "codexPlugins",
 ] as const;
+const MIGRATION_REASON_PLUGIN_EXISTS = "plugin exists";
 const CODEX_APP_SERVER_CONFIG_PATH = [
   "plugins",
   "entries",
@@ -115,12 +116,42 @@ function uniquePluginConfigKey(
   return sanitizeName(`${base}-${next}`) || base;
 }
 
-function buildPluginItems(plugins: readonly CodexPluginSource[]): MigrationItem[] {
+function readExistingCodexPluginEntries(
+  config: MigrationProviderContext["config"],
+): Record<string, unknown> {
+  const entries = readMigrationConfigPath(config as Record<string, unknown>, [
+    ...CODEX_PLUGIN_NATIVE_CONFIG_PATH,
+    "plugins",
+  ]);
+  return isRecord(entries) ? entries : {};
+}
+
+function hasExistingCodexPluginEntry(
+  existingEntries: Record<string, unknown>,
+  configKey: string,
+  pluginName: string,
+): boolean {
+  if (existingEntries[configKey] !== undefined) {
+    return true;
+  }
+  return Object.values(existingEntries).some((entry) => {
+    if (!isRecord(entry)) {
+      return false;
+    }
+    return entry.pluginName === pluginName;
+  });
+}
+
+function buildPluginItems(
+  ctx: MigrationProviderContext,
+  plugins: readonly CodexPluginSource[],
+): MigrationItem[] {
   const baseCounts = new Map<string, number>();
   for (const plugin of plugins.filter((entry) => entry.migratable)) {
     const base = sanitizeName(plugin.pluginName ?? plugin.name) || "codex-plugin";
     baseCounts.set(base, (baseCounts.get(base) ?? 0) + 1);
   }
+  const existingPluginEntries = readExistingCodexPluginEntries(ctx.config);
   const usedCounts = new Map<string, number>();
   let manualIndex = 0;
   const items: MigrationItem[] = [];
@@ -131,11 +162,16 @@ function buildPluginItems(plugins: readonly CodexPluginSource[]): MigrationItem[
       plugin.pluginName
     ) {
       const configKey = uniquePluginConfigKey(plugin, baseCounts, usedCounts);
+      const conflict =
+        !ctx.overwrite &&
+        hasExistingCodexPluginEntry(existingPluginEntries, configKey, plugin.pluginName);
       items.push(
         createMigrationItem({
           id: `plugin:${configKey}`,
           kind: "plugin",
           action: "install",
+          status: conflict ? "conflict" : "planned",
+          reason: conflict ? MIGRATION_REASON_PLUGIN_EXISTS : undefined,
           source: plugin.source,
           target: `plugins.entries.codex.config.codexPlugins.plugins.${configKey}`,
           message: `Install Codex plugin "${plugin.pluginName}" in the OpenClaw-managed Codex app-server runtime.`,
@@ -292,7 +328,43 @@ export function hasCodexPluginConfigConflict(
     return true;
   }
   const nativeConfig = (value.config as Record<string, unknown> | undefined)?.codexPlugins;
-  return hasMigrationConfigPatchConflict(config, CODEX_PLUGIN_NATIVE_CONFIG_PATH, nativeConfig);
+  if (!isRecord(nativeConfig)) {
+    return hasMigrationConfigPatchConflict(config, CODEX_PLUGIN_NATIVE_CONFIG_PATH, nativeConfig);
+  }
+  const existingNativeConfig = readMigrationConfigPath(
+    config as Record<string, unknown>,
+    CODEX_PLUGIN_NATIVE_CONFIG_PATH,
+  );
+  if (existingNativeConfig === undefined) {
+    return false;
+  }
+  if (!isRecord(existingNativeConfig)) {
+    return true;
+  }
+  if (existingNativeConfig.enabled !== undefined && existingNativeConfig.enabled !== true) {
+    return true;
+  }
+  const allowDestructiveActions = nativeConfig.allow_destructive_actions;
+  if (
+    existingNativeConfig.allow_destructive_actions !== undefined &&
+    existingNativeConfig.allow_destructive_actions !== allowDestructiveActions
+  ) {
+    return true;
+  }
+  const plugins = nativeConfig.plugins;
+  if (!isRecord(plugins)) {
+    return false;
+  }
+  return Object.entries(plugins).some(([configKey, plugin]) => {
+    if (!isRecord(plugin)) {
+      return existingNativeConfig[configKey] !== undefined;
+    }
+    return hasExistingCodexPluginEntry(
+      readExistingCodexPluginEntries(config),
+      configKey,
+      typeof plugin.pluginName === "string" ? plugin.pluginName : configKey,
+    );
+  });
 }
 
 function buildPluginConfigItem(
@@ -301,6 +373,7 @@ function buildPluginConfigItem(
   params: { agentDir: string },
 ): MigrationItem | undefined {
   const entries = pluginItems
+    .filter((item) => item.status === "planned")
     .map((item) => readCodexPluginMigrationConfigEntry(item, true))
     .filter((entry): entry is CodexPluginMigrationConfigEntry => entry !== undefined);
   if (entries.length === 0) {
@@ -344,7 +417,7 @@ export async function buildCodexMigrationPlan(
       overwrite: ctx.overwrite,
     })),
   );
-  const pluginItems = buildPluginItems(source.plugins);
+  const pluginItems = buildPluginItems(ctx, source.plugins);
   items.push(...pluginItems);
   const pluginConfigItem = buildPluginConfigItem(ctx, pluginItems, {
     agentDir: targets.agentDir,
@@ -369,7 +442,7 @@ export async function buildCodexMigrationPlan(
   const warnings = [
     ...(items.some((item) => item.status === "conflict")
       ? [
-          "Conflicts were found. Re-run with --overwrite to replace conflicting skill targets after item-level backups.",
+          "Conflicts were found. Re-run with --overwrite to replace conflicting migration targets after item-level backups.",
         ]
       : []),
     ...(source.plugins.length > 0

--- a/extensions/codex/src/migration/plan.ts
+++ b/extensions/codex/src/migration/plan.ts
@@ -12,7 +12,6 @@ import type {
   MigrationPlan,
   MigrationProviderContext,
 } from "openclaw/plugin-sdk/plugin-entry";
-import { isProviderAuthProfileConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { CODEX_PLUGINS_MARKETPLACE_NAME } from "../app-server/config.js";
 import { exists, sanitizeName } from "./helpers.js";
 import {
@@ -34,13 +33,6 @@ const CODEX_PLUGIN_NATIVE_CONFIG_PATH = [
   "codexPlugins",
 ] as const;
 const MIGRATION_REASON_PLUGIN_EXISTS = "plugin exists";
-const CODEX_APP_SERVER_CONFIG_PATH = [
-  "plugins",
-  "entries",
-  "codex",
-  "config",
-  "appServer",
-] as const;
 
 export type CodexPluginMigrationConfigEntry = {
   configKey: string;
@@ -236,39 +228,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
-function hasCustomAppServerConfig(config: MigrationProviderContext["config"]): boolean {
-  const value = readMigrationConfigPath(
-    config as Record<string, unknown>,
-    CODEX_APP_SERVER_CONFIG_PATH,
-  );
-  if (value === undefined) {
-    return false;
-  }
-  if (!isRecord(value)) {
-    return true;
-  }
-  return Object.keys(value).length > 0;
-}
-
-function shouldEnableGuardianAppServerMode(params: {
-  ctx: MigrationProviderContext;
-  agentDir: string;
-}): boolean {
-  if (hasCustomAppServerConfig(params.ctx.config)) {
-    return false;
-  }
-  return isProviderAuthProfileConfigured({
-    provider: "openai-codex",
-    cfg: params.ctx.config,
-    agentDir: params.agentDir,
-  });
-}
-
 export function buildCodexPluginsConfigValue(
   entries: readonly CodexPluginMigrationConfigEntry[],
   params: {
     config?: MigrationProviderContext["config"];
-    guardianAppServerMode?: boolean;
   } = {},
 ): Record<string, unknown> {
   const plugins = Object.fromEntries(
@@ -293,27 +256,10 @@ export function buildCodexPluginsConfigValue(
       plugins,
     },
   };
-  if (params.guardianAppServerMode === true) {
-    config.appServer = { mode: "guardian" };
-  }
   return {
     enabled: true,
     config,
   };
-}
-
-export function buildCodexPluginsConfigValueForContext(
-  ctx: MigrationProviderContext,
-  entries: readonly CodexPluginMigrationConfigEntry[],
-  params: { agentDir: string },
-): Record<string, unknown> {
-  return buildCodexPluginsConfigValue(entries, {
-    config: ctx.config,
-    guardianAppServerMode: shouldEnableGuardianAppServerMode({
-      ctx,
-      agentDir: params.agentDir,
-    }),
-  });
 }
 
 export function hasCodexPluginConfigConflict(
@@ -370,7 +316,6 @@ export function hasCodexPluginConfigConflict(
 function buildPluginConfigItem(
   ctx: MigrationProviderContext,
   pluginItems: readonly MigrationItem[],
-  params: { agentDir: string },
 ): MigrationItem | undefined {
   const entries = pluginItems
     .filter((item) => item.status === "planned")
@@ -379,9 +324,7 @@ function buildPluginConfigItem(
   if (entries.length === 0) {
     return undefined;
   }
-  const value = buildCodexPluginsConfigValueForContext(ctx, entries, {
-    agentDir: params.agentDir,
-  });
+  const value = buildCodexPluginsConfigValue(entries, { config: ctx.config });
   const conflict = !ctx.overwrite && hasCodexPluginConfigConflict(ctx.config, value);
   return createMigrationItem({
     id: CODEX_PLUGIN_CONFIG_ITEM_ID,
@@ -419,9 +362,7 @@ export async function buildCodexMigrationPlan(
   );
   const pluginItems = buildPluginItems(ctx, source.plugins);
   items.push(...pluginItems);
-  const pluginConfigItem = buildPluginConfigItem(ctx, pluginItems, {
-    agentDir: targets.agentDir,
-  });
+  const pluginConfigItem = buildPluginConfigItem(ctx, pluginItems);
   if (pluginConfigItem) {
     items.push(pluginConfigItem);
   }

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -428,7 +428,7 @@ describe("buildCodexMigrationProvider", () => {
     );
   });
 
-  it("migrates to guardian app-server mode when default Codex auth exists and app-server settings are unset", async () => {
+  it("does not change app-server mode when default Codex auth exists and app-server settings are unset", async () => {
     const fixture = await createCodexFixture();
     await writeDefaultCodexAuthProfile(fixture);
     const configState: MigrationProviderContext["config"] = {
@@ -470,20 +470,16 @@ describe("buildCodexMigrationProvider", () => {
         expect.objectContaining({
           id: "config:codex-plugins",
           status: "migrated",
-          details: expect.objectContaining({
-            value: expect.objectContaining({
-              config: expect.objectContaining({
-                appServer: { mode: "guardian" },
-              }),
-            }),
-          }),
         }),
       ]),
     );
+    const configItem = result.items.find((item) => item.id === "config:codex-plugins");
+    expect(
+      (configItem?.details?.value as { config?: Record<string, unknown> } | undefined)?.config,
+    ).not.toHaveProperty("appServer");
     expect(configState.plugins?.entries?.codex).toMatchObject({
       enabled: true,
       config: {
-        appServer: { mode: "guardian" },
         codexPlugins: {
           enabled: true,
           plugins: {
@@ -496,11 +492,11 @@ describe("buildCodexMigrationProvider", () => {
         },
       },
     });
+    expect(configState.plugins?.entries?.codex?.config).not.toHaveProperty("appServer");
   });
 
-  it("preserves explicit app-server settings instead of forcing guardian during plugin migration", async () => {
+  it("preserves explicit app-server settings during plugin migration", async () => {
     const fixture = await createCodexFixture();
-    await writeDefaultCodexAuthProfile(fixture);
     const configState: MigrationProviderContext["config"] = {
       plugins: {
         entries: {

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -95,28 +95,6 @@ async function createCodexFixture(): Promise<{
   return { root, homeDir, codexHome, stateDir, workspaceDir };
 }
 
-async function writeDefaultCodexAuthProfile(fixture: { stateDir: string }): Promise<void> {
-  await writeFile(
-    path.join(fixture.stateDir, "agents", "main", "agent", "auth-profiles.json"),
-    `${JSON.stringify(
-      {
-        version: 1,
-        profiles: {
-          "openai-codex:default": {
-            type: "oauth",
-            provider: "openai-codex",
-            access: "access-token",
-            refresh: "refresh-token",
-            expires: Date.now() + 60_000,
-          },
-        },
-      },
-      null,
-      2,
-    )}\n`,
-  );
-}
-
 afterEach(async () => {
   vi.unstubAllEnvs();
   appServerRequest.mockReset();
@@ -426,73 +404,6 @@ describe("buildCodexMigrationProvider", () => {
         }),
       ]),
     );
-  });
-
-  it("does not change app-server mode when default Codex auth exists and app-server settings are unset", async () => {
-    const fixture = await createCodexFixture();
-    await writeDefaultCodexAuthProfile(fixture);
-    const configState: MigrationProviderContext["config"] = {
-      agents: { defaults: { workspace: fixture.workspaceDir } },
-    } as MigrationProviderContext["config"];
-    appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
-      if (method === "plugin/list") {
-        return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
-      }
-      if (method === "plugin/install") {
-        return { authPolicy: "ON_USE", appsNeedingAuth: [] } satisfies v2.PluginInstallResponse;
-      }
-      if (method === "skills/list") {
-        return { data: [] } satisfies v2.SkillsListResponse;
-      }
-      if (method === "hooks/list") {
-        return { data: [] } satisfies v2.HooksListResponse;
-      }
-      if (method === "config/mcpServer/reload") {
-        return {};
-      }
-      throw new Error(`unexpected request ${method}`);
-    });
-    const provider = buildCodexMigrationProvider({
-      runtime: createConfigRuntime(configState),
-    });
-
-    const result = await provider.apply(
-      makeContext({
-        source: fixture.codexHome,
-        stateDir: fixture.stateDir,
-        workspaceDir: fixture.workspaceDir,
-        config: configState,
-      }),
-    );
-
-    expect(result.items).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: "config:codex-plugins",
-          status: "migrated",
-        }),
-      ]),
-    );
-    const configItem = result.items.find((item) => item.id === "config:codex-plugins");
-    expect(
-      (configItem?.details?.value as { config?: Record<string, unknown> } | undefined)?.config,
-    ).not.toHaveProperty("appServer");
-    expect(configState.plugins?.entries?.codex).toMatchObject({
-      enabled: true,
-      config: {
-        codexPlugins: {
-          enabled: true,
-          plugins: {
-            "google-calendar": {
-              enabled: true,
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "google-calendar",
-            },
-          },
-        },
-      },
-    });
-    expect(configState.plugins?.entries?.codex?.config).not.toHaveProperty("appServer");
   });
 
   it("preserves explicit app-server settings during plugin migration", async () => {

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -364,6 +364,70 @@ describe("buildCodexMigrationProvider", () => {
     expect(configState.plugins?.entries?.codex?.config?.codexPlugins).not.toHaveProperty("*");
   });
 
+  it("plans already configured target Codex plugins as plugin-level conflicts", async () => {
+    const fixture = await createCodexFixture();
+    const configState: MigrationProviderContext["config"] = {
+      plugins: {
+        entries: {
+          codex: {
+            enabled: true,
+            config: {
+              codexPlugins: {
+                enabled: true,
+                allow_destructive_actions: false,
+                plugins: {
+                  "google-calendar": {
+                    enabled: true,
+                    marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+                    pluginName: "google-calendar",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      agents: { defaults: { workspace: fixture.workspaceDir } },
+    } as MigrationProviderContext["config"];
+    appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
+      if (method === "plugin/list") {
+        return pluginList([
+          pluginSummary("google-calendar", { installed: true, enabled: true }),
+          pluginSummary("gmail", { installed: true, enabled: true }),
+        ]);
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+    const provider = buildCodexMigrationProvider();
+
+    const result = await provider.plan(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+        config: configState,
+      }),
+    );
+
+    expect(result.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "plugin:google-calendar",
+          status: "conflict",
+          reason: "plugin exists",
+        }),
+        expect.objectContaining({
+          id: "plugin:gmail",
+          status: "planned",
+        }),
+        expect.objectContaining({
+          id: "config:codex-plugins",
+          status: "planned",
+        }),
+      ]),
+    );
+  });
+
   it("migrates to guardian app-server mode when default Codex auth exists and app-server settings are unset", async () => {
     const fixture = await createCodexFixture();
     await writeDefaultCodexAuthProfile(fixture);
@@ -486,7 +550,7 @@ describe("buildCodexMigrationProvider", () => {
     });
   });
 
-  it("does not merge migrated plugin config over existing codexPlugins without overwrite", async () => {
+  it("merges migrated plugin config with existing Codex plugins when entries do not conflict", async () => {
     const fixture = await createCodexFixture();
     const configState: MigrationProviderContext["config"] = {
       plugins: {
@@ -546,14 +610,18 @@ describe("buildCodexMigrationProvider", () => {
       expect.arrayContaining([
         expect.objectContaining({
           id: "config:codex-plugins",
-          status: "conflict",
-          reason: "target exists",
+          status: "migrated",
         }),
       ]),
     );
     expect(configState.plugins?.entries?.codex?.config?.codexPlugins).toMatchObject({
       allow_destructive_actions: true,
       plugins: {
+        "google-calendar": {
+          enabled: true,
+          marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+          pluginName: "google-calendar",
+        },
         slack: {
           enabled: true,
           marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
@@ -561,10 +629,6 @@ describe("buildCodexMigrationProvider", () => {
         },
       },
     });
-    const codexPlugins = configState.plugins?.entries?.codex?.config?.codexPlugins as
-      | { plugins?: Record<string, unknown> }
-      | undefined;
-    expect(codexPlugins?.plugins).not.toHaveProperty("google-calendar");
   });
 
   it("preserves existing destructive plugin policy when overwrite is explicit", async () => {

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -95,6 +95,28 @@ async function createCodexFixture(): Promise<{
   return { root, homeDir, codexHome, stateDir, workspaceDir };
 }
 
+async function writeDefaultCodexAuthProfile(fixture: { stateDir: string }): Promise<void> {
+  await writeFile(
+    path.join(fixture.stateDir, "agents", "main", "agent", "auth-profiles.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        profiles: {
+          "openai-codex:default": {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "access-token",
+            refresh: "refresh-token",
+            expires: Date.now() + 60_000,
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
 afterEach(async () => {
   vi.unstubAllEnvs();
   appServerRequest.mockReset();
@@ -340,6 +362,128 @@ describe("buildCodexMigrationProvider", () => {
       },
     });
     expect(configState.plugins?.entries?.codex?.config?.codexPlugins).not.toHaveProperty("*");
+  });
+
+  it("migrates to guardian app-server mode when default Codex auth exists and app-server settings are unset", async () => {
+    const fixture = await createCodexFixture();
+    await writeDefaultCodexAuthProfile(fixture);
+    const configState: MigrationProviderContext["config"] = {
+      agents: { defaults: { workspace: fixture.workspaceDir } },
+    } as MigrationProviderContext["config"];
+    appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/install") {
+        return { authPolicy: "ON_USE", appsNeedingAuth: [] } satisfies v2.PluginInstallResponse;
+      }
+      if (method === "skills/list") {
+        return { data: [] } satisfies v2.SkillsListResponse;
+      }
+      if (method === "hooks/list") {
+        return { data: [] } satisfies v2.HooksListResponse;
+      }
+      if (method === "config/mcpServer/reload") {
+        return {};
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+    const provider = buildCodexMigrationProvider({
+      runtime: createConfigRuntime(configState),
+    });
+
+    const result = await provider.apply(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+        config: configState,
+      }),
+    );
+
+    expect(result.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "config:codex-plugins",
+          status: "migrated",
+          details: expect.objectContaining({
+            value: expect.objectContaining({
+              config: expect.objectContaining({
+                appServer: { mode: "guardian" },
+              }),
+            }),
+          }),
+        }),
+      ]),
+    );
+    expect(configState.plugins?.entries?.codex).toMatchObject({
+      enabled: true,
+      config: {
+        appServer: { mode: "guardian" },
+        codexPlugins: {
+          enabled: true,
+          plugins: {
+            "google-calendar": {
+              enabled: true,
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "google-calendar",
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("preserves explicit app-server settings instead of forcing guardian during plugin migration", async () => {
+    const fixture = await createCodexFixture();
+    await writeDefaultCodexAuthProfile(fixture);
+    const configState: MigrationProviderContext["config"] = {
+      plugins: {
+        entries: {
+          codex: {
+            enabled: true,
+            config: {
+              appServer: { sandbox: "workspace-write" },
+            },
+          },
+        },
+      },
+      agents: { defaults: { workspace: fixture.workspaceDir } },
+    } as MigrationProviderContext["config"];
+    appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/install") {
+        return { authPolicy: "ON_USE", appsNeedingAuth: [] } satisfies v2.PluginInstallResponse;
+      }
+      if (method === "skills/list") {
+        return { data: [] } satisfies v2.SkillsListResponse;
+      }
+      if (method === "hooks/list") {
+        return { data: [] } satisfies v2.HooksListResponse;
+      }
+      if (method === "config/mcpServer/reload") {
+        return {};
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+    const provider = buildCodexMigrationProvider({
+      runtime: createConfigRuntime(configState),
+    });
+
+    await provider.apply(
+      makeContext({
+        source: fixture.codexHome,
+        stateDir: fixture.stateDir,
+        workspaceDir: fixture.workspaceDir,
+        config: configState,
+      }),
+    );
+
+    expect(configState.plugins?.entries?.codex?.config?.appServer).toEqual({
+      sandbox: "workspace-write",
+    });
   });
 
   it("does not merge migrated plugin config over existing codexPlugins without overwrite", async () => {

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -428,6 +428,141 @@ describe("migrateApplyCommand", () => {
     ).toEqual(["gmail"]);
   });
 
+  it("keeps all default plugin selections when interactive skills are toggled off", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    const skillPlan = codexSkillPlan();
+    const pluginPlan = codexPluginPlan();
+    const planned = codexSkillPlan({
+      summary: {
+        total: skillPlan.items.length + pluginPlan.items.length,
+        planned: skillPlan.items.length + pluginPlan.items.length,
+        migrated: 0,
+        skipped: 0,
+        conflicts: 0,
+        errors: 0,
+        sensitive: 0,
+      },
+      items: [...skillPlan.items, ...pluginPlan.items],
+    });
+    mocks.provider.plan.mockResolvedValue(planned);
+    mocks.multiselect
+      .mockResolvedValueOnce([MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF])
+      .mockResolvedValueOnce(["plugin:google-calendar", "plugin:gmail"]);
+    mocks.promptYesNo.mockResolvedValue(true);
+    mocks.provider.apply.mockImplementation(async (_ctx, selectedPlan: MigrationPlan) => ({
+      ...selectedPlan,
+      summary: { ...selectedPlan.summary, planned: 0, migrated: selectedPlan.summary.planned },
+      items: selectedPlan.items.map((item) =>
+        item.status === "planned" ? { ...item, status: "migrated" as const } : item,
+      ),
+    }));
+
+    await migrateDefaultCommand(runtime, { provider: "codex" });
+
+    expect(mocks.multiselect).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        message: expect.stringContaining("Select native Codex plugins"),
+        initialValues: ["plugin:google-calendar", "plugin:gmail"],
+      }),
+    );
+    const appliedPlan = mocks.provider.apply.mock.calls[0]?.[1] as MigrationPlan;
+    expect(appliedPlan.summary).toMatchObject({ planned: 4, skipped: 2, conflicts: 0 });
+    expect(appliedPlan.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "skill:alpha",
+          status: "skipped",
+          reason: "not selected for migration",
+        }),
+        expect.objectContaining({
+          id: "skill:beta",
+          status: "skipped",
+          reason: "not selected for migration",
+        }),
+        expect.objectContaining({ id: "plugin:google-calendar", status: "planned" }),
+        expect.objectContaining({ id: "plugin:gmail", status: "planned" }),
+        expect.objectContaining({ id: "config:codex-plugins", status: "planned" }),
+      ]),
+    );
+  });
+
+  it("leaves target-existing Codex plugins unchecked with a conflict hint", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    const planned = codexPluginPlan({
+      summary: {
+        total: 3,
+        planned: 2,
+        migrated: 0,
+        skipped: 0,
+        conflicts: 1,
+        errors: 0,
+        sensitive: 0,
+      },
+      items: [
+        {
+          id: "plugin:google-calendar",
+          kind: "plugin",
+          action: "install",
+          status: "conflict",
+          reason: "plugin exists",
+          details: {
+            configKey: "google-calendar",
+            marketplaceName: "openai-curated",
+            pluginName: "google-calendar",
+          },
+        },
+        codexPluginPlan().items[1]!,
+        codexPluginPlan().items[2]!,
+      ],
+    });
+    mocks.provider.plan.mockResolvedValue(planned);
+    mocks.multiselect.mockResolvedValue(["plugin:gmail"]);
+    mocks.promptYesNo.mockResolvedValue(true);
+    mocks.provider.apply.mockImplementation(async (_ctx, selectedPlan: MigrationPlan) => ({
+      ...selectedPlan,
+      summary: { ...selectedPlan.summary, planned: 0, migrated: selectedPlan.summary.planned },
+      items: selectedPlan.items.map((item) =>
+        item.status === "planned" ? { ...item, status: "migrated" as const } : item,
+      ),
+    }));
+
+    await migrateDefaultCommand(runtime, { provider: "codex" });
+
+    expect(mocks.multiselect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("Select native Codex plugins"),
+        initialValues: ["plugin:gmail"],
+        options: expect.arrayContaining([
+          expect.objectContaining({
+            value: "plugin:google-calendar",
+            label: "google-calendar",
+            hint: expect.stringContaining("conflict: plugin exists"),
+          }),
+          expect.objectContaining({ value: "plugin:gmail", label: "gmail" }),
+        ]),
+      }),
+    );
+    const appliedPlan = mocks.provider.apply.mock.calls[0]?.[1] as MigrationPlan;
+    expect(appliedPlan.summary).toMatchObject({ planned: 2, skipped: 1, conflicts: 0 });
+    expect(appliedPlan.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "plugin:google-calendar",
+          status: "skipped",
+          reason: "not selected for migration",
+        }),
+        expect.objectContaining({ id: "plugin:gmail", status: "planned" }),
+      ]),
+    );
+  });
+
   it("skips interactive Codex plugin migration before confirmation when Skip for now is selected", async () => {
     Object.defineProperty(process.stdin, "isTTY", {
       configurable: true,
@@ -585,22 +720,65 @@ describe("migrateApplyCommand", () => {
     expect(mocks.provider.apply).not.toHaveBeenCalled();
   });
 
-  it("skips interactive Codex skill migration when Skip for now is selected", async () => {
+  it("continues to interactive Codex plugins when skill migration is skipped", async () => {
     Object.defineProperty(process.stdin, "isTTY", {
       configurable: true,
       value: true,
     });
-    const planned = codexSkillPlan();
+    const skillPlan = codexSkillPlan();
+    const pluginPlan = codexPluginPlan();
+    const planned = codexSkillPlan({
+      summary: {
+        total: skillPlan.items.length + pluginPlan.items.length,
+        planned: skillPlan.items.length + pluginPlan.items.length,
+        migrated: 0,
+        skipped: 0,
+        conflicts: 0,
+        errors: 0,
+        sensitive: 0,
+      },
+      items: [...skillPlan.items, ...pluginPlan.items],
+    });
     mocks.provider.plan.mockResolvedValue(planned);
-    mocks.multiselect.mockResolvedValue([MIGRATION_SKILL_SELECTION_SKIP]);
+    mocks.multiselect
+      .mockResolvedValueOnce([MIGRATION_SKILL_SELECTION_SKIP])
+      .mockResolvedValueOnce(["plugin:gmail"]);
+    mocks.promptYesNo.mockResolvedValue(true);
+    mocks.provider.apply.mockImplementation(async (_ctx, selectedPlan: MigrationPlan) => ({
+      ...selectedPlan,
+      summary: { ...selectedPlan.summary, planned: 0, migrated: selectedPlan.summary.planned },
+      items: selectedPlan.items.map((item) =>
+        item.status === "planned" ? { ...item, status: "migrated" as const } : item,
+      ),
+    }));
 
-    const result = await migrateDefaultCommand(runtime, { provider: "codex" });
+    await migrateDefaultCommand(runtime, { provider: "codex" });
 
-    expect(result).toBe(planned);
-    expect(mocks.promptYesNo).not.toHaveBeenCalled();
-    expect(mocks.backupCreateCommand).not.toHaveBeenCalled();
-    expect(mocks.provider.apply).not.toHaveBeenCalled();
+    expect(mocks.multiselect).toHaveBeenCalledTimes(2);
     expect(runtime.log).toHaveBeenCalledWith("Codex skill migration skipped for now.");
+    expect(mocks.promptYesNo).toHaveBeenCalledWith("Apply this migration now?", false);
+    const appliedPlan = mocks.provider.apply.mock.calls[0]?.[1] as MigrationPlan;
+    expect(appliedPlan.summary).toMatchObject({ planned: 3, skipped: 3, conflicts: 0 });
+    expect(appliedPlan.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "skill:alpha",
+          status: "skipped",
+          reason: "not selected for migration",
+        }),
+        expect.objectContaining({
+          id: "skill:beta",
+          status: "skipped",
+          reason: "not selected for migration",
+        }),
+        expect.objectContaining({ id: "plugin:gmail", status: "planned" }),
+        expect.objectContaining({
+          id: "plugin:google-calendar",
+          status: "skipped",
+          reason: "not selected for migration",
+        }),
+      ]),
+    );
   });
 
   it("applies Toggle all off before interactive Codex migration apply", async () => {

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -518,8 +518,8 @@ describe("migrateApplyCommand", () => {
             pluginName: "google-calendar",
           },
         },
-        codexPluginPlan().items[1]!,
-        codexPluginPlan().items[2]!,
+        codexPluginPlan().items[1],
+        codexPluginPlan().items[2],
       ],
     });
     mocks.provider.plan.mockResolvedValue(planned);

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -581,7 +581,42 @@ describe("migrateApplyCommand", () => {
     expect(runtime.log).toHaveBeenCalledWith("Codex plugin migration skipped for now.");
   });
 
-  it("allows interactive Codex plugin migration to choose no plugins", async () => {
+  it("returns without confirmation when both Codex skill and plugin selectors are skipped", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    const skillPlan = codexSkillPlan();
+    const pluginPlan = codexPluginPlan();
+    const planned = codexSkillPlan({
+      summary: {
+        total: skillPlan.items.length + pluginPlan.items.length,
+        planned: skillPlan.items.length + pluginPlan.items.length,
+        migrated: 0,
+        skipped: 0,
+        conflicts: 0,
+        errors: 0,
+        sensitive: 0,
+      },
+      items: [...skillPlan.items, ...pluginPlan.items],
+    });
+    mocks.provider.plan.mockResolvedValue(planned);
+    mocks.multiselect
+      .mockResolvedValueOnce([MIGRATION_SKILL_SELECTION_SKIP])
+      .mockResolvedValueOnce([MIGRATION_SKILL_SELECTION_SKIP]);
+
+    const result = await migrateDefaultCommand(runtime, { provider: "codex" });
+
+    expect(result).toBe(planned);
+    expect(mocks.multiselect).toHaveBeenCalledTimes(2);
+    expect(mocks.promptYesNo).not.toHaveBeenCalled();
+    expect(mocks.backupCreateCommand).not.toHaveBeenCalled();
+    expect(mocks.provider.apply).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith("Codex skill migration skipped for now.");
+    expect(runtime.log).toHaveBeenCalledWith("Codex plugin migration skipped for now.");
+  });
+
+  it("does not apply when interactive Codex plugin migration chooses no plugins", async () => {
     Object.defineProperty(process.stdin, "isTTY", {
       configurable: true,
       value: true,
@@ -589,26 +624,22 @@ describe("migrateApplyCommand", () => {
     const planned = codexPluginPlan();
     mocks.provider.plan.mockResolvedValue(planned);
     mocks.multiselect.mockResolvedValue([MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF]);
-    mocks.promptYesNo.mockResolvedValue(true);
-    mocks.provider.apply.mockImplementation(async (_ctx, selectedPlan: MigrationPlan) => ({
-      ...selectedPlan,
-      summary: { ...selectedPlan.summary, planned: 0, migrated: selectedPlan.summary.planned },
-      items: selectedPlan.items.map((item) =>
-        item.status === "planned" ? { ...item, status: "migrated" as const } : item,
-      ),
-    }));
 
-    await migrateDefaultCommand(runtime, { provider: "codex" });
+    const result = await migrateDefaultCommand(runtime, { provider: "codex" });
 
     expect(mocks.multiselect).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.stringContaining("Select native Codex plugins"),
       }),
     );
-    expect(mocks.promptYesNo).toHaveBeenCalledWith("Apply this migration now?", false);
-    const appliedPlan = mocks.provider.apply.mock.calls[0]?.[1] as MigrationPlan;
-    expect(appliedPlan.summary).toMatchObject({ planned: 0, skipped: 3, conflicts: 0 });
-    expect(appliedPlan.items).toEqual(
+    expect(mocks.promptYesNo).not.toHaveBeenCalled();
+    expect(mocks.backupCreateCommand).not.toHaveBeenCalled();
+    expect(mocks.provider.apply).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(
+      "No Codex skills or native Codex plugins selected for migration.",
+    );
+    expect(result.summary).toMatchObject({ planned: 0, skipped: 3, conflicts: 0 });
+    expect(result.items).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           id: "plugin:google-calendar",
@@ -781,7 +812,7 @@ describe("migrateApplyCommand", () => {
     );
   });
 
-  it("applies Toggle all off before interactive Codex migration apply", async () => {
+  it("does not apply archive-only Codex migration work after Toggle all off", async () => {
     Object.defineProperty(process.stdin, "isTTY", {
       configurable: true,
       value: true,
@@ -789,20 +820,17 @@ describe("migrateApplyCommand", () => {
     const planned = codexSkillPlan();
     mocks.provider.plan.mockResolvedValue(planned);
     mocks.multiselect.mockResolvedValue([MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF]);
-    mocks.promptYesNo.mockResolvedValue(true);
-    mocks.provider.apply.mockImplementation(async (_ctx, selectedPlan: MigrationPlan) => ({
-      ...selectedPlan,
-      summary: { ...selectedPlan.summary, planned: 0, migrated: 1 },
-      items: selectedPlan.items.map((item) =>
-        item.status === "planned" ? { ...item, status: "migrated" as const } : item,
-      ),
-    }));
 
-    await migrateDefaultCommand(runtime, { provider: "codex" });
+    const result = await migrateDefaultCommand(runtime, { provider: "codex" });
 
-    const appliedPlan = mocks.provider.apply.mock.calls[0]?.[1] as MigrationPlan;
-    expect(appliedPlan.summary).toMatchObject({ planned: 1, skipped: 2, conflicts: 0 });
-    expect(appliedPlan.items).toEqual(
+    expect(mocks.promptYesNo).not.toHaveBeenCalled();
+    expect(mocks.backupCreateCommand).not.toHaveBeenCalled();
+    expect(mocks.provider.apply).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(
+      "No Codex skills or native Codex plugins selected for migration.",
+    );
+    expect(result.summary).toMatchObject({ planned: 1, skipped: 2, conflicts: 0 });
+    expect(result.items).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           id: "skill:alpha",
@@ -848,11 +876,15 @@ describe("migrateApplyCommand", () => {
     ]);
     mocks.promptYesNo.mockResolvedValue(true);
     mocks.provider.apply.mockClear();
+    mocks.promptYesNo.mockClear();
 
     await migrateDefaultCommand(runtime, { provider: "codex" });
 
-    appliedPlan = mocks.provider.apply.mock.calls[0]?.[1] as MigrationPlan;
-    expect(appliedPlan.summary).toMatchObject({ planned: 1, skipped: 2, conflicts: 0 });
+    expect(mocks.promptYesNo).not.toHaveBeenCalled();
+    expect(mocks.provider.apply).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(
+      "No Codex skills or native Codex plugins selected for migration.",
+    );
   });
 
   it("does not apply when interactive apply confirmation is declined", async () => {

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -37,6 +37,7 @@ vi.mock("@clack/prompts", () => ({
 }));
 
 vi.mock("./migrate/skill-selection-prompt.js", () => ({
+  promptMigrationSelectionValues: mocks.multiselect,
   promptMigrationSkillSelectionValues: mocks.multiselect,
 }));
 
@@ -154,6 +155,29 @@ function codexPluginPlan(overrides: Partial<MigrationPlan> = {}): MigrationPlan 
       kind: "config",
       action: "merge",
       status: "planned",
+      details: {
+        value: {
+          enabled: true,
+          config: {
+            codexPlugins: {
+              enabled: true,
+              allow_destructive_actions: false,
+              plugins: {
+                "google-calendar": {
+                  enabled: true,
+                  marketplaceName: "openai-curated",
+                  pluginName: "google-calendar",
+                },
+                gmail: {
+                  enabled: true,
+                  marketplaceName: "openai-curated",
+                  pluginName: "gmail",
+                },
+              },
+            },
+          },
+        },
+      },
     },
   ];
   return {
@@ -301,6 +325,205 @@ describe("migrateApplyCommand", () => {
           reason: "not selected for migration",
         }),
         expect.objectContaining({ id: "archive:config.toml", status: "planned" }),
+      ]),
+    );
+  });
+
+  it("prompts for native Codex plugins after interactive skill selection", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    const skillPlan = codexSkillPlan();
+    const pluginPlan = codexPluginPlan();
+    const planned = codexSkillPlan({
+      summary: {
+        total: skillPlan.items.length + pluginPlan.items.length,
+        planned: skillPlan.items.length + pluginPlan.items.length,
+        migrated: 0,
+        skipped: 0,
+        conflicts: 0,
+        errors: 0,
+        sensitive: 0,
+      },
+      items: [...skillPlan.items, ...pluginPlan.items],
+    });
+    mocks.provider.plan.mockResolvedValue(planned);
+    mocks.multiselect
+      .mockResolvedValueOnce(["skill:alpha"])
+      .mockResolvedValueOnce(["plugin:gmail"]);
+    mocks.promptYesNo.mockResolvedValue(true);
+    mocks.provider.apply.mockImplementation(async (_ctx, selectedPlan: MigrationPlan) => ({
+      ...selectedPlan,
+      summary: { ...selectedPlan.summary, planned: 0, migrated: selectedPlan.summary.planned },
+      items: selectedPlan.items.map((item) =>
+        item.status === "planned" ? { ...item, status: "migrated" as const } : item,
+      ),
+    }));
+
+    await migrateDefaultCommand(runtime, { provider: "codex" });
+
+    expect(mocks.multiselect).toHaveBeenCalledTimes(2);
+    expect(mocks.multiselect).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        message: expect.stringContaining("Select Codex skills"),
+      }),
+    );
+    expect(mocks.multiselect).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        message: expect.stringContaining("Select native Codex plugins"),
+        initialValues: ["plugin:google-calendar", "plugin:gmail"],
+        required: false,
+        options: [
+          expect.objectContaining({
+            value: MIGRATION_SKILL_SELECTION_SKIP,
+            label: "Skip for now",
+          }),
+          expect.objectContaining({
+            value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
+            label: "Toggle all on",
+          }),
+          expect.objectContaining({
+            value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
+            label: "Toggle all off",
+          }),
+          expect.objectContaining({ value: "plugin:google-calendar", label: "google-calendar" }),
+          expect.objectContaining({ value: "plugin:gmail", label: "gmail" }),
+        ],
+      }),
+    );
+    expect(mocks.promptYesNo).toHaveBeenCalledWith("Apply this migration now?", false);
+    const appliedPlan = mocks.provider.apply.mock.calls[0]?.[1] as MigrationPlan;
+    expect(appliedPlan.summary).toMatchObject({ planned: 4, skipped: 2, conflicts: 0 });
+    expect(appliedPlan.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "skill:alpha", status: "planned" }),
+        expect.objectContaining({
+          id: "skill:beta",
+          status: "skipped",
+          reason: "not selected for migration",
+        }),
+        expect.objectContaining({
+          id: "plugin:google-calendar",
+          status: "skipped",
+          reason: "not selected for migration",
+        }),
+        expect.objectContaining({ id: "plugin:gmail", status: "planned" }),
+        expect.objectContaining({ id: "config:codex-plugins", status: "planned" }),
+      ]),
+    );
+    expect(
+      Object.keys(
+        (
+          (
+            (
+              appliedPlan.items.find((item) => item.id === "config:codex-plugins")?.details
+                ?.value as Record<string, unknown>
+            ).config as Record<string, unknown>
+          ).codexPlugins as Record<string, unknown>
+        ).plugins as Record<string, unknown>,
+      ),
+    ).toEqual(["gmail"]);
+  });
+
+  it("skips interactive Codex plugin migration before confirmation when Skip for now is selected", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    const planned = codexPluginPlan();
+    mocks.provider.plan.mockResolvedValue(planned);
+    mocks.multiselect.mockResolvedValue([MIGRATION_SKILL_SELECTION_SKIP]);
+
+    const result = await migrateDefaultCommand(runtime, { provider: "codex" });
+
+    expect(result).toBe(planned);
+    expect(mocks.promptYesNo).not.toHaveBeenCalled();
+    expect(mocks.backupCreateCommand).not.toHaveBeenCalled();
+    expect(mocks.provider.apply).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith("Codex plugin migration skipped for now.");
+  });
+
+  it("allows interactive Codex plugin migration to choose no plugins", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    const planned = codexPluginPlan();
+    mocks.provider.plan.mockResolvedValue(planned);
+    mocks.multiselect.mockResolvedValue([MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF]);
+    mocks.promptYesNo.mockResolvedValue(true);
+    mocks.provider.apply.mockImplementation(async (_ctx, selectedPlan: MigrationPlan) => ({
+      ...selectedPlan,
+      summary: { ...selectedPlan.summary, planned: 0, migrated: selectedPlan.summary.planned },
+      items: selectedPlan.items.map((item) =>
+        item.status === "planned" ? { ...item, status: "migrated" as const } : item,
+      ),
+    }));
+
+    await migrateDefaultCommand(runtime, { provider: "codex" });
+
+    expect(mocks.multiselect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("Select native Codex plugins"),
+      }),
+    );
+    expect(mocks.promptYesNo).toHaveBeenCalledWith("Apply this migration now?", false);
+    const appliedPlan = mocks.provider.apply.mock.calls[0]?.[1] as MigrationPlan;
+    expect(appliedPlan.summary).toMatchObject({ planned: 0, skipped: 3, conflicts: 0 });
+    expect(appliedPlan.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "plugin:google-calendar",
+          status: "skipped",
+          reason: "not selected for migration",
+        }),
+        expect.objectContaining({
+          id: "plugin:gmail",
+          status: "skipped",
+          reason: "not selected for migration",
+        }),
+        expect.objectContaining({
+          id: "config:codex-plugins",
+          status: "skipped",
+          reason: "not selected for migration",
+        }),
+      ]),
+    );
+  });
+
+  it("does not prompt for Codex plugins when --plugin selected them explicitly", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    const planned = codexPluginPlan();
+    mocks.provider.plan.mockResolvedValue(planned);
+    mocks.promptYesNo.mockResolvedValue(true);
+    mocks.provider.apply.mockImplementation(async (_ctx, selectedPlan: MigrationPlan) => ({
+      ...selectedPlan,
+      summary: { ...selectedPlan.summary, planned: 0, migrated: selectedPlan.summary.planned },
+      items: selectedPlan.items.map((item) =>
+        item.status === "planned" ? { ...item, status: "migrated" as const } : item,
+      ),
+    }));
+
+    await migrateDefaultCommand(runtime, { provider: "codex", plugins: ["gmail"] });
+
+    expect(mocks.multiselect).not.toHaveBeenCalled();
+    expect(mocks.promptYesNo).toHaveBeenCalledWith("Apply this migration now?", false);
+    const appliedPlan = mocks.provider.apply.mock.calls[0]?.[1] as MigrationPlan;
+    expect(appliedPlan.summary).toMatchObject({ planned: 2, skipped: 1, conflicts: 0 });
+    expect(appliedPlan.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "plugin:google-calendar",
+          status: "skipped",
+          reason: "not selected for migration",
+        }),
+        expect.objectContaining({ id: "plugin:gmail", status: "planned" }),
       ]),
     );
   });

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -104,7 +104,7 @@ async function promptCodexMigrationSkillSelection(
   const selection = resolveInteractiveMigrationSkillSelection(skillItems, selected ?? []);
   if (selection.action === "skip") {
     runtime.log("Codex skill migration skipped for now.");
-    return null;
+    return applyMigrationSelectedSkillItemIds(plan, new Set());
   }
   const selectedPlan = applyMigrationSelectedSkillItemIds(plan, selection.selectedItemIds);
   runtime.log(

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -15,19 +15,26 @@ import { formatMigrationPlan } from "./migrate/output.js";
 import { createMigrationPlan, resolveMigrationProvider } from "./migrate/providers.js";
 import {
   applyMigrationPluginSelection,
+  applyMigrationSelectedPluginItemIds,
   applyMigrationSelectedSkillItemIds,
   applyMigrationSkillSelection,
+  formatMigrationPluginSelectionHint,
+  formatMigrationPluginSelectionLabel,
   formatMigrationSkillSelectionHint,
   formatMigrationSkillSelectionLabel,
+  getDefaultMigrationPluginSelectionValues,
   getDefaultMigrationSkillSelectionValues,
+  getMigrationPluginSelectionValue,
   getMigrationSkillSelectionValue,
+  getSelectableMigrationPluginItems,
   getSelectableMigrationSkillItems,
-  MIGRATION_SKILL_SELECTION_SKIP,
-  MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
-  MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
+  MIGRATION_SELECTION_SKIP,
+  MIGRATION_SELECTION_TOGGLE_ALL_OFF,
+  MIGRATION_SELECTION_TOGGLE_ALL_ON,
+  resolveInteractiveMigrationPluginSelection,
   resolveInteractiveMigrationSkillSelection,
 } from "./migrate/selection.js";
-import { promptMigrationSkillSelectionValues } from "./migrate/skill-selection-prompt.js";
+import { promptMigrationSelectionValues } from "./migrate/skill-selection-prompt.js";
 import type {
   MigrateApplyOptions,
   MigrateCommonOptions,
@@ -61,19 +68,19 @@ async function promptCodexMigrationSkillSelection(
   if (skillItems.length === 0) {
     return plan;
   }
-  const selected = await promptMigrationSkillSelectionValues({
+  const selected = await promptMigrationSelectionValues({
     message: stylePromptMessage("Select Codex skills to migrate into this agent"),
     options: [
       {
-        value: MIGRATION_SKILL_SELECTION_SKIP,
+        value: MIGRATION_SELECTION_SKIP,
         label: "Skip for now",
       },
       {
-        value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
+        value: MIGRATION_SELECTION_TOGGLE_ALL_ON,
         label: "Toggle all on",
       },
       {
-        value: MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
+        value: MIGRATION_SELECTION_TOGGLE_ALL_OFF,
         label: "Toggle all off",
       },
       ...skillItems.map((item) => {
@@ -104,6 +111,81 @@ async function promptCodexMigrationSkillSelection(
     `Selected ${selection.selectedItemIds.size} of ${skillItems.length} Codex skills for migration.`,
   );
   return selectedPlan;
+}
+
+async function promptCodexMigrationPluginSelection(
+  runtime: RuntimeEnv,
+  plan: MigrationPlan,
+  opts: MigrateCommonOptions & { yes?: boolean },
+): Promise<MigrationPlan | null> {
+  if (
+    plan.providerId !== "codex" ||
+    opts.yes ||
+    opts.json ||
+    opts.plugins !== undefined ||
+    !process.stdin.isTTY
+  ) {
+    return plan;
+  }
+  const pluginItems = getSelectableMigrationPluginItems(plan);
+  if (pluginItems.length === 0) {
+    return plan;
+  }
+  const selected = await promptMigrationSelectionValues({
+    message: stylePromptMessage("Select native Codex plugins to activate in this agent"),
+    options: [
+      {
+        value: MIGRATION_SELECTION_SKIP,
+        label: "Skip for now",
+      },
+      {
+        value: MIGRATION_SELECTION_TOGGLE_ALL_ON,
+        label: "Toggle all on",
+      },
+      {
+        value: MIGRATION_SELECTION_TOGGLE_ALL_OFF,
+        label: "Toggle all off",
+      },
+      ...pluginItems.map((item) => {
+        const hint = formatMigrationPluginSelectionHint(item);
+        return {
+          value: getMigrationPluginSelectionValue(item),
+          label: formatMigrationPluginSelectionLabel(item),
+          hint: hint === undefined ? undefined : stylePromptHint(hint),
+        };
+      }),
+    ],
+    initialValues: getDefaultMigrationPluginSelectionValues(pluginItems),
+    required: false,
+    selectableValues: pluginItems.map(getMigrationPluginSelectionValue),
+  });
+  if (isCancel(selected)) {
+    cancel(stylePromptTitle("Migration cancelled.") ?? "Migration cancelled.");
+    runtime.log("Migration cancelled.");
+    return null;
+  }
+  const selection = resolveInteractiveMigrationPluginSelection(pluginItems, selected ?? []);
+  if (selection.action === "skip") {
+    runtime.log("Codex plugin migration skipped for now.");
+    return null;
+  }
+  const selectedPlan = applyMigrationSelectedPluginItemIds(plan, selection.selectedItemIds);
+  runtime.log(
+    `Selected ${selection.selectedItemIds.size} of ${pluginItems.length} native Codex plugins for activation.`,
+  );
+  return selectedPlan;
+}
+
+async function promptCodexMigrationSelections(
+  runtime: RuntimeEnv,
+  plan: MigrationPlan,
+  opts: MigrateCommonOptions & { yes?: boolean },
+): Promise<MigrationPlan | null> {
+  const skillSelectedPlan = await promptCodexMigrationSkillSelection(runtime, plan, opts);
+  if (!skillSelectedPlan) {
+    return null;
+  }
+  return await promptCodexMigrationPluginSelection(runtime, skillSelectedPlan, opts);
 }
 
 export async function migrateListCommand(runtime: RuntimeEnv, opts: { json?: boolean } = {}) {
@@ -185,7 +267,7 @@ export async function migrateApplyCommand(
     if (opts.json) {
       return plan;
     }
-    const selectedPlan = await promptCodexMigrationSkillSelection(runtime, plan, opts);
+    const selectedPlan = await promptCodexMigrationSelections(runtime, plan, opts);
     if (!selectedPlan) {
       return plan;
     }
@@ -248,7 +330,7 @@ export async function migrateDefaultCommand(
       runtime.log("Re-run with --yes to apply this migration non-interactively.");
       return plan;
     }
-    const selectedPlan = await promptCodexMigrationSkillSelection(runtime, plan, opts);
+    const selectedPlan = await promptCodexMigrationSelections(runtime, plan, opts);
     if (!selectedPlan) {
       return plan;
     }

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -188,6 +188,23 @@ async function promptCodexMigrationSelections(
   return await promptCodexMigrationPluginSelection(runtime, skillSelectedPlan, opts);
 }
 
+function hasSelectedCodexMigrationWork(plan: MigrationPlan): boolean {
+  return plan.items.some(
+    (item) =>
+      item.status === "planned" &&
+      ((item.kind === "skill" && item.action === "copy") ||
+        (item.kind === "plugin" && item.action === "install")),
+  );
+}
+
+function shouldSkipCodexApplyAfterInteractiveSelection(plan: MigrationPlan): boolean {
+  return plan.providerId === "codex" && !hasSelectedCodexMigrationWork(plan);
+}
+
+function logNoCodexSelection(runtime: RuntimeEnv): void {
+  runtime.log("No Codex skills or native Codex plugins selected for migration.");
+}
+
 export async function migrateListCommand(runtime: RuntimeEnv, opts: { json?: boolean } = {}) {
   const cfg = getRuntimeConfig();
   ensureStandaloneMigrationProviderRegistryLoaded({ cfg });
@@ -271,6 +288,10 @@ export async function migrateApplyCommand(
     if (!selectedPlan) {
       return plan;
     }
+    if (shouldSkipCodexApplyAfterInteractiveSelection(selectedPlan)) {
+      logNoCodexSelection(runtime);
+      return selectedPlan;
+    }
     const ok = await promptYesNo("Apply this migration now?", false);
     if (!ok) {
       runtime.log("Migration cancelled.");
@@ -333,6 +354,10 @@ export async function migrateDefaultCommand(
     const selectedPlan = await promptCodexMigrationSelections(runtime, plan, opts);
     if (!selectedPlan) {
       return plan;
+    }
+    if (shouldSkipCodexApplyAfterInteractiveSelection(selectedPlan)) {
+      logNoCodexSelection(runtime);
+      return selectedPlan;
     }
     const ok = await promptYesNo("Apply this migration now?", false);
     if (!ok) {

--- a/src/commands/migrate/output.test.ts
+++ b/src/commands/migrate/output.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { MigrationItem, MigrationPlan } from "../../plugins/types.js";
+import { formatMigrationPlan } from "./output.js";
+
+function stripAnsi(value: string): string {
+  return value.replace(/\u001b\[[0-9;]*m/gu, "");
+}
+
+function skillItem(index: number): MigrationItem {
+  return {
+    id: `skill:skill-${index}`,
+    kind: "skill",
+    action: "copy",
+    status: "planned",
+    details: {
+      skillName: `skill-${index}`,
+    },
+  };
+}
+
+function pluginItem(name: string): MigrationItem {
+  return {
+    id: `plugin:${name}`,
+    kind: "plugin",
+    action: "install",
+    status: "planned",
+    details: {
+      configKey: name,
+      marketplaceName: "openai-curated",
+      pluginName: name,
+    },
+  };
+}
+
+function plan(items: MigrationItem[]): MigrationPlan {
+  return {
+    providerId: "codex",
+    source: "/tmp/codex",
+    summary: {
+      total: items.length,
+      planned: items.length,
+      migrated: 0,
+      skipped: 0,
+      conflicts: 0,
+      errors: 0,
+      sensitive: 0,
+    },
+    items,
+  };
+}
+
+describe("formatMigrationPlan", () => {
+  it("does not duplicate native Codex plugins when they are already visible", () => {
+    const lines = formatMigrationPlan(
+      plan([skillItem(1), pluginItem("google-calendar"), pluginItem("gmail")]),
+    ).map(stripAnsi);
+
+    expect(lines.join("\n")).not.toContain("Native Codex plugins:");
+  });
+
+  it("surfaces native Codex plugin names even when normal item output is truncated", () => {
+    const lines = formatMigrationPlan(
+      plan([
+        ...Array.from({ length: 30 }, (_, index) => skillItem(index + 1)),
+        pluginItem("google-calendar"),
+        pluginItem("gmail"),
+      ]),
+    ).map(stripAnsi);
+
+    const output = lines.join("\n");
+    expect(output).toContain("Native Codex plugins:\n- google-calendar\n- gmail");
+    expect(output.indexOf("Native Codex plugins:")).toBeLessThan(output.indexOf("Items:"));
+    expect(output).toContain("- ... 7 more");
+  });
+});

--- a/src/commands/migrate/output.test.ts
+++ b/src/commands/migrate/output.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { MigrationItem, MigrationPlan } from "../../plugins/types.js";
+import { stripAnsi } from "../../terminal/ansi.js";
 import { formatMigrationPlan } from "./output.js";
-
-function stripAnsi(value: string): string {
-  return value.replace(/\u001b\[[0-9;]*m/gu, "");
-}
 
 function skillItem(index: number): MigrationItem {
   return {

--- a/src/commands/migrate/output.ts
+++ b/src/commands/migrate/output.ts
@@ -3,6 +3,10 @@ import type { MigrationApplyResult, MigrationItem, MigrationPlan } from "../../p
 import { writeRuntimeJson } from "../../runtime.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { theme } from "../../terminal/theme.js";
+import {
+  formatMigrationPluginSelectionLabel,
+  getSelectableMigrationPluginItems,
+} from "./selection.js";
 import type { MigrateApplyOptions } from "./types.js";
 
 function formatCount(value: number, label: string): string {
@@ -32,6 +36,16 @@ export function formatMigrationPlan(plan: MigrationPlan): string[] {
     }
   }
   const visibleItems = plan.items.slice(0, 25);
+  const visibleItemIds = new Set(visibleItems.map((item) => item.id));
+  const pluginItems = getSelectableMigrationPluginItems(plan);
+  const hasPluginHiddenByTruncation = pluginItems.some((item) => !visibleItemIds.has(item.id));
+  if (plan.providerId === "codex" && hasPluginHiddenByTruncation) {
+    lines.push("");
+    lines.push(theme.heading("Native Codex plugins:"));
+    for (const item of pluginItems) {
+      lines.push(`- ${formatMigrationPluginSelectionLabel(item)}`);
+    }
+  }
   if (visibleItems.length > 0) {
     lines.push("");
     lines.push(theme.heading("Items:"));

--- a/src/commands/migrate/selection.test.ts
+++ b/src/commands/migrate/selection.test.ts
@@ -497,7 +497,7 @@ describe("applyMigrationPluginSelection", () => {
       "plugin:google-calendar",
       "plugin:gmail",
     ]);
-    expect(formatMigrationPluginSelectionHint(items[1]!)).toBe(
+    expect(formatMigrationPluginSelectionHint(items[1])).toBe(
       "openai-curated; conflict: plugin exists",
     );
   });

--- a/src/commands/migrate/selection.test.ts
+++ b/src/commands/migrate/selection.test.ts
@@ -5,7 +5,9 @@ import {
   applyMigrationSelectedPluginItemIds,
   applyMigrationSelectedSkillItemIds,
   applyMigrationSkillSelection,
+  formatMigrationPluginSelectionHint,
   getDefaultMigrationPluginSelectionValues,
+  getSelectableMigrationPluginItems,
   getDefaultMigrationSkillSelectionValues,
   MIGRATION_SKILL_SELECTION_SKIP,
   MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
@@ -43,12 +45,14 @@ function pluginItem(params: {
   id: string;
   name: string;
   status?: MigrationItem["status"];
+  reason?: string;
 }): MigrationItem {
   return {
     id: params.id,
     kind: "plugin",
     action: "install",
     status: params.status ?? "planned",
+    reason: params.reason,
     source: `openai-curated/${params.name}`,
     target: `plugins.entries.codex.config.codexPlugins.plugins.${params.name}`,
     details: {
@@ -468,9 +472,34 @@ describe("applyMigrationPluginSelection", () => {
     expect(
       getDefaultMigrationPluginSelectionValues([
         pluginItem({ id: "plugin:google-calendar", name: "google-calendar" }),
-        pluginItem({ id: "plugin:gmail", name: "gmail", status: "skipped" }),
+        pluginItem({
+          id: "plugin:gmail",
+          name: "gmail",
+          status: "conflict",
+          reason: "plugin exists",
+        }),
       ]),
     ).toEqual(["plugin:google-calendar"]);
+  });
+
+  it("includes conflicting plugins in the selector with a conflict hint", () => {
+    const items = [
+      pluginItem({ id: "plugin:google-calendar", name: "google-calendar" }),
+      pluginItem({
+        id: "plugin:gmail",
+        name: "gmail",
+        status: "conflict",
+        reason: "plugin exists",
+      }),
+    ];
+
+    expect(getSelectableMigrationPluginItems(plan(items)).map((item) => item.id)).toEqual([
+      "plugin:google-calendar",
+      "plugin:gmail",
+    ]);
+    expect(formatMigrationPluginSelectionHint(items[1]!)).toBe(
+      "openai-curated; conflict: plugin exists",
+    );
   });
 
   it("resolves interactive plugin special options with toggle-off precedence", () => {

--- a/src/commands/migrate/selection.test.ts
+++ b/src/commands/migrate/selection.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import type { MigrationItem, MigrationPlan } from "../../plugins/types.js";
 import {
   applyMigrationPluginSelection,
+  applyMigrationSelectedPluginItemIds,
   applyMigrationSelectedSkillItemIds,
   applyMigrationSkillSelection,
+  getDefaultMigrationPluginSelectionValues,
   getDefaultMigrationSkillSelectionValues,
   MIGRATION_SKILL_SELECTION_SKIP,
   MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
@@ -12,6 +14,7 @@ import {
   MIGRATION_SKILL_NOT_SELECTED_REASON,
   reconcileInteractiveMigrationShortcutValues,
   reconcileInteractiveMigrationSkillToggleValues,
+  resolveInteractiveMigrationPluginSelection,
   resolveInteractiveMigrationSkillSelection,
 } from "./selection.js";
 
@@ -445,6 +448,53 @@ describe("applyMigrationPluginSelection", () => {
         }),
       ]),
     );
+  });
+
+  it("allows interactive selection to choose no plugins", () => {
+    const selected = applyMigrationSelectedPluginItemIds(
+      plan([
+        pluginItem({ id: "plugin:google-calendar", name: "google-calendar" }),
+        pluginItem({ id: "plugin:gmail", name: "gmail" }),
+        codexPluginConfigItem(["google-calendar", "gmail"]),
+      ]),
+      new Set(),
+    );
+
+    expect(selected.summary).toMatchObject({ planned: 0, skipped: 3 });
+    expect(selected.items.every((item) => item.status === "skipped")).toBe(true);
+  });
+
+  it("defaults interactive plugin selection to planned plugins", () => {
+    expect(
+      getDefaultMigrationPluginSelectionValues([
+        pluginItem({ id: "plugin:google-calendar", name: "google-calendar" }),
+        pluginItem({ id: "plugin:gmail", name: "gmail", status: "skipped" }),
+      ]),
+    ).toEqual(["plugin:google-calendar"]);
+  });
+
+  it("resolves interactive plugin special options with toggle-off precedence", () => {
+    const items = [
+      pluginItem({ id: "plugin:google-calendar", name: "google-calendar" }),
+      pluginItem({ id: "plugin:gmail", name: "gmail" }),
+    ];
+
+    expect(
+      resolveInteractiveMigrationPluginSelection(items, [
+        MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON,
+        MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF,
+      ]),
+    ).toEqual({ action: "select", selectedItemIds: new Set() });
+    expect(
+      resolveInteractiveMigrationPluginSelection(items, [MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON]),
+    ).toEqual({
+      action: "select",
+      selectedItemIds: new Set(["plugin:google-calendar", "plugin:gmail"]),
+    });
+    expect(resolveInteractiveMigrationPluginSelection(items, ["plugin:gmail"])).toEqual({
+      action: "select",
+      selectedItemIds: new Set(["plugin:gmail"]),
+    });
   });
 
   it("accepts item ids as non-interactive plugin selectors", () => {

--- a/src/commands/migrate/selection.ts
+++ b/src/commands/migrate/selection.ts
@@ -216,8 +216,16 @@ export function getSelectableMigrationSkillItems(plan: MigrationPlan): Migration
 }
 
 export function getSelectableMigrationPluginItems(plan: MigrationPlan): MigrationItem[] {
+  // Only source-installed curated Codex plugins become selectable install items.
+  // Cached/manual-review plugin bundles are emitted as manual items, the aggregate
+  // Codex plugin config write is a config item, and already skipped/applied/error
+  // items are no longer user-actionable in the selector. Conflicts stay selectable
+  // so the user can explicitly choose or deselect them before apply.
   return plan.items.filter(
-    (item) => item.kind === "plugin" && item.action === "install" && item.status === "planned",
+    (item) =>
+      item.kind === "plugin" &&
+      item.action === "install" &&
+      (item.status === "planned" || item.status === "conflict"),
   );
 }
 
@@ -266,6 +274,9 @@ export function formatMigrationPluginSelectionHint(item: MigrationItem): string 
     readMigrationPluginMarketplaceName(item),
     configKey && configKey !== pluginName ? `config: ${configKey}` : undefined,
   ];
+  if (item.status === "conflict") {
+    parts.push(item.reason ? `conflict: ${item.reason}` : "conflict");
+  }
   return (
     parts
       .filter((value): value is string => typeof value === "string" && value.length > 0)

--- a/src/commands/migrate/selection.ts
+++ b/src/commands/migrate/selection.ts
@@ -4,13 +4,18 @@ import type { MigrationItem, MigrationPlan } from "../../plugins/types.js";
 
 export const MIGRATION_SKILL_NOT_SELECTED_REASON = "not selected for migration";
 export const MIGRATION_PLUGIN_NOT_SELECTED_REASON = "not selected for migration";
-export const MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON = "__openclaw_migrate_toggle_all_on__";
-export const MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF = "__openclaw_migrate_toggle_all_off__";
-export const MIGRATION_SKILL_SELECTION_SKIP = "__openclaw_migrate_skip_for_now__";
+export const MIGRATION_SELECTION_TOGGLE_ALL_ON = "__openclaw_migrate_toggle_all_on__";
+export const MIGRATION_SELECTION_TOGGLE_ALL_OFF = "__openclaw_migrate_toggle_all_off__";
+export const MIGRATION_SELECTION_SKIP = "__openclaw_migrate_skip_for_now__";
+export const MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON = MIGRATION_SELECTION_TOGGLE_ALL_ON;
+export const MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF = MIGRATION_SELECTION_TOGGLE_ALL_OFF;
+export const MIGRATION_SKILL_SELECTION_SKIP = MIGRATION_SELECTION_SKIP;
 
-export type InteractiveMigrationSkillSelection =
+type InteractiveMigrationSelection =
   | { action: "skip" }
   | { action: "select"; selectedItemIds: Set<string> };
+export type InteractiveMigrationSkillSelection = InteractiveMigrationSelection;
+export type InteractiveMigrationPluginSelection = InteractiveMigrationSelection;
 
 function normalizeSelectionRef(value: string): string {
   return value.trim().toLowerCase();
@@ -33,6 +38,11 @@ function readMigrationPluginName(item: MigrationItem): string | undefined {
 
 function readMigrationPluginConfigKey(item: MigrationItem): string | undefined {
   const value = item.details?.configKey;
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function readMigrationPluginMarketplaceName(item: MigrationItem): string | undefined {
+  const value = item.details?.marketplaceName;
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
 }
 
@@ -215,12 +225,22 @@ export function getMigrationSkillSelectionValue(item: MigrationItem): string {
   return item.id;
 }
 
+export function getMigrationPluginSelectionValue(item: MigrationItem): string {
+  return item.id;
+}
+
 export function formatMigrationPluginSelectionLabel(item: MigrationItem): string {
   return readMigrationPluginName(item) ?? item.id.replace(/^plugin:/u, "");
 }
 
 export function getDefaultMigrationSkillSelectionValues(items: readonly MigrationItem[]): string[] {
   return items.filter((item) => item.status === "planned").map(getMigrationSkillSelectionValue);
+}
+
+export function getDefaultMigrationPluginSelectionValues(
+  items: readonly MigrationItem[],
+): string[] {
+  return items.filter((item) => item.status === "planned").map(getMigrationPluginSelectionValue);
 }
 
 export function formatMigrationSkillSelectionLabel(item: MigrationItem): string {
@@ -232,6 +252,20 @@ export function formatMigrationSkillSelectionHint(item: MigrationItem): string |
   if (item.status === "conflict") {
     parts.push(item.reason ? `conflict: ${item.reason}` : "conflict");
   }
+  return (
+    parts
+      .filter((value): value is string => typeof value === "string" && value.length > 0)
+      .join("; ") || undefined
+  );
+}
+
+export function formatMigrationPluginSelectionHint(item: MigrationItem): string | undefined {
+  const pluginName = readMigrationPluginName(item);
+  const configKey = readMigrationPluginConfigKey(item);
+  const parts = [
+    readMigrationPluginMarketplaceName(item),
+    configKey && configKey !== pluginName ? `config: ${configKey}` : undefined,
+  ];
   return (
     parts
       .filter((value): value is string => typeof value === "string" && value.length > 0)
@@ -278,10 +312,18 @@ export function applyMigrationPluginSelection(
   }
   const selectable = getSelectableMigrationPluginItems(plan);
   const selectedIds = resolveSelectedPluginItemIds(selectable, selectedPluginRefs);
+  return applyMigrationSelectedPluginItemIds(plan, selectedIds);
+}
+
+export function applyMigrationSelectedPluginItemIds(
+  plan: MigrationPlan,
+  selectedItemIds: ReadonlySet<string>,
+): MigrationPlan {
+  const selectable = getSelectableMigrationPluginItems(plan);
   const selectableIds = new Set(selectable.map((item) => item.id));
   const selectedConfigKeys = new Set(
     selectable
-      .filter((item) => selectedIds.has(item.id))
+      .filter((item) => selectedItemIds.has(item.id))
       .map(readMigrationPluginConfigKey)
       .filter((value): value is string => value !== undefined),
   );
@@ -289,7 +331,7 @@ export function applyMigrationPluginSelection(
     if (isCodexPluginConfigItem(item)) {
       return applyCodexPluginConfigSelection(item, selectedConfigKeys);
     }
-    if (!selectableIds.has(item.id) || selectedIds.has(item.id)) {
+    if (!selectableIds.has(item.id) || selectedItemIds.has(item.id)) {
       return item;
     }
     return markMigrationItemSkipped(item, MIGRATION_PLUGIN_NOT_SELECTED_REASON);
@@ -360,25 +402,26 @@ function applyCodexPluginConfigSelection(
   };
 }
 
-export function resolveInteractiveMigrationSkillSelection(
+function resolveInteractiveMigrationSelection(
   items: readonly MigrationItem[],
   selectedValues: readonly string[],
-): InteractiveMigrationSkillSelection {
-  const selectableIds = new Set(items.map(getMigrationSkillSelectionValue));
+  getSelectionValue: (item: MigrationItem) => string,
+): InteractiveMigrationSelection {
+  const selectableIds = new Set(items.map(getSelectionValue));
   const selectedItemIds = new Set(selectedValues.filter((value) => selectableIds.has(value)));
   if (selectedItemIds.size > 0) {
     return { action: "select", selectedItemIds };
   }
 
   const selectedValueSet = new Set(selectedValues);
-  if (selectedValueSet.has(MIGRATION_SKILL_SELECTION_SKIP)) {
+  if (selectedValueSet.has(MIGRATION_SELECTION_SKIP)) {
     return { action: "skip" };
   }
 
-  if (selectedValueSet.has(MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF)) {
+  if (selectedValueSet.has(MIGRATION_SELECTION_TOGGLE_ALL_OFF)) {
     return { action: "select", selectedItemIds: new Set() };
   }
-  if (selectedValueSet.has(MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON)) {
+  if (selectedValueSet.has(MIGRATION_SELECTION_TOGGLE_ALL_ON)) {
     return { action: "select", selectedItemIds: selectableIds };
   }
 
@@ -388,34 +431,54 @@ export function resolveInteractiveMigrationSkillSelection(
   };
 }
 
+export function resolveInteractiveMigrationSkillSelection(
+  items: readonly MigrationItem[],
+  selectedValues: readonly string[],
+): InteractiveMigrationSkillSelection {
+  return resolveInteractiveMigrationSelection(
+    items,
+    selectedValues,
+    getMigrationSkillSelectionValue,
+  );
+}
+
+export function resolveInteractiveMigrationPluginSelection(
+  items: readonly MigrationItem[],
+  selectedValues: readonly string[],
+): InteractiveMigrationPluginSelection {
+  return resolveInteractiveMigrationSelection(
+    items,
+    selectedValues,
+    getMigrationPluginSelectionValue,
+  );
+}
+
 export function reconcileInteractiveMigrationSkillToggleValues(
   selectedValues: readonly string[],
   activatedValue: string | undefined,
   selectableValues: readonly string[],
 ): string[] {
-  if (activatedValue === MIGRATION_SKILL_SELECTION_SKIP) {
-    return selectedValues.includes(MIGRATION_SKILL_SELECTION_SKIP)
-      ? [MIGRATION_SKILL_SELECTION_SKIP]
-      : [];
+  if (activatedValue === MIGRATION_SELECTION_SKIP) {
+    return selectedValues.includes(MIGRATION_SELECTION_SKIP) ? [MIGRATION_SELECTION_SKIP] : [];
   }
-  if (activatedValue === MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON) {
-    return [MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, ...selectableValues];
+  if (activatedValue === MIGRATION_SELECTION_TOGGLE_ALL_ON) {
+    return [MIGRATION_SELECTION_TOGGLE_ALL_ON, ...selectableValues];
   }
-  if (activatedValue === MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF) {
-    return [MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF];
+  if (activatedValue === MIGRATION_SELECTION_TOGGLE_ALL_OFF) {
+    return [MIGRATION_SELECTION_TOGGLE_ALL_OFF];
   }
   if (activatedValue !== undefined && selectableValues.includes(activatedValue)) {
     return selectedValues.filter(
       (value) =>
-        value !== MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON &&
-        value !== MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF &&
-        value !== MIGRATION_SKILL_SELECTION_SKIP,
+        value !== MIGRATION_SELECTION_TOGGLE_ALL_ON &&
+        value !== MIGRATION_SELECTION_TOGGLE_ALL_OFF &&
+        value !== MIGRATION_SELECTION_SKIP,
     );
   }
   return selectedValues.filter(
     (value) =>
-      value !== MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON ||
-      !selectedValues.includes(MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF),
+      value !== MIGRATION_SELECTION_TOGGLE_ALL_ON ||
+      !selectedValues.includes(MIGRATION_SELECTION_TOGGLE_ALL_OFF),
   );
 }
 
@@ -428,18 +491,18 @@ export function reconcileInteractiveMigrationShortcutValues(
   const previousSelectable = previousValues.filter((value) => selectableValues.includes(value));
   if (
     key === "a" &&
-    !previousValues.includes(MIGRATION_SKILL_SELECTION_SKIP) &&
+    !previousValues.includes(MIGRATION_SELECTION_SKIP) &&
     previousSelectable.length === selectableValues.length
   ) {
-    return [MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF];
+    return [MIGRATION_SELECTION_TOGGLE_ALL_OFF];
   }
 
   const selectedSelectable = selectedValues.filter((value) => selectableValues.includes(value));
   if (selectedSelectable.length === selectableValues.length) {
-    return [MIGRATION_SKILL_SELECTION_TOGGLE_ALL_ON, ...selectableValues];
+    return [MIGRATION_SELECTION_TOGGLE_ALL_ON, ...selectableValues];
   }
   if (selectedSelectable.length === 0) {
-    return [MIGRATION_SKILL_SELECTION_TOGGLE_ALL_OFF];
+    return [MIGRATION_SELECTION_TOGGLE_ALL_OFF];
   }
   return selectedSelectable;
 }

--- a/src/commands/migrate/skill-selection-prompt.ts
+++ b/src/commands/migrate/skill-selection-prompt.ts
@@ -201,3 +201,5 @@ export function promptMigrationSkillSelectionValues(
 
   return prompt.prompt();
 }
+
+export const promptMigrationSelectionValues = promptMigrationSkillSelectionValues;


### PR DESCRIPTION
## Summary

- add an explicit interactive native Codex plugin selector after the Codex skill selector
- keep `--plugin`, `--yes`, JSON, non-Codex, and non-TTY flows non-interactive/unchanged
- surface native Codex plugin names when normal migration plan output is truncated before plugin items
- document the interactive plugin selection behavior and add a changelog entry

## Real behavior proof

- **Behavior or issue addressed:** Codex migration must visibly surface native plugin activation during interactive migration instead of silently keeping every planned plugin when `--plugin` is omitted.
- **Real environment tested:** Local macOS OpenClaw checkout on this branch, real Codex home at `[local Codex home]`, real OpenClaw workspace at `[local OpenClaw workspace]`, a controlled temporary Codex source at `/private/tmp/openclaw-plugin-migrate-proof/home/.codex` for deterministic interactive plugin inventory, and Node `v22.22.2`.
- **Exact steps or command run after this patch:** `PATH=/Users/kevinlin/.nvm/versions/node/v22.22.2/bin:$PATH pnpm openclaw migrate codex --dry-run`; then `env -u OPENAI_API_KEY -u CODEX_API_KEY HOME=/private/tmp/openclaw-plugin-migrate-proof/home PATH=/private/tmp/openclaw-plugin-migrate-proof/bin:/Users/kevinlin/.nvm/versions/node/v22.22.2/bin:$PATH node scripts/run-node.mjs migrate codex --from /private/tmp/openclaw-plugin-migrate-proof/home/.codex`
- **Evidence after fix:** Terminal output from the real dry-run, with local home/workspace paths redacted:

```text
$ PATH=/Users/kevinlin/.nvm/versions/node/v22.22.2/bin:$PATH pnpm openclaw migrate codex --dry-run
Migration plan: codex
Source: [local Codex home]
Target: [local OpenClaw workspace]
123 items, 97 conflicts, 0 sensitive items

Warnings:
- Conflicts were found. Re-run with --overwrite to replace conflicting skill targets after item-level backups.
- Codex source-installed openai-curated plugins are planned for native activation; cached plugin bundles remain manual-review only.
- Codex config and hook files are archive-only. They are preserved in the migration report, not loaded into OpenClaw automatically.

Native Codex plugins:
- box
- canva
- figma
- github
- gmail
- google-calendar
- google-drive
- linear
- notion
- slack

Items:
- planned: skill/copy skill:ag-bootstrap -> [workspace]/skills/ag-bootstrap (Copy Codex CLI skill into this OpenClaw agent workspace.)
- conflict: skill/copy skill:ag-dir -> [workspace]/skills/ag-dir (Copy Codex CLI skill into this OpenClaw agent workspace.)
- ... 98 more
```

Interactive TTY proof against a controlled temporary Codex source with one skill and two installed `openai-curated` plugins (`gmail`, `google-calendar`):

```text
$ env -u OPENAI_API_KEY -u CODEX_API_KEY HOME=/private/tmp/openclaw-plugin-migrate-proof/home PATH=/private/tmp/openclaw-plugin-migrate-proof/bin:/Users/kevinlin/.nvm/versions/node/v22.22.2/bin:$PATH node scripts/run-node.mjs migrate codex --from /private/tmp/openclaw-plugin-migrate-proof/home/.codex
Migration plan: codex
Source: /private/tmp/openclaw-plugin-migrate-proof/home/.codex
Target: /private/tmp/openclaw-plugin-migrate-proof/home/.openclaw/workspace
4 items, 0 conflicts, 0 sensitive items

Items:
- planned: skill/copy skill:z-proof-skill -> /private/tmp/openclaw-plugin-migrate-proof/home/.openclaw/workspace/skills/z-proof-skill (Copy Codex CLI skill into this OpenClaw agent workspace.)
- planned: plugin/install plugin:gmail -> plugins.entries.codex.config.codexPlugins.plugins.gmail (Install Codex plugin "gmail" in the OpenClaw-managed Codex app-server runtime.)
- planned: plugin/install plugin:google-calendar -> plugins.entries.codex.config.codexPlugins.plugins.google-calendar (Install Codex plugin "google-calendar" in the OpenClaw-managed Codex app-server runtime.)
- planned: config/merge config:codex-plugins -> plugins.entries.codex.config.codexPlugins (Enable OpenClaw's Codex plugin integration and record migrated source-installed curated plugins.)

◆  Select Codex skills to migrate into this agent
│  ◻ Skip for now
│  ◻ Toggle all on
│  ◻ Toggle all off
│  ◼ z-proof-skill (Codex CLI skill)

◇  Select Codex skills to migrate into this agent
│  z-proof-skill
Selected 1 of 1 Codex skills for migration.

◆  Select native Codex plugins to activate in this agent
│  ◻ Skip for now
│  ◻ Toggle all on
│  ◻ Toggle all off
│  ◼ gmail (openai-curated)
│  ◼ google-calendar (openai-curated)

◇  Select native Codex plugins to activate in this agent
│  gmail, google-calendar
Selected 2 of 2 native Codex plugins for activation.
Apply this migration now? [y/N]
Migration cancelled.
```

- **Observed result after fix:** The dry-run lists `Native Codex plugins:` with `box`, `canva`, `figma`, `github`, `gmail`, `google-calendar`, `google-drive`, `linear`, `notion`, and `slack` before the truncated `Items:` block. The interactive run then prompts for Codex skills, prompts separately for native Codex plugin activation, shows the plugin names with their marketplace, records the explicit plugin selection count, reaches the apply confirmation, and cancels without applying.
- **What was not tested:** No plugin activation was applied. The real local Codex app-server plugin inventory path is sandbox-blocked here with `Operation not permitted`, so the interactive selector proof uses a controlled local app-server responder for deterministic `plugin/list` inventory.

## Verification

- [x] `git diff --check`
- [x] `pnpm exec oxfmt --check --threads=1 src/commands/migrate.ts src/commands/migrate/selection.ts src/commands/migrate/skill-selection-prompt.ts src/commands/migrate/output.ts src/commands/migrate.test.ts src/commands/migrate/selection.test.ts src/commands/migrate/output.test.ts docs/cli/migrate.md CHANGELOG.md`
- [x] `pnpm test src/commands/migrate.test.ts src/commands/migrate/selection.test.ts src/commands/migrate/output.test.ts`
- [x] `pnpm check:changed`
- [x] `pnpm test:changed`
- [x] `pnpm check:docs`

Note: local runs warn that Node `v22.15.1` is below the repo engine `>=22.16.0`; the real dry-run proof above used Node `v22.22.2`.
