### PR TITLE
[codex] Preserve recent tail for empty manual compact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/compaction: keep the recent tail after manual `/compact` when Pi returns an empty or no-op compaction summary, preventing blank checkpoints from replacing the live context.
 - fix(discord): gate user allowlist name resolution [AI]. (#79002) Thanks @pgondhi987.
 - fix(msteams): gate startup user allowlist resolution [AI]. (#79003) Thanks @pgondhi987.
 - Harden macOS shell wrapper allowlist parsing [AI]. (#78518) Thanks @pgondhi987.

--- a/src/agents/pi-embedded-runner/manual-compaction-boundary.test.ts
+++ b/src/agents/pi-embedded-runner/manual-compaction-boundary.test.ts
@@ -157,6 +157,67 @@ describe("hardenManualCompactionBoundary", () => {
     ]);
   });
 
+  it("keeps the recent tail when manual compaction produced an empty summary", async () => {
+    const dir = await makeTmpDir();
+    const session = SessionManager.create(dir, dir);
+
+    session.appendMessage({ role: "user", content: "old question", timestamp: 1 });
+    session.appendMessage(createAssistantTextMessage("old answer", 2));
+    session.appendMessage({ role: "user", content: "fresh question", timestamp: 3 });
+    const keepId = requireString(session.getBranch().at(-1)?.id, "keep id");
+    session.appendMessage(createAssistantTextMessage("fresh answer", 4));
+    session.appendCompaction("", keepId, 200);
+    const sessionFile = requireString(session.getSessionFile(), "session file");
+
+    const hardened = await hardenManualCompactionBoundary({ sessionFile });
+    expect(hardened.applied).toBe(false);
+    expect(hardened.firstKeptEntryId).toBe(keepId);
+    expect(hardened.messages.map((message) => message.role)).toEqual([
+      "compactionSummary",
+      "user",
+      "assistant",
+    ]);
+    expect(hardened.messages.map((message) => messageText(message)).join("\n")).toContain(
+      "fresh question",
+    );
+
+    const reopened = SessionManager.open(sessionFile);
+    const latest = reopened.getLeafEntry();
+    expect(latest?.type).toBe("compaction");
+    if (!latest || latest.type !== "compaction") {
+      throw new Error("expected latest leaf to be a compaction entry");
+    }
+    expect(latest.firstKeptEntryId).toBe(keepId);
+  });
+
+  it("keeps the recent tail when manual compaction had no messages to summarize", async () => {
+    const dir = await makeTmpDir();
+    const session = SessionManager.create(dir, dir);
+
+    session.appendMessage({ role: "user", content: "fresh question", timestamp: 1 });
+    const keepId = requireString(session.getBranch().at(-1)?.id, "keep id");
+    session.appendMessage(createAssistantTextMessage("fresh answer", 2));
+    session.appendCompaction("No prior history.", keepId, 200);
+    const sessionFile = requireString(session.getSessionFile(), "session file");
+
+    const hardened = await hardenManualCompactionBoundary({ sessionFile });
+    expect(hardened.applied).toBe(false);
+    expect(hardened.firstKeptEntryId).toBe(keepId);
+    expect(hardened.messages.map((message) => message.role)).toEqual([
+      "compactionSummary",
+      "user",
+      "assistant",
+    ]);
+
+    const reopened = SessionManager.open(sessionFile);
+    const latest = reopened.getLeafEntry();
+    expect(latest?.type).toBe("compaction");
+    if (!latest || latest.type !== "compaction") {
+      throw new Error("expected latest leaf to be a compaction entry");
+    }
+    expect(latest.firstKeptEntryId).toBe(keepId);
+  });
+
   it("is a no-op when the latest leaf is not a compaction entry", async () => {
     const dir = await makeTmpDir();
     const session = SessionManager.create(dir, dir);

--- a/src/agents/pi-embedded-runner/manual-compaction-boundary.ts
+++ b/src/agents/pi-embedded-runner/manual-compaction-boundary.ts
@@ -33,6 +33,42 @@ function replaceLatestCompactionBoundary(params: {
   });
 }
 
+function entryCreatesCompactionInputMessage(entry: SessionEntry): boolean {
+  return (
+    entry.type === "message" || entry.type === "custom_message" || entry.type === "branch_summary"
+  );
+}
+
+function hasMessagesToSummarizeBeforeKeptTail(params: {
+  branch: SessionEntry[];
+  compaction: CompactionEntry;
+}): boolean {
+  const compactionIndex = params.branch.findIndex((entry) => entry.id === params.compaction.id);
+  const firstKeptIndex = params.branch.findIndex(
+    (entry) => entry.id === params.compaction.firstKeptEntryId,
+  );
+  if (compactionIndex <= 0 || firstKeptIndex < 0 || firstKeptIndex >= compactionIndex) {
+    return false;
+  }
+
+  let boundaryStartIndex = 0;
+  for (let i = compactionIndex - 1; i >= 0; i -= 1) {
+    const entry = params.branch[i];
+    if (entry?.type !== "compaction") {
+      continue;
+    }
+    const previousFirstKeptIndex = params.branch.findIndex(
+      (candidate) => candidate.id === entry.firstKeptEntryId,
+    );
+    boundaryStartIndex = previousFirstKeptIndex >= 0 ? previousFirstKeptIndex : i + 1;
+    break;
+  }
+
+  return params.branch
+    .slice(boundaryStartIndex, firstKeptIndex)
+    .some((entry) => entryCreatesCompactionInputMessage(entry));
+}
+
 export async function hardenManualCompactionBoundary(params: {
   sessionFile: string;
   preserveRecentTail?: boolean;
@@ -56,8 +92,8 @@ export async function hardenManualCompactionBoundary(params: {
     };
   }
 
+  const sessionContext = state.buildSessionContext();
   if (params.preserveRecentTail) {
-    const sessionContext = state.buildSessionContext();
     return {
       applied: false,
       firstKeptEntryId: leaf.firstKeptEntryId,
@@ -67,10 +103,24 @@ export async function hardenManualCompactionBoundary(params: {
   }
 
   if (leaf.firstKeptEntryId === leaf.id) {
-    const sessionContext = state.buildSessionContext();
     return {
       applied: false,
       firstKeptEntryId: leaf.id,
+      leafId: state.getLeafId() ?? undefined,
+      messages: sessionContext.messages,
+    };
+  }
+
+  if (
+    !leaf.summary.trim() ||
+    !hasMessagesToSummarizeBeforeKeptTail({
+      branch: state.getBranch(leaf.id),
+      compaction: leaf,
+    })
+  ) {
+    return {
+      applied: false,
+      firstKeptEntryId: leaf.firstKeptEntryId,
       leafId: state.getLeafId() ?? undefined,
       messages: sessionContext.messages,
     };
@@ -86,11 +136,11 @@ export async function hardenManualCompactionBoundary(params: {
   });
   await writeTranscriptFileAtomic(params.sessionFile, [header, ...replacedEntries]);
 
-  const sessionContext = replacedState.buildSessionContext();
+  const replacedSessionContext = replacedState.buildSessionContext();
   return {
     applied: true,
     firstKeptEntryId: leaf.id,
     leafId: replacedState.getLeafId() ?? undefined,
-    messages: sessionContext.messages,
+    messages: replacedSessionContext.messages,
   };
 }


### PR DESCRIPTION
## Summary

Manual `/compact` is unsafe in current OpenClaw when Pi prepares a compaction with no messages to summarize. This PR keeps manual compaction boundary hardening from rewriting those empty/no-op compactions into hard checkpoints, preserving the useful recent tail instead.

## Observed Behavior

A Telegram Pi session had real conversation history. Running `/compact` produced a checkpoint summary saying no conversation content was provided. The active session then dropped to only the empty compaction summary, losing the useful prior chat context.

## Root Cause

Pi compaction can return a valid preparation with `messagesToSummarize: 0` when the actual transcript is below its `keepRecentTokens` threshold. It still calls the summarizer, so the model receives empty `<conversation>` tags and writes a no-content summary.

OpenClaw then hardens manual compaction by rewriting `firstKeptEntryId` to the compaction entry itself, so rebuilt context starts at the empty summary and drops the kept recent messages.

## Culprit Commit

`f4fcaa09a358347e9715067e1058c00b0f4567a1` (`feat(gateway): add compaction checkpoints`, #62146) added `src/agents/pi-embedded-runner/manual-compaction-boundary.ts` and wired manual compaction to call `hardenManualCompactionBoundary()` in `src/agents/pi-embedded-runner/compact.ts`.

That hardener changed manual compaction's `firstKeptEntryId` to the compaction entry id itself.

## Impact

Manual `/compact` can erase usable session context in edge cases. Auto compaction is less dangerous because it does not call the manual hardener, so it may keep recent messages even if the summary is bad. This is not caused by the recent sort-selection performance commits.

## Fix

Do not harden a manual compaction when the saved summary is blank or when the compaction input has no summarizable messages before the kept tail. In those cases, preserve Pi's recent tail instead of rewriting the boundary.

## Verification

- `pnpm test src/agents/pi-embedded-runner/manual-compaction-boundary.test.ts -- --reporter=verbose`
- `pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-runner/manual-compaction-boundary.ts src/agents/pi-embedded-runner/manual-compaction-boundary.test.ts`
- `git diff --check -- src/agents/pi-embedded-runner/manual-compaction-boundary.ts src/agents/pi-embedded-runner/manual-compaction-boundary.test.ts CHANGELOG.md`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`



## Real behavior proof

- Behavior or issue addressed: Manual `/compact` on a Pi-backed gateway session with no summarizable messages must not turn an empty summary into a hard checkpoint that drops the recent conversation tail.
- Real environment tested: Local macOS OpenClaw gateway from this PR branch, isolated temporary OpenClaw home/state, loopback gateway, Pi session storage, and a local OpenAI-compatible provider shim that returned an empty streamed compaction summary.
- Exact steps or command run after this patch: Ran a `pnpm tsx` live script that seeded a Pi session with a fresh user/assistant tail, started `node scripts/run-node.mjs gateway --port <loopback-port> --bind loopback --allow-unconfigured`, called the real `sessions.compact` gateway RPC, then rebuilt session context from disk.
- Evidence after fix: Terminal transcript:
```text
compactRpcReturnedCompacted: true
providerSawEmptyConversation: true
compactionFirstKeptPreserved: true
compactionDidNotSelfBoundary: true
contextRolesPreserveTail: true
contextContainsFreshQuestion: true
contextContainsFreshAnswer: true
providerCalls: 1
summaryLength: 0
tokensAfter: 20
roles: ["compactionSummary","user","assistant"]
```
- Observed result after fix: The gateway completed manual compact while the provider saw an empty `<conversation>`, but the compaction entry preserved Pi's original `firstKeptEntryId`; rebuilt context still included the fresh user question and assistant answer after the empty compaction summary.
- What was not tested: No known gaps.
