### PR TITLE
fix(qa-lab): bump parity baseline to Opus 4.7 / GPT-5.5 and lengthen approval-followthrough timeouts

### DIFF
--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -705,11 +705,11 @@ jobs:
           case "${QA_PARITY_LANE}" in
             candidate)
               model="${OPENCLAW_CI_OPENAI_MODEL}"
-              alt_model="openai/gpt-5.4-alt"
+              alt_model="openai/gpt-5.5-alt"
               ;;
             baseline)
-              model="anthropic/claude-opus-4-6"
-              alt_model="anthropic/claude-sonnet-4-6"
+              model="anthropic/claude-opus-4-7"
+              alt_model="anthropic/claude-sonnet-4-7"
               ;;
             *)
               echo "Unknown QA parity lane: ${QA_PARITY_LANE}" >&2
@@ -779,7 +779,7 @@ jobs:
             --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
             --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
             --candidate-label "${OPENCLAW_CI_OPENAI_MODEL}" \
-            --baseline-label anthropic/claude-opus-4-6 \
+            --baseline-label anthropic/claude-opus-4-7 \
             --output-dir .artifacts/qa-e2e/parity
 
       - name: Upload parity artifacts

--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -187,17 +187,17 @@ jobs:
             --parity-pack agentic \
             --concurrency "${QA_PARITY_CONCURRENCY}" \
             --model "${OPENCLAW_CI_OPENAI_MODEL}" \
-            --alt-model openai/gpt-5.4-alt \
+            --alt-model openai/gpt-5.5-alt \
             --output-dir .artifacts/qa-e2e/gpt54
 
-      - name: Run Opus 4.6 lane
+      - name: Run Opus 4.7 lane
         run: |
           pnpm openclaw qa suite \
             --provider-mode mock-openai \
             --parity-pack agentic \
             --concurrency "${QA_PARITY_CONCURRENCY}" \
-            --model anthropic/claude-opus-4-6 \
-            --alt-model anthropic/claude-sonnet-4-6 \
+            --model anthropic/claude-opus-4-7 \
+            --alt-model anthropic/claude-sonnet-4-7 \
             --output-dir .artifacts/qa-e2e/opus46
 
       - name: Generate parity report
@@ -207,7 +207,7 @@ jobs:
             --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
             --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
             --candidate-label "${OPENCLAW_CI_OPENAI_MODEL}" \
-            --baseline-label anthropic/claude-opus-4-6 \
+            --baseline-label anthropic/claude-opus-4-7 \
             --output-dir .artifacts/qa-e2e/parity
 
       - name: Upload parity artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- QA-lab/parity: bump the live mock-openai parity baseline from `claude-opus-4-6`/`claude-sonnet-4-6` to `claude-opus-4-7`/`claude-sonnet-4-7` and the candidate alt from `gpt-5.4-alt` to `gpt-5.5-alt` in `openclaw-release-checks.yml` and `qa-live-transports-convex.yml`, matching the active Opus 4.7 / GPT-5.5 defaults already used elsewhere on main. Carries forward the surface-bump portion of #74290.
+- QA-lab/scenarios: raise the `approval-turn-tool-followthrough` per-turn fallback timeouts from 20s/30s to 60s so cold mock-gateway parity runs do not flake on the approval-turn chain. Carries forward the timeout-bump portion of #74290.
 - Agents/compaction: keep the recent tail after manual `/compact` when Pi returns an empty or no-op compaction summary, preventing blank checkpoints from replacing the live context.
 - fix(discord): gate user allowlist name resolution [AI]. (#79002) Thanks @pgondhi987.
 - fix(msteams): gate startup user allowlist resolution [AI]. (#79003) Thanks @pgondhi987.

--- a/qa/scenarios/runtime/approval-turn-tool-followthrough.md
+++ b/qa/scenarios/runtime/approval-turn-tool-followthrough.md
@@ -54,14 +54,14 @@ steps:
             message:
               expr: config.preActionPrompt
             timeoutMs:
-              expr: liveTurnTimeoutMs(env, 20000)
+              expr: liveTurnTimeoutMs(env, 60000)
       - call: waitForOutboundMessage
         args:
           - ref: state
           - lambda:
               params: [candidate]
               expr: "candidate.conversation.id === 'qa-operator'"
-          - expr: liveTurnTimeoutMs(env, 20000)
+          - expr: liveTurnTimeoutMs(env, 60000)
       - set: beforeApprovalCursor
         value:
           expr: state.getSnapshot().messages.length
@@ -72,7 +72,7 @@ steps:
             message:
               expr: config.approvalPrompt
             timeoutMs:
-              expr: liveTurnTimeoutMs(env, 30000)
+              expr: liveTurnTimeoutMs(env, 60000)
       - set: expectedReplyAny
         value:
           expr: config.expectedReplyAny.map(normalizeLowercaseStringOrEmpty)
@@ -81,7 +81,7 @@ steps:
         args:
           - lambda:
               expr: "state.getSnapshot().messages.slice(beforeApprovalCursor).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && expectedReplyAny.some((needle) => normalizeLowercaseStringOrEmpty(candidate.text).includes(needle))).at(-1)"
-          - expr: liveTurnTimeoutMs(env, 20000)
+          - expr: liveTurnTimeoutMs(env, 60000)
           - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
     detailsExpr: outbound.text
 ```


### PR DESCRIPTION
## Summary

Slim follow-up to closed PR #74290 picking up only the parts that are still load-bearing on current main:

- Bump the live mock-openai parity baseline from `anthropic/claude-opus-4-6` / `anthropic/claude-sonnet-4-6` to `claude-opus-4-7` / `claude-sonnet-4-7`, and the candidate alt from `openai/gpt-5.4-alt` to `openai/gpt-5.5-alt`, in `openclaw-release-checks.yml:708-712,782` and `qa-live-transports-convex.yml:190,199-200,210`. The Opus 4.7 / GPT-5.5 defaults are already active elsewhere on main (CHANGELOG.md:803, `docs/providers/anthropic.md:108,262`, `openclaw-live-and-e2e-checks-reusable.yml:1894`). The parity baseline was the last surface still one model-generation behind.
- Raise the four `liveTurnTimeoutMs` fallbacks in `qa/scenarios/runtime/approval-turn-tool-followthrough.md` from 20s/30s to 60s. The mock provider's `resolveTurnTimeoutMs` returns the fallback unchanged (`extensions/qa-lab/src/providers/shared/mock-provider-definition.ts:36`), so cold mock-gateway parity runs were timing out exactly where the retired `parity-gate.yml` env-var comments said they would.

#74290 was the natural home for this but is closed because most of its diff was against `.github/workflows/parity-gate.yml`, which `b9eb31b54c` (#74622 'ci: fold parity into QA release validation') deleted on main. Rebasing #74290 would have conflicted on every workflow file and many fixtures already updated. This follow-up keeps just the bumps that survived.

Refs #74290 / #74262.

## What this PR does NOT touch

- The retired `.github/workflows/parity-gate.yml` (deleted on main by #74622).
- Internal artifact directory names `gpt54`/`opus46` (cosmetic; renaming would require updating consumer paths and is out of scope for a slim bump).
- The Discord QA scenario lane (`qa-live-transports-convex.yml:550-551`) and the release-validation lane (`openclaw-release-checks.yml:487`) that intentionally pin `openai/gpt-5.4` for separate purposes.

## Real behavior proof

- Behavior addressed: parity report on release/nightly should compare current Opus 4.7 against current GPT-5.5; cold-startup `approval-turn-tool-followthrough` should not flake on the 20s/30s budgets.
- Tested locally: ran `pnpm exec vitest run extensions/qa-lab/src/providers/mock-openai/server.test.ts extensions/qa-lab/src/qa-gateway-config.test.ts extensions/qa-lab/src/suite-planning.test.ts extensions/qa-lab/src/cli.runtime.test.ts` (all green); `pnpm check:test-types` clean; `pnpm exec oxfmt --check` on all four modified files clean.
- Workflow YAML changes are syntax-only (string substitution) — no semantic shape change. Validated visually that all consumer paths (`--baseline-summary`, `--baseline-label`, `output_dir`, `--candidate-summary`) line up after the rename.
- The 60s timeout matches the existing 60s `waitForGatewayHealthy` budget at line 48 of the same scenario, so the cold-startup window is now consistent across the file.

## Test plan

- [x] `pnpm exec oxfmt --check --threads=1` on all four modified files
- [x] `pnpm check:test-types` clean
- [x] Targeted vitest passes on the qa-lab fixtures most likely to break on baseline-name changes
- [ ] CI parity job runs successfully on at least one nightly cron after merge