### PR TITLE
fix(telegram): treat explicit empty groups as unset for root fallback in single-account bots

### DIFF
--- a/extensions/telegram/src/account-config.ts
+++ b/extensions/telegram/src/account-config.ts
@@ -70,7 +70,10 @@ export function mergeTelegramAccountConfig(
   // Multi-account bots must not inherit channel-level groups unless explicitly set.
   const configuredAccountIds = Object.keys(cfg.channels?.telegram?.accounts ?? {});
   const isMultiAccount = configuredAccountIds.length > 1;
-  const groups = account.groups ?? (isMultiAccount ? undefined : channelGroups);
+  // An explicit `groups: {}` is not nullish but is semantically "unset" for single-account bots.
+  // Treat an empty object the same as undefined so the root channelGroups fallback applies.
+  const accountGroupsDefined = account.groups != null && Object.keys(account.groups).length > 0;
+  const groups = accountGroupsDefined ? account.groups : isMultiAccount ? undefined : channelGroups;
   const allowFrom = resolveMergedAllowFrom({
     baseAllowFrom: base.allowFrom,
     accountAllowFrom: account.allowFrom,

--- a/extensions/telegram/src/accounts.test.ts
+++ b/extensions/telegram/src/accounts.test.ts
@@ -448,6 +448,56 @@ describe("mergeTelegramAccountConfig", () => {
       allowFrom: ["456"],
     });
   });
+
+  it("falls back to root groups when account sets explicit empty groups object", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          enabled: true,
+          groupPolicy: "allowlist",
+          groups: {
+            "-1003221749234": { requireMention: false },
+          },
+          accounts: {
+            default: {
+              botToken: "legacy-token",
+              groupPolicy: "allowlist",
+              groups: {},
+            },
+          },
+        },
+      },
+    };
+
+    expect(mergeTelegramAccountConfig(cfg, "default")).toMatchObject({
+      groups: { "-1003221749234": { requireMention: false } },
+    });
+  });
+
+  it("preserves account groups when non-empty, not falling back to root", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          enabled: true,
+          groups: {
+            "-1000000000001": { requireMention: false },
+          },
+          accounts: {
+            default: {
+              botToken: "legacy-token",
+              groups: {
+                "-1000000000002": { requireMention: true },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const merged = mergeTelegramAccountConfig(cfg, "default");
+    expect(merged.groups).toMatchObject({ "-1000000000002": { requireMention: true } });
+    expect(merged.groups).not.toHaveProperty("-1000000000001");
+  });
 });
 
 describe("resolveTelegramPollActionGateState", () => {


### PR DESCRIPTION
Fixes #79427.

## What and why

`mergeTelegramAccountConfig` uses `account.groups ?? (isMultiAccount ? undefined : channelGroups)` to decide which groups map to use. An explicit `groups: {}` in the account config is not nullish, so the `??` short-circuits and returns the empty object. For single-account bots with `groupPolicy: allowlist`, this means the resolved groups map is empty and every inbound group update is dropped with `reason: not-allowed`, even when the root `channels.telegram.groups` has matching entries.

Fix: treat an empty object (zero keys) the same as absent — fall back to root `channelGroups` when `account.groups` has no keys. The existing behaviour for non-empty `account.groups` is unchanged.

## Changes

- `extensions/telegram/src/account-config.ts` — replace `??` with an explicit empty-object check before the root fallback
- `extensions/telegram/src/accounts.test.ts` — add two regression cases: empty groups falls back, non-empty groups takes precedence

## Real behavior proof

- Behavior or issue addressed: single-account bot with explicit `accounts.default.groups: {}` silently dropped all group updates because root channelGroups was never consulted
- Real environment tested: Linux 6.11.0-1016-nvidia x64, Node v22.14.0, openclaw source at ce61e6bfea
- Exact steps or command run after this patch: node --import tsx /tmp/proof_79427.mjs
- Evidence after fix: merged.groups: {"-1003221749234":{"requireMention":false}} / PASS: empty account.groups falls back to root channelGroups
- Observed result after fix: mergeTelegramAccountConfig returns root groups when account-level groups map has zero keys; 33/33 existing accounts tests pass including two new regression cases
- What was not tested: multi-account bots (groups fallback is disabled by design when configuredAccountIds.length > 1, behaviour unchanged)