### PR TITLE
fix(plugins): emit logger.warn when conversation hook registration is blocked at load time

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -5591,10 +5591,18 @@ module.exports = {
 } };`,
     });
 
+    const warnMessages: string[] = [];
     const registry = loadRegistryFromSinglePlugin({
       plugin,
       pluginConfig: {
         allow: ["conversation-hooks"],
+      },
+      options: {
+        logger: {
+          warn: (msg: string) => {
+            warnMessages.push(msg);
+          },
+        },
       },
     });
 
@@ -5605,6 +5613,14 @@ module.exports = {
       ),
     );
     expect(blockedDiagnostics).toHaveLength(7);
+    const blockedWarnLogs = warnMessages.filter(
+      (msg) =>
+        msg.includes("conversation-hooks") &&
+        msg.includes(
+          "non-bundled plugins must set plugins.entries.conversation-hooks.hooks.allowConversationAccess=true",
+        ),
+    );
+    expect(blockedWarnLogs).toHaveLength(7);
   });
 
   it("allows conversation typed hooks for non-bundled plugins when explicitly enabled", () => {

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2164,23 +2164,27 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     if (isConversationHookName(hookName)) {
       const explicitConversationAccess = policy?.allowConversationAccess;
       if (record.origin !== "bundled" && explicitConversationAccess !== true) {
+        const blockMsg =
+          `typed hook "${hookName}" blocked because non-bundled plugins must set ` +
+          `plugins.entries.${record.id}.hooks.allowConversationAccess=true`;
         pushDiagnostic({
           level: "warn",
           pluginId: record.id,
           source: record.source,
-          message:
-            `typed hook "${hookName}" blocked because non-bundled plugins must set ` +
-            `plugins.entries.${record.id}.hooks.allowConversationAccess=true`,
+          message: blockMsg,
         });
+        registryParams.logger.warn(`[plugins] ${record.id}: ${blockMsg}`);
         return;
       }
       if (record.origin === "bundled" && explicitConversationAccess === false) {
+        const blockMsg = `typed hook "${hookName}" blocked by plugins.entries.${record.id}.hooks.allowConversationAccess=false`;
         pushDiagnostic({
           level: "warn",
           pluginId: record.id,
           source: record.source,
-          message: `typed hook "${hookName}" blocked by plugins.entries.${record.id}.hooks.allowConversationAccess=false`,
+          message: blockMsg,
         });
+        registryParams.logger.warn(`[plugins] ${record.id}: ${blockMsg}`);
         return;
       }
     }


### PR DESCRIPTION
Fixes #79421.

## What and why

When a non-bundled plugin calls `api.on("llm_output", ...)` or any other conversation hook without `plugins.entries.<id>.hooks.allowConversationAccess=true`, the loader silently drops the registration. The denial is recorded only in the plugin-scoped diagnostic sink (`pushDiagnostic`), which is visible exclusively via `openclaw plugins inspect <id> --runtime --json`. Nothing appears in the gateway log or on stderr. Plugin authors have no operational signal that their handler was dropped.

This change adds a `registryParams.logger.warn(...)` call at both conversation-hook block sites in `registerTypedHook` — one for non-bundled plugins missing opt-in, one for bundled plugins with explicit opt-out. The diagnostic sink call is preserved unchanged.

## Changes

- `src/plugins/registry.ts` — extract block message to local variable, add `registryParams.logger.warn(...)` alongside existing `pushDiagnostic` at both block sites
- `src/plugins/loader.test.ts` — extend existing "blocks conversation typed hooks" test with mock logger injection and assertion that 7 blocked-hook calls reach `logger.warn`

## Real behavior proof

- Behavior or issue addressed: non-bundled plugin registering llm_output and before_agent_finalize without allowConversationAccess=true received no logger.warn at load time; hooks were silently dropped
- Real environment tested: Linux 6.11.0-1016-nvidia x64, Node v22.14.0, openclaw source at c1425b5296
- Exact steps or command run after this patch: node --import tsx /tmp/proof_79421.mjs
- Evidence after fix: typedHooks registered: 0 (expected 0 — hooks blocked) / blocked hook warnings: 2 (expected 2 — llm_output + before_agent_finalize) / PASS: conversation-hook blocks are emitted to logger.warn at load time
- Observed result after fix: registryParams.logger.warn emits "[plugins] proof-plugin: typed hook \\"llm_output\\" blocked because non-bundled plugins must set plugins.entries.proof-plugin.hooks.allowConversationAccess=true" and equivalent for before_agent_finalize at load time; 124/124 existing loader tests pass
- What was not tested: bundled plugin with explicit allowConversationAccess=false path (covered by existing vitest suite); production gateway log formatting