### PR TITLE
fix(lint): satisfy shell inline option checks

### DIFF
--- a/src/infra/shell-inline-command.ts
+++ b/src/infra/shell-inline-command.ts
@@ -21,6 +21,16 @@ const POSIX_SHELL_OPTIONS_WITH_SEPARATE_VALUES = new Set([
   "+o",
 ]);
 
+function countSeparateValueShortOptions(optionChars: string): number {
+  let count = 0;
+  for (const char of optionChars) {
+    if (char === "o" || char === "O") {
+      count += 1;
+    }
+  }
+  return count;
+}
+
 function isCombinedCommandFlag(token: string): boolean {
   return parseCombinedCommandFlag(token) !== null;
 }
@@ -42,7 +52,7 @@ function parseCombinedCommandFlag(
   }
   return {
     attachedCommand: null,
-    separateValueCount: [...optionChars].filter((char) => char === "o" || char === "O").length,
+    separateValueCount: countSeparateValueShortOptions(optionChars),
   };
 }
 
@@ -55,7 +65,7 @@ function combinedSeparateValueOptionCount(token: string): number {
   ) {
     return 0;
   }
-  return [...token.slice(1)].filter((char) => char === "o" || char === "O").length;
+  return countSeparateValueShortOptions(token.slice(1));
 }
 
 function consumesSeparateValue(token: string): boolean {
@@ -70,8 +80,8 @@ function isPosixShortOption(token: string, option: string): boolean {
   if (token.length < 2 || token[0] !== "-" || token[1] === "-") {
     return false;
   }
-  const optionChars = token.slice(1);
-  return !optionChars.includes("-") && optionChars.includes(option);
+  const optionChars = new Set(token.slice(1));
+  return !optionChars.has("-") && optionChars.has(option);
 }
 
 function advancePosixInlineOptionScan(token: string): number {


### PR DESCRIPTION
## Summary
- Replace shell option spread/count checks with explicit string iteration and `Set.has` so current `oxlint` passes on main.

## Verification
- `PATH=/Users/steipete/Projects/clawdbot2/node_modules/.bin:$PATH oxlint src/infra/shell-inline-command.ts`

## Real behavior proof

Behavior or issue addressed: current `main` fails `check-lint` on `src/infra/shell-inline-command.ts`, blocking the seven issue PRs from landing.

Real environment tested: local macOS checkout using the repository's installed oxlint binary against the clean `origin/main` worktree.

Exact steps or command run after this patch: `PATH=/Users/steipete/Projects/clawdbot2/node_modules/.bin:$PATH oxlint src/infra/shell-inline-command.ts`

Evidence after fix: command output was `Found 0 warnings and 0 errors. Finished in 27ms on 1 file with 185 rules using 32 threads.`

Observed result after fix: the same file that produced the CI annotations now passes oxlint with no findings.

What was not tested: full repository CI has not completed yet.
