### PR TITLE
fix(imessage): surface silent group-allowlist drops at default log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -590,6 +590,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp: send captioned `MEDIA:` directive auto-replies once instead of emitting an empty media message before the captioned media reply. (#78770) Thanks @ai-hpc.
 - Hooks/cron: log returned `/hooks/agent` isolated-run errors and failed cron jobs with cron diagnostic summaries, so rejected `payload.model` values are visible instead of looking like accepted-but-missing runs. Fixes #78597. (#78655) Thanks @kevinslin.
 - Managed proxy/security: classify raw socket callsites and proxy runtime mutations in boundary checks so new direct egress or unmanaged proxy-state changes cannot land without explicit review. (#77126) Thanks @jesse-merhi.
+- Channels/iMessage: surface the silent group-allowlist drop at default log level by emitting a one-time `warn` per account at monitor startup when `channels.imessage.groupPolicy: "allowlist"` is set without a `channels.imessage.groups` block, plus a one-time `warn` per `chat_id` when the runtime gate drops a specific group, naming the exact `channels.imessage.groups[...]` key to add to allow it. Fixes #78749. (#79190) Thanks @omarshahine.
 
 ## 2026.5.3-1
 

--- a/docs/channels/imessage-from-bluebubbles.md
+++ b/docs/channels/imessage-from-bluebubbles.md
@@ -85,7 +85,12 @@ The bundled iMessage plugin runs **two** separate group allowlist gates back-to-
    - a `groups: { "*": { ... } }` wildcard entry (sets `allowAll = true`), or
    - an explicit per-`chat_id` entry under `groups`.
 
-If gate 1 passes but gate 2 fails, the message is dropped and the rejection logs **only at `verbose`/`debug` level** (`inbound-processing.ts:337`). At the default `info` log level every group message vanishes silently — DMs continue to work because they take a different code path.
+If gate 1 passes but gate 2 fails, the message is dropped. The plugin emits two `warn`-level signals so this is no longer silent at default log level:
+
+- A one-time startup `warn` per account when `groupPolicy: "allowlist"` is set but `channels.imessage.groups` is empty (no `"*"` wildcard, no per-`chat_id` entries) — fired before any messages land.
+- A one-time per-`chat_id` `warn` the first time a specific group is dropped at runtime, naming the chat_id and the exact key to add to `groups` to allow it.
+
+DMs continue to work because they take a different code path.
 
 This is the most common BlueBubbles → bundled-iMessage migration failure mode: operators copy `groupAllowFrom` and `groupPolicy` but skip the `groups` block, because BlueBubbles' `groups: { "*": { "requireMention": true } }` looks like an unrelated mention setting. It's actually load-bearing for the registry gate.
 
@@ -107,15 +112,7 @@ The minimum config to keep group messages flowing after `groupPolicy: "allowlist
 
 `requireMention: true` under `*` is harmless when no mention patterns are configured: the runtime sets `canDetectMention = false` and short-circuits the mention drop at `inbound-processing.ts:512`. With mention patterns configured (`agents.list[].groupChat.mentionPatterns`), it works as expected.
 
-To debug a suspected silent drop, raise log level temporarily:
-
-```bash
-OPENCLAW_LOG_LEVEL=debug openclaw gateway
-```
-
-Then look for `imessage: skipping group message (<chat_id>) not in allowlist`. If you see that line, gate 2 is dropping — add the `groups` block.
-
-Tracker for raising the drop's log severity so this is no longer silent at `info`: [openclaw#78749](https://github.com/openclaw/openclaw/issues/78749).
+If the gateway logs `imessage: dropping group message from chat_id=<id>` or the startup line `imessage: groupPolicy="allowlist" but channels.imessage.groups is empty`, gate 2 is dropping — add the `groups` block.
 
 ## Step-by-step
 
@@ -174,7 +171,7 @@ Tracker for raising the drop's log severity so this is no longer silent at `info
 
 4. **Verify DMs.** Send the agent a direct message; confirm the reply lands.
 
-5. **Verify groups separately.** DMs and groups take different code paths — DM success does not prove groups are routing. Send the agent a message in a paired group chat and confirm the reply lands. If the group goes silent (no agent reply, no error), restart the gateway with `OPENCLAW_LOG_LEVEL=debug openclaw gateway` and look for `imessage: skipping group message (...) not in allowlist`. If that line appears, your `groups` block is missing or empty — see "Group registry footgun" above.
+5. **Verify groups separately.** DMs and groups take different code paths — DM success does not prove groups are routing. Send the agent a message in a paired group chat and confirm the reply lands. If the group goes silent (no agent reply, no error), check the gateway log for `imessage: dropping group message from chat_id=<id>` or the startup `imessage: groupPolicy="allowlist" but channels.imessage.groups is empty` line — both fire at the default log level. If either appears, your `groups` block is missing or empty — see "Group registry footgun" above.
 
 6. **Verify the action surface** — from a paired DM, ask the agent to react, edit, unsend, reply, send a photo, and (in a group) rename the group / add or remove a participant. Each action should land natively in Messages.app. If any throws "iMessage `<action>` requires the imsg private API bridge", run `imsg launch` again and refresh `channels status --probe`.
 

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -239,7 +239,12 @@ If SIP-disabled isn't acceptable for your threat model:
     1. **Sender / chat-target allowlist** (`channels.imessage.groupAllowFrom`) — handle, `chat_guid`, `chat_identifier`, or `chat_id`.
     2. **Group registry** (`channels.imessage.groups`) — with `groupPolicy: "allowlist"`, this gate requires either a `groups: { "*": { ... } }` wildcard entry (sets `allowAll = true`), or an explicit per-`chat_id` entry under `groups`.
 
-    If gate 2 has nothing in it, every group message is dropped — and the rejection logs only at `verbose`/`debug` level, so the drops are silent at the default `info` log level. DMs continue to work because they take a different code path.
+    If gate 2 has nothing in it, every group message is dropped. The plugin emits two `warn`-level signals at the default log level:
+
+    - one-time per account at startup: `imessage: groupPolicy="allowlist" but channels.imessage.groups is empty for account "<id>"`
+    - one-time per `chat_id` at runtime: `imessage: dropping group message from chat_id=<id> ...`
+
+    DMs continue to work because they take a different code path.
 
     Minimum config to keep groups flowing under `groupPolicy: "allowlist"`:
 
@@ -255,7 +260,7 @@ If SIP-disabled isn't acceptable for your threat model:
     }
     ```
 
-    To debug a suspected silent drop, run `OPENCLAW_LOG_LEVEL=debug openclaw gateway` and look for `imessage: skipping group message (<chat_id>) not in allowlist`. If that line appears, gate 2 is dropping — add the `groups` block.
+    If those `warn` lines appear in the gateway log, gate 2 is dropping — add the `groups` block.
     </Warning>
 
     Mention gating for groups:

--- a/extensions/imessage/src/monitor/group-allowlist-warnings.test.ts
+++ b/extensions/imessage/src/monitor/group-allowlist-warnings.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  resetGroupAllowlistWarningsForTesting,
+  warnGroupAllowlistDropPerChatOnce,
+  warnGroupAllowlistMisconfigOnce,
+} from "./group-allowlist-warnings.js";
+
+beforeEach(() => {
+  resetGroupAllowlistWarningsForTesting();
+});
+
+describe("warnGroupAllowlistMisconfigOnce", () => {
+  it("fires when groupPolicy=allowlist and groups is undefined", () => {
+    const messages: string[] = [];
+    const fired = warnGroupAllowlistMisconfigOnce({
+      groupPolicy: "allowlist",
+      groups: undefined,
+      accountId: "default",
+      log: (m) => messages.push(m),
+    });
+    expect(fired).toBe(true);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain('groupPolicy="allowlist"');
+    expect(messages[0]).toContain("channels.imessage.groups is empty");
+    expect(messages[0]).toContain("default");
+  });
+
+  it("fires when groupPolicy=allowlist and groups is empty object", () => {
+    const messages: string[] = [];
+    const fired = warnGroupAllowlistMisconfigOnce({
+      groupPolicy: "allowlist",
+      groups: {},
+      accountId: "default",
+      log: (m) => messages.push(m),
+    });
+    expect(fired).toBe(true);
+    expect(messages).toHaveLength(1);
+  });
+
+  it("does not fire when groupPolicy is not allowlist", () => {
+    const messages: string[] = [];
+    const fired = warnGroupAllowlistMisconfigOnce({
+      groupPolicy: "open",
+      groups: undefined,
+      accountId: "default",
+      log: (m) => messages.push(m),
+    });
+    expect(fired).toBe(false);
+    expect(messages).toHaveLength(0);
+  });
+
+  it("does not fire when groups has a wildcard entry", () => {
+    const messages: string[] = [];
+    const fired = warnGroupAllowlistMisconfigOnce({
+      groupPolicy: "allowlist",
+      groups: { "*": { requireMention: true } },
+      accountId: "default",
+      log: (m) => messages.push(m),
+    });
+    expect(fired).toBe(false);
+    expect(messages).toHaveLength(0);
+  });
+
+  it("does not fire when groups has explicit chat_id entries", () => {
+    const messages: string[] = [];
+    const fired = warnGroupAllowlistMisconfigOnce({
+      groupPolicy: "allowlist",
+      groups: { "12345": {} },
+      accountId: "default",
+      log: (m) => messages.push(m),
+    });
+    expect(fired).toBe(false);
+    expect(messages).toHaveLength(0);
+  });
+
+  it("only fires once per accountId", () => {
+    const messages: string[] = [];
+    const log = (m: string) => messages.push(m);
+    expect(
+      warnGroupAllowlistMisconfigOnce({
+        groupPolicy: "allowlist",
+        groups: undefined,
+        accountId: "default",
+        log,
+      }),
+    ).toBe(true);
+    expect(
+      warnGroupAllowlistMisconfigOnce({
+        groupPolicy: "allowlist",
+        groups: undefined,
+        accountId: "default",
+        log,
+      }),
+    ).toBe(false);
+    expect(messages).toHaveLength(1);
+  });
+
+  it("fires separately for distinct accountIds", () => {
+    const messages: string[] = [];
+    const log = (m: string) => messages.push(m);
+    warnGroupAllowlistMisconfigOnce({
+      groupPolicy: "allowlist",
+      groups: undefined,
+      accountId: "primary",
+      log,
+    });
+    warnGroupAllowlistMisconfigOnce({
+      groupPolicy: "allowlist",
+      groups: undefined,
+      accountId: "secondary",
+      log,
+    });
+    expect(messages).toHaveLength(2);
+  });
+});
+
+describe("warnGroupAllowlistDropPerChatOnce", () => {
+  it("fires once per accountId:chat_id pair", () => {
+    const messages: string[] = [];
+    const log = (m: string) => messages.push(m);
+    expect(warnGroupAllowlistDropPerChatOnce({ accountId: "default", chatId: 42, log })).toBe(true);
+    expect(warnGroupAllowlistDropPerChatOnce({ accountId: "default", chatId: 42, log })).toBe(
+      false,
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain("chat_id=42");
+    expect(messages[0]).toContain("default");
+    expect(messages[0]).toContain('channels.imessage.groups["42"]');
+  });
+
+  it("fires separately for distinct chat_ids on the same account", () => {
+    const messages: string[] = [];
+    const log = (m: string) => messages.push(m);
+    warnGroupAllowlistDropPerChatOnce({ accountId: "default", chatId: 1, log });
+    warnGroupAllowlistDropPerChatOnce({ accountId: "default", chatId: 2, log });
+    warnGroupAllowlistDropPerChatOnce({ accountId: "default", chatId: 2, log });
+    expect(messages).toHaveLength(2);
+  });
+
+  it("treats numeric and string chat_ids as the same key", () => {
+    const messages: string[] = [];
+    const log = (m: string) => messages.push(m);
+    warnGroupAllowlistDropPerChatOnce({ accountId: "default", chatId: 42, log });
+    warnGroupAllowlistDropPerChatOnce({ accountId: "default", chatId: "42", log });
+    expect(messages).toHaveLength(1);
+  });
+
+  it("skips when chat_id is undefined or empty", () => {
+    const messages: string[] = [];
+    const log = (m: string) => messages.push(m);
+    expect(
+      warnGroupAllowlistDropPerChatOnce({ accountId: "default", chatId: undefined, log }),
+    ).toBe(false);
+    expect(warnGroupAllowlistDropPerChatOnce({ accountId: "default", chatId: "", log })).toBe(
+      false,
+    );
+    expect(messages).toHaveLength(0);
+  });
+});

--- a/extensions/imessage/src/monitor/group-allowlist-warnings.ts
+++ b/extensions/imessage/src/monitor/group-allowlist-warnings.ts
@@ -1,0 +1,79 @@
+// Group-allowlist visibility helpers. The runtime gate at line ~336 of
+// inbound-processing.ts drops every group message when groupPolicy="allowlist"
+// and channels.imessage.groups is missing. Without these warnings the drop is
+// invisible at default log level — the most common BlueBubbles → bundled-iMessage
+// migration footgun. See https://github.com/openclaw/openclaw/issues/78749.
+
+type GroupsConfig = Record<
+  string,
+  { requireMention?: boolean; tools?: unknown; toolsBySender?: unknown }
+>;
+
+const startupWarned = new Set<string>();
+const perChatWarned = new Set<string>();
+
+/**
+ * Fires once per `accountId` at monitor startup when `groupPolicy === "allowlist"`
+ * but `channels.imessage.groups` is empty (no `"*"` wildcard, no explicit
+ * `chat_id` entries). Without one of those, every group message is dropped at
+ * the second gate even when the sender passes `groupAllowFrom`.
+ */
+export function warnGroupAllowlistMisconfigOnce(params: {
+  groupPolicy: string;
+  groups: GroupsConfig | undefined;
+  accountId: string;
+  log: (message: string) => void;
+}): boolean {
+  if (params.groupPolicy !== "allowlist") {
+    return false;
+  }
+  const entries = params.groups ? Object.keys(params.groups) : [];
+  if (entries.length > 0) {
+    return false;
+  }
+  const key = `imessage:${params.accountId}`;
+  if (startupWarned.has(key)) {
+    return false;
+  }
+  startupWarned.add(key);
+  params.log(
+    `imessage: groupPolicy="allowlist" but channels.imessage.groups is empty for account "${params.accountId}". ` +
+      `Every inbound group message will be dropped. ` +
+      `Add channels.imessage.groups["*"] = { requireMention: true } to allow all groups, ` +
+      `or explicit per-chat_id entries to allow specific groups.`,
+  );
+  return true;
+}
+
+/**
+ * Fires once per `accountId:chat_id` when the runtime allowlist gate drops a
+ * group message because that chat_id is not in `channels.imessage.groups`.
+ * Bounded by the number of distinct group chats the gateway sees.
+ */
+export function warnGroupAllowlistDropPerChatOnce(params: {
+  accountId: string;
+  chatId: string | number | undefined;
+  log: (message: string) => void;
+}): boolean {
+  const chat = params.chatId == null ? "" : String(params.chatId).trim();
+  if (!chat) {
+    return false;
+  }
+  const key = `imessage:${params.accountId}:${chat}`;
+  if (perChatWarned.has(key)) {
+    return false;
+  }
+  perChatWarned.add(key);
+  params.log(
+    `imessage: dropping group message from chat_id=${chat} (account "${params.accountId}") — ` +
+      `not in channels.imessage.groups allowlist. ` +
+      `Add channels.imessage.groups["${chat}"] or channels.imessage.groups["*"] to allow it.`,
+  );
+  return true;
+}
+
+/** Test helper. Keeps warning-cache state deterministic across test files. */
+export function resetGroupAllowlistWarningsForTesting(): void {
+  startupWarned.clear();
+  perChatWarned.clear();
+}

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -54,6 +54,10 @@ import { combineIMessagePayloads } from "./coalesce.js";
 import { createIMessageEchoCachingSend, deliverReplies } from "./deliver.js";
 import { createSentMessageCache } from "./echo-cache.js";
 import {
+  warnGroupAllowlistDropPerChatOnce,
+  warnGroupAllowlistMisconfigOnce,
+} from "./group-allowlist-warnings.js";
+import {
   buildIMessageInboundContext,
   resolveIMessageInboundDecision,
 } from "./inbound-processing.js";
@@ -192,6 +196,12 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   warnMissingProviderGroupPolicyFallbackOnce({
     providerMissingFallbackApplied,
     providerKey: "imessage",
+    accountId: accountInfo.accountId,
+    log: (message) => runtime.log?.(warn(message)),
+  });
+  warnGroupAllowlistMisconfigOnce({
+    groupPolicy,
+    groups: imessageCfg.groups,
     accountId: accountInfo.accountId,
     log: (message) => runtime.log?.(warn(message)),
   });
@@ -398,6 +408,17 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         decision.reason === "from me";
       if (isLoopDrop) {
         loopRateLimiter.record(rateLimitKey);
+      }
+      // Surface the silent-allowlist drop once per chat. Without this, operators
+      // who migrate from BlueBubbles and copy groupPolicy="allowlist" without
+      // populating channels.imessage.groups see every group message vanish at
+      // default log level. See issue #78749.
+      if (decision.reason === "group id not in allowlist") {
+        warnGroupAllowlistDropPerChatOnce({
+          accountId: accountInfo.accountId,
+          chatId: message.chat_id ?? undefined,
+          log: (msg) => runtime.log?.(warn(msg)),
+        });
       }
       return;
     }


### PR DESCRIPTION
## Summary

Closes #78749.

When `channels.imessage.groupPolicy: "allowlist"` is set without a `channels.imessage.groups` block — the most common BlueBubbles → bundled-iMessage migration footgun, documented in PR #78317 — the runtime gate at `extensions/imessage/src/monitor/inbound-processing.ts:336` drops every group message and logs only at `verbose`. At the default `info` log level, every group message vanishes silently.

This adds two coordinated `warn`-level signals so the misconfiguration is observable at the default log level:

1. **Startup warning** (`warnGroupAllowlistMisconfigOnce`): one-time per `accountId` when monitor boots with `groupPolicy: "allowlist"` AND `channels.imessage.groups` is empty (no `"*"` wildcard, no per-`chat_id` entries). Catches the misconfiguration before any messages land.

2. **Per-chat warning** (`warnGroupAllowlistDropPerChatOnce`): one-time per `accountId:chat_id` when the runtime allowlist gate drops a specific group. Names the chat_id and the exact `channels.imessage.groups[...]` key to add to allow it.

Both warners cap log volume at one line per account / one line per chat, so busy gateways do not get spammed. Helpers stay extension-local per the AGENTS owner-boundary rule (other channels have different group-policy semantics).

## Files

- `extensions/imessage/src/monitor/group-allowlist-warnings.ts` — new helper module with both warners + a `resetForTesting` reset hook
- `extensions/imessage/src/monitor/group-allowlist-warnings.test.ts` — 11 unit tests covering startup misconfig detection, per-chat one-shot semantics, wildcard / explicit-entry suppression, multi-account isolation, numeric/string `chat_id` normalization
- `extensions/imessage/src/monitor/monitor-provider.ts` — wires the startup warner alongside the existing `warnMissingProviderGroupPolicyFallbackOnce`, and emits the per-chat warner on the `decision.kind === "drop"` branch when `decision.reason === "group id not in allowlist"`
- `docs/channels/imessage.md` + `docs/channels/imessage-from-bluebubbles.md` — replaces the "silent at info, raise OPENCLAW_LOG_LEVEL=debug" guidance with the new `warn` lines operators will actually see

## Real behavior proof

- Behavior or issue addressed: silent `verbose`-level drop at `extensions/imessage/src/monitor/inbound-processing.ts:336` when `groupPolicy: "allowlist"` is configured without a `channels.imessage.groups` block (issue #78749).

- Real environment tested: macOS Sequoia 15.x, node v25.8.1, openclaw worktree at branch `fix/imsg-group-drop-observability` head `fdba8f4111`. The new helpers (`extensions/imessage/src/monitor/group-allowlist-warnings.ts`) loaded directly via `node --import tsx` from the live source tree — same callable shape used by the gateway's `monitor-provider.ts` (`log: (msg) => runtime.log?.(warn(msg))`).

- Exact steps or command run after this patch:
  ```
  cd ~/GitHub/openclaw/.worktrees/issue-78749
  node --import tsx /tmp/imsg-78749-proof.mjs
  ```
  where the script imports `warnGroupAllowlistMisconfigOnce`, `warnGroupAllowlistDropPerChatOnce`, and `resetGroupAllowlistWarningsForTesting` from the new module and walks five scenarios (misconfigured startup, first-drop per chat, repeat-drop suppression, second chat fires its own line, wildcard suppresses startup).

- After-fix evidence: console output captured live from the run above:
  ```text
  === Scenario 1: BlueBubbles migration footgun (groupPolicy=allowlist, groups missing) ===
  [warn] imessage: groupPolicy="allowlist" but channels.imessage.groups is empty for account "primary". Every inbound group message will be dropped. Add channels.imessage.groups["*"] = { requireMention: true } to allow all groups, or explicit per-chat_id entries to allow specific groups.

  === Scenario 2: First inbound group message from chat_id=8421 ===
  [warn] imessage: dropping group message from chat_id=8421 (account "primary") — not in channels.imessage.groups allowlist. Add channels.imessage.groups["8421"] or channels.imessage.groups["*"] to allow it.

  === Scenario 3: Same chat_id=8421 again (suppressed, returns false silently) ===
  (fired=false, no log line)

  === Scenario 4: Different chat_id=9907 fires its own one-time warn ===
  [warn] imessage: dropping group message from chat_id=9907 (account "primary") — not in channels.imessage.groups allowlist. Add channels.imessage.groups["9907"] or channels.imessage.groups["*"] to allow it.

  === Scenario 5: Wildcard configured, startup is silent ===
  (fired=false, no log line)
  ```

- Observed result after fix: each `[warn]` line is the exact string `runtime.log?.(warn(message))` would emit through the gateway's `warn`-formatted logger. Scenario 1 catches the misconfiguration before any message lands. Scenario 2 names the dropped chat and the exact `channels.imessage.groups["8421"]` key to add. Scenario 3 confirms the per-chat one-shot suppresses repeats. Scenario 4 confirms a distinct chat_id still surfaces. Scenario 5 confirms the startup warn does not fire when a `"*"` wildcard is present. No silent drops remain at the default `info` log level.

- What was not tested: end-to-end gateway run against a live `imsg launch` daemon driving an iMessage group conversation — the helpers exercised here are the exact units `monitor-provider.ts` calls, but a live-traffic capture would be additional confirmation (would need a paired Mac and a configured group chat).
