### PR TITLE
fix(agents): route PI default streams through transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/chat: hide retired and non-public Google Gemini model IDs from chat model catalogs and route the bare `gemini-3-pro` alias to Gemini 3.1 Pro Preview instead of the shut-down Gemini 3 Pro Preview. Thanks @BunsDev.
 - CLI/install: refuse state-mutating OpenClaw CLI runs as root by default, keep an explicit `OPENCLAW_ALLOW_ROOT=1` escape hatch for intentional root/container use, and update DigitalOcean setup guidance to run OpenClaw as a non-root user. Fixes #67478. Thanks @Jerry-Xin and @natechicago.
 - Auto-reply/media: resolve `scp` from `PATH` when staging sandbox media so nonstandard OpenSSH installs can copy remote attachments.
+- Agents/PI: route PI-native OpenAI-compatible default streams through OpenClaw boundary-aware transports so local-compatible model runs keep API-key injection and transport policy.
 - Gateway/watch: leave `OPENCLAW_TRACE_SYNC_IO` disabled by default in `pnpm gateway:watch:raw` so watch mode avoids noisy Node sync-I/O stack traces unless explicitly requested.
 - Codex app-server: close stdio stdin before force-killing the managed app-server, matching Codex single-client shutdown behavior and avoiding unsettled CLI exits after successful runs.
 - CLI/Codex: dispose registered agent harnesses during short-lived CLI shutdown so successful Codex-backed `agent --local` runs do not leave app-server child processes alive.

--- a/src/agents/pi-embedded-runner/stream-resolution.test.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.test.ts
@@ -1,5 +1,5 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
-import { streamSimple } from "@mariozechner/pi-ai";
+import { getApiProvider, streamSimple } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import * as providerTransportStream from "../provider-transport-stream.js";
 import {
@@ -145,6 +145,31 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     });
 
     expect(streamFn).not.toBe(streamSimple);
+  });
+
+  it("routes PI native OpenAI-compatible provider streams through boundary-aware transports", async () => {
+    const nativeStreamFn = getApiProvider("openai-completions")?.streamSimple;
+    expect(nativeStreamFn).toBeDefined();
+    const innerStreamFn = vi.fn(async (_model, _context, options) => options);
+    overrideBoundaryAwareStreamFnOnce(innerStreamFn as never);
+
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: nativeStreamFn as StreamFn,
+      shouldUseWebSocketTransport: false,
+      sessionId: "session-1",
+      model: {
+        api: "openai-completions",
+        provider: "llama",
+        id: "qwen36-35b-a3b",
+      } as never,
+      resolvedApiKey: "local-token",
+    });
+
+    expect(streamFn).not.toBe(nativeStreamFn);
+    await expect(
+      streamFn({ provider: "llama", id: "qwen36-35b-a3b" } as never, {} as never, {}),
+    ).resolves.toMatchObject({ apiKey: "local-token" });
+    expect(innerStreamFn).toHaveBeenCalledTimes(1);
   });
 
   it("injects the resolved run api key into provider-owned stream functions", async () => {

--- a/src/agents/pi-embedded-runner/stream-resolution.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.ts
@@ -1,5 +1,5 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
-import { streamSimple } from "@mariozechner/pi-ai";
+import { getApiProvider, streamSimple } from "@mariozechner/pi-ai";
 import { createAnthropicVertexStreamFnForModel } from "../anthropic-vertex-stream.js";
 import { createOpenAIWebSocketStreamFn } from "../openai-ws-stream.js";
 import { getModelProviderRequestTransport } from "../provider-request-config.js";
@@ -25,6 +25,21 @@ export function resetEmbeddedAgentBaseStreamFnCacheForTest(): void {
   embeddedAgentBaseStreamFnCache = new WeakMap<object, StreamFn | undefined>();
 }
 
+function isDefaultPiStreamFnForModel(
+  model: EmbeddedRunAttemptParams["model"],
+  streamFn: StreamFn | undefined,
+): boolean {
+  if (!streamFn || streamFn === streamSimple) {
+    return true;
+  }
+  const api = typeof model.api === "string" ? model.api.trim() : "";
+  if (!api) {
+    return false;
+  }
+  const provider = getApiProvider(api as never);
+  return streamFn === provider?.streamSimple || streamFn === provider?.stream;
+}
+
 export function describeEmbeddedAgentStreamStrategy(params: {
   currentStreamFn: StreamFn | undefined;
   providerStreamFn?: StreamFn;
@@ -41,7 +56,7 @@ export function describeEmbeddedAgentStreamStrategy(params: {
   if (params.model.provider === "anthropic-vertex") {
     return "anthropic-vertex";
   }
-  if (params.currentStreamFn === undefined || params.currentStreamFn === streamSimple) {
+  if (isDefaultPiStreamFnForModel(params.model, params.currentStreamFn)) {
     return createBoundaryAwareStreamFnForModel(params.model)
       ? `boundary-aware:${params.model.api}`
       : "stream-simple";
@@ -104,7 +119,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
     return createAnthropicVertexStreamFnForModel(params.model);
   }
 
-  if (params.currentStreamFn === undefined || params.currentStreamFn === streamSimple) {
+  if (isDefaultPiStreamFnForModel(params.model, params.currentStreamFn)) {
     const boundaryAwareStreamFn = createBoundaryAwareStreamFnForModel(params.model);
     if (boundaryAwareStreamFn) {
       // Boundary-aware transports read credentials from options.apiKey just


### PR DESCRIPTION
## Summary

- Problem: PI-native default stream functions for provider APIs were treated as custom session streams.
- Why it matters: OpenAI-compatible local/provider runs could bypass OpenClaw boundary-aware transports and lose runtime API-key injection or transport policy.
- What changed: `resolveEmbeddedAgentStreamFn` now recognizes PI's API-specific default `streamSimple`/`stream` functions via `getApiProvider(api)` and wraps supported models with OpenClaw's boundary-aware transport.
- What did NOT change: Explicit provider-owned streams and real custom session streams still win.

## Verification

- `git diff --check origin/main..HEAD`
- `pnpm test src/agents/pi-embedded-runner/stream-resolution.test.ts` — 18 passed
- `source ~/.profile; timeout 90 pnpm openclaw infer model run --model openai/gpt-5.4-mini --prompt "Reply exactly OK" --json` — returned `OK`

## Real behavior proof

- Behavior or issue addressed: OpenAI-compatible PI default stream resolution now uses OpenClaw boundary-aware transport and keeps runtime API-key injection.
- Real environment tested: local macOS checkout, `.profile` OpenAI key, real OpenAI API model run.
- Exact steps or command run after this patch: `source ~/.profile; timeout 90 pnpm openclaw infer model run --model openai/gpt-5.4-mini --prompt "Reply exactly OK" --json`
- Evidence after fix: copied terminal output from the live command: `{ "ok": true, "capability": "model.run", "transport": "local", "provider": "openai", "model": "gpt-5.4-mini", "outputs": [{ "text": "OK" }] }`
- Observed result after fix: the real OpenAI run completed and returned `OK`.
- What was not tested: non-OpenAI third-party OpenAI-compatible hosted endpoints.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes — existing runtime API-key injection now also applies when PI supplies an API-specific default stream.
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Risks and Mitigations

- Risk: A genuinely custom stream could be misclassified as default.
  - Mitigation: the check only matches PI's provider object function identities for the model API.

## Linked Issue

Closes #79241
