### PR TITLE
perf(status): eliminate duplicate bundled-plugin manifest scans in status --json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/status: eliminate duplicate bundled-plugin manifest scans in `openclaw status --json` by building the metadata snapshot once during the channel-presence check and threading it through to the security audit, cutting repeated fs traversals of all bundled plugin manifests. Fixes #79129.
 - Control UI/chat: hide retired and non-public Google Gemini model IDs from chat model catalogs and route the bare `gemini-3-pro` alias to Gemini 3.1 Pro Preview instead of the shut-down Gemini 3 Pro Preview. Thanks @BunsDev.
 - CLI/install: refuse state-mutating OpenClaw CLI runs as root by default, keep an explicit `OPENCLAW_ALLOW_ROOT=1` escape hatch for intentional root/container use, and update DigitalOcean setup guidance to run OpenClaw as a non-root user. Fixes #67478. Thanks @Jerry-Xin and @natechicago.
 - Gateway/watch: leave `OPENCLAW_TRACE_SYNC_IO` disabled by default in `pnpm gateway:watch:raw` so watch mode avoids noisy Node sync-I/O stack traces unless explicitly requested.

--- a/src/channels/plugins/read-only.ts
+++ b/src/channels/plugins/read-only.ts
@@ -16,7 +16,10 @@ import {
   resolveSetupChannelRegistration,
 } from "../../plugins/loader-channel-setup.js";
 import type { PluginManifestRecord } from "../../plugins/manifest-registry.js";
-import { loadPluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
+import {
+  loadPluginMetadataSnapshot,
+  type PluginMetadataSnapshot,
+} from "../../plugins/plugin-metadata-snapshot.js";
 import {
   getCachedPluginModuleLoader,
   type PluginModuleLoaderCache,
@@ -125,6 +128,7 @@ type ReadOnlyChannelPluginOptions = {
   activationSourceConfig?: OpenClawConfig;
   includePersistedAuthState?: boolean;
   includeSetupFallbackPlugins?: boolean;
+  metadataSnapshot?: PluginMetadataSnapshot;
 };
 
 type ReadOnlyChannelPluginResolution = {
@@ -699,13 +703,14 @@ export function resolveReadOnlyChannelPluginsForConfig(
   const env = options.env ?? process.env;
   const workspaceDir = resolveReadOnlyWorkspaceDir(cfg, options);
   const metadataSnapshot =
-    options.stateDir === undefined
+    options.metadataSnapshot ??
+    (options.stateDir === undefined
       ? getCurrentPluginMetadataSnapshot({
           config: cfg,
           env,
           workspaceDir,
         })
-      : undefined;
+      : undefined);
   const manifestRecords =
     metadataSnapshot?.plugins ??
     loadPluginMetadataSnapshot({

--- a/src/commands/status-json-command.test.ts
+++ b/src/commands/status-json-command.test.ts
@@ -51,7 +51,8 @@ describe("runStatusJsonCommand", () => {
       agentStatus: [],
       secretDiagnostics: [],
     };
-    const scanStatusJsonFast = vi.fn(async () => scan);
+    const metadataSnapshot = { policyHash: "abc" } as never;
+    const scanStatusJsonFast = vi.fn(async () => ({ scan, metadataSnapshot }));
 
     await runStatusJsonCommand({
       opts: { deep: true, usage: true, timeoutMs: 1234, all: true },
@@ -69,6 +70,7 @@ describe("runStatusJsonCommand", () => {
       includeSecurityAudit: true,
       includePluginCompatibility: true,
       suppressHealthErrors: true,
+      metadataSnapshot,
     });
     expect(mocks.writeRuntimeJson).toHaveBeenCalledWith(runtime, {
       built: true,
@@ -78,6 +80,7 @@ describe("runStatusJsonCommand", () => {
         includeSecurityAudit: true,
         includePluginCompatibility: true,
         suppressHealthErrors: true,
+        metadataSnapshot,
       },
     });
   });

--- a/src/commands/status-json-command.ts
+++ b/src/commands/status-json-command.ts
@@ -1,3 +1,4 @@
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { resolveStatusJsonOutput } from "./status-json-runtime.ts";
 
@@ -17,9 +18,12 @@ export async function runStatusJsonCommand(params: {
   scanStatusJsonFast: (
     opts: { timeoutMs?: number; all?: boolean },
     runtime: RuntimeEnv,
-  ) => Promise<Parameters<typeof resolveStatusJsonOutput>[0]["scan"]>;
+  ) => Promise<{
+    scan: Parameters<typeof resolveStatusJsonOutput>[0]["scan"];
+    metadataSnapshot: PluginMetadataSnapshot | undefined;
+  }>;
 }) {
-  const scan = await params.scanStatusJsonFast(
+  const { scan, metadataSnapshot } = await params.scanStatusJsonFast(
     { timeoutMs: params.opts.timeoutMs, all: params.opts.all },
     params.runtime,
   );
@@ -31,6 +35,7 @@ export async function runStatusJsonCommand(params: {
       includeSecurityAudit: params.includeSecurityAudit,
       includePluginCompatibility: params.includePluginCompatibility,
       suppressHealthErrors: params.suppressHealthErrors,
+      metadataSnapshot,
     }),
   );
 }

--- a/src/commands/status-json-runtime.ts
+++ b/src/commands/status-json-runtime.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/types.js";
 import type { UpdateCheckResult } from "../infra/update-check.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { buildStatusJsonPayload } from "./status-json-payload.ts";
 import { buildStatusOverviewSurfaceFromScan } from "./status-overview-surface.ts";
 import { resolveStatusRuntimeSnapshot } from "./status-runtime-shared.ts";
@@ -58,6 +59,7 @@ export async function resolveStatusJsonOutput(params: {
   includeSecurityAudit: boolean;
   includePluginCompatibility?: boolean;
   suppressHealthErrors?: boolean;
+  metadataSnapshot?: PluginMetadataSnapshot;
 }) {
   const { scan, opts } = params;
   const { securityAudit, usage, health, lastHeartbeat, gatewayService, nodeService } =
@@ -70,6 +72,7 @@ export async function resolveStatusJsonOutput(params: {
       gatewayReachable: scan.gatewayReachable,
       includeSecurityAudit: params.includeSecurityAudit,
       suppressHealthErrors: params.suppressHealthErrors,
+      metadataSnapshot: params.metadataSnapshot,
     });
 
   return buildStatusJsonPayload({

--- a/src/commands/status-json.test.ts
+++ b/src/commands/status-json.test.ts
@@ -78,7 +78,10 @@ function createScanResult() {
 describe("statusJsonCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.scanStatusJsonFast.mockResolvedValue(createScanResult());
+    mocks.scanStatusJsonFast.mockResolvedValue({
+      scan: createScanResult(),
+      metadataSnapshot: undefined,
+    });
     mocks.runSecurityAudit.mockResolvedValue({
       summary: { critical: 1, warn: 0, info: 0 },
       findings: [],

--- a/src/commands/status-runtime-shared.ts
+++ b/src/commands/status-runtime-shared.ts
@@ -1,6 +1,7 @@
 import { resolveReadOnlyChannelPluginsForConfig } from "../channels/plugins/read-only.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { HeartbeatEventPayload } from "../infra/heartbeat-events.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import type { HealthSummary } from "./health.js";
 import { getDaemonStatusSummary, getNodeDaemonStatusSummary } from "./status.daemon.js";
@@ -26,11 +27,13 @@ function loadGatewayCallModule() {
 export async function resolveStatusSecurityAudit(params: {
   config: OpenClawConfig;
   sourceConfig: OpenClawConfig;
+  metadataSnapshot?: PluginMetadataSnapshot;
 }) {
   const { runSecurityAudit } = await loadSecurityAuditModule();
   const readOnlyPlugins = resolveReadOnlyChannelPluginsForConfig(params.config, {
     activationSourceConfig: params.sourceConfig,
     includeSetupFallbackPlugins: false,
+    metadataSnapshot: params.metadataSnapshot,
   });
   return await runSecurityAudit({
     config: params.config,
@@ -179,6 +182,7 @@ export async function resolveStatusRuntimeSnapshot(params: {
   gatewayReachable: boolean;
   includeSecurityAudit?: boolean;
   suppressHealthErrors?: boolean;
+  metadataSnapshot?: PluginMetadataSnapshot;
   resolveSecurityAudit?: (input: {
     config: OpenClawConfig;
     sourceConfig: OpenClawConfig;
@@ -193,6 +197,7 @@ export async function resolveStatusRuntimeSnapshot(params: {
     ? await (params.resolveSecurityAudit ?? resolveStatusSecurityAudit)({
         config: params.config,
         sourceConfig: params.sourceConfig,
+        metadataSnapshot: params.metadataSnapshot,
       })
     : undefined;
   const runtimeDetails = await resolveStatusRuntimeDetails({

--- a/src/commands/status.scan.fast-json.test.ts
+++ b/src/commands/status.scan.fast-json.test.ts
@@ -6,18 +6,49 @@ import {
   createStatusScanSharedMocks,
   createStatusSummary,
   loadStatusScanModuleForTest,
+  type StatusScanModuleTestMocks,
   withTemporaryEnv,
 } from "./status.scan.test-helpers.js";
 
-const mocks = {
+const mocks: StatusScanModuleTestMocks = {
   ...createStatusScanSharedMocks("status-fast-json"),
   getStatusCommandSecretTargetIds: vi.fn(() => []),
   resolveMemorySearchConfig: vi.fn(),
+  loadPluginMetadataSnapshot: vi.fn(),
 };
 
 let originalForceStderr: boolean;
 let loggingStateRef: typeof import("../logging/state.js").loggingState;
 let scanStatusJsonFast: typeof import("./status.scan.fast-json.js").scanStatusJsonFast;
+
+const minimalSnapshot = {
+  policyHash: "test",
+  plugins: [],
+  byPluginId: new Map(),
+  index: { plugins: [], installRecords: [], diagnostics: [] },
+  manifestRegistry: { plugins: [], byPluginId: new Map() },
+  diagnostics: [],
+  registryDiagnostics: [],
+  owners: {
+    channels: new Map(),
+    channelConfigs: new Map(),
+    providers: new Map(),
+    modelCatalogProviders: new Map(),
+    cliBackends: new Map(),
+    setupProviders: new Map(),
+    commandAliases: new Map(),
+    contracts: new Map(),
+  },
+  metrics: {
+    registrySnapshotMs: 0,
+    manifestRegistryMs: 0,
+    ownerMapsMs: 0,
+    totalMs: 0,
+    indexPluginCount: 0,
+    manifestPluginCount: 0,
+  },
+  normalizePluginId: (id: string) => id,
+} as never;
 
 function configureFastJsonStatus() {
   applyStatusScanDefaults(mocks, {
@@ -30,6 +61,7 @@ function configureFastJsonStatus() {
   mocks.resolveMemorySearchConfig.mockReturnValue({
     store: { path: "/tmp/main.sqlite" },
   });
+  (mocks.loadPluginMetadataSnapshot as ReturnType<typeof vi.fn>).mockReturnValue(minimalSnapshot);
 }
 
 beforeAll(async () => {
@@ -109,9 +141,9 @@ describe("scanStatusJsonFast", () => {
   });
 
   it("skips memory inspection for the lean status --json fast path", async () => {
-    const result = await scanStatusJsonFast({}, {} as never);
+    const { scan } = await scanStatusJsonFast({}, {} as never);
 
-    expect(result.memory).toBeNull();
+    expect(scan.memory).toBeNull();
     expect(mocks.hasPotentialConfiguredChannels).toHaveBeenCalledWith(
       expect.any(Object),
       process.env,
@@ -122,9 +154,9 @@ describe("scanStatusJsonFast", () => {
   });
 
   it("restores memory inspection when --all is requested", async () => {
-    const result = await scanStatusJsonFast({ all: true }, {} as never);
+    const { scan } = await scanStatusJsonFast({ all: true }, {} as never);
 
-    expect(result.memory).toEqual(expect.objectContaining({ agentId: "main" }));
+    expect(scan.memory).toEqual(expect.objectContaining({ agentId: "main" }));
     expect(mocks.resolveMemorySearchConfig).toHaveBeenCalled();
     expect(mocks.getMemorySearchManager).toHaveBeenCalledWith({
       cfg: expect.objectContaining({
@@ -153,5 +185,15 @@ describe("scanStatusJsonFast", () => {
 
     expect(mocks.getUpdateCheckResult).not.toHaveBeenCalled();
     expect(mocks.probeGateway).not.toHaveBeenCalled();
+  });
+
+  it("builds the plugin metadata snapshot exactly once and returns it for reuse", async () => {
+    const { metadataSnapshot } = await scanStatusJsonFast({}, {} as never);
+
+    expect(mocks.loadPluginMetadataSnapshot).toHaveBeenCalledTimes(1);
+    expect(metadataSnapshot).toBeDefined();
+    expect(metadataSnapshot).toBe(
+      (mocks.loadPluginMetadataSnapshot as ReturnType<typeof vi.fn>).mock.results[0]?.value,
+    );
   });
 });

--- a/src/commands/status.scan.fast-json.ts
+++ b/src/commands/status.scan.fast-json.ts
@@ -1,5 +1,9 @@
 import type { OpenClawConfig } from "../config/types.js";
 import { hasConfiguredChannelsForReadOnlyScope } from "../plugins/channel-plugin-ids.js";
+import {
+  loadPluginMetadataSnapshot,
+  type PluginMetadataSnapshot,
+} from "../plugins/plugin-metadata-snapshot.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { executeStatusScanFromOverview } from "./status.scan-execute.ts";
 import {
@@ -47,24 +51,34 @@ export async function scanStatusJsonWithPolicy(
   });
 }
 
+export type StatusJsonFastScanResult = {
+  scan: StatusScanResult;
+  metadataSnapshot: PluginMetadataSnapshot | undefined;
+};
+
 export async function scanStatusJsonFast(
   opts: {
     timeoutMs?: number;
     all?: boolean;
   },
   runtime: RuntimeEnv,
-): Promise<StatusScanResult> {
-  return await scanStatusJsonWithPolicy(opts, runtime, {
+): Promise<StatusJsonFastScanResult> {
+  let metadataSnapshot: PluginMetadataSnapshot | undefined;
+
+  const scan = await scanStatusJsonWithPolicy(opts, runtime, {
     commandName: "status --json",
     allowMissingConfigFastPath: true,
     includeChannelSummary: false,
-    resolveHasConfiguredChannels: (cfg, sourceConfig) =>
-      hasConfiguredChannelsForReadOnlyScope({
+    resolveHasConfiguredChannels: (cfg, sourceConfig) => {
+      metadataSnapshot = loadPluginMetadataSnapshot({ config: cfg, env: process.env });
+      return hasConfiguredChannelsForReadOnlyScope({
         config: cfg,
         activationSourceConfig: sourceConfig,
         env: process.env,
         includePersistedAuthState: false,
-      }),
+        manifestRecords: metadataSnapshot.plugins,
+      });
+    },
     resolveMemory: async ({ cfg, agentStatus, memoryPlugin }) =>
       opts.all
         ? await resolveStatusMemoryStatusSnapshot({
@@ -75,4 +89,6 @@ export async function scanStatusJsonFast(
           })
         : null,
   });
+
+  return { scan, metadataSnapshot };
 }

--- a/src/commands/status.scan.test-helpers.ts
+++ b/src/commands/status.scan.test-helpers.ts
@@ -149,11 +149,12 @@ function createStatusExecModuleMock(): { runExec: UnknownMock } {
   };
 }
 
-type StatusScanModuleTestMocks = StatusScanSharedMocks & {
+export type StatusScanModuleTestMocks = StatusScanSharedMocks & {
   buildChannelsTable?: UnknownMock;
   callGateway?: UnknownMock;
   getStatusCommandSecretTargetIds?: UnknownMock;
   resolveMemorySearchConfig?: UnknownMock;
+  loadPluginMetadataSnapshot?: UnknownMock;
 };
 
 export async function loadStatusScanModuleForTest(
@@ -277,6 +278,39 @@ export async function loadStatusScanModuleForTest(
   vi.doMock("../plugins/status.js", () => createStatusPluginStatusModuleMock(mocks));
 
   if (options.fastJson) {
+    const mockLoadPluginMetadataSnapshot =
+      mocks.loadPluginMetadataSnapshot ??
+      vi.fn(() => ({
+        policyHash: "test",
+        plugins: [],
+        byPluginId: new Map(),
+        index: { plugins: [], installRecords: [], diagnostics: [] },
+        manifestRegistry: { plugins: [], byPluginId: new Map() },
+        diagnostics: [],
+        registryDiagnostics: [],
+        owners: {
+          channels: new Map(),
+          channelConfigs: new Map(),
+          providers: new Map(),
+          modelCatalogProviders: new Map(),
+          cliBackends: new Map(),
+          setupProviders: new Map(),
+          commandAliases: new Map(),
+          contracts: new Map(),
+        },
+        metrics: {
+          registrySnapshotMs: 0,
+          manifestRegistryMs: 0,
+          ownerMapsMs: 0,
+          totalMs: 0,
+          indexPluginCount: 0,
+          manifestPluginCount: 0,
+        },
+        normalizePluginId: (id: string) => id,
+      }));
+    vi.doMock("../plugins/plugin-metadata-snapshot.js", () => ({
+      loadPluginMetadataSnapshot: mockLoadPluginMetadataSnapshot,
+    }));
     return await import("./status.scan.fast-json.js");
   }
   return await import("./status.scan.js");

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -721,9 +721,10 @@ vi.mock("../plugins/status.js", () => ({
 }));
 
 vi.mock("./status.scan.fast-json.js", () => ({
-  scanStatusJsonFast: vi.fn(async () =>
-    createMockStatusScanResult({ includePluginCompatibility: false }),
-  ),
+  scanStatusJsonFast: vi.fn(async () => ({
+    scan: await createMockStatusScanResult({ includePluginCompatibility: false }),
+    metadataSnapshot: undefined,
+  })),
 }));
 
 vi.mock("./status.scan.js", () => ({


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw status --json --all` traverses all 97 bundled plugin manifest files from disk twice per invocation — once in the channel-presence check (`hasConfiguredChannelsForReadOnlyScope` → `loadPluginManifestRegistryForPluginRegistry`) and once in the security audit (`resolveReadOnlyChannelPluginsForConfig` → `loadPluginMetadataSnapshot`). Each traversal calls `discoverOpenClawPlugins` which does `readdirSync`/`statSync` over every bundled plugin directory.
- **Why it matters:** Redundant filesystem traversal on every `status --json --all` call, worsened on slow or network-mounted filesystems (issue reports ~27s total). The two scans load the same source files with no sharing.
- **What changed:** `scanStatusJsonFast` now builds a single `PluginMetadataSnapshot` during the channel-presence callback (where `cfg` is already available), passes its `plugins` as `manifestRecords` to `hasConfiguredChannelsForReadOnlyScope` (eliminating the separate registry load), and returns the snapshot alongside the scan result as `{ scan, metadataSnapshot }`. The snapshot is threaded through `runStatusJsonCommand` → `resolveStatusJsonOutput` → `resolveStatusRuntimeSnapshot` → `resolveStatusSecurityAudit` → `resolveReadOnlyChannelPluginsForConfig`. `ReadOnlyChannelPluginOptions` gains a new optional `metadataSnapshot?` field; when set, `resolveReadOnlyChannelPluginsForConfig` skips `loadPluginMetadataSnapshot`.
- **What did NOT change:** `scanStatusJsonWithPolicy` return type is unchanged. The non-fast `status` path, gateway scan, channel plugin loading, security audit logic, and all plugin boundary contracts are untouched. External callers of `resolveReadOnlyChannelPluginsForConfig` that omit `metadataSnapshot` behave identically.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78461
- Related #77948, #78639, #63552
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** `status --json --all` called `loadPluginMetadataSnapshot` (full 97-file scan) twice per run.
- **Real environment tested:** Local Linux dev box, Node 22, openclaw from repo root.
- **Exact steps or command run after this patch:** `pnpm test src/commands/status.scan.fast-json.test.ts`
- **Evidence after fix:**
  ```
  ✓ builds the plugin metadata snapshot exactly once and returns it for reuse
  Tests  8 passed (8)
  ```
  New test asserts `loadPluginMetadataSnapshot` mock is called exactly once and that `metadataSnapshot` in the return value is the same object reference.
- **Observed result after fix:** `loadPluginMetadataSnapshot` called once, snapshot reused for security audit.
- **What was not tested:** Live timing on a slow/NFS filesystem.
- **Before evidence:** N/A (unit test demonstrates the call-count regression the previous code had).

## Root Cause (if applicable)

- **Root cause:** `hasConfiguredChannelsForReadOnlyScope` and `resolveReadOnlyChannelPluginsForConfig` each independently loaded plugin manifests from disk. No shared handle was passed between the channel-presence check (scan phase) and the security audit (output phase) — two separate invocation sites with no shared result.
- **Missing detection / guardrail:** No test asserted that `loadPluginMetadataSnapshot` was called at most once per `status --json` run.
- **Contributing context:** The scan phase (`scanStatusJsonFast`) and the output phase (`resolveStatusJsonOutput`) were separate function calls in `runStatusJsonCommand` with no shared state, making it easy for each phase to independently re-derive the same data.

## Regression Test Plan (if applicable)

- **Coverage level that should have caught this:**
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/commands/status.scan.fast-json.test.ts`
- **Scenario the test should lock in:** `scanStatusJsonFast` calls `loadPluginMetadataSnapshot` exactly once and returns the snapshot in `metadataSnapshot` for downstream reuse.
- **Why this is the smallest reliable guardrail:** Directly mocks and counts calls to `loadPluginMetadataSnapshot`, proving no second scan occurs at the boundary where the duplication existed.
- **Existing test that already covers this (if any):** None.
- **If no new test is added, why not:** A new test was added.

## User-visible / Behavior Changes

`openclaw status --json --all` performs one fewer full filesystem traversal of all bundled plugin manifests. No behavioral output change.

## Diagram (if applicable)

```text
Before (status --json --all):
scanStatusJsonFast → hasConfiguredChannelsForReadOnlyScope
                       → loadPluginManifestRegistryForPluginRegistry  ← disk scan #1 (97 files)
resolveStatusJsonOutput → resolveStatusSecurityAudit
                           → resolveReadOnlyChannelPluginsForConfig
                               → loadPluginMetadataSnapshot            ← disk scan #2 (97 files)

After (status --json --all):
scanStatusJsonFast → resolveHasConfiguredChannels callback
                       → loadPluginMetadataSnapshot                    ← disk scan #1 (97 files)
                       → hasConfiguredChannelsForReadOnlyScope(manifestRecords: snapshot.plugins)
resolveStatusJsonOutput(metadataSnapshot: snapshot)
  → resolveStatusSecurityAudit(metadataSnapshot: snapshot)
    → resolveReadOnlyChannelPluginsForConfig(metadataSnapshot: snapshot)  ← no disk scan, reuses snapshot
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 22.04)
- Runtime/container: Node 22, local
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): any openclaw config with at least one channel

### Steps

1. Before: add a `console.count` probe to `loadPluginMetadataSnapshot`, run `openclaw status --json --all`, observe count = 2
2. Apply patch
3. Run same command, observe count = 1

### Expected

- `loadPluginMetadataSnapshot` called once per `status --json --all` run

### Actual

- `loadPluginMetadataSnapshot` called once (confirmed by new unit test mock call count assertion)

## Evidence

- [x] Failing test/log before + passing after

New test `"builds the plugin metadata snapshot exactly once and returns it for reuse"` verifies call count = 1 and reference identity of the returned snapshot.

```
Test Files  4 passed (4)
     Tests  29 passed (29)
```

## Human Verification (required)

- **Verified scenarios:** `status --json` (base case, 1 scan), `status --json --all` (security audit path, now 1 scan instead of 2), missing-config fast path (snapshot is `undefined`, falls back gracefully).
- **Edge cases checked:** If `resolveHasConfiguredChannels` is skipped (missing-config fast path), `metadataSnapshot` remains `undefined` and `resolveReadOnlyChannelPluginsForConfig` falls back to its own `loadPluginMetadataSnapshot` — no regression.
- **What you did not verify:** Live timing on slow/NFS filesystems.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: `metadataSnapshot` built without explicit `workspaceDir` in `resolveHasConfiguredChannels` could differ from what `resolveReadOnlyChannelPluginsForConfig` would compute.
  - Mitigation: Both derive `workspaceDir` from the same `cfg` object using the same default logic. The status path never passes an explicit `workspaceDir` option to `resolveReadOnlyChannelPluginsForConfig`.