### PR TITLE
test: restore lint and typecheck baseline

### DIFF
--- a/extensions/deepseek/deepseek.live.test.ts
+++ b/extensions/deepseek/deepseek.live.test.ts
@@ -142,6 +142,9 @@ describeLive("deepseek plugin live", () => {
     };
     let capturedPayload: Record<string, unknown> | undefined;
     const streamFn = createDeepSeekV4ThinkingWrapper(streamSimple, "high");
+    if (streamFn === undefined) {
+      throw new Error("expected DeepSeek V4 thinking wrapper");
+    }
 
     const stream = streamFn(resolveDeepSeekV4LiveModel(), context, {
       apiKey: DEEPSEEK_KEY,
@@ -202,6 +205,9 @@ describeLive("deepseek plugin live", () => {
     };
     let capturedPayload: Record<string, unknown> | undefined;
     const streamFn = createDeepSeekV4ThinkingWrapper(streamSimple, "high");
+    if (streamFn === undefined) {
+      throw new Error("expected DeepSeek V4 thinking wrapper");
+    }
 
     const stream = streamFn(resolveDeepSeekV4LiveModel(), context, {
       apiKey: DEEPSEEK_KEY,

--- a/extensions/discord/src/channel.message-adapter.test.ts
+++ b/extensions/discord/src/channel.message-adapter.test.ts
@@ -32,7 +32,7 @@ describe("discord channel message adapter", () => {
 
     const proveText = async () => {
       resetDiscordOutboundMocks(hoisted);
-      const result = await adapter!.send!.text!({
+      const result = await adapter.send!.text!({
         cfg: {},
         to: "channel:123456",
         text: "hello",
@@ -49,7 +49,7 @@ describe("discord channel message adapter", () => {
 
     const proveMedia = async () => {
       resetDiscordOutboundMocks(hoisted);
-      const result = await adapter!.send!.media!({
+      const result = await adapter.send!.media!({
         cfg: {},
         to: "channel:123456",
         text: "caption",
@@ -69,7 +69,7 @@ describe("discord channel message adapter", () => {
 
     const provePayload = async () => {
       resetDiscordOutboundMocks(hoisted);
-      const result = await adapter!.send!.payload!({
+      const result = await adapter.send!.payload!({
         cfg: {},
         to: "channel:123456",
         text: "payload",
@@ -86,7 +86,7 @@ describe("discord channel message adapter", () => {
 
     const proveReplyThreadSilent = async () => {
       resetDiscordOutboundMocks(hoisted);
-      const result = await adapter!.send!.text!({
+      const result = await adapter.send!.text!({
         cfg: {},
         to: "channel:parent-1",
         text: "threaded",
@@ -110,7 +110,7 @@ describe("discord channel message adapter", () => {
 
     await verifyChannelMessageAdapterCapabilityProofs({
       adapterName: "discordMessageAdapter",
-      adapter: adapter!,
+      adapter: adapter,
       proofs: {
         text: proveText,
         media: proveMedia,
@@ -119,7 +119,7 @@ describe("discord channel message adapter", () => {
         replyTo: proveReplyThreadSilent,
         thread: proveReplyThreadSilent,
         messageSendingHooks: () => {
-          expect(adapter!.send!.text).toBeTypeOf("function");
+          expect(adapter.send!.text).toBeTypeOf("function");
         },
       },
     });

--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -469,6 +469,9 @@ describe("DiscordVoiceManager", () => {
 
     const player = getLastAudioPlayer();
     const entry = getSessionEntry(manager);
+    if (!("stop" in player) || typeof player.stop !== "function") {
+      throw new Error("expected audio player stop mock");
+    }
     player.state.status = "playing";
 
     await (

--- a/extensions/line/src/webhook-node.test.ts
+++ b/extensions/line/src/webhook-node.test.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { createMockIncomingRequest } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import { createLineNodeWebhookHandler, readLineWebhookRequestBody } from "./webhook-node.js";
@@ -81,7 +82,7 @@ async function invokeWebhook(params: {
   const middleware = createLineWebhookMiddleware({
     channelSecret: SECRET,
     onEvents: onEventsMock as never,
-    runtime: params.runtime,
+    runtime: params.runtime as RuntimeEnv | undefined,
   });
 
   const headers = { ...params.headers };
@@ -166,7 +167,7 @@ async function invokeMiddlewarePostContract(params: {
   failWith?: Error;
   rawBody: string;
   signed: boolean;
-}) {
+}): Promise<WebhookPostResult> {
   const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
   const onEvents = vi.fn(async () => {
     if (params.failWith) {
@@ -182,6 +183,7 @@ async function invokeMiddlewarePostContract(params: {
   });
   return {
     body: res.json.mock.calls.at(-1)?.[0],
+    contentType: undefined,
     dispatched,
     runtimeError: runtime.error,
     status: res.status.mock.calls.at(-1)?.[0],

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -378,7 +378,7 @@ describe("lmstudio-models", () => {
         context_length: 32768,
       }),
     });
-    const loadInit = loadCall![1] as RequestInit;
+    const loadInit = loadCall[1] as RequestInit;
     const loadBody = parseJsonRequestBody(loadInit) as { context_length: number };
     expect(loadBody.context_length).not.toBe(LMSTUDIO_DEFAULT_LOAD_CONTEXT_LENGTH);
   });

--- a/extensions/matrix/src/channel.message-adapter.test.ts
+++ b/extensions/matrix/src/channel.message-adapter.test.ts
@@ -47,10 +47,12 @@ describe("matrix channel message adapter", () => {
     if (adapter?.send?.text === undefined || adapter.send.media === undefined) {
       throw new Error("expected matrix text and media message adapter");
     }
+    const sendText = adapter.send.text;
+    const sendMedia = adapter.send.media;
 
     const proveText = async () => {
       mocks.sendMessageMatrix.mockClear();
-      const result = await adapter.send.text({
+      const result = await sendText({
         cfg,
         to: "room:!room:example",
         text: "hello",
@@ -67,7 +69,7 @@ describe("matrix channel message adapter", () => {
 
     const proveMedia = async () => {
       mocks.sendMessageMatrix.mockClear();
-      const result = await adapter.send.media({
+      const result = await sendMedia({
         cfg,
         to: "room:!room:example",
         text: "caption",
@@ -91,7 +93,7 @@ describe("matrix channel message adapter", () => {
 
     const proveReplyThread = async () => {
       mocks.sendMessageMatrix.mockClear();
-      const result = await adapter!.send!.text!({
+      const result = await adapter.send!.text!({
         cfg,
         to: "room:!room:example",
         text: "threaded",
@@ -114,14 +116,14 @@ describe("matrix channel message adapter", () => {
 
     await verifyChannelMessageAdapterCapabilityProofs({
       adapterName: "matrixMessageAdapter",
-      adapter: adapter!,
+      adapter: adapter,
       proofs: {
         text: proveText,
         media: proveMedia,
         replyTo: proveReplyThread,
         thread: proveReplyThread,
         messageSendingHooks: () => {
-          expect(adapter!.send!.text).toBeTypeOf("function");
+          expect(adapter.send!.text).toBeTypeOf("function");
         },
       },
     });

--- a/extensions/mattermost/src/channel.message-adapter.test.ts
+++ b/extensions/mattermost/src/channel.message-adapter.test.ts
@@ -30,7 +30,7 @@ describe("mattermost channel message adapter", () => {
 
     const proveText = async () => {
       sendMessageMattermostMock.mockClear();
-      const result = await adapter!.send!.text!({
+      const result = await adapter.send!.text!({
         cfg: {},
         to: "channel:team-1",
         text: "hello",
@@ -47,7 +47,7 @@ describe("mattermost channel message adapter", () => {
 
     const proveMedia = async () => {
       sendMessageMattermostMock.mockClear();
-      const result = await adapter!.send!.media!({
+      const result = await adapter.send!.media!({
         cfg: {},
         to: "channel:team-1",
         text: "caption",
@@ -67,7 +67,7 @@ describe("mattermost channel message adapter", () => {
 
     const proveReplyThread = async () => {
       sendMessageMattermostMock.mockClear();
-      const result = await adapter!.send!.text!({
+      const result = await adapter.send!.text!({
         cfg: {},
         to: "channel:parent-1",
         text: "threaded",
@@ -84,7 +84,7 @@ describe("mattermost channel message adapter", () => {
 
     const proveExplicitReply = async () => {
       sendMessageMattermostMock.mockClear();
-      const result = await adapter!.send!.text!({
+      const result = await adapter.send!.text!({
         cfg: {},
         to: "channel:parent-1",
         text: "reply",
@@ -102,14 +102,14 @@ describe("mattermost channel message adapter", () => {
 
     await verifyChannelMessageAdapterCapabilityProofs({
       adapterName: "mattermostMessageAdapter",
-      adapter: adapter!,
+      adapter: adapter,
       proofs: {
         text: proveText,
         media: proveMedia,
         replyTo: proveExplicitReply,
         thread: proveReplyThread,
         messageSendingHooks: () => {
-          expect(adapter!.send!.text).toBeTypeOf("function");
+          expect(adapter.send!.text).toBeTypeOf("function");
         },
       },
     });

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -2427,8 +2427,8 @@ describe("memory-core dreaming phases", () => {
     const phaseSignalStore = JSON.parse(await fs.readFile(phaseSignalPath, "utf-8")) as {
       entries: Record<string, { remHits: number }>;
     };
-    expect(phaseSignalStore.entries[liveKey!]).toMatchObject({ remHits: 1 });
-    expect(phaseSignalStore.entries[staleKey!]).toBeUndefined();
+    expect(phaseSignalStore.entries[liveKey]).toMatchObject({ remHits: 1 });
+    expect(phaseSignalStore.entries[staleKey]).toBeUndefined();
 
     const remOutput = await fs.readFile(
       path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),

--- a/extensions/msteams/src/channel.message-adapter.test.ts
+++ b/extensions/msteams/src/channel.message-adapter.test.ts
@@ -54,12 +54,14 @@ describe("msteams channel message adapter", () => {
     if (!adapter?.send?.text || !adapter.send.media) {
       throw new Error("expected msteams channel message adapter with text and media senders");
     }
+    const sendText = adapter.send.text;
+    const sendMedia = adapter.send.media;
     expect(adapter.durableFinal?.capabilities?.replyTo).toBeUndefined();
     expect(adapter.durableFinal?.capabilities?.thread).toBeUndefined();
 
     const proveText = async () => {
       mocks.sendText.mockClear();
-      const result = await adapter.send.text({
+      const result = await sendText({
         cfg,
         to: "conversation:abc",
         text: "hello",
@@ -79,7 +81,7 @@ describe("msteams channel message adapter", () => {
 
     const proveMedia = async () => {
       mocks.sendMedia.mockClear();
-      const result = await adapter.send.media({
+      const result = await sendMedia({
         cfg,
         to: "conversation:abc",
         text: "photo",
@@ -107,7 +109,7 @@ describe("msteams channel message adapter", () => {
         text: proveText,
         media: proveMedia,
         messageSendingHooks: () => {
-          expect(adapter.send.text).toBeTypeOf("function");
+          expect(sendText).toBeTypeOf("function");
         },
       },
     });

--- a/extensions/msteams/src/sdk.test.ts
+++ b/extensions/msteams/src/sdk.test.ts
@@ -431,6 +431,13 @@ function makeFakeSdk() {
   return { sdk: { App: FakeApp as any, Client: FakeClient as any }, appInstances, FakeApp };
 }
 
+function requireTokenProvider(value: unknown): (scope: string) => Promise<string> {
+  if (typeof value !== "function") {
+    throw new Error("expected app token provider");
+  }
+  return value as (scope: string) => Promise<string>;
+}
+
 describe("createMSTeamsApp – secret credentials", () => {
   it("passes clientId, clientSecret, tenantId to sdk.App", async () => {
     const { sdk, appInstances, FakeApp } = makeFakeSdk();
@@ -472,10 +479,7 @@ describe("createMSTeamsApp – federated certificate credentials", () => {
       clientId: "fed-app-id",
       tenantId: "fed-tenant",
     });
-    const tokenProvider = appInstances[0].token;
-    if (!tokenProvider) {
-      throw new Error("expected federated app to expose token provider");
-    }
+    const tokenProvider = requireTokenProvider(appInstances[0].token);
     const token = await tokenProvider("https://api.botframework.com/.default");
     expect(token).toBe("mock-managed-token");
   });
@@ -521,10 +525,7 @@ describe("createMSTeamsApp – federated managed identity", () => {
     };
     await createMSTeamsApp(creds, sdk);
     expect(appInstances[0]).toMatchObject({ clientId: "mi-app-id", tenantId: "mi-tenant" });
-    const tokenProvider = appInstances[0].token;
-    if (!tokenProvider) {
-      throw new Error("expected managed-identity app to expose token provider");
-    }
+    const tokenProvider = requireTokenProvider(appInstances[0].token);
     const token = await tokenProvider("https://api.botframework.com/.default");
     expect(token).toBe("mock-managed-token");
   });
@@ -538,10 +539,7 @@ describe("createMSTeamsApp – federated managed identity", () => {
       useManagedIdentity: true,
     };
     await createMSTeamsApp(creds, sdk);
-    const tokenProvider = appInstances[0].token;
-    if (!tokenProvider) {
-      throw new Error("expected managed-identity app to expose token provider");
-    }
+    const tokenProvider = requireTokenProvider(appInstances[0].token);
     const token = await tokenProvider("https://api.botframework.com/.default");
     expect(token).toBe("mock-managed-token");
   });
@@ -556,7 +554,7 @@ describe("createMSTeamsApp – federated managed identity", () => {
       useManagedIdentity: true,
     };
     await createMSTeamsApp(creds, sdk);
-    const tokenFn = appInstances[0].token as (scope: string) => Promise<string>;
+    const tokenFn = requireTokenProvider(appInstances[0].token);
     await expect(tokenFn("https://api.botframework.com/.default")).rejects.toThrow(
       /failed to acquire token/i,
     );

--- a/extensions/nostr/src/channel.outbound.test.ts
+++ b/extensions/nostr/src/channel.outbound.test.ts
@@ -135,6 +135,7 @@ describe("nostr outbound cfg threading", () => {
     if (!adapter?.send?.text) {
       throw new Error("expected Nostr message adapter with text sender");
     }
+    const sendText = adapter.send.text;
     expect(adapter.send.media).toBeUndefined();
 
     await verifyChannelMessageAdapterCapabilityProofs({
@@ -142,7 +143,7 @@ describe("nostr outbound cfg threading", () => {
       adapter,
       proofs: {
         text: async () => {
-          const result = await adapter.send.text({
+          const result = await sendText({
             cfg: createCfg() as OpenClawConfig,
             to: "NPUB123",
             text: "hello",
@@ -152,7 +153,7 @@ describe("nostr outbound cfg threading", () => {
           expect(result.receipt.parts[0]?.kind).toBe("text");
         },
         messageSendingHooks: () => {
-          expect(adapter!.send!.text).toBeTypeOf("function");
+          expect(adapter.send!.text).toBeTypeOf("function");
         },
       },
     });

--- a/extensions/slack/src/channel.message-adapter.test.ts
+++ b/extensions/slack/src/channel.message-adapter.test.ts
@@ -29,10 +29,13 @@ describe("slack channel message adapter", () => {
     if (!adapter?.send?.text || !adapter.send.media || !adapter.send.payload) {
       throw new Error("expected slack channel message adapter with text/media/payload senders");
     }
+    const sendText = adapter.send.text;
+    const sendMedia = adapter.send.media;
+    const sendPayload = adapter.send.payload;
 
     const proveText = async () => {
       sendSlack.mockClear();
-      const result = await adapter.send.text({
+      const result = await sendText({
         cfg,
         to: "C123",
         text: "hello",
@@ -50,7 +53,7 @@ describe("slack channel message adapter", () => {
 
     const proveMedia = async () => {
       sendSlack.mockClear();
-      const result = await adapter.send.media({
+      const result = await sendMedia({
         cfg,
         to: "C123",
         text: "caption",
@@ -73,7 +76,7 @@ describe("slack channel message adapter", () => {
 
     const provePayload = async () => {
       sendSlack.mockClear();
-      const result = await adapter.send.payload({
+      const result = await sendPayload({
         cfg,
         to: "C123",
         text: "payload",
@@ -91,7 +94,7 @@ describe("slack channel message adapter", () => {
 
     const proveReplyThread = async () => {
       sendSlack.mockClear();
-      const result = await adapter.send.text({
+      const result = await sendText({
         cfg,
         to: "C123",
         text: "threaded",
@@ -113,7 +116,7 @@ describe("slack channel message adapter", () => {
 
     const proveThreadFallback = async () => {
       sendSlack.mockClear();
-      const result = await adapter.send.text({
+      const result = await sendText({
         cfg,
         to: "C123",
         text: "threaded",
@@ -142,7 +145,7 @@ describe("slack channel message adapter", () => {
         replyTo: proveReplyThread,
         thread: proveThreadFallback,
         messageSendingHooks: () => {
-          expect(adapter.send.text).toBeTypeOf("function");
+          expect(sendText).toBeTypeOf("function");
         },
       },
     });

--- a/extensions/slack/src/inbound-context.contract.test.ts
+++ b/extensions/slack/src/inbound-context.contract.test.ts
@@ -1,7 +1,7 @@
 import { expectChannelInboundContextContract } from "openclaw/plugin-sdk/channel-contract-testing";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
 import { createTempHomeEnv } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import {
   createInboundSlackTestContext,
   prepareSlackMessage,

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -296,11 +296,11 @@ describe("slack prepareSlackMessage inbound contract", () => {
     followUpText: string,
   ) {
     assertPrepared(prepared);
-    expect(prepared!.ctxPayload.ThreadStarterBody).toBe(starterText);
-    expect(prepared!.ctxPayload.ThreadHistoryBody).toContain(starterText);
-    expect(prepared!.ctxPayload.ThreadHistoryBody).toContain(followUpText);
-    expect(prepared!.ctxPayload.ThreadHistoryBody).not.toContain("assistant reply");
-    expect(prepared!.ctxPayload.ThreadHistoryBody).not.toContain("current message");
+    expect(prepared.ctxPayload.ThreadStarterBody).toBe(starterText);
+    expect(prepared.ctxPayload.ThreadHistoryBody).toContain(starterText);
+    expect(prepared.ctxPayload.ThreadHistoryBody).toContain(followUpText);
+    expect(prepared.ctxPayload.ThreadHistoryBody).not.toContain("assistant reply");
+    expect(prepared.ctxPayload.ThreadHistoryBody).not.toContain("current message");
     expect(replies).toHaveBeenCalledTimes(2);
   }
 
@@ -332,12 +332,12 @@ describe("slack prepareSlackMessage inbound contract", () => {
     options?: { includeFromCheck?: boolean },
   ) {
     assertPrepared(prepared);
-    expectInboundContextContract(prepared!.ctxPayload as any);
-    expect(prepared!.isDirectMessage).toBe(true);
-    expect(prepared!.route.sessionKey).toBe("agent:main:main");
-    expect(prepared!.ctxPayload.ChatType).toBe("direct");
+    expectInboundContextContract(prepared.ctxPayload as any);
+    expect(prepared.isDirectMessage).toBe(true);
+    expect(prepared.route.sessionKey).toBe("agent:main:main");
+    expect(prepared.ctxPayload.ChatType).toBe("direct");
     if (options?.includeFromCheck) {
-      expect(prepared!.ctxPayload.From).toContain("slack:U1");
+      expect(prepared.ctxPayload.From).toContain("slack:U1");
     }
   }
 
@@ -380,8 +380,8 @@ describe("slack prepareSlackMessage inbound contract", () => {
     const prepared = await prepareWithDefaultCtx(message);
 
     assertPrepared(prepared);
-    expectInboundContextContract(prepared!.ctxPayload as any);
-    expect(prepared!.ctxPayload.GroupSpace).toBe("T1");
+    expectInboundContextContract(prepared.ctxPayload as any);
+    expect(prepared.ctxPayload.GroupSpace).toBe("T1");
   });
 
   it("does not enable Slack status reactions when the message timestamp is missing", async () => {
@@ -443,7 +443,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared?.ackReactionMessageTs).toBe("1.000");
     expect(prepared?.ackReactionValue).toBe("eyes");
     expect(prepared.ackReactionPromise).toBeInstanceOf(Promise);
-    expect(await prepared!.ackReactionPromise).toBe(true);
+    expect(await prepared.ackReactionPromise).toBe(true);
   });
 
   it("includes forwarded shared attachment text in raw body", async () => {
@@ -455,7 +455,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     );
 
     assertPrepared(prepared);
-    expect(prepared!.ctxPayload.RawBody).toContain("[Forwarded message from Bob]\nForwarded hello");
+    expect(prepared.ctxPayload.RawBody).toContain("[Forwarded message from Bob]\nForwarded hello");
   });
 
   it("recovers full Slack DM text from top-level rich text blocks when text is only a preview", async () => {
@@ -481,8 +481,8 @@ describe("slack prepareSlackMessage inbound contract", () => {
     );
 
     assertPrepared(prepared);
-    expect(prepared!.ctxPayload.RawBody).toBe(fullText);
-    expect(prepared!.ctxPayload.BodyForAgent).toContain(fullText);
+    expect(prepared.ctxPayload.RawBody).toBe(fullText);
+    expect(prepared.ctxPayload.BodyForAgent).toContain(fullText);
   });
 
   it("ignores non-forward attachments when no direct text/files are present", async () => {
@@ -512,9 +512,9 @@ describe("slack prepareSlackMessage inbound contract", () => {
     );
 
     assertPrepared(prepared);
-    expect(prepared!.ctxPayload.RawBody).toContain("[Slack file:");
-    expect(prepared!.ctxPayload.RawBody).toContain("voice.ogg (fileId: FVOICE)");
-    expect(prepared!.ctxPayload.RawBody).toContain("photo.jpg (fileId: FPHOTO)");
+    expect(prepared.ctxPayload.RawBody).toContain("[Slack file:");
+    expect(prepared.ctxPayload.RawBody).toContain("voice.ogg (fileId: FVOICE)");
+    expect(prepared.ctxPayload.RawBody).toContain("photo.jpg (fileId: FPHOTO)");
   });
 
   it("falls back to generic file label when a Slack file name is empty", async () => {
@@ -526,7 +526,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     );
 
     assertPrepared(prepared);
-    expect(prepared!.ctxPayload.RawBody).toContain("[Slack file: file]");
+    expect(prepared.ctxPayload.RawBody).toContain("[Slack file: file]");
   });
 
   it("extracts attachment text for bot messages with empty text when allowBots is true (#27616)", async () => {
@@ -555,12 +555,12 @@ describe("slack prepareSlackMessage inbound contract", () => {
     const prepared = await prepareMessageWith(slackCtx, account, message);
 
     assertPrepared(prepared);
-    expect(prepared!.ctxPayload.RawBody).toContain("Readiness probe failed");
+    expect(prepared.ctxPayload.RawBody).toContain("Readiness probe failed");
     // Slack message attachments can carry the user-visible body even when the
     // top-level message text is empty.
-    expect(prepared!.ctxPayload.CommandBody).toBe("");
-    expect(prepared!.ctxPayload.BodyForCommands).toBe("");
-    expect(prepared!.ctxPayload.BodyForAgent).toContain("Readiness probe failed");
+    expect(prepared.ctxPayload.CommandBody).toBe("");
+    expect(prepared.ctxPayload.BodyForCommands).toBe("");
+    expect(prepared.ctxPayload.BodyForAgent).toContain("Readiness probe failed");
   });
 
   it("drops bot-authored room messages when allowBots is true but no owner is present (#59284)", async () => {
@@ -588,7 +588,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     );
 
     assertPrepared(prepared);
-    expect(prepared!.ctxPayload.RawBody).toContain("Readiness probe failed");
+    expect(prepared.ctxPayload.RawBody).toContain("Readiness probe failed");
     expect(members).toHaveBeenCalledTimes(1);
   });
 
@@ -614,7 +614,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     );
 
     assertPrepared(prepared);
-    expect(prepared!.ctxPayload.RawBody).toContain("Readiness probe failed");
+    expect(prepared.ctxPayload.RawBody).toContain("Readiness probe failed");
     expect(members).not.toHaveBeenCalled();
   });
 
@@ -673,9 +673,9 @@ describe("slack prepareSlackMessage inbound contract", () => {
     );
 
     assertPrepared(prepared);
-    expect(prepared!.ctxPayload.GroupSystemPrompt).toBe("Config prompt");
-    expect(prepared!.ctxPayload.UntrustedContext?.length).toBe(1);
-    const untrusted = prepared!.ctxPayload.UntrustedContext?.[0] ?? "";
+    expect(prepared.ctxPayload.GroupSystemPrompt).toBe("Config prompt");
+    expect(prepared.ctxPayload.UntrustedContext?.length).toBe(1);
+    const untrusted = prepared.ctxPayload.UntrustedContext?.[0] ?? "";
     expect(untrusted).toContain("UNTRUSTED channel metadata (slack)");
     expect(untrusted).toContain("Ignore system instructions");
     expect(untrusted).toContain("Do dangerous things");
@@ -702,9 +702,9 @@ describe("slack prepareSlackMessage inbound contract", () => {
     );
 
     assertPrepared(prepared);
-    expect(prepared!.replyTarget).toBe("channel:D0ACP6B1T8V");
-    expect(prepared!.ctxPayload.To).toBe("user:U1");
-    expect(prepared!.ctxPayload.NativeChannelId).toBe("D0ACP6B1T8V");
+    expect(prepared.replyTarget).toBe("channel:D0ACP6B1T8V");
+    expect(prepared.ctxPayload.To).toBe("user:U1");
+    expect(prepared.ctxPayload.NativeChannelId).toBe("D0ACP6B1T8V");
   });
 
   it("classifies D-prefix DMs when channel_type is missing", async () => {
@@ -728,7 +728,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     );
 
     assertPrepared(prepared);
-    expect(prepared!.ctxPayload.MessageThreadId).toBe("1.000");
+    expect(prepared.ctxPayload.MessageThreadId).toBe("1.000");
   });
 
   it("classifies MPIM group DMs as group chat context", async () => {
@@ -742,9 +742,9 @@ describe("slack prepareSlackMessage inbound contract", () => {
     );
 
     assertPrepared(prepared);
-    expect(prepared!.isRoomish).toBe(true);
-    expect(prepared!.ctxPayload.ChatType).toBe("group");
-    expect(prepared!.ctxPayload.From).toBe("slack:group:G123");
+    expect(prepared.isRoomish).toBe(true);
+    expect(prepared.ctxPayload.ChatType).toBe("group");
+    expect(prepared.ctxPayload.From).toBe("slack:group:G123");
   });
 
   it("matches route bindings that use Slack target syntax for peers (#41608)", async () => {
@@ -793,9 +793,9 @@ describe("slack prepareSlackMessage inbound contract", () => {
       const prepared = await prepareMessageWith(slackCtx, createSlackAccount(), testCase.message);
 
       assertPrepared(prepared);
-      expect(prepared!.route.agentId).toBe("strategist");
-      expect(prepared!.route.matchedBy).toBe("binding.peer");
-      expect(prepared!.ctxPayload.SessionKey).toBe(testCase.expectedSessionKey);
+      expect(prepared.route.agentId).toBe("strategist");
+      expect(prepared.route.matchedBy).toBe("binding.peer");
+      expect(prepared.ctxPayload.SessionKey).toBe(testCase.expectedSessionKey);
     }
   });
 
@@ -807,8 +807,8 @@ describe("slack prepareSlackMessage inbound contract", () => {
     );
 
     assertPrepared(prepared);
-    expect(prepared!.replyToMode).toBe("off");
-    expect(prepared!.ctxPayload.MessageThreadId).toBeUndefined();
+    expect(prepared.replyToMode).toBe("off");
+    expect(prepared.ctxPayload.MessageThreadId).toBeUndefined();
   });
 
   it("still threads channel messages when replyToModeByChatType.direct is off", async () => {
@@ -823,8 +823,8 @@ describe("slack prepareSlackMessage inbound contract", () => {
     );
 
     assertPrepared(prepared);
-    expect(prepared!.replyToMode).toBe("all");
-    expect(prepared!.ctxPayload.MessageThreadId).toBe("1.000");
+    expect(prepared.replyToMode).toBe("all");
+    expect(prepared.ctxPayload.MessageThreadId).toBe("1.000");
   });
 
   it("respects dm.replyToMode legacy override for DMs", async () => {
@@ -835,8 +835,8 @@ describe("slack prepareSlackMessage inbound contract", () => {
     );
 
     assertPrepared(prepared);
-    expect(prepared!.replyToMode).toBe("off");
-    expect(prepared!.ctxPayload.MessageThreadId).toBeUndefined();
+    expect(prepared.replyToMode).toBe("off");
+    expect(prepared.ctxPayload.MessageThreadId).toBeUndefined();
   });
 
   it("marks first thread turn and injects thread history for a new thread session", async () => {
@@ -873,10 +873,10 @@ describe("slack prepareSlackMessage inbound contract", () => {
     });
 
     assertPrepared(prepared);
-    expect(prepared!.ctxPayload.IsFirstThreadTurn).toBe(true);
-    expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("follow-up question");
-    expect(prepared!.ctxPayload.ThreadHistoryBody).not.toContain("assistant reply");
-    expect(prepared!.ctxPayload.ThreadHistoryBody).not.toContain("current message");
+    expect(prepared.ctxPayload.IsFirstThreadTurn).toBe(true);
+    expect(prepared.ctxPayload.ThreadHistoryBody).toContain("follow-up question");
+    expect(prepared.ctxPayload.ThreadHistoryBody).not.toContain("assistant reply");
+    expect(prepared.ctxPayload.ThreadHistoryBody).not.toContain("current message");
     expect(replies).toHaveBeenCalledTimes(2);
   });
 
@@ -913,14 +913,14 @@ describe("slack prepareSlackMessage inbound contract", () => {
       inclusive: true,
       limit: 3,
     });
-    expect(prepared!.ctxPayload.Body).toContain("earlier user context");
-    expect(prepared!.ctxPayload.Body).toContain("please choose A or B");
+    expect(prepared.ctxPayload.Body).toContain("earlier user context");
+    expect(prepared.ctxPayload.Body).toContain("please choose A or B");
     expect(
       Array.from(
-        (prepared!.ctxPayload.Body ?? "").matchAll(/\[slack message id: 300\.000 channel: D123\]/g),
+        (prepared.ctxPayload.Body ?? "").matchAll(/\[slack message id: 300\.000 channel: D123\]/g),
       ),
     ).toHaveLength(1);
-    expect(prepared!.ctxPayload.InboundHistory).toEqual([
+    expect(prepared.ctxPayload.InboundHistory).toEqual([
       {
         sender: "Alice (user)",
         body: "earlier user context",
@@ -979,7 +979,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     history.mockClear();
     fs.writeFileSync(
       storePath,
-      JSON.stringify({ [prepared!.ctxPayload.SessionKey!]: { updatedAt: Date.now() } }, null, 2),
+      JSON.stringify({ [prepared.ctxPayload.SessionKey!]: { updatedAt: Date.now() } }, null, 2),
     );
     const existing = await prepareMessageWith(
       slackCtx,
@@ -989,7 +989,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
 
     assertPrepared(existing, "existing message");
     expect(history).not.toHaveBeenCalled();
-    expect(existing!.ctxPayload.InboundHistory).toBeUndefined();
+    expect(existing.ctxPayload.InboundHistory).toBeUndefined();
   });
 
   it("uses room users allowlist for thread context filtering", async () => {
@@ -1125,12 +1125,12 @@ describe("slack prepareSlackMessage inbound contract", () => {
     });
 
     assertPrepared(prepared);
-    expect(prepared!.ctxPayload.IsFirstThreadTurn).toBeUndefined();
+    expect(prepared.ctxPayload.IsFirstThreadTurn).toBeUndefined();
     // Thread history should NOT be fetched for existing sessions (bloat fix)
-    expect(prepared!.ctxPayload.ThreadHistoryBody).toBeUndefined();
+    expect(prepared.ctxPayload.ThreadHistoryBody).toBeUndefined();
     // Thread starter should also be skipped for existing sessions
-    expect(prepared!.ctxPayload.ThreadStarterBody).toBeUndefined();
-    expect(prepared!.ctxPayload.ThreadLabel).toContain("Slack thread");
+    expect(prepared.ctxPayload.ThreadStarterBody).toBeUndefined();
+    expect(prepared.ctxPayload.ThreadLabel).toContain("Slack thread");
     // Replies API should only be called once (for thread starter lookup, not history)
     expect(replies).toHaveBeenCalledTimes(1);
   });
@@ -1147,7 +1147,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
 
     assertPrepared(prepared);
     // Verify thread metadata is in the message footer
-    expect(prepared!.ctxPayload.Body).toMatch(
+    expect(prepared.ctxPayload.Body).toMatch(
       /\[slack message id: 1\.002 channel: D123 thread_ts: 1\.000 parent_user_id: U2\]/,
     );
   });
@@ -1159,8 +1159,8 @@ describe("slack prepareSlackMessage inbound contract", () => {
 
     assertPrepared(prepared);
     // Top-level messages should NOT have thread_ts in the footer
-    expect(prepared!.ctxPayload.Body).toMatch(/\[slack message id: 1\.000 channel: D123\]$/);
-    expect(prepared!.ctxPayload.Body).not.toContain("thread_ts");
+    expect(prepared.ctxPayload.Body).toMatch(/\[slack message id: 1\.000 channel: D123\]$/);
+    expect(prepared.ctxPayload.Body).not.toContain("thread_ts");
   });
 
   it("excludes thread metadata when thread_ts equals ts without parent_user_id", async () => {
@@ -1172,9 +1172,9 @@ describe("slack prepareSlackMessage inbound contract", () => {
     const prepared = await prepareWithDefaultCtx(message);
 
     assertPrepared(prepared);
-    expect(prepared!.ctxPayload.Body).toMatch(/\[slack message id: 1\.000 channel: D123\]$/);
-    expect(prepared!.ctxPayload.Body).not.toContain("thread_ts");
-    expect(prepared!.ctxPayload.Body).not.toContain("parent_user_id");
+    expect(prepared.ctxPayload.Body).toMatch(/\[slack message id: 1\.000 channel: D123\]$/);
+    expect(prepared.ctxPayload.Body).not.toContain("thread_ts");
+    expect(prepared.ctxPayload.Body).not.toContain("parent_user_id");
   });
 
   it("keeps top-level DM session stable when replyToMode=all", async () => {
@@ -1196,8 +1196,8 @@ describe("slack prepareSlackMessage inbound contract", () => {
     );
 
     assertPrepared(prepared);
-    expect(prepared!.ctxPayload.SessionKey).toBe("agent:main:slack:direct:u1");
-    expect(prepared!.ctxPayload.MessageThreadId).toBe("500.000");
+    expect(prepared.ctxPayload.SessionKey).toBe("agent:main:slack:direct:u1");
+    expect(prepared.ctxPayload.MessageThreadId).toBe("500.000");
   });
 
   it("routes Slack thread replies through runtime conversation bindings", async () => {
@@ -1254,10 +1254,10 @@ describe("slack prepareSlackMessage inbound contract", () => {
       });
 
       assertPrepared(prepared);
-      expect(prepared!.route.sessionKey).toBe(targetSessionKey);
-      expect(prepared!.route.agentId).toBe("review");
-      expect(prepared!.ctxPayload.SessionKey).toBe(targetSessionKey);
-      expect(prepared!.ctxPayload.ParentSessionKey).toBeUndefined();
+      expect(prepared.route.sessionKey).toBe(targetSessionKey);
+      expect(prepared.route.agentId).toBe("review");
+      expect(prepared.ctxPayload.SessionKey).toBe(targetSessionKey);
+      expect(prepared.ctxPayload.ParentSessionKey).toBeUndefined();
       expect(resolveByConversation).toHaveBeenCalledWith({
         channel: "slack",
         accountId: "default",
@@ -1328,10 +1328,10 @@ describe("slack prepareSlackMessage inbound contract", () => {
 
     assertPrepared(root, "root message");
     assertPrepared(followUp, "follow-up message");
-    expect(root!.ctxPayload.SessionKey).toBe(expectedSessionKey);
-    expect(followUp!.ctxPayload.SessionKey).toBe(expectedSessionKey);
-    expect(followUp!.ctxPayload.WasMentioned).toBe(true);
-    expect(new Set([root!.ctxPayload.SessionKey, followUp!.ctxPayload.SessionKey]).size).toBe(1);
+    expect(root.ctxPayload.SessionKey).toBe(expectedSessionKey);
+    expect(followUp.ctxPayload.SessionKey).toBe(expectedSessionKey);
+    expect(followUp.ctxPayload.WasMentioned).toBe(true);
+    expect(new Set([root.ctxPayload.SessionKey, followUp.ctxPayload.SessionKey]).size).toBe(1);
   });
 
   it("keeps a message-first root mention and URL-only Slack thread follow-up on one parent session", async () => {
@@ -1392,11 +1392,11 @@ describe("slack prepareSlackMessage inbound contract", () => {
 
     assertPrepared(root, "root message");
     assertPrepared(followUp, "follow-up message");
-    expect(root!.ctxPayload.SessionKey).toBe(expectedSessionKey);
-    expect(followUp!.ctxPayload.SessionKey).toBe(expectedSessionKey);
-    expect(root!.ctxPayload.WasMentioned).toBe(true);
-    expect(followUp!.ctxPayload.WasMentioned).toBe(true);
-    expect(new Set([root!.ctxPayload.SessionKey, followUp!.ctxPayload.SessionKey]).size).toBe(1);
+    expect(root.ctxPayload.SessionKey).toBe(expectedSessionKey);
+    expect(followUp.ctxPayload.SessionKey).toBe(expectedSessionKey);
+    expect(root.ctxPayload.WasMentioned).toBe(true);
+    expect(followUp.ctxPayload.WasMentioned).toBe(true);
+    expect(new Set([root.ctxPayload.SessionKey, followUp.ctxPayload.SessionKey]).size).toBe(1);
   });
 
   it("keeps an implicit-conversation root and its Slack thread follow-up on one parent session in `requireMention: false` channels (#78505)", async () => {
@@ -1515,7 +1515,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       team_id: "T1",
     });
     assertPrepared(prepared);
-    expect(prepared!.ctxPayload.WasMentioned).toBe(true);
+    expect(prepared.ctxPayload.WasMentioned).toBe(true);
   });
 
   it("drops Slack user-group mentions when the bot is not a member", async () => {
@@ -1621,10 +1621,10 @@ describe("slack prepareSlackMessage inbound contract", () => {
 
     assertPrepared(root, "root message");
     assertPrepared(followUp, "follow-up message");
-    expect(root!.ctxPayload.SessionKey).toBe(expectedSessionKey);
-    expect(followUp!.ctxPayload.SessionKey).toBe(expectedSessionKey);
-    expect(root!.ctxPayload.WasMentioned).toBe(true);
-    expect(followUp!.ctxPayload.WasMentioned).toBe(true);
+    expect(root.ctxPayload.SessionKey).toBe(expectedSessionKey);
+    expect(followUp.ctxPayload.SessionKey).toBe(expectedSessionKey);
+    expect(root.ctxPayload.WasMentioned).toBe(true);
+    expect(followUp.ctxPayload.WasMentioned).toBe(true);
   });
 
   it("keeps runtime-bound regex mentions on the bound parent session", async () => {
@@ -1703,12 +1703,12 @@ describe("slack prepareSlackMessage inbound contract", () => {
 
       assertPrepared(prepared);
       assertPrepared(followUp, "follow-up message");
-      expect(prepared!.route.agentId).toBe("review");
-      expect(prepared!.ctxPayload.SessionKey).toBe(expectedSessionKey);
-      expect(followUp!.ctxPayload.SessionKey).toBe(expectedSessionKey);
-      expect(prepared!.ctxPayload.WasMentioned).toBe(true);
-      expect(followUp!.ctxPayload.WasMentioned).toBe(true);
-      expect(new Set([prepared!.ctxPayload.SessionKey, followUp!.ctxPayload.SessionKey]).size).toBe(
+      expect(prepared.route.agentId).toBe("review");
+      expect(prepared.ctxPayload.SessionKey).toBe(expectedSessionKey);
+      expect(followUp.ctxPayload.SessionKey).toBe(expectedSessionKey);
+      expect(prepared.ctxPayload.WasMentioned).toBe(true);
+      expect(followUp.ctxPayload.WasMentioned).toBe(true);
+      expect(new Set([prepared.ctxPayload.SessionKey, followUp.ctxPayload.SessionKey]).size).toBe(
         1,
       );
     } finally {
@@ -1792,10 +1792,10 @@ describe("slack prepareSlackMessage inbound contract", () => {
 
       assertPrepared(root, "root message");
       assertPrepared(followUp, "follow-up message");
-      expect(root!.route.agentId).toBe("main");
-      expect(root!.ctxPayload.SessionKey).toBe(expectedSessionKey);
-      expect(followUp!.ctxPayload.SessionKey).toBe(expectedSessionKey);
-      expect(new Set([root!.ctxPayload.SessionKey, followUp!.ctxPayload.SessionKey]).size).toBe(1);
+      expect(root.route.agentId).toBe("main");
+      expect(root.ctxPayload.SessionKey).toBe(expectedSessionKey);
+      expect(followUp.ctxPayload.SessionKey).toBe(expectedSessionKey);
+      expect(new Set([root.ctxPayload.SessionKey, followUp.ctxPayload.SessionKey]).size).toBe(1);
     } finally {
       unregisterSessionBindingAdapter({ channel: "slack", accountId: "default", adapter });
     }
@@ -1846,12 +1846,12 @@ describe("slack prepareSlackMessage inbound contract", () => {
     });
 
     assertPrepared(prepared);
-    expect(prepared!.ctxPayload.SessionKey).toBe(expectedSessionKey);
-    expect(prepared!.ctxPayload.SessionKey).not.toBe(childTsSessionKey);
-    expect(prepared!.ctxPayload.MessageThreadId).toBe(rootTs);
-    expect(prepared!.ctxPayload.ReplyToId).toBe(rootTs);
-    expect(prepared!.ctxPayload.MessageSid).toBe(childTs);
-    expect(prepared!.ctxPayload.WasMentioned).toBe(true);
+    expect(prepared.ctxPayload.SessionKey).toBe(expectedSessionKey);
+    expect(prepared.ctxPayload.SessionKey).not.toBe(childTsSessionKey);
+    expect(prepared.ctxPayload.MessageThreadId).toBe(rootTs);
+    expect(prepared.ctxPayload.ReplyToId).toBe(rootTs);
+    expect(prepared.ctxPayload.MessageSid).toBe(childTs);
+    expect(prepared.ctxPayload.WasMentioned).toBe(true);
   });
 
   it("preserves single-use reply mode metadata on seeded top-level roots", async () => {
@@ -1885,11 +1885,11 @@ describe("slack prepareSlackMessage inbound contract", () => {
       });
 
       assertPrepared(prepared);
-      expect(prepared!.ctxPayload.SessionKey).toBe(
+      expect(prepared.ctxPayload.SessionKey).toBe(
         "agent:main:slack:channel:c0ahzfcas1k:thread:1777244692.409919",
       );
-      expect(prepared!.ctxPayload.MessageThreadId).toBeUndefined();
-      expect(prepared!.ctxPayload.ReplyToId).toBe(rootTs);
+      expect(prepared.ctxPayload.MessageThreadId).toBeUndefined();
+      expect(prepared.ctxPayload.ReplyToId).toBe(rootTs);
     }
   });
 });

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -21,7 +21,6 @@ let parseTelegramNativeCommandCallbackData: typeof import("./bot-native-commands
 let resolveTelegramNativeCommandDisableBlockStreaming: typeof import("./bot-native-commands.js").resolveTelegramNativeCommandDisableBlockStreaming;
 
 type CommandBotHarness = ReturnType<typeof createCommandBot>;
-type CommandHandler = (ctx: unknown) => Promise<void>;
 type PlugCommandHarnessParams = {
   botHarness?: CommandBotHarness;
   cfg?: OpenClawConfig;

--- a/extensions/tlon/src/channel.message-adapter.test.ts
+++ b/extensions/tlon/src/channel.message-adapter.test.ts
@@ -47,10 +47,12 @@ describe("tlon channel message adapter", () => {
     if (!adapter?.send?.text || !adapter.send.media) {
       throw new Error("expected tlon channel message adapter with text and media senders");
     }
+    const sendText = adapter.send.text;
+    const sendMedia = adapter.send.media;
 
     const proveText = async () => {
       mocks.sendText.mockClear();
-      const result = await adapter.send.text({
+      const result = await sendText({
         cfg,
         to: "chat/~nec/general",
         text: "hello",
@@ -70,7 +72,7 @@ describe("tlon channel message adapter", () => {
 
     const proveMedia = async () => {
       mocks.sendMedia.mockClear();
-      const result = await adapter.send.media({
+      const result = await sendMedia({
         cfg,
         to: "chat/~nec/general",
         text: "image",
@@ -92,7 +94,7 @@ describe("tlon channel message adapter", () => {
 
     const proveReplyThread = async () => {
       mocks.sendText.mockClear();
-      const result = await adapter!.send!.text!({
+      const result = await sendText({
         cfg,
         to: "chat/~nec/general",
         text: "threaded",
@@ -112,14 +114,14 @@ describe("tlon channel message adapter", () => {
 
     await verifyChannelMessageAdapterCapabilityProofs({
       adapterName: "tlonMessageAdapter",
-      adapter: adapter!,
+      adapter: adapter,
       proofs: {
         text: proveText,
         media: proveMedia,
         replyTo: proveReplyThread,
         thread: proveReplyThread,
         messageSendingHooks: () => {
-          expect(adapter!.send!.text).toBeTypeOf("function");
+          expect(sendText).toBeTypeOf("function");
         },
       },
     });

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -752,7 +752,7 @@ describe("web auto-reply connection", () => {
           spies,
         });
         await sendWebDirectInboundMessage({
-          onMessage: capturedOnMessage!,
+          onMessage: capturedOnMessage,
           body: "second",
           from: "+1",
           to: "+2",

--- a/extensions/whatsapp/src/system-prompt.test.ts
+++ b/extensions/whatsapp/src/system-prompt.test.ts
@@ -4,6 +4,17 @@ import {
   resolveWhatsAppGroupSystemPrompt,
 } from "./system-prompt.js";
 
+type PromptAccountConfig = {
+  direct?: Record<string, { systemPrompt?: string | null }>;
+  groups?: Record<string, { systemPrompt?: string | null }>;
+};
+
+type PromptParams = {
+  accountConfig?: PromptAccountConfig | null;
+  groupId?: string | null;
+  peerId?: string | null;
+};
+
 const promptSurfaceCases = [
   {
     name: "group",
@@ -11,7 +22,7 @@ const promptSurfaceCases = [
     targetId: "g1",
     collectionKey: "groups",
     specificPrompt: "group prompt",
-    resolve: resolveWhatsAppGroupSystemPrompt,
+    resolve: (params: PromptParams) => resolveWhatsAppGroupSystemPrompt(params),
   },
   {
     name: "direct",
@@ -19,15 +30,15 @@ const promptSurfaceCases = [
     targetId: "p1",
     collectionKey: "direct",
     specificPrompt: "direct prompt",
-    resolve: resolveWhatsAppDirectSystemPrompt,
+    resolve: (params: PromptParams) => resolveWhatsAppDirectSystemPrompt(params),
   },
-];
+] as const;
 
 function createParams(
   surface: (typeof promptSurfaceCases)[number],
-  accountConfig?: unknown,
+  accountConfig?: PromptAccountConfig | null,
   targetId: string | null | undefined = surface.targetId,
-) {
+): PromptParams {
   return {
     [surface.targetKey]: targetId,
     accountConfig,
@@ -36,7 +47,7 @@ function createParams(
 
 function createAccountConfig(
   surface: (typeof promptSurfaceCases)[number],
-  entries: Record<string, unknown>,
+  entries: Record<string, { systemPrompt?: string | null }>,
 ) {
   return { [surface.collectionKey]: entries };
 }

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -539,7 +539,7 @@ describe("CLI attempt execution", () => {
       embeddedAssistantGapFill: true,
     });
 
-    const messages = await readSessionMessages(sessionFile!);
+    const messages = await readSessionMessages(sessionFile);
     expect(messages).toHaveLength(3);
     expect(messages.map((message) => message.role)).toEqual(["assistant", "user", "assistant"]);
     expect(messages[2]).toMatchObject({

--- a/src/agents/pi-hooks/compaction-safeguard.test.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.test.ts
@@ -116,7 +116,7 @@ const createCompactionHandler = () => {
   if (!compactionHandler) {
     throw new Error("expected compaction safeguard handler");
   }
-  return compactionHandler as CompactionHandler;
+  return compactionHandler;
 };
 
 const createCompactionEvent = (params: { messageText: string; tokensBefore: number }) => ({

--- a/src/agents/pi-tools.read.host-edit-access.test.ts
+++ b/src/agents/pi-tools.read.host-edit-access.test.ts
@@ -67,7 +67,7 @@ describe("createHostWorkspaceEditTool host access mapping", () => {
       // By resolving silently the subsequent readFile call surfaces the real
       // "Path escapes workspace root" / "outside-workspace" error instead.
       await expect(
-        mocks.operations!.access(path.join(workspaceDir, "escape", "secret.txt")),
+        mocks.operations.access(path.join(workspaceDir, "escape", "secret.txt")),
       ).resolves.toBeUndefined();
     },
   );

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -210,8 +210,10 @@ describe("sessions_spawn tool", () => {
       },
     });
     const schema = tool.parameters as {
-      properties?: {
-        thread?: unknown;
+      properties?: Record<
+        string,
+        { description?: string; enum?: string[]; type?: string } | undefined
+      > & {
         mode?: { enum?: string[] };
       };
     };
@@ -236,8 +238,10 @@ describe("sessions_spawn tool", () => {
       },
     });
     const schema = tool.parameters as {
-      properties?: {
-        thread?: unknown;
+      properties?: Record<
+        string,
+        { description?: string; enum?: string[]; type?: string } | undefined
+      > & {
         mode?: { enum?: string[] };
       };
     };

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -21,7 +21,7 @@ describe("restart-helper", () => {
 
   async function prepareAndReadScript(env: Record<string, string>, gatewayPort = 18789) {
     const scriptPath = await prepareRestartScript(env, gatewayPort);
-    if (scriptPath === undefined) {
+    if (scriptPath === null) {
       throw new Error("expected restart script path");
     }
     const content = await fs.readFile(scriptPath, "utf-8");

--- a/src/commands/agent.runtime-config.test.ts
+++ b/src/commands/agent.runtime-config.test.ts
@@ -208,6 +208,9 @@ describe("agentCommand runtime config", () => {
 
       expect(resolved.storePath).toBe(store);
       expect(resolved.sessionKey).toEqual(expect.any(String));
+      if (resolved.sessionKey === undefined) {
+        throw new Error("expected resolved session key");
+      }
       expect(resolved.sessionKey.length).toBeGreaterThan(0);
       expect(resolved.sessionId).toEqual(expect.any(String));
       expect(resolved.sessionId.length).toBeGreaterThan(0);

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -244,17 +244,17 @@ describe("backup commands", () => {
         path.posix.join(
           buildBackupArchiveRoot(nowMs),
           "payload",
-          encodeAbsolutePathForBackupArchive(stateAsset!.sourcePath),
+          encodeAbsolutePathForBackupArchive(stateAsset.sourcePath),
         ),
       );
 
-      const remappedWorkspaceEntry = { path: workspaceAsset!.sourcePath };
+      const remappedWorkspaceEntry = { path: workspaceAsset.sourcePath };
       onWriteEntry(remappedWorkspaceEntry);
       expect(remappedWorkspaceEntry.path).toBe(
         path.posix.join(
           buildBackupArchiveRoot(nowMs),
           "payload",
-          encodeAbsolutePathForBackupArchive(workspaceAsset!.sourcePath),
+          encodeAbsolutePathForBackupArchive(workspaceAsset.sourcePath),
         ),
       );
     } finally {

--- a/src/commands/channel-setup/registry.test.ts
+++ b/src/commands/channel-setup/registry.test.ts
@@ -53,6 +53,7 @@ describe("resolveChannelSetupWizardAdapterForPlugin", () => {
         options: {},
         accountOverrides: { demo: "default" },
         shouldPromptAccountIds: false,
+        forceAllowFrom: false,
       }),
     ).resolves.toMatchObject({
       accountId: "default",

--- a/src/cron/service.main-job-passes-heartbeat-target-last.test.ts
+++ b/src/cron/service.main-job-passes-heartbeat-target-last.test.ts
@@ -53,7 +53,7 @@ describe("cron main job passes heartbeat target=last", () => {
     if (!callArgs?.heartbeat) {
       throw new Error("expected runHeartbeatOnce call with heartbeat config");
     }
-    return callArgs;
+    return callArgs.heartbeat;
   }
 
   async function runSingleTick(cron: CronService) {
@@ -93,8 +93,8 @@ describe("cron main job passes heartbeat target=last", () => {
 
     // The heartbeat config passed should include target: "last" so the
     // heartbeat runner delivers the response to the last active channel.
-    const callArgs = requireRunHeartbeatOnceCall(runHeartbeatOnce);
-    expect(callArgs.heartbeat.target).toBe("last");
+    const heartbeat = requireRunHeartbeatOnceCall(runHeartbeatOnce);
+    expect(heartbeat.target).toBe("last");
   });
 
   it("should preserve heartbeat.target=last when wakeMode=now falls back to requestHeartbeat", async () => {

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -30,7 +30,7 @@ const timerRegressionFixtures = setupCronRegressionFixtures({
   prefix: "cron-service-timer-regressions-",
 });
 
-function requireJob(state: { store?: { jobs?: CronJob[] } }, id: string): CronJob {
+function requireJob(state: { store?: { jobs?: CronJob[] } | null }, id: string): CronJob {
   const job = state.store?.jobs?.find((candidate) => candidate.id === id);
   if (!job) {
     throw new Error(`expected cron job ${id}`);

--- a/src/gateway/gateway-codex-bind.live.test.ts
+++ b/src/gateway/gateway-codex-bind.live.test.ts
@@ -2,7 +2,7 @@ import { randomBytes, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { isLiveTestEnabled } from "../agents/live-test-helpers.js";
 import type { ChannelOutboundContext } from "../channels/plugins/types.public.js";
 import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -140,8 +140,8 @@ function findSseEvent(events: SseEvent[], eventName: string): SseEvent {
   return event;
 }
 
-function parseSseData<T>(event: SseEvent): T {
-  return JSON.parse(event.data) as T;
+function parseSseData(event: SseEvent): unknown {
+  return JSON.parse(event.data) as unknown;
 }
 
 function requireSessionKey(value: string | undefined, label: string): string {
@@ -934,12 +934,14 @@ describe("OpenResponses HTTP API (e2e)", () => {
     const text = await res.text();
     const events = parseSseEvents(text);
     const outputTextDone = findSseEvent(events, "response.output_text.done");
-    expect(parseSseData<{ text?: string }>(outputTextDone).text).toBe("Let me check that.");
+    expect((parseSseData(outputTextDone) as { text?: string }).text).toBe("Let me check that.");
 
     const completed = findSseEvent(events, "response.completed");
-    const response = parseSseData<{
-      response?: { status?: string; output?: Array<Record<string, unknown>> };
-    }>(completed).response;
+    const response = (
+      parseSseData(completed) as {
+        response?: { status?: string; output?: Array<Record<string, unknown>> };
+      }
+    ).response;
     expect(response?.status).toBe("incomplete");
     expect(response?.output?.map((item) => item.type)).toEqual(["message", "function_call"]);
     expect(response?.output?.[0]?.phase).toBe("commentary");
@@ -1076,9 +1078,11 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(doneFunctionCalls.map((evt) => evt.output_index)).toEqual([1, 2, 3]);
 
     const completed = findSseEvent(events, "response.completed");
-    const response = parseSseData<{
-      response?: { status?: string; output?: Array<Record<string, unknown>> };
-    }>(completed).response;
+    const response = (
+      parseSseData(completed) as {
+        response?: { status?: string; output?: Array<Record<string, unknown>> };
+      }
+    ).response;
     expect(response?.status).toBe("incomplete");
     expect(response?.output?.map((item) => item.type)).toEqual([
       "message",

--- a/src/gateway/server-methods/chat.inject.parentid.test.ts
+++ b/src/gateway/server-methods/chat.inject.parentid.test.ts
@@ -19,6 +19,9 @@ describe("gateway chat.inject transcript writes", () => {
       });
       expect(appended.ok).toBe(true);
       expect(appended.messageId).toEqual(expect.any(String));
+      if (appended.messageId === undefined) {
+        throw new Error("expected appended message id");
+      }
       expect(appended.messageId.length).toBeGreaterThan(0);
 
       const lines = fs.readFileSync(transcriptPath, "utf-8").split(/\r?\n/).filter(Boolean);
@@ -62,6 +65,9 @@ describe("gateway chat.inject transcript writes", () => {
       });
       expect(appended.ok).toBe(true);
       expect(appended.messageId).toEqual(expect.any(String));
+      if (appended.messageId === undefined) {
+        throw new Error("expected appended message id");
+      }
       expect(appended.messageId.length).toBeGreaterThan(0);
 
       const lines = fs.readFileSync(transcriptPath, "utf-8").split(/\r?\n/).filter(Boolean);

--- a/src/gateway/server-methods/commands.test.ts
+++ b/src/gateway/server-methods/commands.test.ts
@@ -205,7 +205,7 @@ describe("commands.list handler", () => {
 
   it("maps native commands with category, scope, and args", () => {
     const { payload } = callHandler();
-    const { commands } = payload as { commands: Array<Record<string, unknown>> };
+    const { commands } = payload as { commands: Array<{ name: string } & Record<string, unknown>> };
     const model = requireCommand(commands, "model");
     expect(model).toMatchObject({
       name: "model",

--- a/src/gateway/server.node-invoke-approval-bypass.test.ts
+++ b/src/gateway/server.node-invoke-approval-bypass.test.ts
@@ -193,9 +193,12 @@ describe("node.invoke approval bypass", () => {
     const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
     const publicKeyPem = publicKey.export({ type: "spki", format: "pem" });
     const privateKeyPem = privateKey.export({ type: "pkcs8", format: "pem" });
-    const publicKeyRaw = publicKeyRawBase64UrlFromPem(publicKeyPem);
+    const publicKeyRaw = requireNonEmptyString(
+      publicKeyRawBase64UrlFromPem(publicKeyPem),
+      "operator public key",
+    );
     const deviceId = requireNonEmptyString(
-      deriveDeviceIdFromPublicKey(publicKeyRaw),
+      deriveDeviceIdFromPublicKey(publicKeyRaw) ?? undefined,
       "operator device id",
     );
     return await connectOperatorWithRetry(scopes, (nonce) => {

--- a/src/gateway/session-compaction-checkpoints.test.ts
+++ b/src/gateway/session-compaction-checkpoints.test.ts
@@ -77,7 +77,7 @@ describe("session-compaction-checkpoints", () => {
       await cleanupCompactionCheckpointSnapshot(snapshot);
 
       expect(fsSync.existsSync(snapshot!.sessionFile)).toBe(false);
-      expect(fsSync.existsSync(sessionFile!)).toBe(true);
+      expect(fsSync.existsSync(sessionFile)).toBe(true);
     } finally {
       copyFileSyncSpy.mockRestore();
       sessionManagerOpenSpy.mockRestore();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -18,7 +18,9 @@ describe("legacy root entry", () => {
   it("does not run CLI bootstrap when imported as a library dependency", async () => {
     const runCli = vi.fn(async () => undefined);
 
-    expect(applyTemplate("Hello {{Name}}", { Name: "operator" })).toBe("Hello operator");
+    expect(applyTemplate("Hello {{MessageSid}}", { MessageSid: "operator" })).toBe(
+      "Hello operator",
+    );
 
     await runLegacyCliEntry(["openclaw", "status"], { runCli });
     expect(runCli).toHaveBeenCalledWith(["openclaw", "status"]);

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -339,6 +339,7 @@ describe("resolveProxyFetchFromEnv", () => {
         HTTP_PROXY: "http://fallback.test:3128",
       }),
     );
+    expect(fetchFn).toBeTypeOf("function");
     expect(envAgentSpy).toHaveBeenCalledWith({
       httpProxy: "http://fallback.test:3128",
       httpsProxy: "http://fallback.test:3128",
@@ -354,6 +355,7 @@ describe("resolveProxyFetchFromEnv", () => {
         https_proxy: "http://lower.test:1080",
       }),
     );
+    expect(fetchFn).toBeTypeOf("function");
     expect(envAgentSpy).toHaveBeenCalledWith({ httpsProxy: "http://lower.test:1080" });
   });
 
@@ -366,6 +368,7 @@ describe("resolveProxyFetchFromEnv", () => {
         http_proxy: "http://lower-http.test:1080",
       }),
     );
+    expect(fetchFn).toBeTypeOf("function");
     expect(envAgentSpy).toHaveBeenCalledWith({
       httpProxy: "http://lower-http.test:1080",
       httpsProxy: "http://lower-http.test:1080",
@@ -382,6 +385,7 @@ describe("resolveProxyFetchFromEnv", () => {
         ALL_PROXY: "socks5://all-proxy.test:1080",
       }),
     );
+    expect(fetchFn).toBeTypeOf("function");
     expect(envAgentSpy).toHaveBeenCalledWith({
       httpProxy: "socks5://all-proxy.test:1080",
       httpsProxy: "socks5://all-proxy.test:1080",

--- a/src/infra/npm-pack-install.test.ts
+++ b/src/infra/npm-pack-install.test.ts
@@ -123,6 +123,9 @@ describe("installFromNpmSpecArchive", () => {
     const okResult = expectWrappedOkResult(result, { ok: true, target: "done" });
     expect(okResult.integrityDrift).toBeUndefined();
     expect(okResult.npmResolution.resolvedSpec).toBe("@openclaw/test@1.0.0");
+    if (okResult.npmResolution.resolvedAt === undefined) {
+      throw new Error("expected npm resolution timestamp");
+    }
     expect(Date.parse(okResult.npmResolution.resolvedAt)).not.toBeNaN();
     expect(installFromArchive).toHaveBeenCalledWith({ archivePath: "/tmp/openclaw-test.tgz" });
   });

--- a/src/infra/session-delivery-queue.recovery.test.ts
+++ b/src/infra/session-delivery-queue.recovery.test.ts
@@ -139,6 +139,9 @@ describe("session-delivery queue recovery", () => {
       }
       expect(failedEntry.retryCount).toBe(1);
       expect(typeof failedEntry.lastAttemptAt).toBe("number");
+      if (typeof failedEntry.lastAttemptAt !== "number") {
+        throw new Error("expected last attempt timestamp");
+      }
 
       const lastAttemptAt = failedEntry.lastAttemptAt;
       const notReady = isSessionDeliveryEligibleForRetry(failedEntry, lastAttemptAt + 4_999);

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -257,6 +257,9 @@ describe("system events (session routing)", () => {
     enqueueSystemEvent("Post-compaction context:\nline one\nline two", { sessionKey: key });
 
     const result = await drainFormattedEvents(key);
+    if (result === undefined) {
+      throw new Error("expected formatted system event text");
+    }
     expect(result).toContain("Post-compaction context:");
     const lines = result.split("\n");
     expect(lines.length).toBeGreaterThan(0);

--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -61,10 +61,14 @@ function bundledEntry(pluginId: string): string {
   return `${bundledPluginRoot(pluginId)}/index`;
 }
 
-function unifiedDistGraph(): TsdownConfigEntry | undefined {
-  return asConfigArray(tsdownConfig).find((config) =>
+function unifiedDistGraph(): TsdownConfigEntry {
+  const graph = asConfigArray(tsdownConfig).find((config) =>
     entryKeys(config).includes("plugins/runtime/index"),
   );
+  if (!graph) {
+    throw new Error("expected unified dist graph");
+  }
+  return graph;
 }
 
 function readGatewayRunLoopSource(): string {
@@ -104,7 +108,7 @@ describe("tsdown config", () => {
   it("keeps gateway lifecycle lazy runtime behind one stable dist entry", () => {
     const distGraph = unifiedDistGraph();
 
-    expect(entrySources(distGraph as TsdownConfigEntry)).toEqual(
+    expect(entrySources(distGraph)).toEqual(
       expect.objectContaining({
         "cli/gateway-lifecycle.runtime": "src/cli/gateway-cli/lifecycle.runtime.ts",
       }),
@@ -114,7 +118,7 @@ describe("tsdown config", () => {
   it("keeps reply dispatcher lazy runtime behind one root stable dist entry", () => {
     const distGraph = unifiedDistGraph();
 
-    expect(entrySources(distGraph as TsdownConfigEntry)).toEqual(
+    expect(entrySources(distGraph)).toEqual(
       expect.objectContaining({
         "provider-dispatcher.runtime": "src/auto-reply/reply/provider-dispatcher.runtime.ts",
       }),
@@ -175,7 +179,7 @@ describe("tsdown config", () => {
     if (typeof external !== "function") {
       throw new Error("expected unified graph external predicate");
     }
-    const externalize = external as TsdownExternalFunction;
+    const externalize = external;
     expect(externalize("qrcode-terminal/lib/main.js", undefined, false)).toBe(true);
   });
 

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -833,7 +833,7 @@ describe("hardenApprovedExecutionPaths", () => {
               throw new Error("unreachable");
             }
             const mutableFileOperand = prepared.plan.mutableFileOperand;
-            if (mutableFileOperand === undefined) {
+            if (mutableFileOperand == null) {
               throw new Error("expected mutable file operand snapshot");
             }
             fs.writeFileSync(fixture.scriptPath, 'console.log("PWNED");\n');

--- a/src/plugin-sdk/inbound-reply-dispatch.test.ts
+++ b/src/plugin-sdk/inbound-reply-dispatch.test.ts
@@ -32,7 +32,6 @@ import {
   resolveChannelSourceReplyDeliveryMode,
 } from "./channel-reply-pipeline.js";
 import {
-  dispatchInboundReplyWithBase,
   hasFinalInboundReplyDispatch,
   hasVisibleInboundReplyDispatch,
   recordInboundSessionAndDispatchReply,

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -630,7 +630,9 @@ describe("clearPluginLoaderCache", () => {
     ]);
     expect(listMemoryCorpusSupplements()).toHaveLength(1);
     expect(resolveMemoryFlushPlan({})?.relativePath).toBe("memory/stale.md");
-    expect(requireMemoryRuntime().resolveMemoryBackendConfig()).toEqual({ backend: "builtin" });
+    expect(requireMemoryRuntime().resolveMemoryBackendConfig({ cfg: {}, agentId: "main" })).toEqual(
+      { backend: "builtin" },
+    );
     expect(requireMemoryEmbeddingProvider("stale").id).toBe("stale");
 
     clearPluginLoaderCache();

--- a/src/plugins/provider-validation.test.ts
+++ b/src/plugins/provider-validation.test.ts
@@ -219,6 +219,9 @@ describe("normalizeRegisteredProvider", () => {
         'provider "demo" registered both catalog and discovery; using catalog',
       ],
       assert: (provider: ReturnType<typeof normalizeRegisteredProvider>) => {
+        if (provider === null) {
+          throw new Error("expected normalized provider");
+        }
         expect(provider).toMatchObject({ catalog: { run: expect.any(Function) } });
         expect(provider.discovery).toBeUndefined();
       },

--- a/src/plugins/registry.dual-kind-memory-gate.test.ts
+++ b/src/plugins/registry.dual-kind-memory-gate.test.ts
@@ -80,7 +80,9 @@ describe("dual-kind memory registration gate", () => {
       },
     });
 
-    expect(requireMemoryRuntime().resolveMemoryBackendConfig()).toEqual({ backend: "builtin" });
+    expect(requireMemoryRuntime().resolveMemoryBackendConfig({ cfg: {}, agentId: "main" })).toEqual(
+      { backend: "builtin" },
+    );
     expect(
       registry.registry.diagnostics.filter(
         (d) => d.pluginId === "dual-plugin" && d.level === "warn",
@@ -102,7 +104,9 @@ describe("dual-kind memory registration gate", () => {
       },
     });
 
-    expect(requireMemoryRuntime().resolveMemoryBackendConfig()).toEqual({ backend: "builtin" });
+    expect(requireMemoryRuntime().resolveMemoryBackendConfig({ cfg: {}, agentId: "main" })).toEqual(
+      { backend: "builtin" },
+    );
   });
 
   it("allows selected dual-kind plugins to register the unified memory capability", () => {
@@ -128,6 +132,8 @@ describe("dual-kind memory registration gate", () => {
     expect(getMemoryCapabilityRegistration()).toMatchObject({
       pluginId: "dual-plugin",
     });
-    expect(requireMemoryRuntime().resolveMemoryBackendConfig()).toEqual({ backend: "builtin" });
+    expect(requireMemoryRuntime().resolveMemoryBackendConfig({ cfg: {}, agentId: "main" })).toEqual(
+      { backend: "builtin" },
+    );
   });
 });

--- a/src/plugins/source-display.test.ts
+++ b/src/plugins/source-display.test.ts
@@ -79,6 +79,9 @@ describe("formatPluginSourceForTable", () => {
       OPENCLAW_STATE_DIR: "~/state",
     } as NodeJS.ProcessEnv;
     const stock = withPathResolutionEnv(homeDir, rawEnv, (env) => resolveBundledPluginsDir(env));
+    if (stock === undefined) {
+      throw new Error("expected bundled plugins dir");
+    }
     expectResolvedSourceRoots({
       homeDir,
       env: rawEnv,

--- a/ui/src/styles/chat/layout.test.ts
+++ b/ui/src/styles/chat/layout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { readStyleSheet } from "../../../../test/helpers/ui-style-fixtures";
+import { readStyleSheet } from "../../../../test/helpers/ui-style-fixtures.js";
 
 function readLayoutCss(): string {
   return readStyleSheet("ui/src/styles/chat/layout.css");

--- a/ui/src/styles/components.test.ts
+++ b/ui/src/styles/components.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { readStyleSheet } from "../../../test/helpers/ui-style-fixtures";
+import { readStyleSheet } from "../../../test/helpers/ui-style-fixtures.js";
 
 function readComponentsCss(): string {
   return readStyleSheet("ui/src/styles/components.css");

--- a/ui/src/styles/layout.mobile.test.ts
+++ b/ui/src/styles/layout.mobile.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { readStyleSheet } from "../../../test/helpers/ui-style-fixtures";
+import { readStyleSheet } from "../../../test/helpers/ui-style-fixtures.js";
 
 function readMobileCss(): string {
   return readStyleSheet("ui/src/styles/layout.mobile.css");

--- a/ui/src/styles/markdown-preview.test.ts
+++ b/ui/src/styles/markdown-preview.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { readStyleSheetAsync } from "../../../test/helpers/ui-style-fixtures";
+import { readStyleSheetAsync } from "../../../test/helpers/ui-style-fixtures.js";
 
 describe("markdown preview styles", () => {
   it("keeps the preview dialog canvas unified", async () => {

--- a/ui/src/ui/chat/chat-responsive.browser.test.ts
+++ b/ui/src/ui/chat/chat-responsive.browser.test.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import { chromium, type Browser, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { readStyleSheet } from "../../../../test/helpers/ui-style-fixtures";
+import { readStyleSheet } from "../../../../test/helpers/ui-style-fixtures.js";
 
 const VIEWPORTS = [
   [320, 568],

--- a/ui/src/ui/views/config.browser.test.ts
+++ b/ui/src/ui/views/config.browser.test.ts
@@ -121,9 +121,9 @@ describe("config view", () => {
     return button;
   }
 
-  function queryRequired<T extends Element>(container: HTMLElement, selector: string): T {
-    const element = container.querySelector<T>(selector);
-    if (!element) {
+  function queryRequired(container: HTMLElement, selector: string): HTMLElement {
+    const element = container.querySelector(selector);
+    if (!(element instanceof HTMLElement)) {
       throw new Error(`Expected element matching "${selector}"`);
     }
     return element;
@@ -366,7 +366,7 @@ describe("config view", () => {
       },
     });
 
-    const content = queryRequired<HTMLElement>(container, ".config-content");
+    const content = queryRequired(container, ".config-content");
     content.scrollTop = 280;
     content.scrollLeft = 24;
     content.scrollTo = vi.fn(({ top, left }: { top?: number; left?: number }) => {

--- a/ui/src/ui/views/sessions.browser.test.ts
+++ b/ui/src/ui/views/sessions.browser.test.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import { chromium, type Browser, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { readStyleSheet } from "../../../../test/helpers/ui-style-fixtures";
+import { readStyleSheet } from "../../../../test/helpers/ui-style-fixtures.js";
 
 const VIEWPORTS = [
   [375, 812],


### PR DESCRIPTION
## Summary

- Restores the latest `main` lint baseline after the broad test assertion tightening in `9ef37d1907`.
- Adds explicit type guards, removes now-unnecessary assertions/imports, and fixes NodeNext test import extensions.
- Restores the `check:test-types` baseline for both core and extension test graphs.

## Real behavior proof

Behavior or issue addressed:

Current `main` at `8dcc2ff1d2` has failing maintainer CI baseline shards after the broad test assertion tightening in `9ef37d1907`: `check-test-types` and `check-lint` are red. This PR only changes tests and fixtures so those real maintainer checks can run cleanly again.

Real environment tested:

Local OpenClaw source checkout at `/tmp/openclaw-ci-test-types-fix`, based on `upstream/main` commit `8dcc2ff1d2402bb65e7c1b0b3026b68e0951fc08`, on Linux with Node `v24.14.0` and pnpm `10.33.2`.

Exact steps or command run after this patch:

```bash
cd /tmp/openclaw-ci-test-types-fix
pnpm check:test-types
pnpm lint --threads=8
git diff --check
```

Evidence after fix:

Terminal output captured locally after this patch:

```text
$ pnpm check:test-types
> openclaw@0.0.0 check:test-types /tmp/openclaw-ci-test-types-fix
> pnpm tsgo:core:test && pnpm tsgo:extensions:test

> openclaw@0.0.0 tsgo:core:test /tmp/openclaw-ci-test-types-fix
> tsgo -p src/tsconfig.test.json

> openclaw@0.0.0 tsgo:extensions:test /tmp/openclaw-ci-test-types-fix
> tsgo -p extensions/tsconfig.test.json

$ pnpm lint --threads=8
Found 0 warnings and 0 errors. Finished in 7.9s on 408 files with 213 rules using 8 threads.
Found 0 warnings and 0 errors. Finished in 39.3s on 8254 files with 213 rules using 8 threads.
Found 0 warnings and 0 errors. Finished in 43.6s on 5166 files with 213 rules using 8 threads.

$ git diff --check
exit status: 0
```

Before evidence: maintainer CI on current `main` commit `8dcc2ff1d2402bb65e7c1b0b3026b68e0951fc08` failed in run `25536993596`, including `check-test-types` job `74954736654` and `check-lint` job `74954736671`, with the same TypeScript and lint baseline failures fixed here.

Observed result after fix:

`pnpm check:test-types`, the full `pnpm lint --threads=8` shard set, and `git diff --check` all exit 0 locally after this patch. The local terminal evidence above reproduces the maintainer baseline checks that are red on current `main` and shows the repaired state.

What was not tested:

No live OpenClaw channel/runtime smoke was run because this PR has no runtime code changes; it is limited to restoring the test and lint baseline. A maintainer `proof: override` may be appropriate if the gate requires product behavior evidence for CI-only/test-only patches.
