### PR TITLE
fix(pairing): preserve narrowed token scopes on upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/media: require authenticated owner or admin context for managed outgoing image bytes instead of trusting requester-session headers.
 - Doctor/gateway: avoid duplicate Node runtime warnings when the daemon install plan already selected a supported Node runtime.
 - Gateway/nodes: ignore malformed non-string capability entries from live nodes instead of throwing while listing the node catalog.
+- Gateway/pairing: preserve deliberately narrowed role-token scopes when approving device scope upgrades instead of regranting the whole approved baseline.
 - Gateway/watch: leave `OPENCLAW_TRACE_SYNC_IO` disabled by default in `pnpm gateway:watch:raw` so watch mode avoids noisy Node sync-I/O stack traces unless explicitly requested.
 - Codex app-server: close stdio stdin before force-killing the managed app-server, matching Codex single-client shutdown behavior and avoiding unsettled CLI exits after successful runs.
 - CLI/Codex: dispose registered agent harnesses during short-lived CLI shutdown so successful Codex-backed `agent --local` runs do not leave app-server child processes alive.

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -333,6 +333,66 @@ describe("device pairing tokens", () => {
     ).resolves.toEqual({ ok: true });
   });
 
+  test("preserves existing operator token scopes when approving a scope upgrade", async () => {
+    const baseDir = await makeDevicePairingDir();
+    await setupPairedOperatorDevice(baseDir, ["operator.read"]);
+
+    const upgrade = await requestDevicePairing(
+      {
+        deviceId: "device-1",
+        publicKey: "public-key-1",
+        role: "operator",
+        scopes: ["operator.write"],
+      },
+      baseDir,
+    );
+
+    await expect(
+      approveDevicePairing(
+        upgrade.request.requestId,
+        { callerScopes: ["operator.read", "operator.write"] },
+        baseDir,
+      ),
+    ).resolves.toMatchObject({ status: "approved" });
+
+    const paired = await getPairedDevice("device-1", baseDir);
+    expect(paired?.approvedScopes).toEqual(["operator.read", "operator.write"]);
+    expect(paired?.tokens?.operator?.scopes).toEqual(["operator.read", "operator.write"]);
+  });
+
+  test("does not widen a down-scoped operator token when approving a scope upgrade", async () => {
+    const baseDir = await makeDevicePairingDir();
+    await setupPairedOperatorDevice(baseDir, ["operator.read", "operator.write"]);
+    await overwritePairedOperatorTokenScopes(baseDir, ["operator.read"]);
+
+    const upgrade = await requestDevicePairing(
+      {
+        deviceId: "device-1",
+        publicKey: "public-key-1",
+        role: "operator",
+        scopes: ["operator.talk.secrets"],
+      },
+      baseDir,
+    );
+
+    await expect(
+      approveDevicePairing(
+        upgrade.request.requestId,
+        { callerScopes: ["operator.read", "operator.talk.secrets", "operator.write"] },
+        baseDir,
+      ),
+    ).resolves.toMatchObject({ status: "approved" });
+
+    const paired = await getPairedDevice("device-1", baseDir);
+    expect(paired?.approvedScopes).toEqual([
+      "operator.read",
+      "operator.write",
+      "operator.talk.secrets",
+    ]);
+    expect(paired?.tokens?.operator?.scopes).toEqual(["operator.read", "operator.talk.secrets"]);
+    expect(paired?.tokens?.operator?.scopes).not.toContain("operator.write");
+  });
+
   test("preserves requested non-operator scopes on newly minted role tokens", async () => {
     const baseDir = await makeDevicePairingDir();
     const request = await requestDevicePairing(

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -437,9 +437,23 @@ function resolveApprovedTokenScopes(params: {
   approvedScopes?: string[];
   existing?: PairedDevice;
 }): string[] {
-  const requestedScopes = resolveRoleScopedDeviceTokenScopes(params.role, params.pending.scopes);
-  if (requestedScopes.length > 0) {
-    return requestedScopes;
+  const pendingScopes = resolveRoleScopedDeviceTokenScopes(params.role, params.pending.scopes);
+  if (pendingScopes.length > 0) {
+    const approvedBaseline = resolveRoleScopedDeviceTokenScopes(
+      params.role,
+      params.existing?.approvedScopes ?? params.existing?.scopes,
+    );
+    const requestedScopeDelta =
+      params.existingToken && approvedBaseline.length > 0
+        ? pendingScopes.filter((scope) => !approvedBaseline.includes(scope))
+        : pendingScopes;
+    if (requestedScopeDelta.length === 0 && params.existingToken) {
+      return resolveRoleScopedDeviceTokenScopes(params.role, params.existingToken.scopes);
+    }
+    return resolveRoleScopedDeviceTokenScopes(
+      params.role,
+      mergeScopes(params.existingToken?.scopes, requestedScopeDelta),
+    );
   }
   return resolveRoleScopedDeviceTokenScopes(
     params.role,

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -628,10 +628,11 @@ export async function approveDevicePairing(
       });
       nextTokenScopesByRole.set(roleForToken, nextScopes);
       if (roleForToken === OPERATOR_ROLE && nextScopes.length > 0) {
-        const callerRequiredScopes = mergeScopes(
-          resolveRoleScopedDeviceTokenScopes(roleForToken, pending.scopes),
-          nextScopes,
-        );
+        const callerRequiredScopes =
+          mergeScopes(
+            resolveRoleScopedDeviceTokenScopes(roleForToken, pending.scopes),
+            nextScopes,
+          ) ?? nextScopes;
         if (!options?.callerScopes) {
           return {
             status: "forbidden",

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -628,16 +628,20 @@ export async function approveDevicePairing(
       });
       nextTokenScopesByRole.set(roleForToken, nextScopes);
       if (roleForToken === OPERATOR_ROLE && nextScopes.length > 0) {
+        const callerRequiredScopes = mergeScopes(
+          resolveRoleScopedDeviceTokenScopes(roleForToken, pending.scopes),
+          nextScopes,
+        );
         if (!options?.callerScopes) {
           return {
             status: "forbidden",
             reason: "caller-scopes-required",
-            scope: nextScopes[0],
+            scope: callerRequiredScopes[0],
           };
         }
         const missingScope = resolveMissingRequestedScope({
           role: OPERATOR_ROLE,
-          requestedScopes: nextScopes,
+          requestedScopes: callerRequiredScopes,
           allowedScopes: options.callerScopes,
         });
         if (missingScope) {


### PR DESCRIPTION
## Summary

- Problem: approving a pairing scope upgrade could mint the role token with the whole approved baseline.
- Why it matters: deliberately down-scoped existing tokens could silently regain old approved scopes during an unrelated upgrade.
- What changed: token scope resolution now merges the existing token scopes with only the newly requested delta.
- What did NOT change: approved device baseline scopes are still updated with the full approved set.

## Verification

- `git diff --check origin/main..HEAD`
- `pnpm test src/infra/device-pairing.test.ts` — 48 passed
- `node -e 'console.log(process.platform, process.version)'` — `darwin v25.9.0`

## Real behavior proof

- Behavior or issue addressed: pairing scope upgrades preserve deliberately narrowed role-token scopes.
- Real environment tested: local macOS checkout running pairing token logic against the real repository code.
- Exact steps or command run after this patch: `pnpm test src/infra/device-pairing.test.ts`
- Evidence after fix: terminal output: `Test Files 1 passed (1); Tests 48 passed (48)`
- Observed result after fix: a down-scoped operator token gains only the newly requested delta and does not regain omitted approved scopes.
- What was not tested: a physical mobile/device pairing flow.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes — minted role-token scopes are narrowed to existing token scopes plus newly requested deltas.
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes — prevents unintended token scope widening.

## Risks and Mitigations

- Risk: users expecting approved baseline to rehydrate token scopes need an explicit rotation path.
  - Mitigation: preserving a deliberately narrowed token is safer for an upgrade approval; approved baseline remains recorded separately.

## Linked Issue

Closes #79246
