### PR TITLE
fix(daemon): include Homebrew paths in LaunchAgent env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,7 @@ Docs: https://docs.openclaw.ai
 - fix(msteams): gate startup user allowlist resolution [AI]. (#79003) Thanks @pgondhi987.
 - Harden macOS shell wrapper allowlist parsing [AI]. (#78518) Thanks @pgondhi987.
 - macOS/config: reject stale or destructive app fallback config writes before direct replacement and keep rejected payloads as private audit artifacts, so `gateway.mode`, metadata, and auth are not silently clobbered. Fixes #64973 and #74890. Thanks @BunsDev.
+- Gateway/macOS: include Apple Silicon Homebrew bin and sbin directories in generated LaunchAgent service PATHs so `openclaw gateway restart` keeps Homebrew Node installs reachable. Fixes #79232. Thanks @BunsDev.
 - Doctor/OpenAI: stop pinning migrated `openai-codex/*` routes to the Codex runtime so mixed-provider agents keep automatic PI routing for MiniMax, Anthropic, and other non-OpenAI model switches.
 - Gateway/macOS: `openclaw gateway stop` now uses `launchctl bootout` by default instead of unconditionally calling `launchctl disable`, so KeepAlive auto-recovery still works after unexpected crashes; use the new `--disable` flag to opt into the persistent-disable behavior when a manual stop should survive reboots. Fixes #77934. Thanks @bmoran1022.
 - Gateway/macOS: `repairLaunchAgentBootstrap` no longer kickstarts an already-running LaunchAgent, preventing unnecessary service restarts and session disconnects when repair runs against a healthy gateway. Fixes #77428. Thanks @ramitrkar-hash.

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -931,7 +931,7 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
       serviceEnvironment: {
         HOME: "/from-service",
         OPENCLAW_PORT: "3000",
-        PATH: "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+        PATH: "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
         TMPDIR: "/tmp",
       },
     });
@@ -953,7 +953,9 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
       },
     });
 
-    expect(plan.environment.PATH).toBe("/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin");
+    expect(plan.environment.PATH).toBe(
+      "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+    );
   });
 
   it("drops legacy inline env values when the key is now managed by .env", async () => {

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -124,7 +124,8 @@ describe("auditGatewayServiceConfig", () => {
   it("accepts canonical macOS gateway service PATH without user-bin defaults", async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-home-"));
     try {
-      const servicePath = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+      const servicePath =
+        "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
 
       const audit = await auditGatewayServiceConfig({
         env: { HOME: home },

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -113,7 +113,16 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
       existsSync: allExist,
     });
 
-    expect(result).toEqual(["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]);
+    expect(result).toEqual([
+      "/opt/homebrew/bin",
+      "/opt/homebrew/sbin",
+      "/usr/local/bin",
+      "/usr/bin",
+      "/bin",
+      "/usr/sbin",
+      "/sbin",
+    ]);
+    expect(result.some((entry) => entry.startsWith("/Users/testuser/"))).toBe(false);
   });
 
   it("can include env-configured version manager dirs on macOS when requested", () => {
@@ -145,7 +154,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     });
 
     const fnmIndex = result.indexOf("/Users/testuser/.fnm/aliases/default/bin");
-    const systemIndex = result.indexOf("/usr/local/bin");
+    const systemIndex = result.indexOf("/opt/homebrew/bin");
 
     expect(fnmIndex).toBe(-1);
     expect(systemIndex).toBe(0);
@@ -191,7 +200,15 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
       existsSync: noneExist,
     });
 
-    expect(result).toEqual(["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]);
+    expect(result).toEqual([
+      "/opt/homebrew/bin",
+      "/opt/homebrew/sbin",
+      "/usr/local/bin",
+      "/usr/bin",
+      "/bin",
+      "/usr/sbin",
+      "/sbin",
+    ]);
     expect(result).not.toContain("/Users/testuser/.local/bin");
     expect(result).not.toContain("/Users/testuser/.npm-global/bin");
     expect(result).not.toContain("/Users/testuser/bin");
@@ -355,7 +372,15 @@ describe("getMinimalServicePathParts - Nix Home Manager", () => {
     });
 
     expect(result).not.toContain("/Users/testuser/.nix-profile/bin");
-    expect(result).toEqual(["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]);
+    expect(result).toEqual([
+      "/opt/homebrew/bin",
+      "/opt/homebrew/sbin",
+      "/usr/local/bin",
+      "/usr/bin",
+      "/bin",
+      "/usr/sbin",
+      "/sbin",
+    ]);
   });
 
   it("places rightmost NIX_PROFILES entry before leftmost on Linux", () => {
@@ -389,7 +414,15 @@ describe("getMinimalServicePathParts - Nix Home Manager", () => {
     const defaultIdx = result.indexOf("/nix/var/nix/profiles/default/bin");
     expect(userIdx).toBe(-1);
     expect(defaultIdx).toBe(-1);
-    expect(result).toEqual(["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]);
+    expect(result).toEqual([
+      "/opt/homebrew/bin",
+      "/opt/homebrew/sbin",
+      "/usr/local/bin",
+      "/usr/bin",
+      "/bin",
+      "/usr/sbin",
+      "/sbin",
+    ]);
   });
 
   it("includes single Nix profile from NIX_PROFILES on Linux", () => {
@@ -450,7 +483,15 @@ describe("buildMinimalServicePath", () => {
       platform: "darwin",
     });
     const parts = splitPath(result, "darwin");
-    expect(parts).toEqual(["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]);
+    expect(parts).toEqual([
+      "/opt/homebrew/bin",
+      "/opt/homebrew/sbin",
+      "/usr/local/bin",
+      "/usr/bin",
+      "/bin",
+      "/usr/sbin",
+      "/sbin",
+    ]);
   });
 
   it("returns PATH as-is on Windows", () => {
@@ -607,7 +648,9 @@ describe("buildServiceEnvironment", () => {
       platform: "darwin",
     });
 
-    expect(env.PATH).toBe("/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin");
+    expect(env.PATH).toBe(
+      "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+    );
   });
 
   it("falls back to os.tmpdir when TMPDIR is not set on Linux", () => {
@@ -699,7 +742,7 @@ describe("buildServiceEnvironment", () => {
     });
 
     expect(env.PATH).toBe(
-      "/opt/homebrew/Cellar/node/22.16.0/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+      "/opt/homebrew/Cellar/node/22.16.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
     );
   });
 });

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -222,7 +222,15 @@ function addNixProfileBinDirs(
 
 function resolveSystemPathDirs(platform: NodeJS.Platform): string[] {
   if (platform === "darwin") {
-    return ["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"];
+    return [
+      "/opt/homebrew/bin",
+      "/opt/homebrew/sbin",
+      "/usr/local/bin",
+      "/usr/bin",
+      "/bin",
+      "/usr/sbin",
+      "/sbin",
+    ];
   }
   if (platform === "linux") {
     return ["/usr/local/bin", "/usr/bin", "/bin"];


### PR DESCRIPTION
## Summary

- Add `/opt/homebrew/bin` and `/opt/homebrew/sbin` to the canonical Darwin service PATH used for generated LaunchAgent environments.
- Keep macOS service PATH generation narrow: only stable system/Homebrew prefixes are added, while user/workspace/version-manager PATH injection remains filtered out by the existing service path builder.
- Update daemon, install-plan, and audit coverage so `openclaw gateway restart` preserves the Homebrew prefixes instead of regenerating the old Intel-only system PATH.

Fixes #79232.

## Why this is the safest fix

The bug is in the canonical Darwin service PATH, not in restart-specific code. `openclaw gateway restart` regenerates the LaunchAgent service environment through `buildServiceEnvironment`, which flows through `resolveSystemPathDirs("darwin")`. Adding the Apple Silicon Homebrew prefixes there fixes install/restart/audit behavior through the existing single path-policy seam.

This avoids broadening trust to shell manager paths, workspace paths, or ambient user PATH entries. `/opt/homebrew/bin` and `/opt/homebrew/sbin` are stable Homebrew system prefixes on Apple Silicon and match the documented macOS Node install path.

## Verification

- `pnpm docs:list`
- `pnpm test src/daemon/service-env.test.ts src/commands/daemon-install-helpers.test.ts src/commands/daemon-install-plan.shared.test.ts src/daemon/service-audit.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/daemon/service-env.ts src/daemon/service-env.test.ts src/daemon/service-audit.test.ts src/commands/daemon-install-helpers.test.ts CHANGELOG.md`
- `git diff --check origin/main...HEAD`
- Testbox: `pnpm check:changed` passed on https://github.com/openclaw/openclaw/actions/runs/25547677880

Not run: live `openclaw gateway restart` LaunchAgent smoke on this workstation, because it would mutate/restart the local user Gateway service. The generated PATH behavior is covered by the daemon/install/audit tests above.
