### PR TITLE
fix(auto-reply): resolve scp from path for media staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/macOS: `openclaw gateway stop --disable` now persists the LaunchAgent disable bit even after a previous bootout left the service not loaded, keeping the explicit stay-down path reliable. (#78412) Thanks @wdeveloper16.
 - Control UI/chat: hide retired and non-public Google Gemini model IDs from chat model catalogs and route the bare `gemini-3-pro` alias to Gemini 3.1 Pro Preview instead of the shut-down Gemini 3 Pro Preview. Thanks @BunsDev.
 - CLI/install: refuse state-mutating OpenClaw CLI runs as root by default, keep an explicit `OPENCLAW_ALLOW_ROOT=1` escape hatch for intentional root/container use, and update DigitalOcean setup guidance to run OpenClaw as a non-root user. Fixes #67478. Thanks @Jerry-Xin and @natechicago.
+- Auto-reply/media: resolve `scp` from `PATH` when staging sandbox media so nonstandard OpenSSH installs can copy remote attachments.
 - Gateway/watch: leave `OPENCLAW_TRACE_SYNC_IO` disabled by default in `pnpm gateway:watch:raw` so watch mode avoids noisy Node sync-I/O stack traces unless explicitly requested.
 - Codex app-server: close stdio stdin before force-killing the managed app-server, matching Codex single-client shutdown behavior and avoiding unsettled CLI exits after successful runs.
 - CLI/Codex: dispose registered agent harnesses during short-lived CLI shutdown so successful Codex-backed `agent --local` runs do not leave app-server child processes alive.

--- a/src/auto-reply/reply.stage-sandbox-media.scp-remote-path.test.ts
+++ b/src/auto-reply/reply.stage-sandbox-media.scp-remote-path.test.ts
@@ -107,6 +107,7 @@ describe("stageSandboxMedia scp remote paths", () => {
         workspaceDir,
       });
 
+      expect(childProcessMocks.spawn.mock.calls[0]?.[0]).toBe("scp");
       const remoteCacheRoot = join(CONFIG_DIR, "media", "remote-cache");
       const expectedSafeDir = join(remoteCacheRoot, slugifySessionKey(sessionKey));
       try {

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -319,7 +319,7 @@ async function scpFile(remoteHost: string, remotePath: string, localPath: string
   }
   return new Promise((resolve, reject) => {
     const child = spawn(
-      "/usr/bin/scp",
+      "scp",
       [
         "-o",
         "BatchMode=yes",


### PR DESCRIPTION
## Summary

- Problem: sandbox media staging hardcoded `/usr/bin/scp`.
- Why it matters: installs where OpenSSH is elsewhere on `PATH` could fail media copy even though `scp` is available.
- What changed: staging now spawns `scp` by command name so the runtime `PATH` decides.
- What did NOT change: the existing batch mode, timeout, and remote path arguments stay the same.

## Verification

- `git diff --check origin/main..HEAD`
- `pnpm test src/auto-reply/reply.stage-sandbox-media.scp-remote-path.test.ts` — 2 passed
- `command -v scp` — `/usr/bin/scp` in the live local environment

## Real behavior proof

- Behavior or issue addressed: sandbox media staging now resolves `scp` from `PATH` instead of hardcoding `/usr/bin/scp`.
- Real environment tested: local macOS checkout with system OpenSSH available on `PATH`.
- Exact steps or command run after this patch: `command -v scp`
- Evidence after fix: terminal output: `/usr/bin/scp`
- Observed result after fix: the live environment resolves `scp` by command name, and the regression test verifies the production spawn call uses `scp`.
- What was not tested: a remote SSH host copy, because the bug is command resolution before SSH connection setup.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes — uses PATH resolution for the same `scp` command.
- Data access scope changed? No

## Risks and Mitigations

- Risk: PATH could prefer a different `scp` binary.
  - Mitigation: this matches normal shell/runtime command resolution and preserves all existing `scp` arguments.

## Linked Issue

Closes #79242
