### PR TITLE
fix(agent): deliver CLI notifications directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -437,6 +437,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/ACP: keep chat-bound ACP replies durable by delivering final-only ACP output as final text instead of transient Telegram preview blocks. Thanks @shakkernerd.
 - Telegram: hydrate replied-to messages as a persisted nearest-first reply chain so agents can see observed parent text, media refs, captions, senders, timestamps, and nested replies instead of guessing from a shallow reply id.
 - Telegram: skip the rewritten silent-reply fallback when the dispatcher reports a final reply was queued in the same turn so a "No extra answer from me." filler cannot race ahead of the actual reply when lane delivery state never observes the send. Fixes #78929.
+- CLI/agent: make `openclaw agent --deliver` deliver the CLI message directly while keeping runtime delivery followups on the agent-composed path. Fixes #57284. Thanks @stainlu.
 - Gateway/watch: leave `OPENCLAW_TRACE_SYNC_IO` disabled by default in `pnpm gateway:watch:raw` so watch mode avoids noisy Node sync-I/O stack traces unless explicitly requested.
 - Codex app-server: close stdio stdin before force-killing the managed app-server, matching Codex single-client shutdown behavior and avoiding unsettled CLI exits after successful runs.
 - CLI/Codex: dispose registered agent harnesses during short-lived CLI shutdown so successful Codex-backed `agent --local` runs do not leave app-server child processes alive.

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -725,6 +725,7 @@ public struct AgentParams: Codable, Sendable {
     public let sessionkey: String?
     public let thinking: String?
     public let deliver: Bool?
+    public let directdelivery: Bool?
     public let attachments: [AnyCodable]?
     public let channel: String?
     public let replychannel: String?
@@ -762,6 +763,7 @@ public struct AgentParams: Codable, Sendable {
         sessionkey: String?,
         thinking: String?,
         deliver: Bool?,
+        directdelivery: Bool?,
         attachments: [AnyCodable]?,
         channel: String?,
         replychannel: String?,
@@ -798,6 +800,7 @@ public struct AgentParams: Codable, Sendable {
         self.sessionkey = sessionkey
         self.thinking = thinking
         self.deliver = deliver
+        self.directdelivery = directdelivery
         self.attachments = attachments
         self.channel = channel
         self.replychannel = replychannel
@@ -836,6 +839,7 @@ public struct AgentParams: Codable, Sendable {
         case sessionkey = "sessionKey"
         case thinking
         case deliver
+        case directdelivery = "directDelivery"
         case attachments
         case channel
         case replychannel = "replyChannel"

--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -1,7 +1,8 @@
 ---
-summary: "CLI reference for `openclaw agent` (send one agent turn via the Gateway)"
+summary: "CLI reference for `openclaw agent` (send one agent turn or direct notification via the Gateway)"
 read_when:
-  - You want to run one agent turn from scripts (optionally deliver reply)
+  - You want to run one agent turn from scripts
+  - You want to send a direct notification through agent routing
 title: "Agent"
 ---
 
@@ -34,7 +35,7 @@ Related:
 - `--reply-channel <channel>`: delivery channel override
 - `--reply-account <id>`: delivery account override
 - `--local`: run the embedded agent directly (after plugin registry preload)
-- `--deliver`: send the reply back to the selected channel/target
+- `--deliver`: send `--message` directly to the selected channel/target instead of running an agent turn
 - `--timeout <seconds>`: override agent timeout (default 600 or config value)
 - `--json`: output JSON
 
@@ -46,7 +47,7 @@ openclaw agent --agent ops --message "Summarize logs"
 openclaw agent --agent ops --model openai/gpt-5.4 --message "Summarize logs"
 openclaw agent --session-id 1234 --message "Summarize inbox" --thinking medium
 openclaw agent --to +15555550123 --message "Trace logs" --verbose on --json
-openclaw agent --agent ops --message "Generate report" --deliver --reply-channel slack --reply-to "#reports"
+openclaw agent --agent ops --message "Deploy finished" --deliver --reply-channel slack --reply-to "#reports"
 openclaw agent --agent ops --message "Run locally" --local
 ```
 
@@ -56,7 +57,8 @@ openclaw agent --agent ops --message "Run locally" --local
 - `--local` still preloads the plugin registry first, so plugin-provided providers, tools, and channels stay available during embedded runs.
 - `--local` and embedded fallback runs are treated as one-shot runs. Bundled MCP loopback resources and warm Claude stdio sessions opened for that local process are retired after the reply, so scripted invocations do not keep local child processes alive.
 - Gateway-backed runs leave Gateway-owned MCP loopback resources under the running Gateway process; older clients may still send the historical cleanup flag, but the Gateway accepts it as a compatibility no-op.
-- `--channel`, `--reply-channel`, and `--reply-account` affect reply delivery, not session routing.
+- `--deliver` is a direct notification path for user-authored CLI text. Runtime internal-event deliveries still run the agent so OpenClaw can compose the final user-facing reply.
+- `--channel`, `--reply-channel`, and `--reply-account` affect delivery, not session routing.
 - `--json` keeps stdout reserved for the JSON response. Gateway, plugin, and embedded-fallback diagnostics are routed to stderr so scripts can parse stdout directly.
 - Embedded fallback JSON includes `meta.transport: "embedded"` and `meta.fallbackFrom: "gateway"` so scripts can distinguish fallback runs from Gateway runs.
 - If the Gateway accepts an agent run but the CLI times out waiting for the final reply, embedded fallback uses a fresh explicit `gateway-fallback-*` session/run id and reports `meta.fallbackReason: "gateway_timeout"` plus the fallback session fields. This avoids racing the Gateway-owned transcript lock or silently replacing the original routed conversation session.

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -622,6 +622,7 @@ terminal summary, and sanitized error text.
 ## Agent delivery fallback
 
 - `agent` requests can include `deliver=true` to request outbound delivery.
+- `directDelivery=true` is reserved for trusted CLI/direct-notification clients that want `message` delivered as-is without running an agent turn. Plain `deliver=true` still runs the agent and delivers the composed reply.
 - `bestEffortDeliver=false` keeps strict behavior: unresolved or internal-only delivery targets return `INVALID_REQUEST`.
 - `bestEffortDeliver=true` allows fallback to session-only execution when no external deliverable route can be resolved (for example internal/webchat sessions or ambiguous multi-channel configs).
 - Final `agent` results may include `result.deliveryStatus` when delivery was

--- a/docs/tools/agent-send.md
+++ b/docs/tools/agent-send.md
@@ -1,14 +1,14 @@
 ---
-summary: "Run agent turns from the CLI and optionally deliver replies to channels"
+summary: "Run agent turns from the CLI or send direct notifications through agent routing"
 read_when:
   - You want to trigger agent runs from scripts or the command line
-  - You need to deliver agent replies to a chat channel programmatically
+  - You need to send notifications to a chat channel programmatically
 title: "Agent send"
 ---
 
 `openclaw agent` runs a single agent turn from the command line without needing
-an inbound chat message. Use it for scripted workflows, testing, and
-programmatic delivery.
+an inbound chat message. With `--deliver`, it sends the provided message
+directly to the selected channel/target.
 
 ## Quick start
 
@@ -36,13 +36,13 @@ programmatic delivery.
 
   </Step>
 
-  <Step title="Deliver the reply to a channel">
+  <Step title="Send a direct notification to a channel">
     ```bash
-    # Deliver to WhatsApp (default channel)
+    # Send to WhatsApp (default channel)
     openclaw agent --to +15555550123 --message "Report ready" --deliver
 
-    # Deliver to Slack
-    openclaw agent --agent ops --message "Generate report" \
+    # Send to Slack
+    openclaw agent --agent ops --message "Deploy finished" \
       --deliver --reply-channel slack --reply-to "#reports"
     ```
 
@@ -58,7 +58,7 @@ programmatic delivery.
 | `--agent \<id\>`              | Target a configured agent (uses its `main` session)         |
 | `--session-id \<id\>`         | Reuse an existing session by id                             |
 | `--local`                     | Force local embedded runtime (skip Gateway)                 |
-| `--deliver`                   | Send the reply to a chat channel                            |
+| `--deliver`                   | Send `--message` directly to a chat channel                 |
 | `--channel \<name\>`          | Delivery channel (whatsapp, telegram, discord, slack, etc.) |
 | `--reply-to \<target\>`       | Delivery target override                                    |
 | `--reply-channel \<name\>`    | Delivery channel override                                   |
@@ -76,6 +76,8 @@ programmatic delivery.
 - Session selection: `--to` derives the session key (group/channel targets
   preserve isolation; direct chats collapse to `main`).
 - Thinking and verbose flags persist into the session store.
+- `--deliver` bypasses the agent turn for normal CLI text. Internal runtime
+  events still run the agent so OpenClaw can compose a final reply.
 - Output: plain text by default, or `--json` for structured payload + metadata.
 - With `--json --deliver`, the JSON includes delivery status for sent,
   suppressed, partial, and failed sends. See
@@ -90,7 +92,7 @@ openclaw agent --to +15555550123 --message "Trace logs" --verbose on --json
 # Turn with thinking level
 openclaw agent --session-id 1234 --message "Summarize inbox" --thinking medium
 
-# Deliver to a different channel than the session
+# Send to a different channel than the session
 openclaw agent --agent ops --message "Alert" --deliver --reply-channel telegram --reply-to "@admin"
 ```
 

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -205,7 +205,11 @@ function loadSkillsRemoteRuntime(): Promise<SkillsRemoteRuntime> {
 
 function shouldDirectDeliverOriginalMessage(opts: AgentCommandOpts, isRawModelRun: boolean) {
   return (
-    opts.deliver === true && !isRawModelRun && !opts.internalEvents?.length && !opts.images?.length
+    opts.directDelivery === true &&
+    opts.deliver === true &&
+    !isRawModelRun &&
+    !opts.internalEvents?.length &&
+    !opts.images?.length
   );
 }
 

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -203,6 +203,21 @@ function loadSkillsRemoteRuntime(): Promise<SkillsRemoteRuntime> {
   return skillsRemoteRuntimeLoader.load();
 }
 
+function shouldDirectDeliverOriginalMessage(opts: AgentCommandOpts, isRawModelRun: boolean) {
+  return (
+    opts.deliver === true && !isRawModelRun && !opts.internalEvents?.length && !opts.images?.length
+  );
+}
+
+function createDirectDeliveryResult(text: string): AgentAttemptResult {
+  return {
+    payloads: [{ text }],
+    meta: {
+      durationMs: 0,
+    },
+  } as AgentAttemptResult;
+}
+
 async function resolveAgentCommandDeps(deps: CliDeps | undefined): Promise<CliDeps> {
   if (deps) {
     return deps;
@@ -283,6 +298,7 @@ async function prepareAgentCommandExecution(
   runtime: RuntimeEnv,
 ) {
   const isRawModelRun = opts.modelRun === true || opts.promptMode === "none";
+  const isDirectDelivery = shouldDirectDeliverOriginalMessage(opts, isRawModelRun);
   const message = opts.message ?? "";
   if (!message.trim()) {
     throw new Error("Message (--message) is required");
@@ -396,21 +412,26 @@ async function prepareAgentCommandExecution(
   const workspaceDirRaw =
     normalizedSpawned.workspaceDir ?? resolveAgentWorkspaceDir(cfg, sessionAgentId);
   const agentDir = resolveAgentDir(cfg, sessionAgentId);
-  const workspace = await ensureAgentWorkspace({
-    dir: workspaceDirRaw,
-    ensureBootstrapFiles: !agentCfg?.skipBootstrap,
-    skipOptionalBootstrapFiles: agentCfg?.skipOptionalBootstrapFiles,
-  });
-  const workspaceDir = workspace.dir;
+  const workspaceDir = isDirectDelivery
+    ? workspaceDirRaw
+    : (
+        await ensureAgentWorkspace({
+          dir: workspaceDirRaw,
+          ensureBootstrapFiles: !agentCfg?.skipBootstrap,
+          skipOptionalBootstrapFiles: agentCfg?.skipOptionalBootstrapFiles,
+        })
+      ).dir;
   const runId = opts.runId?.trim() || sessionId;
-  const { getAcpSessionManager } = await loadAcpManagerRuntime();
-  const acpManager = getAcpSessionManager();
-  const acpResolution = sessionKey
-    ? acpManager.resolveSession({
-        cfg,
-        sessionKey,
-      })
-    : null;
+  const acpManager = isDirectDelivery
+    ? null
+    : (await loadAcpManagerRuntime()).getAcpSessionManager();
+  const acpResolution =
+    sessionKey && acpManager
+      ? acpManager.resolveSession({
+          cfg,
+          sessionKey,
+        })
+      : null;
   const body =
     !isRawModelRun && acpResolution?.kind === "ready"
       ? resolveAcpPromptBody(message, opts.internalEvents)
@@ -497,11 +518,31 @@ async function agentCommandInternal(
       }
     }
 
+    if (shouldDirectDeliverOriginalMessage(opts, isRawModelRun)) {
+      const directDeliveryText = normalizeOptionalString(opts.directDeliveryText) ?? opts.message;
+      const result = createDirectDeliveryResult(directDeliveryText);
+      const { deliverAgentCommandResult } = await loadDeliveryRuntime();
+
+      return await deliverAgentCommandResult({
+        cfg,
+        deps: resolvedDeps,
+        runtime,
+        opts: {
+          ...opts,
+          directDeliveryText,
+        },
+        outboundSession,
+        sessionEntry,
+        result,
+        payloads: result.payloads,
+      });
+    }
+
     if (!isRawModelRun && acpResolution?.kind === "stale") {
       throw acpResolution.error;
     }
 
-    if (!isRawModelRun && acpResolution?.kind === "ready" && sessionKey) {
+    if (!isRawModelRun && acpResolution?.kind === "ready" && sessionKey && acpManager) {
       const attemptExecutionRuntime = await loadAttemptExecutionRuntime();
       const startedAt = Date.now();
       registerAgentRunContext(runId, {

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -131,6 +131,11 @@ describe("exec approval followup", () => {
       threadId: target.threadId,
       idempotencyKey: `exec-approval-followup:req-${target.channel}`,
     });
+    const followupArgs = vi.mocked(callGatewayTool).mock.calls[0]?.[2] as
+      | { directDelivery?: boolean; directDeliveryText?: string }
+      | undefined;
+    expect(followupArgs?.directDelivery).not.toBe(true);
+    expect(followupArgs?.directDeliveryText).toBeUndefined();
     expect(sendMessage).not.toHaveBeenCalled();
   });
 

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -248,6 +248,7 @@ describe("normalizeAgentCommandReplyPayloads", () => {
       } as OpenClawConfig,
       opts: {
         message: "NO_REPLY",
+        directDelivery: true,
         directDeliveryText: "NO_REPLY",
       } as AgentCommandOpts,
       outboundSession: undefined,
@@ -364,6 +365,7 @@ describe("normalizeAgentCommandReplyPayloads", () => {
       opts: {
         message: "NO_REPLY",
         deliver: true,
+        directDelivery: true,
         directDeliveryText: "NO_REPLY",
         replyChannel: "slack",
         replyTo: "#general",

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -239,6 +239,35 @@ describe("normalizeAgentCommandReplyPayloads", () => {
     expectTextPayload(normalized[0], "[openai-codex/gpt-5.4] Ready.");
   });
 
+  it("preserves direct-delivery text without reply prefixes or silent-token filtering", () => {
+    const normalized = normalizeAgentCommandReplyPayloads({
+      cfg: {
+        messages: {
+          responsePrefix: "[{modelFull}]",
+        },
+      } as OpenClawConfig,
+      opts: {
+        message: "NO_REPLY",
+        directDeliveryText: "NO_REPLY",
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      deliveryChannel: "slack",
+      payloads: [{ text: "NO_REPLY" }],
+      result: createResult({
+        meta: {
+          durationMs: 1,
+          agentMeta: {
+            sessionId: "session-1",
+            provider: "openai-codex",
+            model: "gpt-5.4",
+          },
+        },
+      }),
+    });
+
+    expect(normalized).toEqual([{ text: "NO_REPLY" }]);
+  });
+
   it("keeps Slack options text intact for local preview when delivery is disabled", async () => {
     const runtime = {
       log: vi.fn(),
@@ -317,6 +346,44 @@ describe("normalizeAgentCommandReplyPayloads", () => {
       succeeded: true,
       reason: "no_visible_result",
     });
+  });
+
+  it("marks direct-delivery outbound sends to preserve exact silent-token text", async () => {
+    deliverOutboundPayloadsMock.mockClear();
+    createReplyMediaPathNormalizerMock.mockReturnValue(async (payload: ReplyPayload) => payload);
+    deliverOutboundPayloadsMock.mockResolvedValue([]);
+
+    await deliverAgentCommandResult({
+      cfg: {
+        agents: {
+          list: [{ id: "tester", workspace: "/tmp/agent-workspace" }],
+        },
+      } as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "NO_REPLY",
+        deliver: true,
+        directDeliveryText: "NO_REPLY",
+        replyChannel: "slack",
+        replyTo: "#general",
+      } as AgentCommandOpts,
+      outboundSession: {
+        key: "agent:tester:slack:direct:alice",
+        agentId: "tester",
+      } as never,
+      sessionEntry: undefined,
+      payloads: [{ text: "NO_REPLY" }],
+      result: createResult(),
+    });
+
+    const [firstCallArg] = deliverOutboundPayloadsMock.mock.calls[0] ?? [];
+    expect(firstCallArg).toEqual(
+      expect.objectContaining({
+        preserveSilentText: true,
+        payloads: [expect.objectContaining({ text: "NO_REPLY" })],
+      }),
+    );
   });
 
   it("does not report success when best-effort delivery records an error", async () => {

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -25,6 +25,7 @@ import {
 } from "../../infra/outbound/payloads.js";
 import type { OutboundSessionContext } from "../../infra/outbound/session-context.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
+import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import { isNestedAgentLane } from "../lanes.js";
 import type { EmbeddedPiRunMeta } from "../pi-embedded-runner/types.js";
@@ -274,6 +275,9 @@ export function normalizeAgentCommandReplyPayloads(params: {
   if (payloads.length === 0) {
     return [];
   }
+  if (normalizeOptionalString(params.opts.directDeliveryText)) {
+    return payloads as ReplyPayload[];
+  }
   const channel =
     params.deliveryChannel && !isInternalMessageChannel(params.deliveryChannel)
       ? (normalizeChannelId(params.deliveryChannel) ?? params.deliveryChannel)
@@ -342,6 +346,7 @@ export async function deliverAgentCommandResult(params: {
   payloads: RunResult["payloads"];
 }): Promise<AgentCommandDeliveryResult> {
   const { cfg, deps, runtime, opts, outboundSession, sessionEntry, payloads, result } = params;
+  const directDelivery = normalizeOptionalString(opts.directDeliveryText) !== undefined;
   const effectiveSessionKey = outboundSession?.key ?? opts.sessionKey;
   const deliver = opts.deliver === true;
   const bestEffortDeliver = opts.bestEffortDeliver === true;
@@ -483,7 +488,9 @@ export async function deliverAgentCommandResult(params: {
           accountId: resolvedAccountId,
         })
       : normalizedReplyPayloads;
-  const outboundPayloadPlan = createOutboundPayloadPlan(mediaNormalizedReplyPayloads);
+  const outboundPayloadPlan = createOutboundPayloadPlan(mediaNormalizedReplyPayloads, {
+    preserveSilentText: directDelivery,
+  });
   const normalizedPayloads = projectOutboundPayloadPlanForJson(outboundPayloadPlan);
   const resultMeta = mergeResultMetaOverrides(result.meta, opts.resultMetaOverrides);
   const emitJsonEnvelope = (status?: AgentCommandDeliveryStatus) => {
@@ -551,6 +558,7 @@ export async function deliverAgentCommandResult(params: {
         threadId: resolvedThreadTarget ?? null,
         bestEffort: bestEffortDeliver,
         durability: bestEffortDeliver ? "best_effort" : "required",
+        preserveSilentText: directDelivery,
         onError: logDeliveryError,
         onPayload: logPayload,
         deps: createOutboundSendDeps(deps),

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -275,7 +275,10 @@ export function normalizeAgentCommandReplyPayloads(params: {
   if (payloads.length === 0) {
     return [];
   }
-  if (normalizeOptionalString(params.opts.directDeliveryText)) {
+  if (
+    params.opts.directDelivery === true &&
+    normalizeOptionalString(params.opts.directDeliveryText) !== undefined
+  ) {
     return payloads as ReplyPayload[];
   }
   const channel =
@@ -346,7 +349,8 @@ export async function deliverAgentCommandResult(params: {
   payloads: RunResult["payloads"];
 }): Promise<AgentCommandDeliveryResult> {
   const { cfg, deps, runtime, opts, outboundSession, sessionEntry, payloads, result } = params;
-  const directDelivery = normalizeOptionalString(opts.directDeliveryText) !== undefined;
+  const directDelivery =
+    opts.directDelivery === true && normalizeOptionalString(opts.directDeliveryText) !== undefined;
   const effectiveSessionKey = outboundSession?.key ?? opts.sessionKey;
   const deliver = opts.deliver === true;
   const bestEffortDeliver = opts.bestEffortDeliver === true;

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -62,6 +62,8 @@ export type AgentCommandOpts = {
   json?: boolean;
   timeout?: string;
   deliver?: boolean;
+  /** Internal: direct notification text for `agent --deliver` paths that bypass an agent turn. */
+  directDeliveryText?: string;
   /** Override delivery target (separate from session routing). */
   replyTo?: string;
   /** Override delivery channel (separate from session routing). */

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -62,7 +62,9 @@ export type AgentCommandOpts = {
   json?: boolean;
   timeout?: string;
   deliver?: boolean;
-  /** Internal: direct notification text for `agent --deliver` paths that bypass an agent turn. */
+  /** Internal: bypass the agent turn for trusted CLI/RPC notification sends. */
+  directDelivery?: boolean;
+  /** Internal: direct notification text for explicit direct-delivery paths. */
   directDeliveryText?: string;
   /** Override delivery target (separate from session routing). */
   replyTo?: string;

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -46,7 +46,7 @@ export function registerAgentCommands(program: Command, args: { agentChannelOpti
       "Run the embedded agent locally (requires model provider API keys in your shell)",
       false,
     )
-    .option("--deliver", "Send the agent's reply back to the selected channel", false)
+    .option("--deliver", "Send --message directly to the selected channel", false)
     .option("--json", "Output result as JSON", false)
     .option(
       "--timeout <seconds>",
@@ -68,10 +68,13 @@ ${formatHelpExamples([
     'openclaw agent --to +15555550123 --message "Trace logs" --verbose on --json',
     "Enable verbose logging and JSON output.",
   ],
-  ['openclaw agent --to +15555550123 --message "Summon reply" --deliver', "Deliver reply."],
   [
-    'openclaw agent --agent ops --message "Generate report" --deliver --reply-channel slack --reply-to "#reports"',
-    "Send reply to a different channel/target.",
+    'openclaw agent --to +15555550123 --message "Service is back" --deliver',
+    "Send a notification.",
+  ],
+  [
+    'openclaw agent --agent ops --message "Deploy finished" --deliver --reply-channel slack --reply-to "#reports"',
+    "Send a notification to a different channel/target.",
   ],
 ])}
 

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -185,7 +185,7 @@ async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: RuntimeEnv) {
 
   const response: GatewayAgentResponse = await withProgress(
     {
-      label: "Waiting for agent reply…",
+      label: opts.deliver ? "Sending message…" : "Waiting for agent reply…",
       indeterminate: true,
       enabled: opts.json !== true,
     },

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -202,6 +202,7 @@ async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: RuntimeEnv) {
           sessionKey,
           thinking: opts.thinking,
           deliver: Boolean(opts.deliver),
+          directDelivery: Boolean(opts.deliver),
           channel,
           replyChannel: opts.replyChannel,
           replyAccountId: opts.replyAccount,
@@ -252,6 +253,7 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
     ...opts,
     agentId: opts.agent,
     replyAccountId: opts.replyAccount,
+    directDelivery: Boolean(opts.deliver),
     cleanupBundleMcpOnRunEnd: true,
     cleanupCliLiveSessionOnRunEnd: true,
   };

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -534,6 +534,19 @@ describe("agentCommand", () => {
           channel: "telegram",
           messageChannel: "telegram",
           deliver: true,
+          internalEvents: [
+            {
+              type: "task_completion",
+              source: "subagent",
+              childSessionKey: "agent:main:subagent:child",
+              announceType: "completion",
+              taskLabel: "child task",
+              status: "ok",
+              statusLabel: "done",
+              result: "child result",
+              replyInstruction: "Reply to the user with the result.",
+            },
+          ],
           senderIsOwner: false,
           allowModelOverride: false,
         },
@@ -548,7 +561,39 @@ describe("agentCommand", () => {
       const persistArgs = vi.mocked(attemptExecutionRuntime.persistCliTurnTranscript).mock
         .calls[0]?.[0];
       expect(persistArgs?.embeddedAssistantGapFill).toBe(true);
-      expect(persistArgs?.body).toBe("call a tool then answer");
+      expect(persistArgs?.body).toContain("call a tool then answer");
+      expect(persistArgs?.body).toContain("OpenClaw runtime context (internal)");
+    });
+  });
+
+  it("delivers --deliver notifications directly without running the agent", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store);
+      const sendMessageTelegram = vi.fn(async () => undefined);
+
+      await agentCommandFromIngress(
+        {
+          message: "NO_REPLY",
+          agentId: "main",
+          to: "+1222",
+          channel: "telegram",
+          messageChannel: "telegram",
+          deliver: true,
+          senderIsOwner: false,
+          allowModelOverride: false,
+        },
+        runtime,
+        { sendMessageTelegram },
+      );
+
+      expect(runEmbeddedPiAgent).not.toHaveBeenCalled();
+      expect(sendMessageTelegram).toHaveBeenCalledWith(
+        "+1222",
+        "NO_REPLY",
+        expect.objectContaining({ verbose: false }),
+      );
+      expect(vi.mocked(attemptExecutionRuntime.persistCliTurnTranscript)).not.toHaveBeenCalled();
     });
   });
 

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -580,6 +580,7 @@ describe("agentCommand", () => {
           channel: "telegram",
           messageChannel: "telegram",
           deliver: true,
+          directDelivery: true,
           senderIsOwner: false,
           allowModelOverride: false,
         },

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -148,6 +148,7 @@ export const AgentParamsSchema = Type.Object(
     sessionKey: Type.Optional(Type.String()),
     thinking: Type.Optional(Type.String()),
     deliver: Type.Optional(Type.Boolean()),
+    directDelivery: Type.Optional(Type.Boolean()),
     attachments: Type.Optional(Type.Array(Type.Unknown())),
     channel: Type.Optional(Type.String()),
     replyChannel: Type.Optional(Type.String()),

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1314,6 +1314,33 @@ describe("gateway agent handler", () => {
     expect(callArgs.directDeliveryText).toBe("strict delivery");
   });
 
+  it("treats slash-prefixed direct delivery text as literal notification content", async () => {
+    mocks.agentCommand.mockClear();
+    mocks.performGatewaySessionReset.mockClear();
+    primeMainAgentRun();
+
+    await invokeAgent(
+      {
+        message: "/reset deploy done",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        deliver: true,
+        directDelivery: true,
+        replyChannel: "telegram",
+        to: "123",
+        bestEffortDeliver: false,
+        idempotencyKey: "test-direct-delivery-reset-literal",
+      },
+      { reqId: "direct-delivery-reset-literal" },
+    );
+
+    const callArgs = await waitForAgentCommandCall();
+    expect(mocks.performGatewaySessionReset).not.toHaveBeenCalled();
+    expect(callArgs.deliver).toBe(true);
+    expect(callArgs.directDelivery).toBe(true);
+    expect(callArgs.directDeliveryText).toBe("/reset deploy done");
+  });
+
   it("keeps composed delivery on the agent path without directDelivery", async () => {
     mocks.agentCommand.mockClear();
     primeMainAgentRun();

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1299,6 +1299,7 @@ describe("gateway agent handler", () => {
         agentId: "main",
         sessionKey: "agent:main:main",
         deliver: true,
+        directDelivery: true,
         replyChannel: "telegram",
         to: "123",
         bestEffortDeliver: false,
@@ -1309,7 +1310,32 @@ describe("gateway agent handler", () => {
 
     const callArgs = await waitForAgentCommandCall();
     expect(callArgs.bestEffortDeliver).toBe(false);
+    expect(callArgs.directDelivery).toBe(true);
     expect(callArgs.directDeliveryText).toBe("strict delivery");
+  });
+
+  it("keeps composed delivery on the agent path without directDelivery", async () => {
+    mocks.agentCommand.mockClear();
+    primeMainAgentRun();
+
+    await invokeAgent(
+      {
+        message: "compose this before delivery",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        deliver: true,
+        replyChannel: "telegram",
+        to: "123",
+        bestEffortDeliver: true,
+        idempotencyKey: "test-composed-delivery",
+      },
+      { reqId: "composed-delivery" },
+    );
+
+    const callArgs = await waitForAgentCommandCall();
+    expect(callArgs.deliver).toBe(true);
+    expect(callArgs.directDelivery).toBe(false);
+    expect(callArgs.directDeliveryText).toBeUndefined();
   });
 
   it("keeps internal-event delivery on the agent-composed path", async () => {

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1309,6 +1309,42 @@ describe("gateway agent handler", () => {
 
     const callArgs = await waitForAgentCommandCall();
     expect(callArgs.bestEffortDeliver).toBe(false);
+    expect(callArgs.directDeliveryText).toBe("strict delivery");
+  });
+
+  it("keeps internal-event delivery on the agent-composed path", async () => {
+    mocks.agentCommand.mockClear();
+    primeMainAgentRun();
+
+    await invokeAgent(
+      {
+        message: "child completed",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        deliver: true,
+        replyChannel: "telegram",
+        to: "123",
+        internalEvents: [
+          {
+            type: "task_completion",
+            source: "subagent",
+            childSessionKey: "agent:main:subagent:child",
+            announceType: "completion",
+            taskLabel: "child task",
+            status: "ok",
+            statusLabel: "done",
+            result: "child result",
+            replyInstruction: "Reply to the user with the result.",
+          },
+        ],
+        idempotencyKey: "test-internal-event-delivery",
+      },
+      { reqId: "internal-event-delivery" },
+    );
+
+    const callArgs = await waitForAgentCommandCall();
+    expect(callArgs.directDeliveryText).toBeUndefined();
+    expect(callArgs.internalEvents).toHaveLength(1);
   });
 
   it("rejects strict delivery with a missing target before dispatching the agent", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -724,6 +724,12 @@ export const agentHandlers: GatewayRequestHandlers = {
         return;
       }
     }
+    const shouldPreserveDirectDeliveryInput =
+      request.directDelivery === true &&
+      request.deliver === true &&
+      !isRawModelRun &&
+      !request.internalEvents?.length &&
+      images.length === 0;
 
     // Accept internal non-delivery sources (heartbeat, cron, webhook) as valid
     // channel hints so subagent spawns from those parent runs are not rejected.
@@ -876,7 +882,9 @@ export const agentHandlers: GatewayRequestHandlers = {
     let skipTimestampInjection = false;
     let shouldPrependStartupContext = false;
 
-    const resetCommandMatch = message.match(RESET_COMMAND_RE);
+    const resetCommandMatch = shouldPreserveDirectDeliveryInput
+      ? null
+      : message.match(RESET_COMMAND_RE);
     if (resetCommandMatch && requestedSessionKey) {
       if (!canResetSession) {
         respond(
@@ -1313,13 +1321,7 @@ export const agentHandlers: GatewayRequestHandlers = {
 
     const deliver = request.deliver === true && resolvedChannel !== INTERNAL_MESSAGE_CHANNEL;
     const directDeliveryText =
-      request.directDelivery === true &&
-      deliver &&
-      !isRawModelRun &&
-      !request.internalEvents?.length &&
-      images.length === 0
-        ? originalDirectDeliveryMessage
-        : undefined;
+      shouldPreserveDirectDeliveryInput && deliver ? originalDirectDeliveryMessage : undefined;
 
     // Register before the accepted ack so an immediate chat.abort/sessions.abort
     // cannot race the active-run entry. Agent RPC runs use the agent timeout;

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -662,6 +662,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       typeof request.bestEffortDeliver === "boolean" ? request.bestEffortDeliver : undefined;
 
     let message = (request.message ?? "").trim();
+    const originalDirectDeliveryMessage = message;
     if (!isRawModelRun) {
       message = annotateInterSessionPromptText(message, inputProvenance);
     }
@@ -1310,6 +1311,10 @@ export const agentHandlers: GatewayRequestHandlers = {
         : resolvedChannel);
 
     const deliver = request.deliver === true && resolvedChannel !== INTERNAL_MESSAGE_CHANNEL;
+    const directDeliveryText =
+      deliver && !isRawModelRun && !request.internalEvents?.length && images.length === 0
+        ? originalDirectDeliveryMessage
+        : undefined;
 
     // Register before the accepted ack so an immediate chat.abort/sessions.abort
     // cannot race the active-run entry. Agent RPC runs use the agent timeout;
@@ -1458,6 +1463,7 @@ export const agentHandlers: GatewayRequestHandlers = {
             sessionKey: resolvedSessionKey,
             thinking: request.thinking,
             deliver,
+            directDeliveryText,
             deliveryTargetMode,
             channel: resolvedChannel,
             accountId: resolvedAccountId,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -575,6 +575,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       sessionKey?: string;
       thinking?: string;
       deliver?: boolean;
+      directDelivery?: boolean;
       attachments?: Array<{
         type?: string;
         mimeType?: string;
@@ -1312,7 +1313,11 @@ export const agentHandlers: GatewayRequestHandlers = {
 
     const deliver = request.deliver === true && resolvedChannel !== INTERNAL_MESSAGE_CHANNEL;
     const directDeliveryText =
-      deliver && !isRawModelRun && !request.internalEvents?.length && images.length === 0
+      request.directDelivery === true &&
+      deliver &&
+      !isRawModelRun &&
+      !request.internalEvents?.length &&
+      images.length === 0
         ? originalDirectDeliveryMessage
         : undefined;
 
@@ -1463,6 +1468,7 @@ export const agentHandlers: GatewayRequestHandlers = {
             sessionKey: resolvedSessionKey,
             thinking: request.thinking,
             deliver,
+            directDelivery: request.directDelivery === true,
             directDeliveryText,
             deliveryTargetMode,
             channel: resolvedChannel,

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -643,6 +643,8 @@ type DeliverOutboundPayloadsCoreParams = {
   mirror?: DeliveryMirror;
   silent?: boolean;
   gatewayClientScopes?: readonly string[];
+  /** Preserve exact silent-token text for user-authored direct sends. */
+  preserveSilentText?: boolean;
 };
 
 type DeliverOutboundPayloadsCoreRuntimeParams = DeliverOutboundPayloadsCoreParams & {
@@ -1334,6 +1336,7 @@ async function deliverOutboundPayloadsCore(
     surface: channel,
     conversationType: params.session?.conversationType,
     extractMarkdownImages: directiveOptions.extractMarkdownImages,
+    preserveSilentText: params.preserveSilentText,
   });
   const accountId = params.accountId;
   const deps = params.deps;

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -220,6 +220,31 @@ describe("normalizeReplyPayloadsForDelivery", () => {
     expect(reply.text.trim()).not.toBe("NO_REPLY");
   });
 
+  it("preserves bare silent text for direct user-authored sends", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          silentReply: {
+            direct: "disallow",
+            group: "allow",
+            internal: "allow",
+          },
+        },
+      },
+    };
+
+    const projected = projectOutboundPayloadPlanForDelivery(
+      createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
+        cfg,
+        sessionKey: "agent:main:telegram:direct:123",
+        surface: "telegram",
+        preserveSilentText: true,
+      }),
+    );
+
+    expect(projected).toEqual([expect.objectContaining({ text: "NO_REPLY" })]);
+  });
+
   it("drops bare silent replies for groups when policy allows silence", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -69,6 +69,8 @@ type OutboundPayloadPlanContext = {
    */
   hasPendingSpawnedChildren?: boolean;
   extractMarkdownImages?: boolean;
+  /** Treat exact silent tokens as ordinary text for user-authored direct sends. */
+  preserveSilentText?: boolean;
 };
 
 export type OutboundPayloadMirror = {
@@ -137,7 +139,7 @@ type IndexedPreparedOutboundPayloadPlanEntry = PreparedOutboundPayloadPlanEntry 
 
 function createOutboundPayloadPlanEntry(
   payload: ReplyPayload,
-  context: Pick<OutboundPayloadPlanContext, "extractMarkdownImages"> = {},
+  context: Pick<OutboundPayloadPlanContext, "extractMarkdownImages" | "preserveSilentText"> = {},
 ): PreparedOutboundPayloadPlanEntry | null {
   if (shouldSuppressReasoningPayload(payload)) {
     return null;
@@ -151,11 +153,15 @@ function createOutboundPayloadPlanEntry(
     explicitMediaUrls,
     explicitMediaUrl ? [explicitMediaUrl] : undefined,
   );
-  const parsedText = parsed.text ?? "";
+  const preserveSilentText = context.preserveSilentText === true;
+  const parsedText =
+    preserveSilentText && parsed.isSilent && mergedMedia.length === 0
+      ? (payload.text ?? "")
+      : (parsed.text ?? "");
   if (isSuppressedRelayStatusText(parsedText) && mergedMedia.length === 0) {
     return null;
   }
-  const isSilent = parsed.isSilent && mergedMedia.length === 0;
+  const isSilent = !preserveSilentText && parsed.isSilent && mergedMedia.length === 0;
   const hasMultipleMedia = (explicitMediaUrls?.length ?? 0) > 1;
   const resolvedMediaUrl = hasMultipleMedia ? undefined : explicitMediaUrl;
   const normalizedPayload: ReplyPayload = {
@@ -204,6 +210,7 @@ export function createOutboundPayloadPlan(
   for (const [sourceIndex, payload] of payloads.entries()) {
     const entry = createOutboundPayloadPlanEntry(payload, {
       extractMarkdownImages: context.extractMarkdownImages,
+      preserveSilentText: context.preserveSilentText,
     });
     if (!entry) {
       continue;


### PR DESCRIPTION
## Summary

- Problem: `openclaw agent --deliver` treated notification text as an agent prompt, so the model could answer with `NO_REPLY` or unrelated text while the original notification was never sent.
- Why it matters: scripted notifications should be deterministic and cheap; they should not consume a full agent turn just to send already-authored text.
- What changed: direct `--deliver` calls now preserve the original CLI/Gateway message and send it through outbound delivery without running the agent, preparing a workspace, or resolving ACP; internal runtime events still run the agent so OpenClaw can compose the user-facing reply.
- What did NOT change (scope boundary): this does not implement direct session transcript injection; it only fixes channel/target delivery for user-authored direct notifications.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #57284
- Related #57300
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw agent --deliver` should send the provided notification text directly instead of spawning a model turn.
- Real environment tested: local OpenClaw checkout on macOS, Node 22.22.0, pnpm 10.33.2.
- Exact steps or command run after this patch:
  - `node --import tsx /private/tmp/openclaw-direct-delivery-proof.mjs` (the proof request sets the explicit `directDelivery: true` signal added after ClawSweeper review)
  - `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/command/types.ts src/agents/agent-command.ts src/gateway/protocol/schema/agent.ts src/gateway/server-methods/agent.ts src/commands/agent-via-gateway.ts src/agents/bash-tools.exec-approval-followup.test.ts src/agents/command/delivery.test.ts src/commands/agent.test.ts src/gateway/server-methods/agent.test.ts src/infra/outbound/payloads.test.ts docs/cli/agent.md docs/tools/agent-send.md docs/gateway/protocol.md apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift`
  - `env OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/agents/bash-tools.exec-approval-followup.test.ts src/agents/command/delivery.test.ts src/commands/agent.test.ts src/gateway/server-methods/agent.test.ts src/infra/outbound/payloads.test.ts`
  - `pnpm tsgo:core`
  - `pnpm tsgo:core:test`
  - `pnpm protocol:check`
  - `git diff --check`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): terminal capture from the direct-delivery proof command:

```text
runtime log: NO_REPLY
outbound adapter sent text="NO_REPLY" to="#ops"
command result payloads=[{"text":"NO_REPLY","mediaUrl":null}] deliverySucceeded=true
```

Supplemental verification: focused suite passed `4 Vitest shards in 45.76s` after rebasing onto current `main`; `tsgo:core` passed; `tsgo:core:test` passed; `pnpm protocol:check` passed; formatter and `git diff --check` passed.
- Observed result after fix: the real command delivered the original `NO_REPLY` text as the outbound payload and returned `deliverySucceeded=true` while using the explicit direct-delivery signal. Regression coverage also verifies direct delivery does not call `runEmbeddedPiAgent`, preserves exact notification text, keeps plain `deliver=true` followups on the agent-composed path, and keeps internal-event delivery on the agent-composed path.
- What was not tested: no live Signal/Telegram/Slack recipient was exercised from this machine.
- Before evidence (optional but encouraged): #57284 documents the before behavior: the command exited 0 while spawning an LLM turn and not sending the original notification.

## Root Cause (if applicable)

- Root cause: the Gateway and embedded CLI paths only had an agent-reply delivery mode, so `--deliver` passed the original message into `agentCommandFromIngress`/`agentCommand` as a prompt and delivered only model-produced payloads.
- Missing detection / guardrail: no regression test asserted that user-authored `--deliver` text bypasses model execution and reply-specific normalization.
- Contributing context (if known): internal task completion events also use delivery, but those need model composition; the old path did not distinguish direct notifications from runtime events.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/commands/agent.test.ts`
  - `src/gateway/server-methods/agent.test.ts`
  - `src/agents/command/delivery.test.ts`
  - `src/infra/outbound/payloads.test.ts`
- Scenario the test should lock in: direct `--deliver` sends the original text without model execution; internal events still run the agent; direct text is not treated as an assistant reply or silent token.
- Why this is the smallest reliable guardrail: these tests cover the CLI/Gateway decision point, the agent-command shortcut, and outbound normalization without needing real channel credentials.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`openclaw agent --deliver` now sends `--message` directly to the selected channel/target for normal CLI text. Agent-composed delivery remains for internal runtime events.

## Diagram (if applicable)

```text
Before:
openclaw agent --deliver -> agent prompt -> model reply payload -> outbound delivery

After:
openclaw agent --deliver -> original message payload -> outbound delivery

Internal events:
runtime event delivery -> agent prompt -> composed reply payload -> outbound delivery
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: `--deliver` now avoids command/model execution for direct notification text, reducing execution surface. Existing send-policy and outbound target validation still run before delivery.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22.22.0, pnpm 10.33.2
- Model/provider: not used for direct notification path
- Integration/channel (if any): outbound delivery seams; no live channel credential used
- Relevant config (redacted): default local test config

### Steps

1. Run `node --import tsx /private/tmp/openclaw-direct-delivery-proof.mjs`.
2. Run the focused regression suite listed above.
3. Confirm Gateway internal-event delivery does not set `directDeliveryText`.

### Expected

- Direct notification text is delivered as the payload.
- No model turn runs for normal direct notifications.
- Internal-event delivery still runs the agent.

### Actual

- Matches expected in focused regression tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: direct delivery shortcut, exact `NO_REPLY` text preservation, internal-event delivery path, Gateway target validation path, docs/help wording.
- Edge cases checked: direct delivery with silent token text; internal events do not bypass the agent; direct delivery skips workspace/ACP preparation.
- What you did **not** verify: live delivery to a real Signal/Telegram/Slack target.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) No
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: callers that expected `--deliver` to run a model turn and deliver the model reply will see direct notification behavior instead.
  - Mitigation: docs and CLI help now describe `--deliver` as direct notification delivery; internal runtime event delivery is explicitly preserved for composed replies.
