### PR TITLE
Fix agent image validation for per-agent models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/agent: validate first-message image attachments against the requested session's per-agent model instead of the global default, so fresh sessions with vision-capable agent overrides accept inline images. Fixes #79407. Thanks @jialudev.
 - Cron/agents: recognize same-target `edit`↔`write` recovery in `isSameToolMutationAction`, so a successful `write` to a path clears an earlier failed `edit` on the same path. Stops cron from reporting fatal failures when an agent self-heals across `edit` and `write`, while preserving same-tool fingerprint matching, blocking different-target writes, and excluding tools (including `apply_patch`) whose real call args do not produce a stable `path` fingerprint segment. Fixes #79024. Thanks @RenzoMXD.
 - Gateway/Tailscale: add opt-in `gateway.tailscale.preserveFunnel` so when `tailscale.mode = "serve"` and an externally configured Tailscale Funnel route already covers the gateway port, OpenClaw skips re-applying `tailscale serve` on startup and skips the `resetOnExit` teardown for that run, keeping operator-managed Funnel exposure alive across gateway restarts. Fixes #57241. Thanks @RenzoMXD.
 - Agents/compaction: keep the recent tail after manual `/compact` when Pi returns an empty or no-op compaction summary, preventing blank checkpoints from replacing the live context.

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -33,6 +33,9 @@ const mocks = vi.hoisted(() => ({
   resolveExplicitAgentSessionKey: vi.fn(),
   resolveBareResetBootstrapFileAccess: vi.fn(() => true),
   listAgentIds: vi.fn(() => ["main"]),
+  resolveAgentEffectiveModelPrimary: vi.fn(
+    (_cfg: unknown, _agentId: string): string | undefined => undefined,
+  ),
   loadConfigReturn: {} as Record<string, unknown>,
   loadVoiceWakeRoutingConfig: vi.fn(),
   resolveVoiceWakeRouteByTrigger: vi.fn(),
@@ -91,7 +94,7 @@ vi.mock("../../agents/agent-scope.js", () => ({
     cfg.agents?.list?.find((agent) => agent.id === agentId),
   resolveAgentWorkspaceDir: (cfg: { agents?: { defaults?: { workspace?: string } } }) =>
     cfg?.agents?.defaults?.workspace ?? "/tmp/workspace",
-  resolveAgentEffectiveModelPrimary: () => undefined,
+  resolveAgentEffectiveModelPrimary: mocks.resolveAgentEffectiveModelPrimary,
 }));
 
 vi.mock("../../auto-reply/reply/session-reset-prompt.js", async () => {
@@ -428,6 +431,7 @@ describe("gateway agent handler", () => {
     mocks.resolveExplicitAgentSessionKey.mockReset().mockReturnValue(undefined);
     mocks.resolveBareResetBootstrapFileAccess.mockReset().mockReturnValue(true);
     mocks.listAgentIds.mockReset().mockReturnValue(["main"]);
+    mocks.resolveAgentEffectiveModelPrimary.mockReset().mockReturnValue(undefined);
     mocks.resolveSendPolicy.mockReset().mockReturnValue("allow");
     dateOnlyFakeClockActive = false;
     vi.useRealTimers();
@@ -1103,6 +1107,94 @@ describe("gateway agent handler", () => {
     const logMeta = (context.logGateway.error as unknown as ReturnType<typeof vi.fn>).mock
       .calls[0]?.[1] as { error?: string } | undefined;
     expect(logMeta?.error).toContain("\n    at ");
+  });
+
+  it("validates fresh-session image attachments against the per-agent model", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "local/text-only",
+          },
+        },
+        list: [
+          {
+            id: "writer",
+            model: {
+              primary: "local/vision",
+            },
+          },
+        ],
+      },
+      models: {
+        providers: {
+          local: {},
+        },
+      },
+    };
+    const sessionKey = "agent:writer:main";
+    mocks.loadConfigReturn = cfg;
+    mocks.listAgentIds.mockReturnValue(["main", "writer"]);
+    mocks.resolveAgentEffectiveModelPrimary.mockImplementation(
+      (runtimeCfg: unknown, agentId: string) => {
+        const typedCfg = runtimeCfg as typeof cfg;
+        const agent = typedCfg.agents.list.find((candidate) => candidate.id === agentId);
+        return agent?.model?.primary ?? typedCfg.agents.defaults.model.primary;
+      },
+    );
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: "fresh-session-id",
+        updatedAt: Date.now(),
+      },
+      canonicalKey: sessionKey,
+    });
+    mocks.updateSessionStore.mockResolvedValue(undefined);
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+    const context = {
+      ...makeContext(),
+      loadGatewayModelCatalog: vi.fn(async () => [
+        { provider: "local", id: "text-only", name: "text-only", input: ["text"] },
+        { provider: "local", id: "vision", name: "vision", input: ["text", "image"] },
+      ]),
+    } as unknown as GatewayRequestContext;
+
+    await invokeAgent(
+      {
+        message: "inspect this",
+        agentId: "writer",
+        sessionKey,
+        idempotencyKey: "test-agent-fresh-session-agent-model-attachments",
+        attachments: [
+          {
+            type: "file",
+            mimeType: "image/png",
+            fileName: "pixel.png",
+            content:
+              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+          },
+        ],
+      },
+      { context, reqId: "agent-fresh-session-agent-model-attachments" },
+    );
+
+    const callArgs = await waitForAgentCommandCall<{
+      images?: Array<{ data: string; mimeType: string; type: string }>;
+      imageOrder?: unknown[];
+    }>();
+    expect(context.loadGatewayModelCatalog).toHaveBeenCalledWith({ readOnly: false });
+    expect(callArgs.images).toEqual([
+      expect.objectContaining({
+        type: "image",
+        mimeType: "image/png",
+      }),
+    ]);
+    expect(callArgs.imageOrder).toEqual(["inline"]);
   });
 
   it("keeps model-run gateway prompts undecorated and forwards raw-run flags", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -629,8 +629,13 @@ export const agentHandlers: GatewayRequestHandlers = {
       let baseProvider: string | undefined;
       let baseModel: string | undefined;
       if (requestedSessionKeyRaw) {
-        const { cfg: sessCfg, entry: sessEntry } = loadSessionEntry(requestedSessionKeyRaw);
-        const modelRef = resolveSessionModelRef(sessCfg, sessEntry, undefined);
+        const {
+          cfg: sessCfg,
+          entry: sessEntry,
+          canonicalKey,
+        } = loadSessionEntry(requestedSessionKeyRaw);
+        const sessionAgentId = resolveAgentIdFromSessionKey(canonicalKey);
+        const modelRef = resolveSessionModelRef(sessCfg, sessEntry, sessionAgentId);
         baseProvider = modelRef.provider;
         baseModel = modelRef.model;
       }


### PR DESCRIPTION
## Summary

- resolve `agent.run` attachment validation against the canonical session agent before checking image support
- add a regression test for a fresh per-agent session whose agent model supports images while the global default is text-only
- add the Unreleased changelog entry

Fixes #79407.

## Real behavior proof

- **Behavior or issue addressed:** first-message `agent.run` image attachments for a fresh per-agent session were validated against the global default model instead of the requested session's agent model, causing vision-capable agent overrides to be rejected when the global default was text-only.
- **Real environment tested:** local OpenClaw checkout on Linux from this PR branch, using actual `src/gateway/session-utils.ts` runtime model resolution and Gateway model image-support helpers with an isolated config shape matching the issue. Jared's shared yoyo Gateway was not touched.
- **Exact steps or command run after this patch:** ran a live Node/tsx command from the repo root that compares the old missing-agent-id resolution path against the fixed session-agent resolution path for `agent:writer:main`.
- **Evidence after fix:** copied terminal output from the live command:

```console
$ node --import tsx -e 'import { resolveGatewayModelSupportsImages, resolveSessionModelRef } from "./src/gateway/session-utils.ts"; const cfg={agents:{defaults:{model:{primary:"local/text-only"}},list:[{id:"writer",model:{primary:"local/vision"}}]},models:{providers:{local:{}}}}; const entry={sessionId:"fresh-session-id",updatedAt:Date.now()}; const catalog=[{provider:"local",id:"text-only",name:"text-only",input:["text"]},{provider:"local",id:"vision",name:"vision",input:["text","image"]}]; const withoutSessionAgent=resolveSessionModelRef(cfg,entry,undefined); const withSessionAgent=resolveSessionModelRef(cfg,entry,"writer"); const result={withoutSessionAgent:{...withoutSessionAgent,supportsInlineImages:await resolveGatewayModelSupportsImages({provider:withoutSessionAgent.provider,model:withoutSessionAgent.model,loadGatewayModelCatalog:async()=>catalog})},withSessionAgent:{...withSessionAgent,supportsInlineImages:await resolveGatewayModelSupportsImages({provider:withSessionAgent.provider,model:withSessionAgent.model,loadGatewayModelCatalog:async()=>catalog})}}; console.log(JSON.stringify(result,null,2));'
{
  "withoutSessionAgent": {
    "provider": "local",
    "model": "text-only",
    "supportsInlineImages": false
  },
  "withSessionAgent": {
    "provider": "local",
    "model": "vision",
    "supportsInlineImages": true
  }
}
```

- **Observed result after fix:** resolving the fresh session with the canonical session agent selects `local/vision` and reports `supportsInlineImages: true`; the previous missing-agent-id path selects `local/text-only` and reports `supportsInlineImages: false`, matching the reported rejection cause.
- **What was not tested:** I did not start a full local Gateway or call a real model provider because this workstation has Jared's shared OpenClaw yoyo runtime on reserved state/port; the focused runtime command and regression test avoid touching that service.

## Verification

- `pnpm docs:list`
- `pnpm exec oxfmt --check --threads=1 src/gateway/server-methods/agent.ts src/gateway/server-methods/agent.test.ts`
- `git diff --check`
- `pnpm test src/gateway/server-methods/agent.test.ts`
- `pnpm check:changed`