### PR TITLE
fix(auth): propagate scope-mismatch reason instead of collapsing to device_token_mismatch

### DIFF
--- a/src/gateway/protocol/connect-error-details.ts
+++ b/src/gateway/protocol/connect-error-details.ts
@@ -11,6 +11,7 @@ export const ConnectErrorDetailCodes = {
   AUTH_PASSWORD_NOT_CONFIGURED: "AUTH_PASSWORD_NOT_CONFIGURED", // pragma: allowlist secret
   AUTH_BOOTSTRAP_TOKEN_INVALID: "AUTH_BOOTSTRAP_TOKEN_INVALID",
   AUTH_DEVICE_TOKEN_MISMATCH: "AUTH_DEVICE_TOKEN_MISMATCH",
+  AUTH_DEVICE_TOKEN_SCOPE_MISMATCH: "AUTH_DEVICE_TOKEN_SCOPE_MISMATCH",
   AUTH_RATE_LIMITED: "AUTH_RATE_LIMITED",
   AUTH_TAILSCALE_IDENTITY_MISSING: "AUTH_TAILSCALE_IDENTITY_MISSING",
   AUTH_TAILSCALE_PROXY_MISSING: "AUTH_TAILSCALE_PROXY_MISSING",
@@ -158,6 +159,8 @@ export function resolveAuthConnectErrorDetailCode(
       return ConnectErrorDetailCodes.AUTH_RATE_LIMITED;
     case "device_token_mismatch":
       return ConnectErrorDetailCodes.AUTH_DEVICE_TOKEN_MISMATCH;
+    case "scope_mismatch":
+      return ConnectErrorDetailCodes.AUTH_DEVICE_TOKEN_SCOPE_MISMATCH;
     case undefined:
       return ConnectErrorDetailCodes.AUTH_REQUIRED;
     default:

--- a/src/gateway/server/ws-connection/auth-context.test.ts
+++ b/src/gateway/server/ws-connection/auth-context.test.ts
@@ -126,6 +126,27 @@ describe("resolveConnectAuthDecision", () => {
     expect(decision.authResult.reason).toBe("device_token_mismatch");
   });
 
+  it("reports scope-mismatch from verifyDeviceToken as scope_mismatch (not device_token_mismatch)", async () => {
+    const verifyDeviceToken = vi.fn<VerifyDeviceTokenFn>(async () => ({
+      ok: false,
+      reason: "scope-mismatch",
+    }));
+    const decision = await resolveConnectAuthDecision({
+      state: createBaseState({
+        deviceTokenCandidateSource: "explicit-device-token",
+      }),
+      hasDeviceIdentity: true,
+      deviceId: "dev-1",
+      publicKey: "pub-1",
+      role: "operator",
+      scopes: ["operator.read", "operator.admin"],
+      verifyBootstrapToken: async () => ({ ok: false, reason: "bootstrap_token_invalid" }),
+      verifyDeviceToken,
+    });
+    expect(decision.authOk).toBe(false);
+    expect(decision.authResult.reason).toBe("scope_mismatch");
+  });
+
   it("accepts valid device tokens and marks auth method as device-token", async () => {
     const rateLimiter = createRateLimiter();
     const verifyDeviceToken = vi.fn<VerifyDeviceTokenFn>(async () => ({ ok: true }));

--- a/src/gateway/server/ws-connection/auth-context.ts
+++ b/src/gateway/server/ws-connection/auth-context.ts
@@ -32,7 +32,7 @@ export type ConnectAuthState = {
   deviceTokenCandidateSource?: DeviceTokenCandidateSource;
 };
 
-type VerifyDeviceTokenResult = { ok: boolean };
+type VerifyDeviceTokenResult = { ok: boolean; reason?: string };
 type VerifyBootstrapTokenResult = { ok: boolean; reason?: string };
 
 export type ConnectAuthDecision = {
@@ -214,10 +214,12 @@ export async function resolveConnectAuthDecision(params: {
         params.rateLimiter?.reset(params.clientIp, AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET);
       }
     } else {
+      const isScopeMismatch = tokenCheck.reason === "scope-mismatch";
       authResult = {
         ok: false,
-        reason:
-          params.state.deviceTokenCandidateSource === "explicit-device-token"
+        reason: isScopeMismatch
+          ? "scope_mismatch"
+          : params.state.deviceTokenCandidateSource === "explicit-device-token"
             ? "device_token_mismatch"
             : (authResult.reason ?? "device_token_mismatch"),
       };

--- a/src/gateway/server/ws-connection/auth-messages.ts
+++ b/src/gateway/server/ws-connection/auth-messages.ts
@@ -55,6 +55,8 @@ export function formatGatewayAuthFailureMessage(params: {
       return "unauthorized: too many failed authentication attempts (retry later)";
     case "device_token_mismatch":
       return "unauthorized: device token mismatch (rotate/reissue device token)";
+    case "scope_mismatch":
+      return "unauthorized: device token scope mismatch (re-pair or approve scope upgrade in Control UI)";
     default:
       break;
   }


### PR DESCRIPTION
## Summary

Fixes #79292

When `verifyDeviceToken` returns `{ ok: false, reason: 'scope-mismatch' }`, `resolveConnectAuthDecision` was discarding that reason and always emitting `device_token_mismatch`. This caused the gateway to show users a misleading error ("rotate/reissue device token") when the actual problem is that the connecting client requested scopes beyond what the stored device token allows — specifically `operator.admin` and `operator.pairing` which bootstrap tokens do not include.

## Root cause

`VerifyDeviceTokenResult` was typed as `{ ok: boolean }` with no `reason` field, so the scope-mismatch reason from `verifyDeviceToken` was silently lost. `resolveConnectAuthDecision` then fell back to the generic `device_token_mismatch` string for explicit device tokens.

## Changes

- **`auth-context.ts`**: Widen `VerifyDeviceTokenResult` to include `reason?: string`. When the reason is `scope-mismatch`, propagate it as `scope_mismatch` on the auth result instead of using the generic fallback.
- **`connect-error-details.ts`**: Add `AUTH_DEVICE_TOKEN_SCOPE_MISMATCH` error code and map `scope_mismatch` reason in `resolveAuthConnectErrorDetailCode`.
- **`auth-messages.ts`**: Add human-readable message for `scope_mismatch`: *"unauthorized: device token scope mismatch (re-pair or approve scope upgrade in Control UI)"*
- **`auth-context.test.ts`**: Regression test verifying scope-mismatch propagation.

## Before / After

| Scenario | Before | After |
|---|---|---|
| Client requests `operator.admin` but token only has 4 bootstrap scopes | `device_token_mismatch` → "rotate/reissue device token" | `scope_mismatch` → "device token scope mismatch (re-pair or approve scope upgrade)" |
| Token value actually wrong | `device_token_mismatch` (correct) | `device_token_mismatch` (unchanged) |

## Testing

```
pnpm vitest run src/gateway/server/ws-connection/auth-context.test.ts
# 10 tests, all pass
```

## Real behavior proof

Executed directly on a running OpenClaw host (Node v25.5.0, 2026-05-08T08:37:58Z). Demonstrates the before/after behavior of the auth decision function:

**Scenario A: client requests `operator.admin` (scope-mismatch from `verifyDeviceToken`)**
```
BEFORE fix: device_token_mismatch
AFTER fix:  scope_mismatch
```

**Scenario B: token value is actually wrong (genuine mismatch — unchanged)**
```
BEFORE fix: device_token_mismatch
AFTER fix:  device_token_mismatch
```

**User-facing error message:**
```
scope-mismatch BEFORE: "unauthorized: device token mismatch (rotate/reissue device token)"
scope-mismatch AFTER:  "unauthorized: device token scope mismatch (re-pair or approve scope upgrade in Control UI)"
```

macOS/iOS/Control UI clients request `operator.admin` + `operator.pairing` on connect, but bootstrap tokens only include 4 scopes. Before this fix, `verifyDeviceToken` returned `scope-mismatch` but `resolveConnectAuthDecision` discarded it and showed the generic "rotate/reissue device token" message, causing users to delete valid paired devices and re-pair unnecessarily.