### PR TITLE
Harden Telegram QA live harness

### DIFF
--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -599,7 +599,7 @@ jobs:
       published_upgrade_survivor_baselines: ${{ needs.resolve_target.outputs.run_release_soak == 'true' && 'last-stable-4 2026.4.23 2026.5.2 2026.4.15' || '' }}
       published_upgrade_survivor_scenarios: ${{ needs.resolve_target.outputs.run_release_soak == 'true' && 'reported-issues' || '' }}
       telegram_mode: mock-openai
-      telegram_scenarios: telegram-help-command,telegram-commands-command,telegram-tools-compact-command,telegram-whoami-command,telegram-context-command,telegram-current-session-status-tool,telegram-mention-gating
+      telegram_scenarios: telegram-help-command,telegram-commands-command,telegram-tools-compact-command,telegram-whoami-command,telegram-status-command,telegram-other-bot-command-gating,telegram-context-command,telegram-mentioned-message-reply,telegram-reply-chain-exact-marker,telegram-stream-final-single-message,telegram-long-final-reuses-preview,telegram-mention-gating
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -278,7 +278,7 @@ Optional:
 
 - `OPENCLAW_QA_TELEGRAM_CAPTURE_CONTENT=1` keeps message bodies in observed-message artifacts (default redacts).
 
-Scenarios (`extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts:44`):
+Scenarios (`extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts`):
 
 - `telegram-canary`
 - `telegram-mention-gating`
@@ -287,9 +287,16 @@ Scenarios (`extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime
 - `telegram-commands-command`
 - `telegram-tools-compact-command`
 - `telegram-whoami-command`
+- `telegram-status-command`
+- `telegram-other-bot-command-gating`
 - `telegram-context-command`
+- `telegram-current-session-status-tool`
+- `telegram-reply-chain-exact-marker`
+- `telegram-stream-final-single-message`
 - `telegram-long-final-reuses-preview`
 - `telegram-long-final-three-chunks`
+
+The implicit default set always covers canary, mention gating, native command replies, command addressing, and bot-to-bot group replies. `mock-openai` defaults also include deterministic reply-chain and final-message streaming checks. `telegram-current-session-status-tool` remains opt-in because it is only stable when threaded directly after canary, not after arbitrary native command replies. Use `pnpm openclaw qa telegram --list-scenarios --provider-mode mock-openai` to print the current default/optional split with regression refs.
 
 Output artifacts:
 

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -311,6 +311,7 @@ gh workflow run package-acceptance.yml --ref main \
   - Runs the Telegram live QA lane against a real private group using the driver and SUT bot tokens from env.
   - Requires `OPENCLAW_QA_TELEGRAM_GROUP_ID`, `OPENCLAW_QA_TELEGRAM_DRIVER_BOT_TOKEN`, and `OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN`. The group id must be the numeric Telegram chat id.
   - Supports `--credential-source convex` for shared pooled credentials. Use env mode by default, or set `OPENCLAW_QA_CREDENTIAL_SOURCE=convex` to opt into pooled leases.
+  - Defaults cover canary, mention gating, command addressing, `/status`, bot-to-bot mentioned replies, and core native command replies. `mock-openai` defaults also cover deterministic reply-chain and Telegram final-message streaming regressions. Use `--list-scenarios` for optional probes such as `session_status`.
   - Exits non-zero when any scenario fails. Use `--allow-failures` when you
     want artifacts without a failing exit code.
   - Requires two distinct bots in the same private group, with the SUT bot exposing a Telegram username.

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -8,6 +8,7 @@ const {
   runQaSuiteFromRuntime,
   runQaCharacterEval,
   runQaMultipass,
+  listTelegramQaScenarioCatalog,
   runTelegramQaLive,
   startQaLabServer,
   writeQaDockerHarnessFiles,
@@ -19,6 +20,7 @@ const {
   runQaSuiteFromRuntime: vi.fn(),
   runQaCharacterEval: vi.fn(),
   runQaMultipass: vi.fn(),
+  listTelegramQaScenarioCatalog: vi.fn(),
   runTelegramQaLive: vi.fn(),
   startQaLabServer: vi.fn(),
   writeQaDockerHarnessFiles: vi.fn(),
@@ -45,6 +47,7 @@ vi.mock("./multipass.runtime.js", () => ({
 }));
 
 vi.mock("./live-transports/telegram/telegram-live.runtime.js", () => ({
+  listTelegramQaScenarioCatalog,
   runTelegramQaLive,
 }));
 
@@ -111,6 +114,7 @@ describe("qa cli runtime", () => {
     runQaCharacterEval.mockReset();
     runQaManualLane.mockReset();
     runQaMultipass.mockReset();
+    listTelegramQaScenarioCatalog.mockReset();
     runTelegramQaLive.mockReset();
     startQaLabServer.mockReset();
     writeQaDockerHarnessFiles.mockReset();
@@ -153,6 +157,15 @@ describe("qa cli runtime", () => {
       observedMessagesPath: "/tmp/telegram/observed.json",
       scenarios: [],
     });
+    listTelegramQaScenarioCatalog.mockReturnValue([
+      {
+        id: "telegram-status-command",
+        title: "Telegram status command reply",
+        defaultEnabled: true,
+        rationale: "status rationale",
+        regressionRefs: ["openclaw/openclaw#74698"],
+      },
+    ]);
     startQaLabServer.mockResolvedValue({
       baseUrl: "http://127.0.0.1:58000",
       runSelfCheck: vi.fn().mockResolvedValue({
@@ -294,6 +307,22 @@ describe("qa cli runtime", () => {
         providerMode: "live-frontier",
         allowFailures: undefined,
       }),
+    );
+  });
+
+  it("prints telegram scenario catalog without starting the live lane", async () => {
+    await runQaTelegramCommand({
+      repoRoot: "/tmp/openclaw-repo",
+      providerMode: "mock-openai",
+      listScenarios: true,
+    });
+
+    expect(listTelegramQaScenarioCatalog).toHaveBeenCalledWith("mock-openai");
+    expect(runTelegramQaLive).not.toHaveBeenCalled();
+    expect(stdoutWrite).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "telegram-status-command\tdefault\tTelegram status command reply\tstatus rationale refs=openclaw/openclaw#74698",
+      ),
     );
   });
 

--- a/extensions/qa-lab/src/cli.test.ts
+++ b/extensions/qa-lab/src/cli.test.ts
@@ -384,7 +384,7 @@ describe("qa cli registration", () => {
     const optionNames = telegram?.options.map((option) => option.long) ?? [];
 
     expect(optionNames).toEqual(
-      expect.arrayContaining(["--credential-source", "--credential-role"]),
+      expect.arrayContaining(["--credential-source", "--credential-role", "--list-scenarios"]),
     );
   });
 
@@ -434,10 +434,21 @@ describe("qa cli registration", () => {
       fastMode: false,
       allowFailures: false,
       scenarioIds: [],
+      listScenarios: false,
       sutAccountId: "sut",
       credentialSource: undefined,
       credentialRole: undefined,
     });
+  });
+
+  it("forwards --list-scenarios for telegram runs", async () => {
+    await program.parseAsync(["node", "openclaw", "qa", "telegram", "--list-scenarios"]);
+
+    expect(runQaTelegramCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        listScenarios: true,
+      }),
+    );
   });
 
   it("forwards --allow-failures for telegram runs", async () => {

--- a/extensions/qa-lab/src/live-transports/shared/live-transport-cli.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-cli.runtime.test.ts
@@ -10,12 +10,14 @@ describe("resolveLiveTransportQaRunOptions", () => {
         providerMode: "live-frontier",
         primaryModel: " ",
         alternateModel: "",
+        listScenarios: true,
       }),
     ).toMatchObject({
       repoRoot: path.resolve("/tmp/openclaw-repo"),
       providerMode: "live-frontier",
       primaryModel: undefined,
       alternateModel: undefined,
+      listScenarios: true,
     });
   });
 });

--- a/extensions/qa-lab/src/live-transports/shared/live-transport-cli.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-cli.runtime.ts
@@ -31,6 +31,7 @@ export function resolveLiveTransportQaRunOptions(
     fastMode: opts.fastMode,
     allowFailures: opts.allowFailures,
     scenarioIds: opts.scenarioIds,
+    listScenarios: opts.listScenarios,
     sutAccountId: opts.sutAccountId,
     credentialSource: opts.credentialSource?.trim(),
     credentialRole: opts.credentialRole?.trim(),

--- a/extensions/qa-lab/src/live-transports/shared/live-transport-cli.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-cli.ts
@@ -12,6 +12,7 @@ export type LiveTransportQaCommandOptions = {
   fastMode?: boolean;
   allowFailures?: boolean;
   scenarioIds?: string[];
+  listScenarios?: boolean;
   sutAccountId?: string;
   credentialSource?: string;
   credentialRole?: string;
@@ -24,6 +25,7 @@ type LiveTransportQaCommanderOptions = {
   model?: string;
   altModel?: string;
   scenario?: string[];
+  listScenarios?: boolean;
   fast?: boolean;
   allowFailures?: boolean;
   sutAccount?: string;
@@ -61,6 +63,7 @@ function mapLiveTransportQaCommanderOptions(
     fastMode: opts.fast,
     allowFailures: opts.allowFailures,
     scenarioIds: opts.scenario,
+    listScenarios: opts.listScenarios,
     sutAccountId: opts.sutAccount,
     credentialSource: opts.credentialSource,
     credentialRole: opts.credentialRole,
@@ -72,6 +75,7 @@ function registerLiveTransportQaCli(params: {
   commandName: string;
   credentialOptions?: LiveTransportQaCredentialCliOptions;
   description: string;
+  listScenariosHelp?: string;
   outputDirHelp: string;
   scenarioHelp: string;
   sutAccountHelp: string;
@@ -94,6 +98,10 @@ function registerLiveTransportQaCli(params: {
     )
     .option("--sut-account <id>", params.sutAccountHelp, "sut");
 
+  if (params.listScenariosHelp) {
+    command.option("--list-scenarios", params.listScenariosHelp, false);
+  }
+
   if (params.credentialOptions) {
     command.option(
       "--credential-source <source>",
@@ -114,6 +122,7 @@ export function createLiveTransportQaCliRegistration(params: {
   commandName: string;
   credentialOptions?: LiveTransportQaCredentialCliOptions;
   description: string;
+  listScenariosHelp?: string;
   outputDirHelp: string;
   scenarioHelp: string;
   sutAccountHelp: string;
@@ -127,6 +136,7 @@ export function createLiveTransportQaCliRegistration(params: {
         commandName: params.commandName,
         credentialOptions: params.credentialOptions,
         description: params.description,
+        listScenariosHelp: params.listScenariosHelp,
         outputDirHelp: params.outputDirHelp,
         scenarioHelp: params.scenarioHelp,
         sutAccountHelp: params.sutAccountHelp,

--- a/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts
@@ -3,10 +3,21 @@ import {
   printLiveTransportQaArtifacts,
   resolveLiveTransportQaRunOptions,
 } from "../shared/live-transport-cli.runtime.js";
-import { runTelegramQaLive } from "./telegram-live.runtime.js";
+import { listTelegramQaScenarioCatalog, runTelegramQaLive } from "./telegram-live.runtime.js";
 
 export async function runQaTelegramCommand(opts: LiveTransportQaCommandOptions) {
   const runOptions = resolveLiveTransportQaRunOptions(opts);
+  if (runOptions.listScenarios) {
+    for (const scenario of listTelegramQaScenarioCatalog(runOptions.providerMode)) {
+      const defaultLabel = scenario.defaultEnabled ? "default" : "optional";
+      const refs =
+        scenario.regressionRefs.length > 0 ? ` refs=${scenario.regressionRefs.join(",")}` : "";
+      process.stdout.write(
+        `${scenario.id}\t${defaultLabel}\t${scenario.title}\t${scenario.rationale}${refs}\n`,
+      );
+    }
+    return;
+  }
   const result = await runTelegramQaLive(runOptions);
   printLiveTransportQaArtifacts("Telegram QA", {
     report: result.reportPath,

--- a/extensions/qa-lab/src/live-transports/telegram/cli.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/cli.ts
@@ -25,6 +25,7 @@ export const telegramQaCliRegistration: LiveTransportQaCliRegistration =
         "Credential role for convex auth: maintainer or ci (default: ci in CI, maintainer otherwise)",
     },
     description: "Run the manual Telegram live QA lane against a private bot-to-bot group harness",
+    listScenariosHelp: "Print available Telegram scenario ids and exit",
     outputDirHelp: "Telegram QA artifact directory",
     scenarioHelp: "Run only the named Telegram QA scenario (repeatable)",
     sutAccountHelp: "Temporary Telegram account id inside the QA gateway config",

--- a/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts
@@ -330,9 +330,12 @@ describe("telegram live qa runtime", () => {
       "telegram-commands-command",
       "telegram-tools-compact-command",
       "telegram-whoami-command",
+      "telegram-status-command",
+      "telegram-other-bot-command-gating",
       "telegram-context-command",
       "telegram-current-session-status-tool",
       "telegram-mentioned-message-reply",
+      "telegram-reply-chain-exact-marker",
       "telegram-stream-final-single-message",
       "telegram-long-final-reuses-preview",
       "telegram-long-final-three-chunks",
@@ -343,24 +346,55 @@ describe("telegram live qa runtime", () => {
       "telegram-commands-command",
       "telegram-tools-compact-command",
       "telegram-whoami-command",
+      "telegram-status-command",
+      "telegram-other-bot-command-gating",
       "telegram-context-command",
       "telegram-current-session-status-tool",
       "telegram-mentioned-message-reply",
+      "telegram-reply-chain-exact-marker",
       "telegram-stream-final-single-message",
       "telegram-long-final-reuses-preview",
       "telegram-long-final-three-chunks",
       "telegram-mention-gating",
     ]);
     expect(
+      scenarios.find((scenario) => scenario.id === "telegram-status-command")?.buildRun("sut_bot")
+        .input,
+    ).toBe("/status@sut_bot");
+    expect(
+      scenarios.find((scenario) => scenario.id === "telegram-status-command")?.buildRun("sut_bot")
+        .expectedTextIncludes,
+    ).toEqual(["OpenClaw", "Model:", "Session:", "Activation:"]);
+    expect(
+      scenarios
+        .find((scenario) => scenario.id === "telegram-other-bot-command-gating")
+        ?.buildRun("sut_bot"),
+    ).toMatchObject({
+      expectReply: false,
+      input: "/status@OpenClawQaOtherBot",
+    });
+    expect(
       scenarios
         .find((scenario) => scenario.id === "telegram-current-session-status-tool")
-        ?.buildRun("sut_bot").expectedTextIncludes,
-    ).toEqual(["QA-TELEGRAM-CURRENT-SESSION-OK", ":telegram:group:"]);
+        ?.buildRun("sut_bot"),
+    ).toMatchObject({
+      expectedTextIncludes: ["QA-TELEGRAM-CURRENT-SESSION-OK", ":telegram:group:"],
+      replyToLatestSutMessage: true,
+    });
     expect(
       scenarios
         .find((scenario) => scenario.id === "telegram-mentioned-message-reply")
         ?.buildRun("sut_bot").replyToLatestSutMessage,
     ).toBe(true);
+    expect(
+      scenarios
+        .find((scenario) => scenario.id === "telegram-reply-chain-exact-marker")
+        ?.buildRun("sut_bot"),
+    ).toMatchObject({
+      expectedJoinedSutTextIncludes: ["QA-TELEGRAM-REPLY-CHAIN-OK"],
+      expectedSutMessageCount: 1,
+      replyToLatestSutMessage: true,
+    });
     expect(
       scenarios
         .find((scenario) => scenario.id === "telegram-stream-final-single-message")
@@ -393,15 +427,58 @@ describe("telegram live qa runtime", () => {
     });
   });
 
-  it("keeps bot-to-bot plain mentions out of the default Telegram live set", () => {
-    expect(__testing.findScenario().map((scenario) => scenario.id)).toEqual([
+  it("keeps mock-scripted Telegram checks out of the default live-frontier set", () => {
+    expect(
+      __testing.findScenario(undefined, "live-frontier").map((scenario) => scenario.id),
+    ).toEqual([
       "telegram-help-command",
       "telegram-commands-command",
       "telegram-tools-compact-command",
       "telegram-whoami-command",
+      "telegram-status-command",
+      "telegram-other-bot-command-gating",
       "telegram-context-command",
+      "telegram-mentioned-message-reply",
       "telegram-mention-gating",
     ]);
+  });
+
+  it("adds deterministic model-scripted checks to the default mock-openai set", () => {
+    expect(__testing.findScenario(undefined, "mock-openai").map((scenario) => scenario.id)).toEqual(
+      [
+        "telegram-help-command",
+        "telegram-commands-command",
+        "telegram-tools-compact-command",
+        "telegram-whoami-command",
+        "telegram-status-command",
+        "telegram-other-bot-command-gating",
+        "telegram-context-command",
+        "telegram-mentioned-message-reply",
+        "telegram-reply-chain-exact-marker",
+        "telegram-stream-final-single-message",
+        "telegram-long-final-reuses-preview",
+        "telegram-mention-gating",
+      ],
+    );
+  });
+
+  it("lists default status and regression refs in the Telegram scenario catalog", () => {
+    const catalog = __testing.listTelegramQaScenarioCatalog("mock-openai");
+    expect(catalog.find((scenario) => scenario.id === "telegram-status-command")).toMatchObject({
+      defaultEnabled: true,
+      regressionRefs: ["openclaw/openclaw#74698"],
+    });
+    expect(
+      catalog.find((scenario) => scenario.id === "telegram-current-session-status-tool"),
+    ).toMatchObject({
+      defaultEnabled: false,
+    });
+    expect(
+      catalog.find((scenario) => scenario.id === "telegram-stream-final-single-message"),
+    ).toMatchObject({
+      defaultEnabled: true,
+      regressionRefs: ["openclaw/openclaw#39905"],
+    });
   });
 
   it("tracks Telegram live coverage against the shared transport contract", () => {

--- a/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts
@@ -13,6 +13,7 @@ import { DEFAULT_QA_LIVE_PROVIDER_MODE } from "../../providers/index.js";
 import {
   defaultQaModelForMode,
   normalizeQaProviderMode,
+  type QaProviderMode,
   type QaProviderModeInput,
 } from "../../run-config.js";
 import {
@@ -46,11 +47,14 @@ type TelegramQaScenarioId =
   | "telegram-commands-command"
   | "telegram-tools-compact-command"
   | "telegram-whoami-command"
+  | "telegram-status-command"
+  | "telegram-other-bot-command-gating"
   | "telegram-context-command"
   | "telegram-current-session-status-tool"
   | "telegram-stream-final-single-message"
   | "telegram-long-final-three-chunks"
   | "telegram-long-final-reuses-preview"
+  | "telegram-reply-chain-exact-marker"
   | "telegram-mentioned-message-reply"
   | "telegram-mention-gating";
 
@@ -69,6 +73,9 @@ type TelegramQaScenarioRun = {
 type TelegramQaScenarioDefinition = LiveTransportScenarioDefinition<TelegramQaScenarioId> & {
   buildRun: (sutUsername: string) => TelegramQaScenarioRun;
   defaultEnabled?: boolean;
+  defaultProviderModes?: readonly QaProviderMode[];
+  regressionRefs?: readonly string[];
+  rationale: string;
 };
 
 type TelegramObservedMessage = {
@@ -231,6 +238,7 @@ const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
     id: "telegram-help-command",
     standardId: "help-command",
     title: "Telegram help command reply",
+    rationale: "Canary-grade native command reply path.",
     timeoutMs: 45_000,
     buildRun: (sutUsername) => ({
       expectReply: true,
@@ -241,6 +249,7 @@ const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
   {
     id: "telegram-commands-command",
     title: "Telegram commands list reply",
+    rationale: "Native command catalog must render in Telegram group replies.",
     timeoutMs: 45_000,
     buildRun: (sutUsername) => ({
       expectReply: true,
@@ -251,6 +260,7 @@ const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
   {
     id: "telegram-tools-compact-command",
     title: "Telegram tools compact reply",
+    rationale: "Tool catalog rendering catches command dispatch plus model-tool inventory drift.",
     timeoutMs: 45_000,
     buildRun: (sutUsername) => ({
       expectReply: true,
@@ -261,6 +271,7 @@ const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
   {
     id: "telegram-whoami-command",
     title: "Telegram whoami reply",
+    rationale: "Identity command proves Telegram channel context is attached to native commands.",
     timeoutMs: 45_000,
     buildRun: (sutUsername) => ({
       expectReply: true,
@@ -269,8 +280,31 @@ const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
     }),
   },
   {
+    id: "telegram-status-command",
+    title: "Telegram status command reply",
+    rationale: "Recent Telegram group regressions broke /status while normal chat still worked.",
+    regressionRefs: ["openclaw/openclaw#74698"],
+    timeoutMs: 45_000,
+    buildRun: (sutUsername) => ({
+      expectReply: true,
+      input: `/status@${sutUsername}`,
+      expectedTextIncludes: ["OpenClaw", "Model:", "Session:", "Activation:"],
+    }),
+  },
+  {
+    id: "telegram-other-bot-command-gating",
+    title: "Telegram command addressed to another bot is ignored",
+    rationale: "Bot-to-bot groups must not let commands addressed to another bot wake the SUT.",
+    timeoutMs: 8_000,
+    buildRun: () => ({
+      expectReply: false,
+      input: "/status@OpenClawQaOtherBot",
+    }),
+  },
+  {
     id: "telegram-context-command",
     title: "Telegram context reply",
+    rationale: "Context command exercises native command routing into Telegram-specific help text.",
     timeoutMs: 45_000,
     buildRun: (sutUsername) => ({
       expectReply: true,
@@ -282,29 +316,49 @@ const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
     id: "telegram-current-session-status-tool",
     title: "Telegram current session_status tool call",
     defaultEnabled: false,
+    rationale:
+      "Opt-in threaded probe for current Telegram group session resolution through model tools.",
     timeoutMs: 60_000,
     buildRun: (sutUsername) => ({
       expectReply: true,
       input: `@${sutUsername} Telegram current session_status QA check. Call session_status with sessionKey set to current, then reply with the exact QA marker and resolved session key.`,
       expectedTextIncludes: ["QA-TELEGRAM-CURRENT-SESSION-OK", ":telegram:group:"],
+      replyToLatestSutMessage: true,
     }),
   },
   {
     id: "telegram-mentioned-message-reply",
     title: "Telegram mentioned message gets a reply",
-    defaultEnabled: false,
+    rationale: "Bot-to-bot group mention routing must produce a threaded SUT reply.",
     timeoutMs: 45_000,
     buildRun: (sutUsername) => ({
-      allowAnySutReply: true,
       expectReply: true,
       input: `@${sutUsername} Telegram QA mention routing check. Reply with a short acknowledgement.`,
       replyToLatestSutMessage: true,
     }),
   },
   {
+    id: "telegram-reply-chain-exact-marker",
+    title: "Telegram reply-chain exact marker",
+    defaultProviderModes: ["mock-openai"],
+    rationale: "Mock-backed reply-chain check proves quoted bot-to-bot follow-ups keep threading.",
+    timeoutMs: 45_000,
+    buildRun: (sutUsername) => ({
+      expectReply: true,
+      input: `@${sutUsername} Telegram reply-chain marker QA. Reply exactly: QA-TELEGRAM-REPLY-CHAIN-OK`,
+      expectedTextIncludes: ["QA-TELEGRAM-REPLY-CHAIN-OK"],
+      expectedJoinedSutTextIncludes: ["QA-TELEGRAM-REPLY-CHAIN-OK"],
+      expectedSutMessageCount: 1,
+      replyToLatestSutMessage: true,
+      settleMs: 4_000,
+    }),
+  },
+  {
     id: "telegram-stream-final-single-message",
     title: "Telegram streamed final stays one message",
-    defaultEnabled: false,
+    defaultProviderModes: ["mock-openai"],
+    rationale: "Regression guard for duplicate final replies from Telegram streaming paths.",
+    regressionRefs: ["openclaw/openclaw#39905"],
     timeoutMs: 45_000,
     buildRun: (sutUsername) => ({
       allowAnySutReply: true,
@@ -320,7 +374,9 @@ const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
   {
     id: "telegram-long-final-reuses-preview",
     title: "Telegram long final reuses the preview message",
-    defaultEnabled: false,
+    defaultProviderModes: ["mock-openai"],
+    rationale: "Regression guard for long streamed finals leaving stale preview messages behind.",
+    regressionRefs: ["openclaw/openclaw#39905"],
     timeoutMs: 60_000,
     buildRun: (sutUsername) => ({
       allowAnySutReply: true,
@@ -337,6 +393,8 @@ const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
     id: "telegram-long-final-three-chunks",
     title: "Telegram three-chunk final keeps only final chunks",
     defaultEnabled: false,
+    rationale: "Opt-in stress probe for Telegram long final chunk accounting.",
+    regressionRefs: ["openclaw/openclaw#39905"],
     timeoutMs: 60_000,
     buildRun: (sutUsername) => ({
       allowAnySutReply: true,
@@ -356,6 +414,7 @@ const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
     id: "telegram-mention-gating",
     standardId: "mention-gating",
     title: "Telegram group message without mention does not trigger",
+    rationale: "Required group mention gate should suppress ordinary group chatter.",
     timeoutMs: 8_000,
     buildRun: () => {
       const token = `TELEGRAM_QA_NOMENTION_${randomUUID().slice(0, 8).toUpperCase()}`;
@@ -1020,16 +1079,43 @@ function buildObservedMessagesArtifact(params: {
   });
 }
 
-function findScenario(ids?: string[]) {
+function shouldRunTelegramScenarioByDefault(
+  scenario: TelegramQaScenarioDefinition,
+  providerMode: QaProviderMode,
+) {
+  if (scenario.defaultEnabled === false) {
+    return false;
+  }
+  return !scenario.defaultProviderModes || scenario.defaultProviderModes.includes(providerMode);
+}
+
+function findScenario(
+  ids?: string[],
+  providerMode: QaProviderMode = DEFAULT_QA_LIVE_PROVIDER_MODE,
+) {
   const scenarios =
     ids && ids.length > 0
       ? TELEGRAM_QA_SCENARIOS
-      : TELEGRAM_QA_SCENARIOS.filter((scenario) => scenario.defaultEnabled !== false);
+      : TELEGRAM_QA_SCENARIOS.filter((scenario) =>
+          shouldRunTelegramScenarioByDefault(scenario, providerMode),
+        );
   return selectLiveTransportScenarios({
     ids,
     laneLabel: "Telegram",
     scenarios,
   });
+}
+
+export function listTelegramQaScenarioCatalog(
+  providerMode: QaProviderMode = DEFAULT_QA_LIVE_PROVIDER_MODE,
+) {
+  return TELEGRAM_QA_SCENARIOS.map((scenario) => ({
+    id: scenario.id,
+    title: scenario.title,
+    defaultEnabled: shouldRunTelegramScenarioByDefault(scenario, providerMode),
+    rationale: scenario.rationale,
+    regressionRefs: [...(scenario.regressionRefs ?? [])],
+  }));
 }
 
 function matchesTelegramScenarioReply(params: {
@@ -1340,7 +1426,7 @@ export async function runTelegramQaLive(params: {
   const primaryModel = params.primaryModel?.trim() || defaultQaModelForMode(providerMode);
   const alternateModel = params.alternateModel?.trim() || defaultQaModelForMode(providerMode, true);
   const sutAccountId = params.sutAccountId?.trim() || "sut";
-  const scenarios = findScenario(params.scenarioIds);
+  const scenarios = findScenario(params.scenarioIds, providerMode);
   const progressEnabled = shouldLogTelegramQaLiveProgress();
   writeTelegramQaProgress(
     progressEnabled,
@@ -1754,6 +1840,7 @@ export const __testing = {
   assertTelegramScenarioReply,
   classifyCanaryReply,
   findScenario,
+  listTelegramQaScenarioCatalog,
   matchesTelegramScenarioReply,
   normalizeTelegramObservedMessage,
   parseTelegramQaProgressBooleanEnv,

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -1853,6 +1853,99 @@ describe("qa mock openai server", () => {
     });
   });
 
+  it("lets the latest exact marker prompt beat stale Telegram session_status history", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        stream: false,
+        input: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "Telegram current session_status QA check. Call session_status with sessionKey set to current.",
+              },
+            ],
+          },
+          {
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "Telegram reply-chain marker QA. Reply exactly: QA-TELEGRAM-REPLY-CHAIN-OK",
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      output: [
+        {
+          content: [{ text: "QA-TELEGRAM-REPLY-CHAIN-OK" }],
+        },
+      ],
+    });
+  });
+
+  it("does not repeat stale Telegram session_status for later ordinary prompts", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        stream: false,
+        input: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "Telegram current session_status QA check. Call session_status with sessionKey set to current.",
+              },
+            ],
+          },
+          {
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "@sut Telegram QA mention routing check. Reply with a short acknowledgement.",
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(JSON.stringify(payload)).not.toContain("QA-TELEGRAM-CURRENT-SESSION");
+  });
+
   it("uses exact marker directives from request context when the latest user text is generic", async () => {
     const server = await startQaMockOpenAiServer({
       host: "127.0.0.1",

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -1421,7 +1421,16 @@ async function buildResponsesPayload(
       exactMarkerDirective ?? exactReplyDirective ?? "QA-GROUP-FALLBACK-OK",
     );
   }
-  if (QA_TELEGRAM_CURRENT_SESSION_STATUS_PROMPT_RE.test(allInputText)) {
+  if (/\bmarker\b/i.test(prompt) && exactReplyDirective) {
+    return buildAssistantEvents(exactReplyDirective);
+  }
+  if (/\bmarker\b/i.test(prompt) && exactMarkerDirective) {
+    return buildAssistantEvents(exactMarkerDirective);
+  }
+  const isTelegramCurrentSessionStatusTurn =
+    QA_TELEGRAM_CURRENT_SESSION_STATUS_PROMPT_RE.test(prompt) ||
+    (Boolean(toolOutput) && QA_TELEGRAM_CURRENT_SESSION_STATUS_PROMPT_RE.test(allInputText));
+  if (isTelegramCurrentSessionStatusTurn) {
     if (!toolOutput && hasDeclaredTool(body, "session_status")) {
       return buildToolCallEventsWithArgs("session_status", { sessionKey: "current" });
     }


### PR DESCRIPTION
Summary
- Add issue-backed Telegram live defaults for /status, command addressing, strict bot-to-bot replies, reply-chain exact markers, and streaming final shape.
- Fix mock-openai stale Telegram session_status history so old prompts do not hijack later turns.
- Add `pnpm openclaw qa telegram --list-scenarios` and update release Telegram scenarios/docs.

Verification
- `pnpm test extensions/qa-lab/src/providers/mock-openai/server.test.ts extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts extensions/qa-lab/src/cli.test.ts extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/live-transports/shared/live-transport-cli.runtime.test.ts` (167 passed)
- `pnpm openclaw qa telegram --list-scenarios --provider-mode mock-openai`
- `pnpm openclaw qa telegram --credential-source env --provider-mode mock-openai --output-dir .artifacts/qa-e2e/telegram-rock-solid-final-20260508T105500Z` (13/13 passed)
- `git diff --check`