### PR TITLE
fix(voice-call): auto respond to provider speech webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Voice Call: route final provider webhook speech events through the inbound auto-response path while skipping speech that resolves an active `continueCall` waiter. Fixes #79118. Thanks @dvy.
 - Google/Gemini: normalize retired `google/gemini-3-pro-preview` catalog selections to `google/gemini-3.1-pro-preview` before they are written to model config.
 - Control UI: read the Quick Settings exec policy badge from `tools.exec.security` instead of the non-schema `agents.defaults.exec.security` path, so configured `full`/`deny` values render accurately. Fixes #78311. Thanks @FriedBack.
 - Control UI/usage: add transcript-backed historical lineage rollups for rotated logical sessions, with current-instance vs historical-lineage scope controls and long-range presets so usage history stays visible after restarts and updates. Fixes #50701. Thanks @dev-gideon-llc and @BunsDev.

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -5,7 +5,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import type { VoiceCallConfig } from "./config.js";
 import type { CallManagerContext } from "./manager/context.js";
-import { processEvent as processManagerEvent } from "./manager/events.js";
+import { processEvent as processManagerEvent, type ProcessEventResult } from "./manager/events.js";
 import { getCallByProviderCallId as getCallByProviderCallIdFromMaps } from "./manager/lookup.js";
 import {
   continueCall as continueCallWithContext,
@@ -345,8 +345,8 @@ export class CallManager {
   /**
    * Process a webhook event.
    */
-  processEvent(event: NormalizedEvent): void {
-    processManagerEvent(this.getContext(), event);
+  processEvent(event: NormalizedEvent): ProcessEventResult {
+    return processManagerEvent(this.getContext(), event);
   }
 
   private shouldDeferConversationInitialMessageUntilStreamConnect(): boolean {

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -25,6 +25,16 @@ type EventContext = Pick<
   | "onCallAnswered"
 >;
 
+export type ProcessEventResult = {
+  processed: boolean;
+  speech?: {
+    final: boolean;
+    accepted: boolean;
+    transcript: string;
+    resolvedTranscriptWaiter: boolean;
+  };
+};
+
 function shouldAcceptInbound(config: EventContext["config"], from: string | undefined): boolean {
   const { inboundPolicy: policy, allowFrom } = config;
 
@@ -106,10 +116,10 @@ function createWebhookCall(params: {
   return callRecord;
 }
 
-export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
+export function processEvent(ctx: EventContext, event: NormalizedEvent): ProcessEventResult {
   const dedupeKey = event.dedupeKey || event.id;
   if (ctx.processedEventIds.has(dedupeKey)) {
-    return;
+    return { processed: false };
   }
 
   let call = findCall({
@@ -134,11 +144,11 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
         console.warn(
           `[voice-call] Inbound call rejected by policy but no provider to hang up (providerCallId: ${pid}, from: ${event.from}); call will time out on provider side.`,
         );
-        return;
+        return { processed: false };
       }
       ctx.processedEventIds.add(dedupeKey);
       if (ctx.rejectedProviderCallIds.has(pid)) {
-        return;
+        return { processed: false };
       }
       ctx.rejectedProviderCallIds.add(pid);
       const callId = event.callId ?? pid;
@@ -154,7 +164,7 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
           const message = formatErrorMessage(err);
           console.warn(`[voice-call] Failed to reject inbound call ${pid}:`, message);
         });
-      return;
+      return { processed: true };
     }
 
     call = createWebhookCall({
@@ -170,7 +180,7 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
   }
 
   if (!call) {
-    return;
+    return { processed: false };
   }
 
   if (event.providerCallId && event.providerCallId !== call.providerCallId) {
@@ -190,6 +200,8 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
     ctx.processedEventIds.add(dedupeKey);
     call.processedEventIds.push(dedupeKey);
   }
+
+  let resolvedTranscriptWaiter = false;
 
   switch (event.type) {
     case "call.initiated":
@@ -248,8 +260,19 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
           console.warn(
             `[voice-call] Ignoring speech event with mismatched turn token for ${call.callId}`,
           );
-          break;
+          const result: ProcessEventResult = {
+            processed: true,
+            speech: {
+              final: true,
+              accepted: false,
+              transcript: event.transcript,
+              resolvedTranscriptWaiter: false,
+            },
+          };
+          persistCallRecord(ctx.storePath, call);
+          return result;
         }
+        resolvedTranscriptWaiter = hadWaiter;
         addTranscriptEntry(call, "user", event.transcript);
       }
       transitionState(call, "listening");
@@ -266,7 +289,7 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
         endReason: event.reason,
         endedAt: event.timestamp,
       });
-      return;
+      return { processed: true };
 
     case "call.error":
       if (!event.retryable) {
@@ -277,7 +300,7 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
           endedAt: event.timestamp,
           transcriptRejectReason: `Call error: ${event.error}`,
         });
-        return;
+        return { processed: true };
       }
       // Keep retryable provider errors replayable so a redelivery can still
       // drive later recovery or terminal handling for the same event key.
@@ -285,4 +308,16 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
   }
 
   persistCallRecord(ctx.storePath, call);
+  if (event.type === "call.speech") {
+    return {
+      processed: true,
+      speech: {
+        final: event.isFinal,
+        accepted: true,
+        transcript: event.transcript,
+        resolvedTranscriptWaiter: event.isFinal ? resolvedTranscriptWaiter : false,
+      },
+    };
+  }
+  return { processed: true };
 }

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -1380,6 +1380,122 @@ describe("VoiceCallWebhookServer stream disconnect grace", () => {
   });
 });
 
+describe("VoiceCallWebhookServer provider speech webhooks", () => {
+  const createSpeechProvider = (event: NormalizedEvent): VoiceCallProvider => ({
+    ...provider,
+    verifyWebhook: () => ({ ok: true, verifiedRequestKey: `verified:${event.id}` }),
+    parseWebhookEvent: () => ({
+      events: [event],
+      statusCode: 200,
+    }),
+  });
+
+  const createSpeechManager = (
+    call: CallRecord,
+    result: ReturnType<CallManager["processEvent"]>,
+  ): CallManager => {
+    const processEvent = vi.fn(() => result);
+    return {
+      getActiveCalls: () => [call],
+      getCall: (callId: string) => (callId === call.callId ? call : undefined),
+      endCall: vi.fn(async () => ({ success: true })),
+      processEvent,
+    } as unknown as CallManager;
+  };
+
+  it("auto-responds to accepted final provider speech for inbound calls", async () => {
+    const call = createCall(Date.now() - 1_000);
+    call.callId = "call-inbound";
+    call.direction = "inbound";
+    call.state = "listening";
+    const speechEvent: NormalizedEvent = {
+      id: "evt-provider-speech",
+      type: "call.speech",
+      callId: call.callId,
+      providerCallId: call.providerCallId,
+      timestamp: Date.now(),
+      transcript: "can you help me",
+      isFinal: true,
+    };
+    const manager = createSpeechManager(call, {
+      processed: true,
+      speech: {
+        final: true,
+        accepted: true,
+        transcript: speechEvent.transcript,
+        resolvedTranscriptWaiter: false,
+      },
+    });
+    const server = new VoiceCallWebhookServer(
+      createConfig({ serve: { port: 0, bind: "127.0.0.1", path: "/voice/webhook" } }),
+      manager,
+      createSpeechProvider(speechEvent),
+    );
+    const handleInboundResponse = vi.fn(async () => {});
+    (
+      server as unknown as {
+        handleInboundResponse: (callId: string, transcript: string) => Promise<void>;
+      }
+    ).handleInboundResponse = handleInboundResponse;
+
+    try {
+      const baseUrl = await server.start();
+      const response = await postWebhookForm(server, baseUrl, "CallSid=provider-call-1");
+
+      expect(response.status).toBe(200);
+      expect(handleInboundResponse).toHaveBeenCalledWith("call-inbound", "can you help me");
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("does not auto-respond when provider speech resolves a pending continueCall waiter", async () => {
+    const call = createCall(Date.now() - 1_000);
+    call.callId = "call-outbound";
+    call.direction = "outbound";
+    call.metadata = { mode: "conversation" };
+    const speechEvent: NormalizedEvent = {
+      id: "evt-waiter-speech",
+      type: "call.speech",
+      callId: call.callId,
+      providerCallId: call.providerCallId,
+      timestamp: Date.now(),
+      transcript: "turn answer",
+      isFinal: true,
+    };
+    const manager = createSpeechManager(call, {
+      processed: true,
+      speech: {
+        final: true,
+        accepted: true,
+        transcript: speechEvent.transcript,
+        resolvedTranscriptWaiter: true,
+      },
+    });
+    const server = new VoiceCallWebhookServer(
+      createConfig({ serve: { port: 0, bind: "127.0.0.1", path: "/voice/webhook" } }),
+      manager,
+      createSpeechProvider(speechEvent),
+    );
+    const handleInboundResponse = vi.fn(async () => {});
+    (
+      server as unknown as {
+        handleInboundResponse: (callId: string, transcript: string) => Promise<void>;
+      }
+    ).handleInboundResponse = handleInboundResponse;
+
+    try {
+      const baseUrl = await server.start();
+      const response = await postWebhookForm(server, baseUrl, "CallSid=provider-call-1");
+
+      expect(response.status).toBe(200);
+      expect(handleInboundResponse).not.toHaveBeenCalled();
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
 describe("VoiceCallWebhookServer barge-in suppression during initial message", () => {
   const createTwilioProvider = (
     clearTtsQueue: ReturnType<typeof vi.fn<TwilioProviderTestDouble["clearTtsQueue"]>>,

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -853,11 +853,43 @@ export class VoiceCallWebhookServer {
   private processParsedEvents(events: NormalizedEvent[]): void {
     for (const event of events) {
       try {
-        this.manager.processEvent(event);
+        const result = this.manager.processEvent(event);
+        this.handleParsedSpeechAutoResponse(event, result);
       } catch (err) {
         console.error(`[voice-call] Error processing event ${event.type}:`, err);
       }
     }
+  }
+
+  private handleParsedSpeechAutoResponse(
+    event: NormalizedEvent,
+    result: ReturnType<CallManager["processEvent"]> | undefined,
+  ): void {
+    if (
+      event.type !== "call.speech" ||
+      !event.isFinal ||
+      !result?.processed ||
+      !result.speech?.accepted ||
+      result.speech.resolvedTranscriptWaiter
+    ) {
+      return;
+    }
+    const transcript = result.speech.transcript.trim();
+    if (!transcript) {
+      return;
+    }
+    const call = this.manager.getCall(event.callId);
+    if (!call) {
+      return;
+    }
+    const callMode = call.metadata?.mode as string | undefined;
+    const shouldRespond = call.direction === "inbound" || callMode === "conversation";
+    if (!shouldRespond) {
+      return;
+    }
+    this.handleInboundResponse(call.callId, result.speech.transcript).catch((err) => {
+      console.warn("[voice-call] Failed to auto-respond:", err);
+    });
   }
 
   private writeWebhookResponse(res: http.ServerResponse, payload: WebhookResponsePayload): void {


### PR DESCRIPTION
## Summary

- route final provider webhook `call.speech` events into the same voice-call auto-response path used by realtime media-stream transcripts
- return structured manager event results so webhook handling can skip speech that resolved an active `continueCall` waiter or was rejected by turn-token mismatch
- add focused webhook coverage for inbound provider speech auto-response and waiter-resolution non-duplication

Fixes #79118.

## Verification

- `pnpm test extensions/voice-call/src/webhook.test.ts extensions/voice-call/src/manager/events.test.ts`
- `pnpm test extensions/voice-call/src/webhook.test.ts extensions/voice-call/src/manager/events.test.ts extensions/voice-call/src/manager.closed-loop.test.ts extensions/voice-call/src/providers/telnyx.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/voice-call/src/manager/events.ts extensions/voice-call/src/manager.ts extensions/voice-call/src/webhook.ts extensions/voice-call/src/webhook.test.ts CHANGELOG.md`
- `pnpm check:changed`

## Notes

No live Telnyx carrier call was run; the fix is source-backed and covered by the provider-webhook path tests.