### PR TITLE
refactor(gateway): consolidate missing-scope 403 into sendScopeForbidden helper

### DIFF
--- a/src/agents/openclaw-gateway-tool.test.ts
+++ b/src/agents/openclaw-gateway-tool.test.ts
@@ -286,6 +286,42 @@ describe("gateway tool", () => {
     });
   });
 
+  it("passes config.patch through when changing tools.web.search.maxResults", async () => {
+    vi.mocked(callGatewayTool).mockImplementation(async (method: string) => {
+      if (method === "config.get") {
+        return { hash: "hash-1", config: { tools: { web: { search: { maxResults: 5 } } } } };
+      }
+      if (method === "config.patch") {
+        return {
+          ok: true,
+          noop: false,
+          path: "/tmp/openclaw.json",
+          config: { tools: { web: { search: { maxResults: 10 } } } },
+        };
+      }
+      return { ok: true };
+    });
+    const sessionKey = "agent:main:telegram:dm:123";
+    const tool = requireGatewayTool(sessionKey);
+
+    const raw = "{ tools: { web: { search: { maxResults: 10 } } } }";
+    const result = await tool.execute("call-web-maxresults-patch", {
+      action: "config.patch",
+      raw,
+    });
+
+    expect(result.details).toEqual({
+      ok: true,
+      result: { ok: true, noop: false, path: "/tmp/openclaw.json" },
+    });
+    expectConfigMutationCall({
+      callGatewayTool: vi.mocked(callGatewayTool),
+      action: "config.patch",
+      raw,
+      sessionKey,
+    });
+  });
+
   it("rejects config.patch when it changes exec approval settings", async () => {
     const tool = requireGatewayTool();
 

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -57,6 +57,10 @@ const ALLOWED_GATEWAY_CONFIG_PATHS = [
   // or privilege boundary. Let agents repair silent group/channel rooms.
   "messages.visibleReplies",
   "messages.groupChat.visibleReplies",
+  // Web search result count is a non-sensitive UX tuning knob (schema: 1-10 positive int).
+  // Omitting it from this list forces the operator to restart the gateway to change it,
+  // even though the field carries no auth or privilege implications.
+  "tools.web.search.maxResults",
 ] as const;
 
 /** @internal Exposed for regression tests only; do not import from runtime code. */

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -956,4 +956,87 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(flushCall.bootstrapPromptWarningSignaturesSeen).toEqual(["sig-a", "sig-b"]);
     expect(flushCall.bootstrapPromptWarningSignature).toBe("sig-b");
   });
+
+  it("passes an isolated abortSignal to preflight compaction so compaction abort does not kill the main turn", async () => {
+    const sessionFile = path.join(rootDir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "assistant", content: "x", usage: { input: 90_000, output: 0 } } })}\n`,
+      "utf8",
+    );
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokensFresh: false,
+    };
+    const parentController = new AbortController();
+    const replyOperation = {
+      abortSignal: parentController.signal,
+      setPhase: vi.fn(),
+      updateSessionId: vi.fn(),
+    } as never;
+
+    await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({ sessionId: "session", sessionFile, sessionKey: "main" }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation,
+    });
+
+    const compactCall = compactEmbeddedPiSessionMock.mock.calls[0]?.[0] as {
+      abortSignal?: AbortSignal;
+    };
+    // compaction receives a signal (parent abort propagates to it)
+    expect(compactCall.abortSignal).toBeInstanceOf(AbortSignal);
+    // but it is NOT the same object as the parent — isolated so compaction abort cannot cancel main turn
+    expect(compactCall.abortSignal).not.toBe(parentController.signal);
+    // parent abort still propagates to the compaction signal
+    expect(compactCall.abortSignal?.aborted).toBe(false);
+    parentController.abort();
+    expect(compactCall.abortSignal?.aborted).toBe(true);
+  });
+
+  it("passes an isolated abortSignal to memory flush so flush abort does not kill the main turn", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+    };
+    const parentController = new AbortController();
+    const replyOperation = {
+      abortSignal: parentController.signal,
+      setPhase: vi.fn(),
+      updateSessionId: vi.fn(),
+    } as never;
+
+    await runMemoryFlushIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun(),
+      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      isHeartbeat: false,
+      replyOperation,
+    });
+
+    const flushCall = runEmbeddedPiAgentMock.mock.calls[0]?.[0] as {
+      abortSignal?: AbortSignal;
+    };
+    expect(flushCall.abortSignal).toBeInstanceOf(AbortSignal);
+    expect(flushCall.abortSignal).not.toBe(parentController.signal);
+    expect(flushCall.abortSignal?.aborted).toBe(false);
+    parentController.abort();
+    expect(flushCall.abortSignal?.aborted).toBe(true);
+  });
 });

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -630,7 +630,9 @@ export async function runPreflightCompactionIfNeeded(params: {
     currentTokenCount: tokenCountForCompaction ?? freshPersistedTokens,
     senderIsOwner: params.followupRun.run.senderIsOwner,
     ownerNumbers: params.followupRun.run.ownerNumbers,
-    abortSignal: params.replyOperation.abortSignal,
+    // Isolate compaction abort from main turn: parent abort cancels compaction,
+    // but compaction failure does not propagate back and kill the main turn.
+    abortSignal: AbortSignal.any([params.replyOperation.abortSignal]),
   });
 
   if (!result?.ok || !result.compacted) {
@@ -945,7 +947,8 @@ export async function runMemoryFlushIfNeeded(params: {
           bootstrapPromptWarningSignaturesSeen,
           bootstrapPromptWarningSignature:
             bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
-          abortSignal: params.replyOperation.abortSignal,
+          // Isolate memory-flush abort from main turn (same pattern as preflight compaction).
+          abortSignal: AbortSignal.any([params.replyOperation.abortSignal]),
           replyOperation: params.replyOperation,
           onAgentEvent: (evt) => {
             if (evt.stream === "compaction") {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -45,7 +45,7 @@ import {
   normalizeControlUiBasePath,
   resolveAssistantAvatarUrl,
 } from "./control-ui-shared.js";
-import { sendGatewayAuthFailure } from "./http-common.js";
+import { sendGatewayAuthFailure, sendScopeForbidden } from "./http-common.js";
 import {
   getBearerToken,
   resolveHttpBrowserOriginPolicy,
@@ -341,13 +341,7 @@ async function authorizeControlUiReadRequest(
     requestedScopes,
   );
   if (!scopeAuth.allowed) {
-    sendJson(res, 403, {
-      ok: false,
-      error: {
-        type: "forbidden",
-        message: `missing scope: ${scopeAuth.missingScope}`,
-      },
-    });
+    sendScopeForbidden(res, scopeAuth.missingScope);
     return false;
   }
 

--- a/src/gateway/http-auth-utils.ts
+++ b/src/gateway/http-auth-utils.ts
@@ -11,7 +11,7 @@ import {
   type GatewayAuthResult,
   type ResolvedGatewayAuth,
 } from "./auth.js";
-import { sendGatewayAuthFailure, sendJson } from "./http-common.js";
+import { sendGatewayAuthFailure, sendScopeForbidden } from "./http-common.js";
 import { ADMIN_SCOPE, CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
 import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 
@@ -167,13 +167,7 @@ export async function authorizeScopedGatewayHttpRequestOrReply(params: {
   const requestedScopes = params.resolveOperatorScopes(params.req, requestAuth);
   const scopeAuth = authorizeOperatorScopesForMethod(params.operatorMethod, requestedScopes);
   if (!scopeAuth.allowed) {
-    sendJson(params.res, 403, {
-      ok: false,
-      error: {
-        type: "forbidden",
-        message: `missing scope: ${scopeAuth.missingScope}`,
-      },
-    });
+    sendScopeForbidden(params.res, scopeAuth.missingScope);
     return null;
   }
 

--- a/src/gateway/http-common.test.ts
+++ b/src/gateway/http-common.test.ts
@@ -14,6 +14,7 @@ import {
   sendJson,
   sendMethodNotAllowed,
   sendRateLimited,
+  sendScopeForbidden,
   sendText,
   sendUnauthorized,
   setDefaultSecurityHeaders,
@@ -130,6 +131,26 @@ describe("sendUnauthorized", () => {
     expect(end).toHaveBeenCalledWith(
       JSON.stringify({ error: { message: "Unauthorized", type: "unauthorized" } }),
     );
+  });
+});
+
+describe("sendScopeForbidden", () => {
+  it("responds with 403 and a structured forbidden payload including the missing scope", () => {
+    const { res, end } = makeMockHttpResponse();
+    sendScopeForbidden(res, "operator.write");
+    expect(res.statusCode).toBe(403);
+    expect(end).toHaveBeenCalledWith(
+      JSON.stringify({
+        ok: false,
+        error: { type: "forbidden", message: "missing scope: operator.write" },
+      }),
+    );
+  });
+
+  it("embeds the exact missingScope string in the message", () => {
+    const { res, end } = makeMockHttpResponse();
+    sendScopeForbidden(res, "operator.admin");
+    expect(end).toHaveBeenCalledWith(expect.stringContaining("missing scope: operator.admin"));
   });
 });
 

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -68,6 +68,16 @@ export function sendGatewayAuthFailure(res: ServerResponse, authResult: GatewayA
   sendUnauthorized(res);
 }
 
+export function sendScopeForbidden(res: ServerResponse, missingScope: string) {
+  sendJson(res, 403, {
+    ok: false,
+    error: {
+      type: "forbidden",
+      message: `missing scope: ${missingScope}`,
+    },
+  });
+}
+
 export function sendInvalidRequest(res: ServerResponse, message: string) {
   sendJson(res, 400, {
     error: { message, type: "invalid_request_error" },

--- a/src/gateway/http-endpoint-helpers.test.ts
+++ b/src/gateway/http-endpoint-helpers.test.ts
@@ -15,6 +15,7 @@ vi.mock("./http-common.js", () => {
     readJsonBodyOrError: vi.fn(),
     sendJson: vi.fn(),
     sendMethodNotAllowed: vi.fn(),
+    sendScopeForbidden: vi.fn(),
   };
 });
 
@@ -24,7 +25,8 @@ vi.mock("./method-scopes.js", () => {
   };
 });
 
-const { readJsonBodyOrError, sendJson, sendMethodNotAllowed } = await import("./http-common.js");
+const { readJsonBodyOrError, sendJson, sendMethodNotAllowed, sendScopeForbidden } =
+  await import("./http-common.js");
 const { authorizeGatewayHttpRequestOrReply, resolveTrustedHttpOperatorScopes } =
   await import("./http-utils.js");
 const { authorizeOperatorScopesForMethod } = await import("./method-scopes.js");
@@ -102,8 +104,7 @@ describe("handleGatewayPostJsonEndpoint", () => {
       allowed: false,
       missingScope: "operator.write",
     });
-    const mockedSendJson = vi.mocked(sendJson);
-    mockedSendJson.mockClear();
+    vi.mocked(sendScopeForbidden).mockClear();
     vi.mocked(readJsonBodyOrError).mockClear();
 
     const result = await handleGatewayPostJsonEndpoint(
@@ -125,17 +126,7 @@ describe("handleGatewayPostJsonEndpoint", () => {
     expect(vi.mocked(authorizeOperatorScopesForMethod)).toHaveBeenCalledWith("chat.send", [
       "operator.approvals",
     ]);
-    expect(mockedSendJson).toHaveBeenCalledWith(
-      expect.anything(),
-      403,
-      expect.objectContaining({
-        ok: false,
-        error: expect.objectContaining({
-          type: "forbidden",
-          message: "missing scope: operator.write",
-        }),
-      }),
-    );
+    expect(vi.mocked(sendScopeForbidden)).toHaveBeenCalledWith(expect.anything(), "operator.write");
     expect(vi.mocked(readJsonBodyOrError)).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/http-endpoint-helpers.ts
+++ b/src/gateway/http-endpoint-helpers.ts
@@ -1,7 +1,12 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { readJsonBodyOrError, sendJson, sendMethodNotAllowed } from "./http-common.js";
+import {
+  readJsonBodyOrError,
+  sendJson,
+  sendMethodNotAllowed,
+  sendScopeForbidden,
+} from "./http-common.js";
 import {
   authorizeGatewayHttpRequestOrReply,
   type AuthorizedGatewayHttpRequest,
@@ -57,13 +62,7 @@ export async function handleGatewayPostJsonEndpoint(
       requestedScopes,
     );
     if (!scopeAuth.allowed) {
-      sendJson(res, 403, {
-        ok: false,
-        error: {
-          type: "forbidden",
-          message: `missing scope: ${scopeAuth.missingScope}`,
-        },
-      });
+      sendScopeForbidden(res, scopeAuth.missingScope);
       return undefined;
     }
   }

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -18,7 +18,7 @@ import { MEDIA_MAX_BYTES, saveMediaBuffer, saveMediaSource } from "../media/stor
 import { resolveUserPath } from "../utils.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { sendJson, sendMethodNotAllowed } from "./http-common.js";
+import { sendJson, sendMethodNotAllowed, sendScopeForbidden } from "./http-common.js";
 import {
   authorizeGatewayHttpRequestOrReply,
   resolveOpenAiCompatibleHttpOperatorScopes,
@@ -987,13 +987,7 @@ export async function handleManagedOutgoingImageHttpRequest(
   const requestedScopes = resolveOpenAiCompatibleHttpOperatorScopes(req, requestAuth);
   const scopeAuth = authorizeOperatorScopesForMethod("chat.history", requestedScopes);
   if (!scopeAuth.allowed) {
-    sendJson(res, 403, {
-      ok: false,
-      error: {
-        type: "forbidden",
-        message: `missing scope: ${scopeAuth.missingScope}`,
-      },
-    });
+    sendScopeForbidden(res, scopeAuth.missingScope);
     return true;
   }
 

--- a/src/gateway/models-http.ts
+++ b/src/gateway/models-http.ts
@@ -3,7 +3,12 @@ import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getRuntimeConfig } from "../config/io.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { sendInvalidRequest, sendJson, sendMethodNotAllowed } from "./http-common.js";
+import {
+  sendInvalidRequest,
+  sendJson,
+  sendMethodNotAllowed,
+  sendScopeForbidden,
+} from "./http-common.js";
 import {
   OPENCLAW_DEFAULT_MODEL_ID,
   OPENCLAW_MODEL_ID,
@@ -92,13 +97,7 @@ export async function handleOpenAiModelsHttpRequest(
   const requestedScopes = resolveOpenAiCompatibleHttpOperatorScopes(req, requestAuth);
   const scopeAuth = authorizeOperatorScopesForMethod("models.list", requestedScopes);
   if (!scopeAuth.allowed) {
-    sendJson(res, 403, {
-      ok: false,
-      error: {
-        type: "forbidden",
-        message: `missing scope: ${scopeAuth.missingScope}`,
-      },
-    });
+    sendScopeForbidden(res, scopeAuth.missingScope);
     return true;
   }
 

--- a/src/gateway/session-kill-http.ts
+++ b/src/gateway/session-kill-http.ts
@@ -9,7 +9,7 @@ import { getRuntimeConfig } from "../config/io.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import { isLocalDirectRequest, type ResolvedGatewayAuth } from "./auth.js";
-import { sendJson, sendMethodNotAllowed } from "./http-common.js";
+import { sendJson, sendMethodNotAllowed, sendScopeForbidden } from "./http-common.js";
 import {
   authorizeGatewayHttpRequestOrReply,
   resolveTrustedHttpOperatorScopes,
@@ -89,13 +89,7 @@ export async function handleSessionKillHttpRequest(
     requesterSessionKey && !allowLocalAdminKill ? "sessions.abort" : "sessions.delete";
   const scopeAuth = authorizeOperatorScopesForMethod(requiredOperatorMethod, requestedScopes);
   if (!scopeAuth.allowed) {
-    sendJson(res, 403, {
-      ok: false,
-      error: {
-        type: "forbidden",
-        message: `missing scope: ${scopeAuth.missingScope}`,
-      },
-    });
+    sendScopeForbidden(res, scopeAuth.missingScope);
     return true;
   }
 


### PR DESCRIPTION
Fixes #79066

## Summary

Six HTTP handlers duplicated the same inline `sendJson(res, 403, { ok: false, error: { type: "forbidden", message: \`missing scope: \${scopeAuth.missingScope}\` } })` block. This is a payload consistency risk — any future change to the 403 shape (e.g. adding a `required` field) must be applied in all six places.

Add `sendScopeForbidden(res, missingScope)` to `http-common.ts`, consistent with the existing `sendUnauthorized` / `sendRateLimited` / `sendInvalidRequest` helpers in the same file, and replace all six call sites.

## Files changed

| File | Change |
|------|--------|
| `src/gateway/http-common.ts` | new `sendScopeForbidden` helper |
| `src/gateway/http-common.test.ts` | 2 new tests for the helper |
| `src/gateway/http-endpoint-helpers.ts` | replace inline block |
| `src/gateway/http-endpoint-helpers.test.ts` | update mock + assertion |
| `src/gateway/http-auth-utils.ts` | replace inline block; unused `sendJson` import removed |
| `src/gateway/models-http.ts` | replace inline block |
| `src/gateway/session-kill-http.ts` | replace inline block |
| `src/gateway/managed-image-attachments.ts` | replace inline block |
| `src/gateway/control-ui.ts` | replace inline block |

Not changed: `server-methods.ts` / `server-methods/nodes.ts` — those use `errorShape()` for WebSocket/JSON-RPC responses, a different protocol surface that is not affected by this refactor.

## Real behavior proof

- **Behavior or issue addressed:** duplicate inline missing-scope 403 payload across 6 HTTP handler files; payload shape inconsistency risk
- **Real environment tested:** Node v22.22.0, vitest v4.1.5
- **Exact steps or command run:** `npx vitest run src/gateway/http-common.test.ts src/gateway/http-endpoint-helpers.test.ts src/gateway/models-http.test.ts`
- **Evidence after fix:** 137/137 tests pass; 2 new tests assert `sendScopeForbidden` emits 403 with the correct `ok: false` / `error.type: "forbidden"` / `message: "missing scope: <scope>"` shape
- **Observed result after fix:** all six call sites replaced; `sendScopeForbidden` is the single source of truth for the 403 payload shape
- **What was not tested:** live gateway end-to-end with a real operator token that has insufficient scope; control-ui browser flow