### PR TITLE
test(msteams): fix lifecycle test types

### DIFF
--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -12,6 +12,19 @@ type FakeServer = EventEmitter & {
   headersTimeout: number;
 };
 
+type RegisterHandlerDeps = { cfg: OpenClawConfig };
+type MSTeamsChannelResolution = {
+  input: string;
+  resolved: boolean;
+  teamId?: string;
+  channelId?: string;
+};
+type MSTeamsUserResolution = {
+  input: string;
+  resolved: boolean;
+  id?: string;
+};
+
 const expressControl = vi.hoisted(() => ({
   mode: { value: "listening" as "listening" | "error" },
   apps: [] as Array<{
@@ -94,7 +107,7 @@ vi.mock("express", () => {
 });
 
 const registerMSTeamsHandlers = vi.hoisted(() =>
-  vi.fn(() => ({
+  vi.fn((_handler: unknown, _deps: RegisterHandlerDeps) => ({
     run: vi.fn(async () => {}),
   })),
 );
@@ -118,12 +131,13 @@ const loadMSTeamsSdkWithAuth = vi.hoisted(() =>
 );
 
 vi.mock("./monitor-handler.js", () => ({
-  registerMSTeamsHandlers: (...args: unknown[]) => registerMSTeamsHandlers(...args),
+  registerMSTeamsHandlers: (handler: unknown, deps: RegisterHandlerDeps) =>
+    registerMSTeamsHandlers(handler, deps),
 }));
 
 const resolveAllowlistMocks = vi.hoisted(() => ({
-  resolveMSTeamsChannelAllowlist: vi.fn(async () => []),
-  resolveMSTeamsUserAllowlist: vi.fn(async () => []),
+  resolveMSTeamsChannelAllowlist: vi.fn(async (): Promise<MSTeamsChannelResolution[]> => []),
+  resolveMSTeamsUserAllowlist: vi.fn(async (): Promise<MSTeamsUserResolution[]> => []),
 }));
 
 vi.mock("./resolve-allowlist.js", () => ({
@@ -331,13 +345,13 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       entries: ["Product/Roadmap"],
     });
 
-    const registeredCfg = registerMSTeamsHandlers.mock.calls[0]?.[1] as { cfg: OpenClawConfig };
-    expect(registeredCfg.cfg.channels?.msteams?.allowFrom).toEqual([
+    const registeredCfg = registerMSTeamsHandlers.mock.calls[0]?.[1];
+    expect(registeredCfg?.cfg.channels?.msteams?.allowFrom).toEqual([
       "Alice",
       "user:40a1a0ed-4ff2-4164-a219-55518990c197",
       "40a1a0ed-4ff2-4164-a219-55518990c197",
     ]);
-    expect(registeredCfg.cfg.channels?.msteams?.groupAllowFrom).toEqual([
+    expect(registeredCfg?.cfg.channels?.msteams?.groupAllowFrom).toEqual([
       "Bob",
       "msteams:user:50a1a0ed-4ff2-4164-a219-55518990c198",
       "50a1a0ed-4ff2-4164-a219-55518990c198",
@@ -383,9 +397,9 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       entries: ["Bob"],
     });
 
-    const registeredCfg = registerMSTeamsHandlers.mock.calls[0]?.[1] as { cfg: OpenClawConfig };
-    expect(registeredCfg.cfg.channels?.msteams?.allowFrom).toEqual(["Alice", "alice-aad"]);
-    expect(registeredCfg.cfg.channels?.msteams?.groupAllowFrom).toEqual(["Bob", "bob-aad"]);
+    const registeredCfg = registerMSTeamsHandlers.mock.calls[0]?.[1];
+    expect(registeredCfg?.cfg.channels?.msteams?.allowFrom).toEqual(["Alice", "alice-aad"]);
+    expect(registeredCfg?.cfg.channels?.msteams?.groupAllowFrom).toEqual(["Bob", "bob-aad"]);
 
     abort.abort();
     await task;


### PR DESCRIPTION
## Summary
- Type the MS Teams lifecycle test mocks so the extension test typecheck lane no longer infers `never[]`/empty mock call tuples.
- Keep runtime test behavior unchanged.

## Verification
- `pnpm tsgo:test:extensions`
- `pnpm test extensions/msteams/src/monitor.lifecycle.test.ts`

## Real behavior proof

Behavior or issue addressed: current PR merge refs fail `check-test-types` on `extensions/msteams/src/monitor.lifecycle.test.ts` because the test mocks infer `never[]` and empty call tuples.

Real environment tested: clean local worktree at current `origin/main` with repository dependencies linked from the main checkout.

Exact steps or command run after this patch: `pnpm tsgo:test:extensions` and `pnpm test extensions/msteams/src/monitor.lifecycle.test.ts`.

Evidence after fix: `pnpm tsgo:test:extensions` exited 0; `pnpm test extensions/msteams/src/monitor.lifecycle.test.ts` reported `Test Files 1 passed (1)` and `Tests 5 passed (5)`.

Observed result after fix: the previously failing MS Teams lifecycle test type errors are gone and the targeted runtime test still passes.

What was not tested: full repository CI has not completed yet.
