### PR TITLE
fix: add operation and url context to buildTimeoutAbortSignal calls

### DIFF
--- a/extensions/matrix/src/matrix/sdk/transport.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.ts
@@ -117,6 +117,8 @@ async function fetchWithMatrixGuardedRedirects(params: {
   const { signal, cleanup } = buildTimeoutAbortSignal({
     timeoutMs: params.timeoutMs,
     signal: params.signal,
+    url: params.url,
+    operation: "matrix fetch with redirects",
   });
 
   for (let redirectCount = 0; redirectCount <= maxRedirects; redirectCount += 1) {

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -361,6 +361,8 @@ async function loadReferenceImages(params: {
         : await (async () => {
             const { signal, cleanup } = buildTimeoutAbortSignal({
               timeoutMs: params.timeoutMs ?? DEFAULT_REFERENCE_FETCH_TIMEOUT_MS,
+              url: resolvedPath ?? resolvedInput,
+              operation: "load reference media",
             });
             try {
               return await loadWebMedia(resolvedPath ?? resolvedInput, {


### PR DESCRIPTION
## Summary

Two `buildTimeoutAbortSignal` call sites were missing `operation` and `url` parameters, causing timeout/fetch warnings to be logged without sufficient context for diagnosis.

## Fix

Added `operation` and `url` to the `buildTimeoutAbortSignal` calls in both files:

- `src/agents/tools/music-generate-tool.ts`: Added `url: resolvedPath ?? resolvedInput` and `operation: "load reference media"` so that any timeout or fetch error while loading reference media will include the media URL and operation name in the warning.
- `extensions/matrix/src/matrix/sdk/transport.ts`: Added `url: params.url` and `operation: "matrix fetch with redirects"` so that timeout warnings during Matrix protocol fetches include the target URL.

Both parameters are optional in `TimeoutAbortSignalParams`, so this change is backward-compatible.

## Changes

- `src/agents/tools/music-generate-tool.ts`: +2 lines
- `extensions/matrix/src/matrix/sdk/transport.ts`: +2 lines

Closes #79195
