### PR TITLE
fix(ui): read exec security from tools config

### DIFF
--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -241,6 +241,19 @@ describe("renderApp assistant avatar routing", () => {
     expect(shell?.style.getPropertyValue("--chat-message-max-width")).toBe("min(1280px, 82%)");
   });
 
+  it("passes tools.exec.security to Quick Settings", () => {
+    renderApp(
+      createState({
+        configForm: {
+          tools: { exec: { security: "full" } },
+          agents: { defaults: { exec: { security: "deny" } } },
+        },
+      }),
+    );
+
+    expect(quickSettingsProps.current?.security.execPolicy).toBe("full");
+  });
+
   it("does not throw when stale cron state contains a job without a payload", () => {
     expect(() =>
       renderApp(


### PR DESCRIPTION
## Summary

- Problem: Quick Settings read exec security from stale `agents.defaults.exec.security`.
- Why it matters: the UI could show the wrong exec policy when the active config lives under `tools.exec.security`.
- What changed: Quick Settings now reads `config.tools.exec.security`.
- What did NOT change: gateway auth extraction and Quick Settings rendering stay unchanged.

## Verification

- `git diff --check origin/main..HEAD`
- `pnpm test ui/src/ui/app-render.assistant-avatar.test.ts` — 4 passed
- `node -e 'console.log(process.platform, process.version)'` — `darwin v25.9.0`

## Real behavior proof

- Behavior or issue addressed: Control UI Quick Settings reflects active `tools.exec.security` instead of stale agent-default exec security.
- Real environment tested: local macOS checkout running Control UI render behavior against the real repository code.
- Exact steps or command run after this patch: `pnpm test ui/src/ui/app-render.assistant-avatar.test.ts`
- Evidence after fix: terminal output: `Test Files 1 passed (1); Tests 4 passed (4)`
- Observed result after fix: render regression passes `tools.exec.security: "full"` with stale agent default `deny` and Quick Settings receives `full`.
- What was not tested: manual browser screenshot of the Control UI.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Risks and Mitigations

- Risk: older configs that only carried the legacy agent-default exec policy display the default allowlist value.
  - Mitigation: current config source of truth is `tools.exec.security`; the test locks that path.

## Linked Issue

Closes #79247
