### PR TITLE
fix(webhooks): enforce session tree boundary for childSessionKey in run_task

### DIFF
--- a/extensions/webhooks/src/http.test.ts
+++ b/extensions/webhooks/src/http.test.ts
@@ -226,6 +226,7 @@ describe("createTaskFlowWebhookRequestHandler", () => {
       controllerId: "webhooks/zapier",
       goal: "Triage inbox",
     });
+    const childSessionKey = target.taskFlow.sessionKey + ":subagent:child";
     const res = await dispatchJsonRequest({
       handler,
       path: target.path,
@@ -234,7 +235,7 @@ describe("createTaskFlowWebhookRequestHandler", () => {
         action: "run_task",
         flowId: flow.flowId,
         runtime: "acp",
-        childSessionKey: "agent:main:subagent:child",
+        childSessionKey: childSessionKey,
         task: "Inspect the next message batch",
         status: "running",
         startedAt: 10,
@@ -248,11 +249,38 @@ describe("createTaskFlowWebhookRequestHandler", () => {
     expect(parsed.result.created).toBe(true);
     expect(parsed.result.task).toMatchObject({
       parentFlowId: flow.flowId,
-      childSessionKey: "agent:main:subagent:child",
+      childSessionKey: childSessionKey,
       runtime: "acp",
     });
     expect(parsed.result.task.ownerKey).toBeUndefined();
     expect(parsed.result.task.requesterSessionKey).toBeUndefined();
+  });
+
+  it("rejects childSessionKey outside the route's session tree", async () => {
+    const { handler, target, secret } = createHandler();
+    const flow = target.taskFlow.createManaged({
+      controllerId: "webhooks/zapier",
+      goal: "Triage inbox",
+    });
+    const res = await dispatchJsonRequest({
+      handler,
+      path: target.path,
+      secret,
+      body: {
+        action: "run_task",
+        flowId: flow.flowId,
+        runtime: "acp",
+        childSessionKey: "agent:main:subagent:unrelated",
+        task: "Inspect the next message batch",
+        status: "running",
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const parsed = parseJsonBody(res);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.result.created).toBe(false);
+    expect(parsed.result.reason).toMatch(/session tree/);
   });
 
   it("returns 404 for missing flow mutations", async () => {

--- a/extensions/webhooks/src/http.ts
+++ b/extensions/webhooks/src/http.ts
@@ -627,6 +627,25 @@ async function executeWebhookAction(params: {
       };
     }
     case "run_task": {
+      // Validate childSessionKey belongs to the route's session tree before
+      // delegating to the task runtime. Without this check, a webhook route
+      // bound to session A could specify childSessionKey for session B and
+      // subsequently cancel or manipulate that unrelated session.
+      if (action.childSessionKey != null) {
+        const routeSessionKey = target.taskFlow.sessionKey;
+        const childKey = action.childSessionKey;
+        if (
+          childKey === routeSessionKey ||
+          !childKey.toLowerCase().startsWith(routeSessionKey.toLowerCase() + ":")
+        ) {
+          return {
+            created: false,
+            found: true,
+            reason:
+              "childSessionKey must be a descendant of the route's session tree",
+          };
+        }
+      }
       const result = target.taskFlow.runTask({
         flowId: action.flowId,
         runtime: action.runtime,


### PR DESCRIPTION
## Summary

The `run_task` webhook action accepted any `childSessionKey` value without verifying it belonged to the route's session tree. This allowed a webhook route bound to session A to spawn child tasks under session B, enabling cross-session manipulation.

## Fix

Added a session tree validation check at the start of the `run_task` handler. If `childSessionKey` is provided, it must be a case-insensitive descendant of the route's `sessionKey` (i.e., it must start with `routeSessionKey + ":"`). Requests that violate this constraint return `{ created: false, found: true, reason: "childSessionKey must be a descendant of the route's session tree" }` instead of delegating to the task runtime.

## Changes

- `extensions/webhooks/src/http.ts`: Added session tree boundary check in the `run_task` case (lines 630–648)
- `extensions/webhooks/src/http.test.ts`: Updated existing `run_task` test to use a dynamically generated valid descendant session key; added new test case verifying rejection of non-descendant session keys

## Testing

The existing test for `run_task` was updated to use a session-key-aware `childSessionKey` (descendant of the route's session). A new test case verifies that `childSessionKey: "agent:main:subagent:unrelated"` is rejected with the appropriate reason.

Closes #79038
