### PR TITLE
docs: redirect publishing shortlink

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -397,6 +397,10 @@
       "destination": "/clawhub"
     },
     {
+      "source": "/publishing",
+      "destination": "/clawhub/publishing"
+    },
+    {
       "source": "/tools/clawhub",
       "destination": "/clawhub"
     },


### PR DESCRIPTION
## Summary

- Add a Mintlify redirect from `/publishing` to `/clawhub/publishing`
- Lets ClawHub use the shorter public URL `https://docs.openclaw.ai/publishing#package-scope-must-match-selected-owner`

## Real behavior proof

Before this redirect is deployed, the short URL is not routed by the live docs site:

```text
$ curl -sSIL https://docs.openclaw.ai/publishing#package-scope-must-match-selected-owner | sed -n '1,4p'
HTTP/2 404
```

After this PR, Mintlify has an explicit redirect entry from `/publishing` to `/clawhub/publishing`; the fragment is client-side and remains `#package-scope-must-match-selected-owner` for the target page.

## Validation

- `pnpm format:docs:check`
- `pnpm docs:check-mdx`
- `git diff --check`

## Paired ClawHub PR

Pairs with openclaw/clawhub#2098, which updates the emitted ClawHub docs links.
