### PR TITLE
fix(gateway): ignore malformed node catalog capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,7 @@ Docs: https://docs.openclaw.ai
 - Agents/PI: route PI-native OpenAI-compatible default streams through OpenClaw boundary-aware transports so local-compatible model runs keep API-key injection and transport policy.
 - Gateway/media: require authenticated owner or admin context for managed outgoing image bytes instead of trusting requester-session headers.
 - Doctor/gateway: avoid duplicate Node runtime warnings when the daemon install plan already selected a supported Node runtime.
+- Gateway/nodes: ignore malformed non-string capability entries from live nodes instead of throwing while listing the node catalog.
 - Gateway/watch: leave `OPENCLAW_TRACE_SYNC_IO` disabled by default in `pnpm gateway:watch:raw` so watch mode avoids noisy Node sync-I/O stack traces unless explicitly requested.
 - Codex app-server: close stdio stdin before force-killing the managed app-server, matching Codex single-client shutdown behavior and avoiding unsettled CLI exits after successful runs.
 - CLI/Codex: dispose registered agent harnesses during short-lived CLI shutdown so successful Codex-backed `agent --local` runs do not leave app-server child processes alive.

--- a/src/gateway/node-catalog.test.ts
+++ b/src/gateway/node-catalog.test.ts
@@ -289,4 +289,30 @@ describe("gateway/node-catalog", () => {
       }),
     );
   });
+
+  it("ignores malformed node capability entries instead of throwing", () => {
+    const catalog = createKnownNodeCatalog({
+      pairedDevices: [],
+      pairedNodes: [],
+      connectedNodes: [
+        {
+          nodeId: "bad-node",
+          connId: "conn-1",
+          client: {} as never,
+          displayName: "Bad Node",
+          caps: ["camera", undefined],
+          commands: ["system.run", null],
+          connectedAtMs: 1,
+        } as never,
+      ],
+    });
+
+    expect(listKnownNodes(catalog)).toEqual([
+      expect.objectContaining({
+        nodeId: "bad-node",
+        caps: ["camera"],
+        commands: ["system.run"],
+      }),
+    ]);
+  });
 });

--- a/src/gateway/node-catalog.ts
+++ b/src/gateway/node-catalog.ts
@@ -47,13 +47,16 @@ type KnownNodeCatalog = {
   entriesById: Map<string, KnownNodeEntry>;
 };
 
-function uniqueSortedStrings(...items: Array<readonly string[] | undefined>): string[] {
+function uniqueSortedStrings(...items: Array<readonly unknown[] | undefined>): string[] {
   const values = new Set<string>();
   for (const item of items) {
-    if (!item) {
+    if (!Array.isArray(item)) {
       continue;
     }
     for (const value of item) {
+      if (typeof value !== "string") {
+        continue;
+      }
       const trimmed = value.trim();
       if (trimmed) {
         values.add(trimmed);


### PR DESCRIPTION
## Summary

- Problem: malformed live node capability or command arrays could throw while listing known nodes.
- Why it matters: one bad node entry could break node catalog rendering/status instead of showing the valid data.
- What changed: catalog string normalization now accepts unknown arrays and filters non-string entries before trim/sort.
- What did NOT change: valid string capability and command values are still deduplicated and sorted.

## Verification

- `git diff --check origin/main..HEAD`
- `pnpm test src/gateway/node-catalog.test.ts` — 6 passed
- `node -e 'console.log(process.platform, process.version)'` — `darwin v25.9.0`

## Real behavior proof

- Behavior or issue addressed: node catalog listing tolerates malformed live capability and command entries.
- Real environment tested: local macOS checkout running node catalog behavior against the real repository code.
- Exact steps or command run after this patch: `pnpm test src/gateway/node-catalog.test.ts`
- Evidence after fix: terminal output: `Test Files 1 passed (1); Tests 6 passed (6)`
- Observed result after fix: malformed `caps`/`commands` arrays with non-string values list only valid string values instead of throwing.
- What was not tested: a physical paired node sending malformed capabilities.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Risks and Mitigations

- Risk: malformed values are silently dropped.
  - Mitigation: capability arrays are display/discovery metadata; non-strings were unusable and previously crashed the listing path.

## Linked Issue

Closes #79245
