### PR TITLE
Fast-path native slash commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,7 @@ Docs: https://docs.openclaw.ai
 
 - Cron/agents: recognize same-target `edit`↔`write` recovery in `isSameToolMutationAction`, so a successful `write` to a path clears an earlier failed `edit` on the same path. Stops cron from reporting fatal failures when an agent self-heals across `edit` and `write`, while preserving same-tool fingerprint matching, blocking different-target writes, and excluding tools (including `apply_patch`) whose real call args do not produce a stable `path` fingerprint segment. Fixes #79024. Thanks @RenzoMXD.
 - Agents/compaction: keep the recent tail after manual `/compact` when Pi returns an empty or no-op compaction summary, preventing blank checkpoints from replacing the live context.
+- Native commands: handle slash commands before workspace and agent-reply bootstrap so Telegram `/status` and other command-only native replies do not wait behind full agent turn setup.
 - fix(discord): gate user allowlist name resolution [AI]. (#79002) Thanks @pgondhi987.
 - fix(msteams): gate startup user allowlist resolution [AI]. (#79003) Thanks @pgondhi987.
 - Infra/fetch-timeout: pass `operation` and `url` context to `buildTimeoutAbortSignal` from the music-generate reference fetch and the Matrix guarded redirect transport, so the `fetch timeout reached; aborting operation` warning carries actionable structured fields instead of a bare line. Fixes #79195. Thanks @pandadev66.

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -1,0 +1,231 @@
+import type { ModelAliasIndex } from "../../agents/model-selection.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { normalizeOptionalString } from "../../shared/string-coerce.js";
+import type { GetReplyOptions } from "../get-reply-options.types.js";
+import type { ReplyPayload } from "../reply-payload.js";
+import type { MsgContext } from "../templating.js";
+import { buildCommandContext } from "./commands-context.js";
+import { clearInlineDirectives } from "./get-reply-directives-utils.js";
+import { resolveReplyDirectives } from "./get-reply-directives.js";
+import { initFastReplySessionState } from "./get-reply-fast-path.js";
+import { handleInlineActions } from "./get-reply-inline-actions.js";
+import { stripStructuralPrefixes } from "./mentions.js";
+import type { createTypingController } from "./typing.js";
+
+type AgentDefaults = NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
+
+const commandsRuntimeLoader = createLazyImportLoader(() => import("./commands.runtime.js"));
+const statusCommandRuntimeLoader = createLazyImportLoader(() => import("./commands-status.js"));
+
+function loadCommandsRuntime() {
+  return commandsRuntimeLoader.load();
+}
+
+function loadStatusCommandRuntime() {
+  return statusCommandRuntimeLoader.load();
+}
+
+function resolveNativeSlashCommandName(ctx: MsgContext): string | undefined {
+  if (ctx.CommandSource !== "native") {
+    return undefined;
+  }
+  const commandText = stripStructuralPrefixes(
+    ctx.BodyForCommands ?? ctx.CommandBody ?? ctx.RawBody ?? ctx.Body ?? "",
+  ).trim();
+  const match = commandText.match(/^\/([^\s:]+)(?::|\s|$)/);
+  return normalizeOptionalString(match?.[1])?.toLowerCase();
+}
+
+function shouldRunNativeSlashCommandFastPath(ctx: MsgContext): boolean {
+  const commandName = resolveNativeSlashCommandName(ctx);
+  return Boolean(commandName && commandName !== "new" && commandName !== "reset");
+}
+
+export async function maybeResolveNativeSlashCommandFastReply(params: {
+  ctx: MsgContext;
+  cfg: OpenClawConfig;
+  agentId: string;
+  agentDir: string;
+  agentCfg: AgentDefaults;
+  commandAuthorized: boolean;
+  defaultProvider: string;
+  defaultModel: string;
+  aliasIndex: ModelAliasIndex;
+  provider: string;
+  model: string;
+  workspaceDir: string;
+  typing: ReturnType<typeof createTypingController>;
+  opts?: GetReplyOptions;
+  skillFilter?: string[];
+}): Promise<
+  { handled: true; reply: ReplyPayload | ReplyPayload[] | undefined } | { handled: false }
+> {
+  if (!shouldRunNativeSlashCommandFastPath(params.ctx)) {
+    return { handled: false };
+  }
+
+  const sessionState = initFastReplySessionState({
+    ctx: params.ctx,
+    cfg: params.cfg,
+    agentId: params.agentId,
+    commandAuthorized: params.commandAuthorized,
+    workspaceDir: params.workspaceDir,
+  });
+  const command = buildCommandContext({
+    ctx: params.ctx,
+    cfg: params.cfg,
+    agentId: params.agentId,
+    sessionKey: sessionState.sessionKey,
+    isGroup: sessionState.isGroup,
+    triggerBodyNormalized: sessionState.triggerBodyNormalized,
+    commandAuthorized: params.commandAuthorized,
+  });
+  if (command.commandBodyNormalized === "/status") {
+    const targetSessionEntry =
+      sessionState.sessionStore[sessionState.sessionKey] ?? sessionState.sessionEntry;
+    const { buildStatusReply } = await loadStatusCommandRuntime();
+    return {
+      handled: true,
+      reply: await buildStatusReply({
+        cfg: params.cfg,
+        command,
+        sessionEntry: targetSessionEntry,
+        sessionKey: sessionState.sessionKey,
+        parentSessionKey: targetSessionEntry?.parentSessionKey ?? params.ctx.ParentSessionKey,
+        sessionScope: sessionState.sessionScope,
+        storePath: sessionState.storePath,
+        provider: params.provider,
+        model: params.model,
+        workspaceDir: params.workspaceDir,
+        resolvedThinkLevel: undefined,
+        resolvedVerboseLevel: "off",
+        resolvedReasoningLevel: "off",
+        resolvedElevatedLevel: "off",
+        resolveDefaultThinkingLevel: async () => undefined,
+        isGroup: sessionState.isGroup,
+        defaultGroupActivation: () => "always",
+        mediaDecisions: params.ctx.MediaUnderstandingDecisions,
+      }),
+    };
+  }
+
+  const commandResult = await (
+    await loadCommandsRuntime()
+  ).handleCommands({
+    ctx: sessionState.sessionCtx,
+    rootCtx: params.ctx,
+    cfg: params.cfg,
+    command,
+    agentId: params.agentId,
+    agentDir: params.agentDir,
+    directives: clearInlineDirectives(sessionState.triggerBodyNormalized),
+    elevated: {
+      enabled: false,
+      allowed: false,
+      failures: [],
+    },
+    sessionEntry: sessionState.sessionEntry,
+    previousSessionEntry: sessionState.previousSessionEntry,
+    sessionStore: sessionState.sessionStore,
+    sessionKey: sessionState.sessionKey,
+    storePath: sessionState.storePath,
+    sessionScope: sessionState.sessionScope,
+    workspaceDir: params.workspaceDir,
+    opts: params.opts,
+    defaultGroupActivation: () => "always",
+    resolvedThinkLevel: undefined,
+    resolvedVerboseLevel: "off",
+    resolvedReasoningLevel: "off",
+    resolvedElevatedLevel: "off",
+    blockReplyChunking: undefined,
+    resolvedBlockStreamingBreak: "text_end",
+    resolveDefaultThinkingLevel: async () => undefined,
+    provider: params.provider,
+    model: params.model,
+    contextTokens: params.agentCfg?.contextTokens ?? 0,
+    isGroup: sessionState.isGroup,
+    skillCommands: [],
+    typing: params.typing,
+  });
+  if (!commandResult.shouldContinue) {
+    return { handled: true, reply: commandResult.reply };
+  }
+
+  const directiveResult = await resolveReplyDirectives({
+    ctx: params.ctx,
+    cfg: params.cfg,
+    agentId: params.agentId,
+    agentDir: params.agentDir,
+    workspaceDir: params.workspaceDir,
+    agentCfg: params.agentCfg,
+    sessionCtx: sessionState.sessionCtx,
+    sessionEntry: sessionState.sessionEntry,
+    sessionStore: sessionState.sessionStore,
+    sessionKey: sessionState.sessionKey,
+    storePath: sessionState.storePath,
+    sessionScope: sessionState.sessionScope,
+    groupResolution: sessionState.groupResolution,
+    isGroup: sessionState.isGroup,
+    triggerBodyNormalized: sessionState.triggerBodyNormalized,
+    resetTriggered: false,
+    commandAuthorized: params.commandAuthorized,
+    defaultProvider: params.defaultProvider,
+    defaultModel: params.defaultModel,
+    aliasIndex: params.aliasIndex,
+    provider: params.provider,
+    model: params.model,
+    hasResolvedHeartbeatModelOverride: false,
+    typing: params.typing,
+    opts: params.opts,
+    skillFilter: params.skillFilter,
+  });
+  if (directiveResult.kind === "reply") {
+    return { handled: true, reply: directiveResult.reply };
+  }
+
+  const inlineActionResult = await handleInlineActions({
+    ctx: params.ctx,
+    sessionCtx: sessionState.sessionCtx,
+    cfg: params.cfg,
+    agentId: params.agentId,
+    agentDir: params.agentDir,
+    sessionEntry: sessionState.sessionEntry,
+    previousSessionEntry: sessionState.previousSessionEntry,
+    sessionStore: sessionState.sessionStore,
+    sessionKey: sessionState.sessionKey,
+    storePath: sessionState.storePath,
+    sessionScope: sessionState.sessionScope,
+    workspaceDir: params.workspaceDir,
+    isGroup: sessionState.isGroup,
+    opts: params.opts,
+    typing: params.typing,
+    allowTextCommands: directiveResult.result.allowTextCommands,
+    inlineStatusRequested: directiveResult.result.inlineStatusRequested,
+    command: directiveResult.result.command,
+    skillCommands: directiveResult.result.skillCommands,
+    directives: directiveResult.result.directives,
+    cleanedBody: directiveResult.result.cleanedBody,
+    elevatedEnabled: directiveResult.result.elevatedEnabled,
+    elevatedAllowed: directiveResult.result.elevatedAllowed,
+    elevatedFailures: directiveResult.result.elevatedFailures,
+    defaultActivation: () => directiveResult.result.defaultActivation,
+    resolvedThinkLevel: directiveResult.result.resolvedThinkLevel,
+    resolvedVerboseLevel: directiveResult.result.resolvedVerboseLevel,
+    resolvedReasoningLevel: directiveResult.result.resolvedReasoningLevel,
+    resolvedElevatedLevel: directiveResult.result.resolvedElevatedLevel,
+    blockReplyChunking: directiveResult.result.blockReplyChunking,
+    resolvedBlockStreamingBreak: directiveResult.result.resolvedBlockStreamingBreak,
+    resolveDefaultThinkingLevel: directiveResult.result.modelState.resolveDefaultThinkingLevel,
+    provider: directiveResult.result.provider,
+    model: directiveResult.result.model,
+    contextTokens: directiveResult.result.contextTokens,
+    directiveAck: directiveResult.result.directiveAck,
+    abortedLastRun: sessionState.abortedLastRun,
+    skillFilter: params.skillFilter,
+  });
+  if (inlineActionResult.kind === "reply") {
+    return { handled: true, reply: inlineActionResult.reply };
+  }
+  return { handled: false };
+}

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -130,6 +130,86 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     expect(vi.mocked(runPreparedReplyMock)).toHaveBeenCalledOnce();
   });
 
+  it("handles native /status before workspace bootstrap", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-status-fast-"));
+    const targetSessionKey = "agent:main:telegram:123";
+    const cfg = markCompleteReplyConfig({
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.5",
+          workspace: path.join(home, "workspace"),
+        },
+      },
+      session: { store: path.join(home, "sessions.json") },
+    } as OpenClawConfig);
+
+    const reply = await getReplyFromConfig(
+      buildGetReplyCtx({
+        Body: "/status",
+        BodyForAgent: "/status",
+        RawBody: "/status",
+        CommandBody: "/status",
+        CommandSource: "native",
+        CommandAuthorized: true,
+        SessionKey: "telegram:slash:123",
+        CommandTargetSessionKey: targetSessionKey,
+      }),
+      undefined,
+      cfg,
+    );
+
+    expect(reply).toEqual(expect.objectContaining({ text: expect.stringContaining("OpenClaw") }));
+    expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
+    expect(mocks.initSessionState).not.toHaveBeenCalled();
+    expect(mocks.resolveReplyDirectives).not.toHaveBeenCalled();
+    expect(vi.mocked(runPreparedReplyMock)).not.toHaveBeenCalled();
+  });
+
+  it("handles native slash directives before workspace bootstrap", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-slash-fast-"));
+    const targetSessionKey = "agent:main:telegram:123";
+    const cfg = markCompleteReplyConfig({
+      agents: {
+        defaults: {
+          model: "anthropic/claude-opus-4-6",
+          workspace: path.join(home, "workspace"),
+        },
+      },
+      session: { store: path.join(home, "sessions.json") },
+    } as OpenClawConfig);
+    mocks.resolveReplyDirectives.mockResolvedValueOnce({
+      kind: "reply",
+      reply: { text: "model status" },
+    });
+
+    await expect(
+      getReplyFromConfig(
+        buildGetReplyCtx({
+          Body: "/model status",
+          BodyForAgent: "/model status",
+          RawBody: "/model status",
+          CommandBody: "/model status",
+          CommandSource: "native",
+          CommandAuthorized: true,
+          SessionKey: "telegram:slash:123",
+          CommandTargetSessionKey: targetSessionKey,
+        }),
+        undefined,
+        cfg,
+      ),
+    ).resolves.toEqual({ text: "model status" });
+
+    expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
+    expect(mocks.initSessionState).not.toHaveBeenCalled();
+    expect(vi.mocked(runPreparedReplyMock)).not.toHaveBeenCalled();
+    expect(mocks.resolveReplyDirectives).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: targetSessionKey,
+        workspaceDir: expect.any(String),
+      }),
+    );
+  });
+
   it("uses native command target session keys during fast bootstrap", () => {
     const result = initFastReplySessionState({
       ctx: buildGetReplyCtx({

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -36,6 +36,7 @@ import {
   shouldUseReplyFastTestRuntime,
 } from "./get-reply-fast-path.js";
 import { handleInlineActions } from "./get-reply-inline-actions.js";
+import { maybeResolveNativeSlashCommandFastReply } from "./get-reply-native-slash-fast-path.js";
 import { runPreparedReply } from "./get-reply-run.js";
 import { finalizeInboundContext } from "./inbound-context.js";
 import { hasInboundMedia } from "./inbound-media.js";
@@ -248,16 +249,7 @@ export async function getReplyFromConfig(
   }
 
   const workspaceDirRaw = resolveAgentWorkspaceDir(cfg, agentId) ?? DEFAULT_AGENT_WORKSPACE_DIR;
-  const workspace = await traceGetReplyPhase("reply.ensure_workspace", async () =>
-    useFastTestBootstrap
-      ? (await fs.mkdir(workspaceDirRaw, { recursive: true }), { dir: workspaceDirRaw })
-      : await ensureAgentWorkspace({
-          dir: workspaceDirRaw,
-          ensureBootstrapFiles: !agentCfg?.skipBootstrap && !isFastTestEnv,
-          skipOptionalBootstrapFiles: agentCfg?.skipOptionalBootstrapFiles,
-        }),
-  );
-  const workspaceDir = workspace.dir;
+  const workspaceDirForNativeCommand = workspaceDirRaw;
   const agentDir = resolveAgentDir(cfg, agentId);
   const timeoutMs = resolveAgentTimeoutMs({ cfg, overrideSeconds: opts?.timeoutOverrideSeconds });
   const configuredTypingSeconds =
@@ -274,6 +266,41 @@ export async function getReplyFromConfig(
   opts?.onTypingController?.(typing);
 
   const finalized = finalizeInboundContext(ctx);
+  const nativeSlashCommandFastReply = await traceGetReplyPhase(
+    "reply.native_slash_command_fast_path",
+    () =>
+      maybeResolveNativeSlashCommandFastReply({
+        ctx: finalized,
+        cfg,
+        agentId,
+        agentDir,
+        agentCfg,
+        commandAuthorized: finalized.CommandAuthorized,
+        defaultProvider,
+        defaultModel,
+        aliasIndex,
+        provider,
+        model,
+        workspaceDir: workspaceDirForNativeCommand,
+        typing,
+        opts: resolvedOpts,
+        skillFilter: mergedSkillFilter,
+      }),
+  );
+  if (nativeSlashCommandFastReply.handled) {
+    return nativeSlashCommandFastReply.reply;
+  }
+
+  const workspace = await traceGetReplyPhase("reply.ensure_workspace", async () =>
+    useFastTestBootstrap
+      ? (await fs.mkdir(workspaceDirRaw, { recursive: true }), { dir: workspaceDirRaw })
+      : await ensureAgentWorkspace({
+          dir: workspaceDirRaw,
+          ensureBootstrapFiles: !agentCfg?.skipBootstrap && !isFastTestEnv,
+          skipOptionalBootstrapFiles: agentCfg?.skipOptionalBootstrapFiles,
+        }),
+  );
+  const workspaceDir = workspace.dir;
 
   if (!isFastTestEnv && hasInboundMedia(finalized)) {
     await traceGetReplyPhase("reply.apply_media_understanding", () =>


### PR DESCRIPTION
## Summary

Fast-path native slash commands before workspace bootstrap and agent reply setup. This keeps command-only Telegram replies like `/status` out of the slow full-turn path.

## Proof

- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/get-reply.ts src/auto-reply/reply/get-reply-native-slash-fast-path.ts src/auto-reply/reply/get-reply.fast-path.test.ts`
- `pnpm test src/auto-reply/reply/get-reply.fast-path.test.ts`
- `pnpm check:changed`
