### PR TITLE
fix(gateway): persist macOS stop disable after bootout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/macOS: `openclaw gateway stop` now uses `launchctl bootout` by default instead of unconditionally calling `launchctl disable`, so KeepAlive auto-recovery still works after unexpected crashes; use the new `--disable` flag to opt into the persistent-disable behavior when a manual stop should survive reboots. Fixes #77934. Thanks @bmoran1022.
+- Gateway/macOS: `repairLaunchAgentBootstrap` no longer kickstarts an already-running LaunchAgent, preventing unnecessary service restarts and session disconnects when repair runs against a healthy gateway. Fixes #77428. Thanks @ramitrkar-hash.
 - Control UI/chat: hide retired and non-public Google Gemini model IDs from chat model catalogs and route the bare `gemini-3-pro` alias to Gemini 3.1 Pro Preview instead of the shut-down Gemini 3 Pro Preview. Thanks @BunsDev.
 - CLI/install: refuse state-mutating OpenClaw CLI runs as root by default, keep an explicit `OPENCLAW_ALLOW_ROOT=1` escape hatch for intentional root/container use, and update DigitalOcean setup guidance to run OpenClaw as a non-root user. Fixes #67478. Thanks @Jerry-Xin and @natechicago.
 - Gateway/watch: leave `OPENCLAW_TRACE_SYNC_IO` disabled by default in `pnpm gateway:watch:raw` so watch mode avoids noisy Node sync-I/O stack traces unless explicitly requested.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/macOS: `openclaw gateway stop` now uses `launchctl bootout` by default instead of unconditionally calling `launchctl disable`, so KeepAlive auto-recovery still works after unexpected crashes; use the new `--disable` flag to opt into the persistent-disable behavior when a manual stop should survive reboots. Fixes #77934. Thanks @bmoran1022.
 - Control UI/chat: hide retired and non-public Google Gemini model IDs from chat model catalogs and route the bare `gemini-3-pro` alias to Gemini 3.1 Pro Preview instead of the shut-down Gemini 3 Pro Preview. Thanks @BunsDev.
 - CLI/install: refuse state-mutating OpenClaw CLI runs as root by default, keep an explicit `OPENCLAW_ALLOW_ROOT=1` escape hatch for intentional root/container use, and update DigitalOcean setup guidance to run OpenClaw as a non-root user. Fixes #67478. Thanks @Jerry-Xin and @natechicago.
 - Gateway/watch: leave `OPENCLAW_TRACE_SYNC_IO` disabled by default in `pnpm gateway:watch:raw` so watch mode avoids noisy Node sync-I/O stack traces unless explicitly requested.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,7 @@ Docs: https://docs.openclaw.ai
 
 - Gateway/macOS: `openclaw gateway stop` now uses `launchctl bootout` by default instead of unconditionally calling `launchctl disable`, so KeepAlive auto-recovery still works after unexpected crashes; use the new `--disable` flag to opt into the persistent-disable behavior when a manual stop should survive reboots. Fixes #77934. Thanks @bmoran1022.
 - Gateway/macOS: `repairLaunchAgentBootstrap` no longer kickstarts an already-running LaunchAgent, preventing unnecessary service restarts and session disconnects when repair runs against a healthy gateway. Fixes #77428. Thanks @ramitrkar-hash.
+- Gateway/macOS: `openclaw gateway stop --disable` now persists the LaunchAgent disable bit even after a previous bootout left the service not loaded, keeping the explicit stay-down path reliable. (#78412) Thanks @wdeveloper16.
 - Control UI/chat: hide retired and non-public Google Gemini model IDs from chat model catalogs and route the bare `gemini-3-pro` alias to Gemini 3.1 Pro Preview instead of the shut-down Gemini 3 Pro Preview. Thanks @BunsDev.
 - CLI/install: refuse state-mutating OpenClaw CLI runs as root by default, keep an explicit `OPENCLAW_ALLOW_ROOT=1` escape hatch for intentional root/container use, and update DigitalOcean setup guidance to run OpenClaw as a non-root user. Fixes #67478. Thanks @Jerry-Xin and @natechicago.
 - Gateway/watch: leave `OPENCLAW_TRACE_SYNC_IO` disabled by default in `pnpm gateway:watch:raw` so watch mode avoids noisy Node sync-I/O stack traces unless explicitly requested.

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -483,11 +483,13 @@ openclaw gateway restart
     - `gateway status`: `--url`, `--token`, `--password`, `--timeout`, `--no-probe`, `--require-rpc`, `--deep`, `--json`
     - `gateway install`: `--port`, `--runtime <node|bun>`, `--token`, `--wrapper <path>`, `--force`, `--json`
     - `gateway restart`: `--safe`, `--force`, `--wait <duration>`, `--json`
-    - `gateway uninstall|start|stop`: `--json`
+    - `gateway uninstall|start`: `--json`
+    - `gateway stop`: `--disable`, `--json`
 
   </Accordion>
   <Accordion title="Lifecycle behavior">
-    - Use `gateway restart` to restart a managed service. Do not chain `gateway stop` and `gateway start` as a restart substitute; on macOS, `gateway stop` intentionally disables the LaunchAgent before stopping it.
+    - Use `gateway restart` to restart a managed service. Do not chain `gateway stop` and `gateway start` as a restart substitute.
+    - On macOS, `gateway stop` uses `launchctl bootout` by default, which removes the LaunchAgent from the current boot session without persisting a disable — KeepAlive auto-recovery remains active for future crashes and `gateway start` re-enables cleanly without a manual `launchctl enable`. Pass `--disable` to persistently suppress KeepAlive and RunAtLoad so the gateway does not respawn until the next explicit `gateway start`; use this when a manual stop should survive reboots or system restarts.
     - `gateway restart --safe` asks the running Gateway to preflight active OpenClaw work and defer the restart until reply delivery, embedded runs, and task runs drain. `--safe` cannot be combined with `--force` or `--wait`.
     - `gateway restart --wait 30s` overrides the configured restart drain budget for that restart. Bare numbers are milliseconds; units such as `s`, `m`, and `h` are accepted. `--wait 0` waits indefinitely.
     - `gateway restart --force` skips the active-work drain and restarts immediately. Use it when an operator has already inspected the listed task blockers and wants the gateway back now.

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -217,7 +217,9 @@ openclaw gateway restart
 openclaw gateway stop
 ```
 
-Use `openclaw gateway restart` for restarts. Do not chain `openclaw gateway stop` and `openclaw gateway start`; on macOS, `gateway stop` intentionally disables the LaunchAgent before stopping it.
+Use `openclaw gateway restart` for restarts. Do not chain `openclaw gateway stop` and `openclaw gateway start` as a restart substitute.
+
+On macOS, `gateway stop` uses `launchctl bootout` by default — this removes the LaunchAgent from the current boot session without persisting a disable, so KeepAlive auto-recovery still works after unexpected crashes and `gateway start` re-enables cleanly. To persistently suppress auto-respawn across reboots, pass `--disable`: `openclaw gateway stop --disable`.
 
 LaunchAgent labels are `ai.openclaw.gateway` (default) or `ai.openclaw.<profile>` (named profile). `openclaw doctor` audits and repairs service config drift.
 

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -216,6 +216,30 @@ describe("runServiceRestart token drift", () => {
     expect(service.stop).not.toHaveBeenCalled();
   });
 
+  it("runs a requested managed stop even when the service is not loaded", async () => {
+    const onNotLoaded = vi.fn(async () => ({
+      result: "stopped" as const,
+      message: "Gateway stop signal sent to unmanaged process on port 18789: 4200.",
+    }));
+    service.isLoaded.mockResolvedValue(false);
+
+    await runServiceStop({
+      serviceNoun: "Gateway",
+      service,
+      opts: { json: true, disable: true },
+      stopWhenNotLoaded: true,
+      onNotLoaded,
+    });
+
+    const payload = readJsonLog<{ result?: string; service?: { loaded?: boolean } }>();
+    expect(payload.result).toBe("stopped");
+    expect(payload.service?.loaded).toBe(false);
+    expect(service.stop).toHaveBeenCalledWith(
+      expect.objectContaining({ env: process.env, disable: true }),
+    );
+    expect(onNotLoaded).not.toHaveBeenCalled();
+  });
+
   it("emits started when a not-loaded start path repairs the service", async () => {
     service.isLoaded.mockResolvedValue(false);
 

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -32,6 +32,7 @@ type DaemonLifecycleOptions = {
   force?: boolean;
   wait?: string;
   restartIntent?: GatewayRestartIntent;
+  disable?: boolean;
 };
 
 type RestartPostCheckContext = {
@@ -413,7 +414,7 @@ export async function runServiceStop(params: {
     return;
   }
   try {
-    await params.service.stop({ env: process.env, stdout });
+    await params.service.stop({ env: process.env, stdout, disable: params.opts?.disable });
   } catch (err) {
     fail(`${params.serviceNoun} stop failed: ${String(err)}`);
     return;

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -363,6 +363,7 @@ export async function runServiceStop(params: {
   service: GatewayService;
   opts?: DaemonLifecycleOptions;
   onNotLoaded?: (ctx: ServiceRecoveryContext) => Promise<ServiceRecoveryResult | null>;
+  stopWhenNotLoaded?: boolean;
 }) {
   const json = Boolean(params.opts?.json);
   const { stdout, emit, fail } = createDaemonActionContext({ action: "stop", json });
@@ -383,6 +384,20 @@ export async function runServiceStop(params: {
     }
   }
   if (!loaded) {
+    if (params.stopWhenNotLoaded) {
+      try {
+        await params.service.stop({ env: process.env, stdout, disable: params.opts?.disable });
+      } catch (err) {
+        fail(`${params.serviceNoun} stop failed: ${String(err)}`);
+        return;
+      }
+      emit({
+        ok: true,
+        result: "stopped",
+        service: buildDaemonServiceSnapshot(params.service, false),
+      });
+      return;
+    }
     try {
       const handled = await params.onNotLoaded?.({ json, stdout, fail });
       if (handled) {

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -123,7 +123,7 @@ describe("runDaemonRestart health checks", () => {
     safe?: boolean;
     force?: boolean;
   }) => Promise<boolean>;
-  let runDaemonStop: (opts?: { json?: boolean }) => Promise<void>;
+  let runDaemonStop: (opts?: { json?: boolean; disable?: boolean }) => Promise<void>;
   let envSnapshot: ReturnType<typeof captureEnv>;
 
   function mockUnmanagedRestart({
@@ -445,6 +445,19 @@ describe("runDaemonRestart health checks", () => {
     expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(18789);
     expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4200, "SIGTERM");
     expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4300, "SIGTERM");
+  });
+
+  it("routes macOS disable stops through the service manager when not loaded", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+
+    await runDaemonStop({ json: true, disable: true });
+
+    expect(runServiceStop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        opts: { json: true, disable: true },
+        stopWhenNotLoaded: true,
+      }),
+    );
   });
 
   it("skips gateway port resolution on stop when the service manager handles the stop", async () => {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -249,6 +249,7 @@ export async function runDaemonStop(opts: DaemonLifecycleOptions = {}) {
     serviceNoun: "Gateway",
     service,
     opts,
+    stopWhenNotLoaded: process.platform === "darwin" && Boolean(opts.disable),
     onNotLoaded: async () => {
       gatewayPortPromise ??= resolveGatewayLifecyclePort(service).catch(() =>
         resolveGatewayPortFallback(),

--- a/src/cli/daemon-cli/register-service-commands.ts
+++ b/src/cli/daemon-cli/register-service-commands.ts
@@ -116,7 +116,7 @@ export function addGatewayServiceCommands(parent: Command, opts?: { statusDescri
     .option("--json", "Output JSON", false)
     .option(
       "--disable",
-      "Persistently disable KeepAlive auto-recovery (launchd only); use --disable to prevent respawn until next `gateway start`",
+      "Persistently suppress KeepAlive/RunAtLoad so the gateway does not respawn until next start (launchd only)",
       false,
     )
     .action(async (cmdOpts) => {

--- a/src/cli/daemon-cli/register-service-commands.ts
+++ b/src/cli/daemon-cli/register-service-commands.ts
@@ -114,6 +114,11 @@ export function addGatewayServiceCommands(parent: Command, opts?: { statusDescri
     .command("stop")
     .description("Stop the Gateway service (launchd/systemd/schtasks)")
     .option("--json", "Output JSON", false)
+    .option(
+      "--disable",
+      "Persistently disable KeepAlive auto-recovery (launchd only); use --disable to prevent respawn until next `gateway start`",
+      false,
+    )
     .action(async (cmdOpts) => {
       const { runDaemonStop } = await loadDaemonLifecycleModule();
       await runDaemonStop(cmdOpts);

--- a/src/cli/daemon-cli/types.ts
+++ b/src/cli/daemon-cli/types.ts
@@ -29,4 +29,5 @@ export type DaemonLifecycleOptions = {
   force?: boolean;
   safe?: boolean;
   wait?: string;
+  disable?: boolean;
 };

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -403,9 +403,10 @@ describe("launchd bootstrap repair", () => {
     expect(state.launchctlCalls.some((call) => call[0] === "kickstart")).toBe(false);
   });
 
-  it("treats bootstrap exit 130 as success and nudges the already-loaded service", async () => {
+  it("treats bootstrap exit 130 as success and nudges the already-loaded service when stopped", async () => {
     state.bootstrapError = "Service already loaded";
     state.bootstrapCode = 130;
+    state.serviceRunning = false;
     const env = createDefaultLaunchdEnv();
 
     const repair = await repairLaunchAgentBootstrap({ env });
@@ -417,9 +418,21 @@ describe("launchd bootstrap repair", () => {
     ]);
   });
 
-  it("treats 'already exists in domain' bootstrap failures as success and nudges the service", async () => {
+  it("skips kickstart when already-loaded service is actively running", async () => {
+    state.bootstrapError = "Service already loaded";
+    state.bootstrapCode = 130;
+    const env = createDefaultLaunchdEnv();
+
+    const repair = await repairLaunchAgentBootstrap({ env });
+
+    expect(repair).toEqual({ ok: true, status: "already-loaded" });
+    expect(state.launchctlCalls.some((call) => call[0] === "kickstart")).toBe(false);
+  });
+
+  it("treats 'already exists in domain' bootstrap failures as success and nudges the service when stopped", async () => {
     state.bootstrapError =
       "Could not bootstrap service: 5: Input/output error: already exists in domain for gui/501";
+    state.serviceRunning = false;
     const env = createDefaultLaunchdEnv();
 
     const repair = await repairLaunchAgentBootstrap({ env });
@@ -448,6 +461,7 @@ describe("launchd bootstrap repair", () => {
   it("returns a typed kickstart failure when already-loaded recovery cannot nudge the service", async () => {
     state.bootstrapError = "Service already loaded";
     state.bootstrapCode = 130;
+    state.serviceRunning = false;
     state.kickstartError = "launchctl kickstart failed: permission denied";
     state.kickstartFailuresRemaining = 1;
     const env = createDefaultLaunchdEnv();

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -610,7 +610,7 @@ describe("launchd install", () => {
     expect(state.fileModes.get(plistPath)).toBe(0o600);
   });
 
-  it("stops LaunchAgent by disabling relaunch before stopping the process", async () => {
+  it("stops LaunchAgent via bootout by default, preserving KeepAlive for future crashes", async () => {
     const env = createDefaultLaunchdEnv();
     const stdout = new PassThrough();
     let output = "";
@@ -622,13 +622,31 @@ describe("launchd install", () => {
 
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const serviceId = `${domain}/ai.openclaw.gateway`;
+    expect(state.launchctlCalls).toContainEqual(["bootout", serviceId]);
+    expect(state.launchctlCalls.some((call) => call[0] === "disable")).toBe(false);
+    expect(state.launchctlCalls.some((call) => call[0] === "stop")).toBe(false);
+    expect(output).toContain("Stopped LaunchAgent");
+  });
+
+  it("stops LaunchAgent with disable+stop when --disable is passed", async () => {
+    const env = createDefaultLaunchdEnv();
+    const stdout = new PassThrough();
+    let output = "";
+    stdout.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    await stopLaunchAgent({ env, stdout, disable: true });
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const serviceId = `${domain}/ai.openclaw.gateway`;
     expect(state.launchctlCalls).toContainEqual(["disable", serviceId]);
     expect(state.launchctlCalls).toContainEqual(["stop", "ai.openclaw.gateway"]);
     expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(false);
     expect(output).toContain("Stopped LaunchAgent");
   });
 
-  it("treats already-unloaded services as successfully stopped without bootout fallback", async () => {
+  it("treats already-unloaded services as successfully stopped without bootout fallback (--disable)", async () => {
     const env = createDefaultLaunchdEnv();
     const stdout = new PassThrough();
     let output = "";
@@ -640,7 +658,7 @@ describe("launchd install", () => {
       output += chunk.toString();
     });
 
-    await stopLaunchAgent({ env, stdout });
+    await stopLaunchAgent({ env, stdout, disable: true });
 
     expect(state.launchctlCalls).toContainEqual([
       "disable",
@@ -651,7 +669,24 @@ describe("launchd install", () => {
     expect(output).not.toContain("degraded");
   });
 
-  it("falls back to bootout when disable fails so stop remains authoritative", async () => {
+  it("treats already-unloaded services as successfully stopped in default bootout path", async () => {
+    const env = createDefaultLaunchdEnv();
+    const stdout = new PassThrough();
+    let output = "";
+    state.serviceLoaded = false;
+    state.serviceRunning = false;
+    stdout.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    await stopLaunchAgent({ env, stdout });
+
+    expect(state.launchctlCalls.some((call) => call[0] === "disable")).toBe(false);
+    expect(output).toContain("Stopped LaunchAgent");
+    expect(output).not.toContain("degraded");
+  });
+
+  it("falls back to bootout when disable fails so stop remains authoritative (--disable)", async () => {
     const env = createDefaultLaunchdEnv();
     const stdout = new PassThrough();
     let output = "";
@@ -660,7 +695,7 @@ describe("launchd install", () => {
       output += chunk.toString();
     });
 
-    await stopLaunchAgent({ env, stdout });
+    await stopLaunchAgent({ env, stdout, disable: true });
 
     expect(state.launchctlCalls.some((call) => call[0] === "stop")).toBe(false);
     expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(true);
@@ -668,7 +703,7 @@ describe("launchd install", () => {
     expect(output).toContain("used bootout fallback");
   });
 
-  it("falls back to bootout when stop does not fully stop the service", async () => {
+  it("falls back to bootout when stop does not fully stop the service (--disable)", async () => {
     const env = createDefaultLaunchdEnv();
     const stdout = new PassThrough();
     let output = "";
@@ -677,7 +712,7 @@ describe("launchd install", () => {
       output += chunk.toString();
     });
 
-    await runStopLaunchAgentWithFakeTimers({ env, stdout });
+    await runStopLaunchAgentWithFakeTimers({ env, stdout, disable: true });
 
     expect(state.launchctlCalls.some((call) => call[0] === "stop")).toBe(true);
     expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(true);
@@ -685,7 +720,7 @@ describe("launchd install", () => {
     expect(output).toContain("did not fully stop the service");
   });
 
-  it("treats launchctl print state=running as running even when pid is missing", async () => {
+  it("treats launchctl print state=running as running even when pid is missing (--disable)", async () => {
     const env = createDefaultLaunchdEnv();
     const stdout = new PassThrough();
     let output = "";
@@ -695,14 +730,14 @@ describe("launchd install", () => {
       output += chunk.toString();
     });
 
-    await runStopLaunchAgentWithFakeTimers({ env, stdout });
+    await runStopLaunchAgentWithFakeTimers({ env, stdout, disable: true });
 
     expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(true);
     expect(output).toContain("Stopped LaunchAgent (degraded)");
     expect(output).toContain("did not fully stop the service");
   });
 
-  it("falls back to bootout when launchctl stop itself errors", async () => {
+  it("falls back to bootout when launchctl stop itself errors (--disable)", async () => {
     const env = createDefaultLaunchdEnv();
     const stdout = new PassThrough();
     let output = "";
@@ -711,14 +746,14 @@ describe("launchd install", () => {
       output += chunk.toString();
     });
 
-    await stopLaunchAgent({ env, stdout });
+    await stopLaunchAgent({ env, stdout, disable: true });
 
     expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(true);
     expect(output).toContain("Stopped LaunchAgent (degraded)");
     expect(output).toContain("launchctl stop failed; used bootout fallback");
   });
 
-  it("falls back to bootout when launchctl print cannot confirm the stop state", async () => {
+  it("falls back to bootout when launchctl print cannot confirm the stop state (--disable)", async () => {
     const env = createDefaultLaunchdEnv();
     const stdout = new PassThrough();
     let output = "";
@@ -728,27 +763,39 @@ describe("launchd install", () => {
       output += chunk.toString();
     });
 
-    await runStopLaunchAgentWithFakeTimers({ env, stdout });
+    await runStopLaunchAgentWithFakeTimers({ env, stdout, disable: true });
 
     expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(true);
     expect(output).toContain("Stopped LaunchAgent (degraded)");
     expect(output).toContain("could not confirm stop");
   });
 
-  it("throws when launchctl print cannot confirm stop and bootout also fails", async () => {
+  it("throws when launchctl print cannot confirm stop and bootout also fails (--disable)", async () => {
     const env = createDefaultLaunchdEnv();
     state.printError = "launchctl print permission denied";
     state.printFailuresRemaining = 10;
     state.bootoutError = "launchctl bootout permission denied";
 
     await expect(
-      runStopLaunchAgentWithFakeTimers({ env, stdout: new PassThrough() }),
+      runStopLaunchAgentWithFakeTimers({ env, stdout: new PassThrough(), disable: true }),
     ).rejects.toThrow(
       "launchctl print could not confirm stop; used bootout fallback and left service unloaded: launchctl print permission denied; launchctl bootout failed: launchctl bootout permission denied",
     );
   });
 
-  it("sanitizes launchctl details before writing warnings", async () => {
+  it("throws when default bootout fails", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.bootoutError = "launchctl bootout permission denied";
+    state.bootoutCode = 1;
+
+    await expect(stopLaunchAgent({ env, stdout: new PassThrough() })).rejects.toThrow(
+      "launchctl bootout failed: launchctl bootout permission denied",
+    );
+    expect(state.launchctlCalls.some((call) => call[0] === "disable")).toBe(false);
+    expect(state.launchctlCalls.some((call) => call[0] === "stop")).toBe(false);
+  });
+
+  it("sanitizes launchctl details before writing warnings (--disable)", async () => {
     const env = createDefaultLaunchdEnv();
     const stdout = new PassThrough();
     let output = "";
@@ -757,7 +804,7 @@ describe("launchd install", () => {
       output += chunk.toString();
     });
 
-    await stopLaunchAgent({ env, stdout });
+    await stopLaunchAgent({ env, stdout, disable: true });
 
     expect(output).not.toContain("\u001b[31m");
     expect(output).not.toContain("\nred\n");

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -464,6 +464,13 @@ export async function repairLaunchAgentBootstrap(args: {
     return { ok: true, status: repairStatus };
   }
 
+  // Service is already bootstrapped. Only kickstart if it is not actively running —
+  // kickstarting a healthy running service causes unnecessary session disconnects.
+  const runtime = await readLaunchAgentRuntime(env);
+  if (runtime.status === "running") {
+    return { ok: true, status: repairStatus };
+  }
+
   const kick = await execLaunchctl(["kickstart", serviceTarget]);
   if (kick.code !== 0) {
     return {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -593,21 +593,36 @@ async function waitForLaunchAgentStopped(serviceTarget: string): Promise<LaunchA
   return lastUnknown ?? { state: "running" };
 }
 
-export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
+export async function stopLaunchAgent({
+  stdout,
+  env,
+  disable: persistDisable,
+}: GatewayServiceControlArgs): Promise<void> {
   const serviceEnv = env ?? (process.env as GatewayServiceEnv);
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env: serviceEnv });
   const serviceTarget = `${domain}/${label}`;
 
-  // Keep the LaunchAgent installed, but persistently suppress KeepAlive/RunAtLoad
-  // before stopping the current process. Without `disable`, launchd can relaunch
-  // the process as soon as `stop` exits.
-  const disable = await execLaunchctl(["disable", serviceTarget]);
-  if (disable.code !== 0) {
+  if (!persistDisable) {
+    // Default: bootout only. Removes the job from the current launchd domain without
+    // persisting a disable, so KeepAlive auto-recovery survives future crashes and
+    // `openclaw gateway start` re-enables cleanly without a manual `launchctl enable`.
+    const bootout = await execLaunchctl(["bootout", serviceTarget]);
+    if (bootout.code !== 0 && !isLaunchctlNotLoaded(bootout)) {
+      throw new Error(`launchctl bootout failed: ${formatLaunchctlResultDetail(bootout)}`);
+    }
+    stdout.write(`${formatLine("Stopped LaunchAgent", serviceTarget)}\n`);
+    return;
+  }
+
+  // --disable: persistently suppress KeepAlive/RunAtLoad before stopping.
+  // Without this, launchd can relaunch the process as soon as `stop` exits.
+  const disableResult = await execLaunchctl(["disable", serviceTarget]);
+  if (disableResult.code !== 0) {
     await bootoutLaunchAgentOrThrow({
       serviceTarget,
       stdout,
-      warning: `launchctl disable failed; used bootout fallback and left service unloaded: ${formatLaunchctlResultDetail(disable)}`,
+      warning: `launchctl disable failed; used bootout fallback and left service unloaded: ${formatLaunchctlResultDetail(disableResult)}`,
     });
     return;
   }

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -22,6 +22,7 @@ export type GatewayServiceManageArgs = {
 export type GatewayServiceControlArgs = {
   stdout: NodeJS.WritableStream;
   env?: GatewayServiceEnv;
+  disable?: boolean;
 };
 
 export type GatewayServiceRestartResult = { outcome: "completed" } | { outcome: "scheduled" };


### PR DESCRIPTION
## Summary
- carry forward #78412's macOS LaunchAgent stop/recovery changes and close the remaining `--disable` tail
- route `openclaw gateway stop --disable` through the managed LaunchAgent stop path even when a previous `bootout` makes launchd report the service as not loaded
- add CLI/lifecycle regression coverage and changelog credit

## Bug / Behavior
#78412 changes the default macOS stop path from `launchctl disable` to `launchctl bootout`, preserving KeepAlive recovery unless the operator explicitly requests `--disable`. On the PR head, that explicit stay-down path still failed after a previous bootout: `launchctl print` returned not-loaded, `runServiceStop` returned `not-loaded`, and `stopLaunchAgent(..., disable: true)` never ran, leaving `launchctl print-disabled gui/501` as `"ai.openclaw.gateway" => enabled`.

This PR keeps the default bootout behavior, but lets macOS `stop --disable` continue through the service manager even when launchd says the service is not loaded, so the disable bit is actually persisted.

Fixes #77934.
Fixes #77428.
Replaces #78412.

## Real behavior proof
- **Behavior addressed:** macOS `openclaw gateway stop --disable` must persist the LaunchAgent disable bit even after a prior default stop used `launchctl bootout` and left the service not loaded.
- **Real environment tested:** Parallels macOS Tahoe VM, `Darwin 25.3.0`, uid `501`, isolated `OPENCLAW_STATE_DIR=$HOME/.openclaw-78412-proof` and `OPENCLAW_CONFIG_PATH=$HOME/.openclaw-78412-proof/openclaw.json`.
- **Exact steps or command run after this patch:** Installed the patched package, ran `openclaw gateway install --force --token proof-token --port 18789 --json`, then `openclaw gateway stop --json`, then `openclaw gateway stop --disable --json`, then inspected `launchctl print-disabled gui/501` and `launchctl print gui/501/ai.openclaw.gateway`.
- **Evidence after fix:** Terminal output from the patched package showed default stop preserving the enabled map and explicit disable flipping it:

```text
install: ok=true result=installed
launchctl print-disabled gui/501: "ai.openclaw.gateway" => enabled

openclaw gateway stop --json:
{ "action": "stop", "ok": true, "result": "stopped", "service": { "label": "LaunchAgent", "loaded": false } }
launchctl print-disabled gui/501: "ai.openclaw.gateway" => enabled
launchctl print gui/501/ai.openclaw.gateway: rc=113 Could not find service

openclaw gateway stop --disable --json:
{ "action": "stop", "ok": true, "result": "stopped", "service": { "label": "LaunchAgent", "loaded": false } }
launchctl print-disabled gui/501: "ai.openclaw.gateway" => disabled
```

- **Observed result after fix:** The default `bootout` path still leaves KeepAlive recovery enabled, while the explicit `--disable` path now persists `"ai.openclaw.gateway" => disabled` after the service is already not loaded.
- **What was not tested:** Nothing else.

For comparison, the unpatched #78412 head `2be5de518334ae350422a14fdccfa526603c4376` returned `result: "not-loaded"` for `openclaw gateway stop --disable --json` after default stop, and `launchctl print-disabled gui/501` stayed `"ai.openclaw.gateway" => enabled`.

## Verification
- `pnpm install`
- `pnpm test src/cli/daemon-cli/lifecycle-core.test.ts src/cli/daemon-cli/lifecycle.test.ts src/daemon/launchd.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/cli/daemon-cli/lifecycle-core.ts src/cli/daemon-cli/lifecycle.ts src/cli/daemon-cli/lifecycle-core.test.ts src/cli/daemon-cli/lifecycle.test.ts docs/cli/gateway.md docs/gateway/index.md src/daemon/launchd.ts src/daemon/launchd.test.ts src/cli/daemon-cli/register-service-commands.ts src/cli/daemon-cli/types.ts src/daemon/service-types.ts`
- `git diff --check origin/main...HEAD`
- `pnpm build`
- Parallels macOS Tahoe VM reproduce/fix proof above
