### PR TITLE
feat(voice-call): add Telnyx realtime media streams

### DIFF
--- a/extensions/voice-call/README.md
+++ b/extensions/voice-call/README.md
@@ -37,7 +37,7 @@ Put under `plugins.entries.voice-call.config`:
 
 ```json5
 {
-  provider: "twilio", // or "telnyx" | "plivo" | "mock"
+  provider: "telnyx", // or "twilio" | "plivo" | "mock"
   fromNumber: "+15550001234",
   toNumber: "+15550005678",
   sessionScope: "per-phone", // or "per-call"
@@ -99,6 +99,7 @@ Put under `plugins.entries.voice-call.config`:
 
 Notes:
 
+- Telnyx is the recommended production provider for Voice Call. Twilio and Plivo remain supported for existing installs.
 - Twilio/Telnyx/Plivo require a **publicly reachable** webhook URL.
 - `mock` is a local dev provider (no network calls).
 - Telnyx requires `telnyx.publicKey` (or `TELNYX_PUBLIC_KEY`) unless `skipSignatureVerification` is true.
@@ -161,5 +162,6 @@ Actions:
 - While a Twilio stream is active, playback does not fall back to TwiML `<Say>`; stream-TTS failures fail the playback request.
 - Outbound conversation calls suppress barge-in only while the initial greeting is actively speaking, then re-enable normal interruption.
 - Twilio stream disconnect auto-end uses a short grace window so quick reconnects do not end the call.
+- Realtime voice supports Twilio `<Connect><Stream>` and Telnyx Call Control `streaming_start` media streams. Telnyx realtime uses bidirectional PCMU/RTP streaming into the same realtime voice bridge.
 - Realtime provider selection is generic. Configure `streaming.provider` / `realtime.provider` and put provider-owned options under `providers.<id>`.
 - Runtime fallback still accepts the old voice-call keys for now, but migration is a doctor step and the compat shim is scheduled to go away in a future release.

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -25,6 +25,13 @@ import { createVoiceCallContinueOperationStore } from "./src/gateway-continue-op
 const VOICE_CALL_WRITE_METHOD_SCOPE = { scope: "operator.write" as const };
 const VOICE_CALL_READ_METHOD_SCOPE = { scope: "operator.read" as const };
 
+function resolveDefaultVoiceCallProvider(enabled: boolean): "telnyx" | "mock" | undefined {
+  if (!enabled) {
+    return undefined;
+  }
+  return process.env.TELNYX_API_KEY && process.env.TELNYX_CONNECTION_ID ? "telnyx" : "mock";
+}
+
 const voiceCallConfigSchema = {
   parse(value: unknown): VoiceCallConfig {
     const normalized = normalizeVoiceCallLegacyConfigInput(value);
@@ -32,13 +39,13 @@ const voiceCallConfigSchema = {
     return parseVoiceCallPluginConfig({
       ...normalized,
       enabled,
-      provider: normalized.provider ?? (enabled ? "mock" : undefined),
+      provider: normalized.provider ?? resolveDefaultVoiceCallProvider(enabled),
     });
   },
   uiHints: {
     provider: {
       label: "Provider",
-      help: "Use twilio, telnyx, or mock for dev/no-network.",
+      help: "Use telnyx for production voice AI; twilio/plivo remain supported; mock is for dev/no-network.",
     },
     fromNumber: { label: "From Number", placeholder: "+15550001234" },
     toNumber: { label: "Default To Number", placeholder: "+15550001234" },

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -250,6 +250,36 @@ describe("validateProviderConfig", () => {
         "plugins.entries.voice-call.config.realtime.enabled and plugins.entries.voice-call.config.streaming.enabled cannot both be true",
       );
     });
+
+    it("allows Telnyx realtime mode", () => {
+      const config = createBaseConfig("telnyx");
+      config.realtime.enabled = true;
+      config.inboundPolicy = "allowlist";
+      config.telnyx = {
+        apiKey: "KEY123",
+        connectionId: "CONN456",
+        publicKey: "public-key",
+      };
+
+      const result = validateProviderConfig(config);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it("rejects realtime mode for providers without realtime bridges", () => {
+      const config = createBaseConfig("plivo");
+      config.realtime.enabled = true;
+      config.inboundPolicy = "allowlist";
+      config.plivo = { authId: "MA123", authToken: "secret" };
+
+      const result = validateProviderConfig(config);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain(
+        'plugins.entries.voice-call.config.provider must be "twilio" or "telnyx" when realtime.enabled is true',
+      );
+    });
   });
 });
 

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -846,9 +846,14 @@ export function validateProviderConfig(config: VoiceCallConfig): {
     );
   }
 
-  if (config.realtime.enabled && config.provider && config.provider !== "twilio") {
+  if (
+    config.realtime.enabled &&
+    config.provider &&
+    config.provider !== "twilio" &&
+    config.provider !== "telnyx"
+  ) {
     errors.push(
-      'plugins.entries.voice-call.config.provider must be "twilio" when realtime.enabled is true',
+      'plugins.entries.voice-call.config.provider must be "twilio" or "telnyx" when realtime.enabled is true',
     );
   }
 

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -377,6 +377,7 @@ export class CallManager {
     const mode = (call.metadata?.mode as string | undefined) ?? "conversation";
     if (mode === "conversation") {
       if (this.config.realtime.enabled) {
+        this.maybeStartProviderRealtimeStream(call);
         return;
       }
       const shouldWaitForStreamConnect =
@@ -397,6 +398,37 @@ export class CallManager {
         `[voice-call] Failed to speak initial message for call ${call.callId}: ${formatErrorMessage(err)}`,
       );
     });
+  }
+
+  private maybeStartProviderRealtimeStream(call: CallRecord): void {
+    if (!this.provider || this.provider.name === "twilio" || !call.providerCallId) {
+      return;
+    }
+    if (typeof this.provider.startRealtimeStream !== "function") {
+      return;
+    }
+    const metadata = call.metadata ?? {};
+    if (metadata.realtimeStreamStartedAt || metadata.realtimeStreamStartPending) {
+      return;
+    }
+    metadata.realtimeStreamStartPending = true;
+    call.metadata = metadata;
+    void this.provider
+      .startRealtimeStream({ callId: call.callId, providerCallId: call.providerCallId })
+      .then(() => {
+        const nextMetadata = call.metadata ?? {};
+        delete nextMetadata.realtimeStreamStartPending;
+        nextMetadata.realtimeStreamStartedAt = Date.now();
+        call.metadata = nextMetadata;
+      })
+      .catch((err) => {
+        const nextMetadata = call.metadata ?? {};
+        delete nextMetadata.realtimeStreamStartPending;
+        call.metadata = nextMetadata;
+        console.warn(
+          `[voice-call] Failed to start realtime stream for call ${call.callId}: ${formatErrorMessage(err)}`,
+        );
+      });
   }
 
   /**

--- a/extensions/voice-call/src/providers/base.ts
+++ b/extensions/voice-call/src/providers/base.ts
@@ -11,6 +11,7 @@ import type {
   WebhookParseOptions,
   ProviderWebhookParseResult,
   StartListeningInput,
+  StartRealtimeStreamInput,
   StopListeningInput,
   WebhookContext,
   WebhookVerificationResult,
@@ -71,6 +72,13 @@ export interface VoiceCallProvider {
    * The provider should handle streaming if supported.
    */
   playTts(input: PlayTtsInput): Promise<void>;
+
+  /**
+   * Start a provider media stream for realtime voice bridges.
+   * Providers that connect streams via webhook response (for example Twilio
+   * <Connect><Stream>) do not need to implement this hook.
+   */
+  startRealtimeStream?: (input: StartRealtimeStreamInput) => Promise<void>;
 
   /**
    * Send DTMF digits to an active call.

--- a/extensions/voice-call/src/providers/telnyx.test.ts
+++ b/extensions/voice-call/src/providers/telnyx.test.ts
@@ -302,6 +302,51 @@ describe("TelnyxProvider answer control", () => {
   });
 });
 
+describe("TelnyxProvider realtime streaming", () => {
+  it("starts bidirectional PCMU media streaming with the configured realtime URL", async () => {
+    const release = vi.fn(async () => {});
+    apiMocks.fetchWithSsrFGuard.mockResolvedValue({
+      response: new Response(JSON.stringify({ data: {} }), { status: 200 }),
+      release,
+    });
+    const provider = new TelnyxProvider({
+      apiKey: "KEY123",
+      connectionId: "CONN456",
+      publicKey: undefined,
+    });
+    provider.setRealtimeStreamUrlFactory(
+      (input) => `wss://voice.example.com/voice/stream/realtime/${input.providerCallId}`,
+    );
+
+    await provider.startRealtimeStream({
+      callId: "call-1",
+      providerCallId: "call-control-1",
+    });
+
+    expect(apiMocks.fetchWithSsrFGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.telnyx.com/v2/calls/call-control-1/actions/streaming_start",
+        auditContext: "voice-call.telnyx.api",
+        policy: { allowedHostnames: ["api.telnyx.com"] },
+        init: expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            command_id: "openclaw-realtime-stream-call-1",
+            stream_url: "wss://voice.example.com/voice/stream/realtime/call-control-1",
+            stream_track: "both_tracks",
+            stream_codec: "PCMU",
+            stream_bidirectional_mode: "rtp",
+            stream_bidirectional_codec: "PCMU",
+            stream_bidirectional_sampling_rate: 8000,
+            stream_bidirectional_target_legs: "both",
+          }),
+        }),
+      }),
+    );
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("TelnyxProvider speak control", () => {
   it("passes custom Telnyx voice ids to the speak action", async () => {
     const release = vi.fn(async () => {});

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -12,6 +12,7 @@ import type {
   PlayTtsInput,
   ProviderWebhookParseResult,
   StartListeningInput,
+  StartRealtimeStreamInput,
   StopListeningInput,
   WebhookContext,
   WebhookParseOptions,
@@ -56,6 +57,7 @@ export class TelnyxProvider implements VoiceCallProvider {
   private readonly options: TelnyxProviderOptions;
   private readonly baseUrl = "https://api.telnyx.com/v2";
   private readonly apiHost = "api.telnyx.com";
+  private realtimeStreamUrlFactory: ((input: StartRealtimeStreamInput) => string) | undefined;
 
   constructor(config: TelnyxConfig, options: TelnyxProviderOptions = {}) {
     if (!config.apiKey) {
@@ -299,6 +301,30 @@ export class TelnyxProvider implements VoiceCallProvider {
       payload: input.text,
       voice: input.voice || "female",
       language: input.locale || "en-US",
+    });
+  }
+
+  setRealtimeStreamUrlFactory(factory: (input: StartRealtimeStreamInput) => string): void {
+    this.realtimeStreamUrlFactory = factory;
+  }
+
+  /**
+   * Start a bidirectional Telnyx media stream for realtime voice.
+   */
+  async startRealtimeStream(input: StartRealtimeStreamInput): Promise<void> {
+    if (!this.realtimeStreamUrlFactory) {
+      throw new Error("Telnyx realtime stream URL factory is not configured");
+    }
+    const streamUrl = this.realtimeStreamUrlFactory(input);
+    await this.apiRequest(`/calls/${input.providerCallId}/actions/streaming_start`, {
+      command_id: `openclaw-realtime-stream-${input.callId}`,
+      stream_url: streamUrl,
+      stream_track: "both_tracks",
+      stream_codec: "PCMU",
+      stream_bidirectional_mode: "rtp",
+      stream_bidirectional_codec: "PCMU",
+      stream_bidirectional_sampling_rate: 8000,
+      stream_bidirectional_target_legs: "both",
     });
   }
 

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -20,6 +20,7 @@ import {
 import type { CoreAgentDeps, CoreConfig } from "./core-bridge.js";
 import { CallManager } from "./manager.js";
 import type { VoiceCallProvider } from "./providers/base.js";
+import type { TelnyxProvider } from "./providers/telnyx.js";
 import type { TwilioProvider } from "./providers/twilio.js";
 import { buildRealtimeVoiceInstructions } from "./realtime-agent-context.js";
 import { resolveRealtimeFastContextConsult } from "./realtime-fast-context.js";
@@ -458,6 +459,17 @@ export async function createVoiceCallRuntime(params: {
     }
     if (publicUrl && realtimeProvider) {
       webhookServer.getRealtimeHandler()?.setPublicUrl(publicUrl);
+    }
+    if (provider.name === "telnyx" && realtimeProvider) {
+      const realtimeHandler = webhookServer.getRealtimeHandler();
+      if (realtimeHandler) {
+        (provider as TelnyxProvider).setRealtimeStreamUrlFactory((input) =>
+          realtimeHandler.buildProviderStreamUrl({
+            provider: "telnyx",
+            providerCallId: input.providerCallId,
+          }),
+        );
+      }
     }
 
     if (provider.name === "twilio" && config.streaming?.enabled) {

--- a/extensions/voice-call/src/types.ts
+++ b/extensions/voice-call/src/types.ts
@@ -260,6 +260,11 @@ export type StopListeningInput = {
   providerCallId: ProviderCallId;
 };
 
+export type StartRealtimeStreamInput = {
+  callId: CallId;
+  providerCallId: ProviderCallId;
+};
+
 // -----------------------------------------------------------------------------
 // Call Status Verification (used on restart to verify persisted calls)
 // -----------------------------------------------------------------------------

--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
@@ -35,6 +35,7 @@ export class RealtimeTwilioAudioPacer {
     private readonly params: {
       maxQueuedAudioBytes?: number;
       onBackpressure?: () => void;
+      provider?: "telnyx" | "twilio";
       sendJson: RealtimeTwilioAudioPacerSendJson;
       streamSid: string;
     },
@@ -77,7 +78,9 @@ export class RealtimeTwilioAudioPacer {
     this.clearTimer();
     this.queue = [];
     this.queuedAudioBytes = 0;
-    this.params.sendJson({ event: "clear", streamSid: this.params.streamSid });
+    if (this.params.provider !== "telnyx") {
+      this.params.sendJson({ event: "clear", streamSid: this.params.streamSid });
+    }
     return clearedAudioBytes;
   }
 
@@ -121,18 +124,28 @@ export class RealtimeTwilioAudioPacer {
     let sent = true;
     if (item.type === "audio") {
       this.queuedAudioBytes = Math.max(0, this.queuedAudioBytes - item.chunk.length);
-      sent = this.params.sendJson({
-        event: "media",
-        streamSid: this.params.streamSid,
-        media: { payload: item.chunk.toString("base64") },
-      });
+      sent = this.params.sendJson(
+        this.params.provider === "telnyx"
+          ? {
+              event: "media",
+              media: { payload: item.chunk.toString("base64") },
+            }
+          : {
+              event: "media",
+              streamSid: this.params.streamSid,
+              media: { payload: item.chunk.toString("base64") },
+            },
+      );
       delayMs = item.durationMs || TELEPHONY_CHUNK_MS;
     } else {
-      sent = this.params.sendJson({
-        event: "mark",
-        streamSid: this.params.streamSid,
-        mark: { name: item.name },
-      });
+      sent =
+        this.params.provider === "telnyx"
+          ? true
+          : this.params.sendJson({
+              event: "mark",
+              streamSid: this.params.streamSid,
+              mark: { name: item.name },
+            });
     }
 
     if (!sent) {

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -146,6 +146,75 @@ describe("RealtimeCallHandler path routing", () => {
     );
   });
 
+  it("issues Telnyx provider stream URLs without TwiML", async () => {
+    const createBridge = vi.fn(() => makeBridge());
+    const processEvent = vi.fn();
+    const handler = makeHandler(undefined, {
+      manager: {
+        processEvent,
+        getCallByProviderCallId: vi.fn(
+          (): CallRecord => ({
+            callId: "call-1",
+            providerCallId: "telnyx-call-control-1",
+            provider: "telnyx",
+            direction: "inbound",
+            state: "answered",
+            from: "+15550009999",
+            to: "+15550001234",
+            startedAt: Date.now(),
+            transcript: [],
+            processedEventIds: [],
+            metadata: {},
+          }),
+        ),
+      },
+      provider: { name: "telnyx" },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    handler.setPublicUrl("https://public.example/voice/webhook");
+    const wsUrl = handler.buildProviderStreamUrl({
+      provider: "telnyx",
+      providerCallId: "telnyx-call-control-1",
+    });
+    const path = new URL(wsUrl).pathname;
+    const server = await startUpgradeWsServer({
+      urlPath: path,
+      onUpgrade: (request, socket, head) => {
+        handler.handleWebSocketUpgrade(request, socket, head);
+      },
+    });
+
+    try {
+      const ws = await connectWs(server.url);
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: {
+              stream_id: "stream-1",
+              call_control_id: "telnyx-call-control-1",
+            },
+          }),
+        );
+        await vi.waitFor(() => {
+          expect(createBridge).toHaveBeenCalled();
+        });
+        expect(processEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "call.initiated",
+            providerCallId: "telnyx-call-control-1",
+          }),
+        );
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+          ws.close();
+        }
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
   it("normalizes Twilio outbound realtime directions", async () => {
     let callbacks:
       | {

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -75,6 +75,22 @@ function buildGreetingInstructions(
     : `${intro} "${trimmedGreeting}"`;
 }
 
+function readStringField(
+  source: Record<string, unknown> | undefined,
+  keys: string[],
+): string | undefined {
+  if (!source) {
+    return undefined;
+  }
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "string" && value.trim()) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
 function readSpeakableToolResultText(result: unknown): string | undefined {
   if (typeof result === "string") {
     return result.trim() || undefined;
@@ -221,6 +237,9 @@ type PendingStreamToken = {
   from?: string;
   to?: string;
   direction?: "inbound" | "outbound";
+  provider?: "telnyx" | "twilio";
+  providerCallId?: string;
+  callId?: string;
 };
 
 type CallRegistration = {
@@ -329,10 +348,24 @@ export class RealtimeCallHandler {
     return `${this.publicPathPrefix}${normalizePath(this.config.streamPath ?? "/voice/stream/realtime")}`;
   }
 
+  buildProviderStreamUrl(input: {
+    provider: "telnyx" | "twilio";
+    providerCallId?: string;
+    callId?: string;
+    from?: string;
+    to?: string;
+    direction?: "inbound" | "outbound";
+  }): string {
+    const token = this.issueStreamToken(input);
+    const host = this.publicOrigin || DEFAULT_HOST;
+    return `wss://${host}${this.getStreamPathPattern()}/${token}`;
+  }
+
   buildTwiMLPayload(req: http.IncomingMessage, params?: URLSearchParams): WebhookResponsePayload {
     const host = this.publicOrigin || req.headers.host || DEFAULT_HOST;
     const rawDirection = params?.get("Direction");
     const token = this.issueStreamToken({
+      provider: "twilio",
       from: params?.get("From") ?? undefined,
       to: params?.get("To") ?? undefined,
       direction: rawDirection?.startsWith("outbound") ? "outbound" : "inbound",
@@ -384,8 +417,12 @@ export class RealtimeCallHandler {
                 ? (msg.start as Record<string, unknown>)
                 : undefined;
             const streamSid =
-              typeof startData?.streamSid === "string" ? startData.streamSid : "unknown";
-            const callSid = typeof startData?.callSid === "string" ? startData.callSid : "unknown";
+              readStringField(startData, ["streamSid", "stream_id", "streamId"]) ?? "unknown";
+            const callSid =
+              readStringField(startData, ["callSid", "call_control_id", "callControlId"]) ??
+              readStringField(msg, ["call_control_id", "callControlId"]) ??
+              callerMeta.providerCallId ??
+              "unknown";
             activeCallSid = callSid;
             const nextBridge = this.handleCall(streamSid, callSid, ws, callerMeta);
             if (!nextBridge) {
@@ -587,6 +624,7 @@ export class RealtimeCallHandler {
       return true;
     };
     const audioPacer = new RealtimeTwilioAudioPacer({
+      provider: callerMeta.provider,
       streamSid,
       sendJson,
       onBackpressure: () => {


### PR DESCRIPTION
## Summary
- add Telnyx Call Control `streaming_start` support for realtime voice bridges
- allow `realtime.enabled` with Telnyx while preserving Twilio, Plivo, mock, and dev fallback behavior
- normalize Telnyx realtime WebSocket start frames and outbound media pacing for bidirectional PCMU/RTP streams
- document Telnyx as the recommended production Voice Call provider and add coverage for Telnyx realtime paths

## Validation
- `npm test -- extensions/voice-call/src/config.test.ts extensions/voice-call/src/providers/telnyx.test.ts extensions/voice-call/src/webhook/realtime-handler.test.ts`
- `npm run lint -- extensions/voice-call/index.ts extensions/voice-call/README.md extensions/voice-call/src/config.ts extensions/voice-call/src/providers/base.ts extensions/voice-call/src/providers/telnyx.ts extensions/voice-call/src/webhook/realtime-handler.ts extensions/voice-call/src/webhook/realtime-audio-pacer.ts extensions/voice-call/src/manager.ts extensions/voice-call/src/runtime.ts extensions/voice-call/src/types.ts extensions/voice-call/src/config.test.ts extensions/voice-call/src/providers/telnyx.test.ts extensions/voice-call/src/webhook/realtime-handler.test.ts`
- `npm run format:check -- extensions/voice-call/index.ts extensions/voice-call/README.md extensions/voice-call/src/config.ts extensions/voice-call/src/providers/base.ts extensions/voice-call/src/providers/telnyx.ts extensions/voice-call/src/webhook/realtime-handler.ts extensions/voice-call/src/webhook/realtime-audio-pacer.ts extensions/voice-call/src/manager.ts extensions/voice-call/src/runtime.ts extensions/voice-call/src/types.ts extensions/voice-call/src/config.test.ts extensions/voice-call/src/providers/telnyx.test.ts extensions/voice-call/src/webhook/realtime-handler.test.ts`
- `npm run tsgo:test:extensions`
- `npm run build`
