### PR TITLE
Add Gmail integration with inbox, draft, and send flow

### DIFF
--- a/extensions/google/gmail-api.test.ts
+++ b/extensions/google/gmail-api.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildGmailApiUrl,
+  buildGmailDraftCreateRequest,
+  buildGmailDraftMime,
+  buildGmailSearchQuery,
+  encodeBase64UrlUtf8,
+} from "./gmail-api.js";
+
+describe("buildGmailSearchQuery", () => {
+  it("combines inbox, unread, sender, subject, labels, and free-text terms", () => {
+    expect(
+      buildGmailSearchQuery({
+        inInbox: true,
+        unread: true,
+        from: "boss@example.com",
+        subject: "quarterly review",
+        labels: ["IMPORTANT"],
+        hasWords: ["follow up", "budget"],
+        query: "newer_than:7d",
+      }),
+    ).toBe(
+      'in:inbox is:unread label:IMPORTANT from:boss@example.com subject:(quarterly review) "follow up" "budget" newer_than:7d',
+    );
+  });
+});
+
+describe("buildGmailDraftMime", () => {
+  it("builds a plain-text MIME message", () => {
+    const mime = buildGmailDraftMime({
+      to: ["alex@example.com"],
+      cc: "team@example.com",
+      subject: "Hello",
+      textBody: "Thanks for the update.",
+      inReplyTo: "<msg-1@example.com>",
+    });
+
+    expect(mime).toContain("To: alex@example.com");
+    expect(mime).toContain("Cc: team@example.com");
+    expect(mime).toContain("Subject: Hello");
+    expect(mime).toContain("In-Reply-To: <msg-1@example.com>");
+    expect(mime).toContain('Content-Type: text/plain; charset="UTF-8"');
+    expect(mime).toContain("Thanks for the update.");
+  });
+
+  it("builds a multipart alternative MIME message when html is present", () => {
+    const mime = buildGmailDraftMime({
+      to: "alex@example.com",
+      subject: "Hello",
+      textBody: "Plain version",
+      htmlBody: "<p>HTML version</p>",
+    });
+
+    expect(mime).toContain("Content-Type: multipart/alternative");
+    expect(mime).toContain("Plain version");
+    expect(mime).toContain("<p>HTML version</p>");
+  });
+
+  it("throws when required fields are missing", () => {
+    expect(() =>
+      buildGmailDraftMime({
+        to: [],
+        subject: "Hello",
+        textBody: "hi",
+      }),
+    ).toThrow(/recipient/);
+
+    expect(() =>
+      buildGmailDraftMime({
+        to: "a@example.com",
+        subject: "",
+        textBody: "hi",
+      }),
+    ).toThrow(/subject/);
+
+    expect(() =>
+      buildGmailDraftMime({
+        to: "a@example.com",
+        subject: "Hello",
+      }),
+    ).toThrow(/textBody or htmlBody/);
+  });
+});
+
+describe("buildGmailDraftCreateRequest", () => {
+  it("encodes the MIME payload as base64url and preserves thread id", () => {
+    const request = buildGmailDraftCreateRequest({
+      to: "alex@example.com",
+      subject: "Draft",
+      textBody: "Body",
+      threadId: "thread-123",
+    });
+
+    expect(request.message.threadId).toBe("thread-123");
+    expect(request.message.raw).not.toContain("+");
+    expect(request.message.raw).not.toContain("/");
+    expect(request.message.raw).not.toContain("=");
+  });
+});
+
+describe("buildGmailApiUrl", () => {
+  it("builds a Gmail API URL with query params", () => {
+    expect(
+      buildGmailApiUrl("/messages", {
+        maxResults: 25,
+        q: "in:inbox",
+        includeSpamTrash: false,
+      }),
+    ).toBe("https://gmail.googleapis.com/gmail/v1/users/me/messages?maxResults=25&q=in%3Ainbox");
+  });
+});
+
+describe("encodeBase64UrlUtf8", () => {
+  it("produces base64url output", () => {
+    expect(encodeBase64UrlUtf8("hello?")).toBe("aGVsbG8_");
+  });
+});

--- a/extensions/google/gmail-api.ts
+++ b/extensions/google/gmail-api.ts
@@ -1,0 +1,173 @@
+import type {
+  GmailDraftCreateRequest,
+  GmailDraftMessageInput,
+  GmailEncodedMessageRequest,
+  GmailSearchParams,
+} from "./gmail-types.js";
+
+const GMAIL_API_BASE_URL = "https://gmail.googleapis.com/gmail/v1/users/me";
+const MIME_CRLF = "\r\n";
+
+function normalizeRecipientList(value?: string | string[]): string[] {
+  if (!value) {
+    return [];
+  }
+  const list = Array.isArray(value) ? value : [value];
+  return list.map((entry) => entry.trim()).filter(Boolean);
+}
+
+function encodeHeaderValue(value: string): string {
+  return value.replace(/\r?\n/g, " ").trim();
+}
+
+function buildHeader(name: string, value?: string | string[]): string | null {
+  const list = normalizeRecipientList(value);
+  if (typeof value === "string" && name.toLowerCase() === "subject") {
+    return `${name}: ${encodeHeaderValue(value)}`;
+  }
+  if (list.length === 0) {
+    return null;
+  }
+  return `${name}: ${list.map(encodeHeaderValue).join(", ")}`;
+}
+
+function buildTextMime(params: GmailDraftMessageInput): string {
+  const headers = [
+    buildHeader("From", params.from),
+    buildHeader("To", params.to),
+    buildHeader("Cc", params.cc),
+    buildHeader("Bcc", params.bcc),
+    buildHeader("Subject", params.subject),
+    buildHeader("In-Reply-To", params.inReplyTo),
+    buildHeader("References", params.references),
+    "MIME-Version: 1.0",
+    'Content-Type: text/plain; charset="UTF-8"',
+    "Content-Transfer-Encoding: 7bit",
+  ].filter((value): value is string => Boolean(value));
+  return `${headers.join(MIME_CRLF)}${MIME_CRLF}${MIME_CRLF}${params.textBody ?? ""}`;
+}
+
+function buildHtmlMime(params: GmailDraftMessageInput): string {
+  const boundary = `openclaw-gmail-${Math.random().toString(16).slice(2)}`;
+  const headers = [
+    buildHeader("From", params.from),
+    buildHeader("To", params.to),
+    buildHeader("Cc", params.cc),
+    buildHeader("Bcc", params.bcc),
+    buildHeader("Subject", params.subject),
+    buildHeader("In-Reply-To", params.inReplyTo),
+    buildHeader("References", params.references),
+    "MIME-Version: 1.0",
+    `Content-Type: multipart/alternative; boundary="${boundary}"`,
+  ].filter((value): value is string => Boolean(value));
+  const parts: string[] = [];
+  if (params.textBody) {
+    parts.push(
+      `--${boundary}`,
+      'Content-Type: text/plain; charset="UTF-8"',
+      "Content-Transfer-Encoding: 7bit",
+      "",
+      params.textBody,
+    );
+  }
+  parts.push(
+    `--${boundary}`,
+    'Content-Type: text/html; charset="UTF-8"',
+    "Content-Transfer-Encoding: 7bit",
+    "",
+    params.htmlBody ?? "",
+    `--${boundary}--`,
+  );
+  return `${headers.join(MIME_CRLF)}${MIME_CRLF}${MIME_CRLF}${parts.join(MIME_CRLF)}`;
+}
+
+export function encodeBase64UrlUtf8(value: string): string {
+  return Buffer.from(value, "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+export function buildGmailDraftMime(params: GmailDraftMessageInput): string {
+  if (!normalizeRecipientList(params.to).length) {
+    throw new Error("Draft requires at least one 'to' recipient");
+  }
+  if (!params.subject.trim()) {
+    throw new Error("Draft requires a subject");
+  }
+  if (!params.textBody && !params.htmlBody) {
+    throw new Error("Draft requires textBody or htmlBody");
+  }
+  return params.htmlBody ? buildHtmlMime(params) : buildTextMime(params);
+}
+
+export function buildGmailEncodedMessageRequest(
+  params: GmailDraftMessageInput,
+): GmailEncodedMessageRequest {
+  return {
+    raw: encodeBase64UrlUtf8(buildGmailDraftMime(params)),
+    ...(params.threadId ? { threadId: params.threadId } : {}),
+  };
+}
+
+export function buildGmailDraftCreateRequest(
+  params: GmailDraftMessageInput,
+): GmailDraftCreateRequest {
+  return {
+    message: buildGmailEncodedMessageRequest(params),
+  };
+}
+
+export function buildGmailSearchQuery(params: GmailSearchParams): string {
+  const parts: string[] = [];
+  if (params.inInbox) {
+    parts.push("in:inbox");
+  }
+  if (params.unread) {
+    parts.push("is:unread");
+  }
+  for (const label of params.labels ?? []) {
+    const trimmed = label.trim();
+    if (trimmed) {
+      parts.push(`label:${trimmed}`);
+    }
+  }
+  if (params.newerThanDays && Number.isFinite(params.newerThanDays) && params.newerThanDays > 0) {
+    parts.push(`newer_than:${Math.floor(params.newerThanDays)}d`);
+  }
+  if (params.from?.trim()) {
+    parts.push(`from:${params.from.trim()}`);
+  }
+  if (params.to?.trim()) {
+    parts.push(`to:${params.to.trim()}`);
+  }
+  if (params.subject?.trim()) {
+    parts.push(`subject:(${params.subject.trim()})`);
+  }
+  for (const word of params.hasWords ?? []) {
+    const trimmed = word.trim();
+    if (trimmed) {
+      parts.push(`"${trimmed.replace(/"/g, '\\"')}"`);
+    }
+  }
+  if (params.query?.trim()) {
+    parts.push(params.query.trim());
+  }
+  return parts.join(" ").trim();
+}
+
+export function buildGmailApiUrl(
+  path: string,
+  query?: Record<string, string | number | boolean | undefined>,
+): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  const url = new URL(`${GMAIL_API_BASE_URL}${normalizedPath}`);
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (value === undefined || value === false || value === "") {
+      continue;
+    }
+    url.searchParams.set(key, String(value));
+  }
+  return url.toString();
+}

--- a/extensions/google/gmail-auth-store.ts
+++ b/extensions/google/gmail-auth-store.ts
@@ -1,0 +1,93 @@
+import {
+  ensureAuthProfileStore,
+  listProfilesForProvider,
+  upsertAuthProfileWithLock,
+  writeOAuthCredentials,
+  type OAuthCredential,
+} from "openclaw/plugin-sdk/provider-auth";
+
+export const GMAIL_PROVIDER_ID = "google-gmail";
+
+export type GmailStoredProfile = {
+  profileId: string;
+  email?: string;
+  displayName?: string;
+  expires?: number;
+};
+
+function isOAuthCredential(value: unknown): value is OAuthCredential {
+  return !!value && typeof value === "object" && (value as { type?: string }).type === "oauth";
+}
+
+export function listGmailStoredProfiles(agentDir?: string): GmailStoredProfile[] {
+  const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+  return listProfilesForProvider(store, GMAIL_PROVIDER_ID)
+    .map((profileId) => {
+      const credential = store.profiles[profileId];
+      if (!isOAuthCredential(credential)) {
+        return null;
+      }
+      return {
+        profileId,
+        email: credential.email,
+        displayName: credential.displayName,
+        expires: credential.expires,
+      };
+    })
+    .filter((value): value is GmailStoredProfile => value !== null);
+}
+
+export function resolveStoredGmailCredential(params: { agentDir?: string; profileId?: string }): {
+  profileId: string;
+  credential: OAuthCredential;
+} {
+  const store = ensureAuthProfileStore(params.agentDir, { allowKeychainPrompt: false });
+  const candidateIds = params.profileId
+    ? [params.profileId]
+    : listProfilesForProvider(store, GMAIL_PROVIDER_ID);
+
+  for (const profileId of candidateIds) {
+    const credential = store.profiles[profileId];
+    if (isOAuthCredential(credential)) {
+      return { profileId, credential };
+    }
+  }
+
+  throw new Error("No Gmail OAuth profile is configured.");
+}
+
+export async function storeGmailOAuthCredentials(params: {
+  agentDir?: string;
+  access: string;
+  refresh: string;
+  expires: number;
+  email?: string;
+  displayName?: string;
+}): Promise<string> {
+  return await writeOAuthCredentials(
+    GMAIL_PROVIDER_ID,
+    {
+      access: params.access,
+      refresh: params.refresh,
+      expires: params.expires,
+      ...(params.email ? { email: params.email } : {}),
+    },
+    params.agentDir,
+    {
+      ...(params.email ? { profileName: params.email } : {}),
+      ...(params.displayName ? { displayName: params.displayName } : {}),
+    },
+  );
+}
+
+export async function persistGmailRefresh(params: {
+  agentDir?: string;
+  profileId: string;
+  credential: OAuthCredential;
+}): Promise<void> {
+  await upsertAuthProfileWithLock({
+    agentDir: params.agentDir,
+    profileId: params.profileId,
+    credential: params.credential,
+  });
+}

--- a/extensions/google/gmail-client.test.ts
+++ b/extensions/google/gmail-client.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import { createGmailClient } from "./gmail-client.js";
+
+function jsonResponse(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("createGmailClient", () => {
+  it("lists messages with bearer auth", async () => {
+    const fetchFn = vi.fn(async () => jsonResponse({ messages: [{ id: "m1", threadId: "t1" }] }));
+    const client = createGmailClient({
+      auth: { accessToken: "token-1" },
+      fetchFn,
+    });
+
+    const result = await client.listMessages({ maxResults: 10, query: "in:inbox" });
+
+    expect(result.messages?.[0]?.id).toBe("m1");
+    expect(fetchFn).toHaveBeenCalledWith(
+      expect.stringContaining("/messages?maxResults=10&q=in%3Ainbox"),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer token-1" }),
+      }),
+    );
+  });
+
+  it("creates a draft with encoded raw MIME", async () => {
+    const fetchFn = vi.fn(async () => jsonResponse({ id: "draft-1" }));
+    const client = createGmailClient({
+      auth: { accessToken: "token-1" },
+      fetchFn,
+    });
+
+    const result = await client.createDraft({
+      to: "alex@example.com",
+      subject: "Re: Hello",
+      textBody: "Sounds good.",
+      threadId: "thread-1",
+    });
+
+    expect(result.id).toBe("draft-1");
+    expect(fetchFn).toHaveBeenCalledWith(
+      expect.stringContaining("/drafts"),
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer token-1" }),
+        body: expect.any(String),
+      }),
+    );
+    const [, init] = fetchFn.mock.calls[0] as [string, { body: string }];
+    const parsed = JSON.parse(init.body);
+    expect(parsed.message.threadId).toBe("thread-1");
+    expect(parsed.message.raw).toEqual(expect.any(String));
+  });
+
+  it("sends a message with encoded raw MIME", async () => {
+    const fetchFn = vi.fn(async () => jsonResponse({ id: "sent-1", threadId: "thread-1" }));
+    const client = createGmailClient({
+      auth: { accessToken: "token-1" },
+      fetchFn,
+    });
+
+    const result = await client.sendMessage({
+      to: "alex@example.com",
+      subject: "Hello",
+      textBody: "Sent body",
+      threadId: "thread-1",
+    });
+
+    expect(result.id).toBe("sent-1");
+    expect(fetchFn).toHaveBeenCalledWith(
+      expect.stringContaining("/messages/send"),
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer token-1" }),
+        body: expect.any(String),
+      }),
+    );
+    const [, init] = fetchFn.mock.calls[0] as [string, { body: string }];
+    const parsed = JSON.parse(init.body);
+    expect(parsed.threadId).toBe("thread-1");
+    expect(parsed.raw).toEqual(expect.any(String));
+  });
+
+  it("refreshes an expired access token before calling Gmail when a refresh token exists", async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(jsonResponse({ id: "m1", threadId: "t1" }));
+    const refreshTokenFn = vi.fn().mockResolvedValue({
+      access: "fresh-token",
+      refresh: "refresh-1",
+      expires: Date.now() + 3600_000,
+    });
+    const onTokenRefresh = vi.fn();
+
+    const client = createGmailClient({
+      auth: {
+        accessToken: "expired-token",
+        refreshToken: "refresh-1",
+        expiresAt: Date.now() - 1000,
+      },
+      fetchFn,
+      refreshTokenFn,
+      onTokenRefresh,
+    });
+
+    const result = await client.getMessage("m1");
+
+    expect(result.id).toBe("m1");
+    expect(refreshTokenFn).toHaveBeenCalledWith({ refreshToken: "refresh-1" });
+    expect(fetchFn).toHaveBeenCalledWith(
+      expect.stringContaining("/messages/m1?format=full"),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer fresh-token" }),
+      }),
+    );
+    expect(onTokenRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/google/gmail-client.ts
+++ b/extensions/google/gmail-client.ts
@@ -1,0 +1,151 @@
+import {
+  buildGmailApiUrl,
+  buildGmailDraftCreateRequest,
+  buildGmailEncodedMessageRequest,
+  buildGmailSearchQuery,
+} from "./gmail-api.js";
+import { refreshGmailAccessToken, type GmailOAuthCredentials } from "./gmail-oauth.js";
+import type {
+  GmailDraft,
+  GmailDraftMessageInput,
+  GmailListMessagesResponse,
+  GmailMessage,
+  GmailSearchParams,
+  GmailSentMessage,
+  GmailThread,
+} from "./gmail-types.js";
+import { fetchWithTimeout } from "./oauth.http.js";
+
+export type GmailClientAuth = {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: number;
+};
+
+export type GmailClient = {
+  auth: GmailClientAuth;
+  listMessages: (params?: {
+    maxResults?: number;
+    pageToken?: string;
+    query?: string;
+    labelIds?: string[];
+    includeSpamTrash?: boolean;
+  }) => Promise<GmailListMessagesResponse>;
+  searchMessages: (
+    params?: GmailSearchParams & { maxResults?: number; pageToken?: string },
+  ) => Promise<GmailListMessagesResponse>;
+  getMessage: (
+    id: string,
+    format?: "full" | "metadata" | "minimal" | "raw",
+  ) => Promise<GmailMessage>;
+  getThread: (id: string, format?: "full" | "metadata" | "minimal") => Promise<GmailThread>;
+  createDraft: (input: GmailDraftMessageInput) => Promise<GmailDraft>;
+  sendMessage: (input: GmailDraftMessageInput) => Promise<GmailSentMessage>;
+};
+
+type GmailClientOptions = {
+  auth: GmailClientAuth;
+  fetchFn?: typeof fetchWithTimeout;
+  refreshTokenFn?: (params: { refreshToken: string }) => Promise<GmailOAuthCredentials>;
+  onTokenRefresh?: (cred: GmailOAuthCredentials) => Promise<void> | void;
+};
+
+async function parseJsonResponse<T>(response: Response, action: string): Promise<T> {
+  if (!response.ok) {
+    throw new Error(`Gmail ${action} failed: ${await response.text()}`);
+  }
+  return (await response.json()) as T;
+}
+
+export function createGmailClient(options: GmailClientOptions): GmailClient {
+  let auth = { ...options.auth };
+  const fetchFn = options.fetchFn ?? fetchWithTimeout;
+  const refreshTokenFn = options.refreshTokenFn ?? refreshGmailAccessToken;
+
+  async function resolveAccessToken(): Promise<string> {
+    const now = Date.now();
+    if (!auth.expiresAt || auth.expiresAt > now || !auth.refreshToken) {
+      return auth.accessToken;
+    }
+    const refreshed = await refreshTokenFn({ refreshToken: auth.refreshToken });
+    auth = {
+      accessToken: refreshed.access,
+      refreshToken: refreshed.refresh,
+      expiresAt: refreshed.expires,
+    };
+    await options.onTokenRefresh?.(refreshed);
+    return auth.accessToken;
+  }
+
+  async function gmailFetch<T>(path: string, init: RequestInit = {}, action: string): Promise<T> {
+    const token = await resolveAccessToken();
+    const response = await fetchFn(path, {
+      ...init,
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+        ...(init.body ? { "Content-Type": "application/json" } : {}),
+        ...(init.headers ?? {}),
+      },
+    });
+    return await parseJsonResponse<T>(response, action);
+  }
+
+  return {
+    get auth() {
+      return auth;
+    },
+    listMessages: async (params) =>
+      await gmailFetch<GmailListMessagesResponse>(
+        buildGmailApiUrl("/messages", {
+          maxResults: params?.maxResults,
+          pageToken: params?.pageToken,
+          q: params?.query,
+          labelIds: params?.labelIds?.join(","),
+          includeSpamTrash: params?.includeSpamTrash,
+        }),
+        undefined,
+        "list messages",
+      ),
+    searchMessages: async (params) =>
+      await gmailFetch<GmailListMessagesResponse>(
+        buildGmailApiUrl("/messages", {
+          maxResults: params?.maxResults,
+          pageToken: params?.pageToken,
+          q: buildGmailSearchQuery(params ?? {}),
+        }),
+        undefined,
+        "search messages",
+      ),
+    getMessage: async (id, format = "full") =>
+      await gmailFetch<GmailMessage>(
+        buildGmailApiUrl(`/messages/${encodeURIComponent(id)}`, { format }),
+        undefined,
+        "get message",
+      ),
+    getThread: async (id, format = "full") =>
+      await gmailFetch<GmailThread>(
+        buildGmailApiUrl(`/threads/${encodeURIComponent(id)}`, { format }),
+        undefined,
+        "get thread",
+      ),
+    createDraft: async (input) =>
+      await gmailFetch<GmailDraft>(
+        buildGmailApiUrl("/drafts"),
+        {
+          method: "POST",
+          body: JSON.stringify(buildGmailDraftCreateRequest(input)),
+        },
+        "create draft",
+      ),
+    sendMessage: async (input) =>
+      await gmailFetch<GmailSentMessage>(
+        buildGmailApiUrl("/messages/send"),
+        {
+          method: "POST",
+          body: JSON.stringify(buildGmailEncodedMessageRequest(input)),
+        },
+        "send message",
+      ),
+  };
+}

--- a/extensions/google/gmail-gateway.test.ts
+++ b/extensions/google/gmail-gateway.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  buildGmailAuthUrl: vi.fn(),
+  exchangeGmailCodeForTokens: vi.fn(),
+  resolveGooglePersonalOAuthIdentity: vi.fn(),
+  listGmailStoredProfiles: vi.fn(),
+  resolveStoredGmailCredential: vi.fn(),
+  storeGmailOAuthCredentials: vi.fn(),
+  persistGmailRefresh: vi.fn(),
+  createGmailClient: vi.fn(),
+  resolveOpenClawAgentDir: vi.fn(() => "/tmp/openclaw-agent"),
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
+  resolveOpenClawAgentDir: mocks.resolveOpenClawAgentDir,
+}));
+
+vi.mock("openclaw/plugin-sdk/error-runtime", () => ({
+  formatErrorMessage: (error: unknown) => (error instanceof Error ? error.message : String(error)),
+}));
+
+vi.mock("./gmail-auth-store.js", () => ({
+  GMAIL_PROVIDER_ID: "google-gmail",
+  listGmailStoredProfiles: mocks.listGmailStoredProfiles,
+  resolveStoredGmailCredential: mocks.resolveStoredGmailCredential,
+  storeGmailOAuthCredentials: mocks.storeGmailOAuthCredentials,
+  persistGmailRefresh: mocks.persistGmailRefresh,
+}));
+
+vi.mock("./gmail-oauth.js", () => ({
+  buildGmailAuthUrl: mocks.buildGmailAuthUrl,
+  exchangeGmailCodeForTokens: mocks.exchangeGmailCodeForTokens,
+}));
+
+vi.mock("./oauth.project.js", () => ({
+  resolveGooglePersonalOAuthIdentity: mocks.resolveGooglePersonalOAuthIdentity,
+}));
+
+vi.mock("./gmail-client.js", () => ({
+  createGmailClient: mocks.createGmailClient,
+}));
+
+import { registerGmailGatewayMethods } from "./gmail-gateway.js";
+
+type RegisteredMethod = {
+  handler: (ctx: {
+    params: Record<string, unknown>;
+    respond: (ok: boolean, result?: unknown, error?: unknown) => void;
+  }) => Promise<void>;
+};
+
+function buildApi() {
+  const methods = new Map<string, RegisteredMethod>();
+  return {
+    api: {
+      config: {},
+      registerGatewayMethod: vi.fn((name: string, handler: RegisteredMethod["handler"]) => {
+        methods.set(name, { handler });
+      }),
+    },
+    methods,
+  };
+}
+
+async function invoke(
+  methods: Map<string, RegisteredMethod>,
+  name: string,
+  params: Record<string, unknown> = {},
+) {
+  const method = methods.get(name);
+  if (!method) {
+    throw new Error(`Missing method ${name}`);
+  }
+  return await new Promise<{ ok: boolean; result?: unknown; error?: unknown }>((resolve) => {
+    void method.handler({ params, respond: (ok, result, error) => resolve({ ok, result, error }) });
+  });
+}
+
+describe("registerGmailGatewayMethods", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns Gmail auth URL", async () => {
+    mocks.buildGmailAuthUrl.mockReturnValue("https://accounts.google.test/oauth");
+    const { api, methods } = buildApi();
+
+    registerGmailGatewayMethods(api as never);
+    const response = await invoke(methods, "gmail.auth.url", {
+      challenge: "challenge-1",
+      state: "state-1",
+      redirectUri: "http://localhost:3000/overview",
+    });
+
+    expect(response.ok).toBe(true);
+    expect(response.result).toEqual({
+      providerId: "google-gmail",
+      url: "https://accounts.google.test/oauth",
+    });
+    expect(mocks.buildGmailAuthUrl).toHaveBeenCalledWith({
+      challenge: "challenge-1",
+      state: "state-1",
+      redirectUri: "http://localhost:3000/overview",
+    });
+  });
+
+  it("exchanges OAuth code and stores Gmail credentials", async () => {
+    mocks.exchangeGmailCodeForTokens.mockResolvedValue({
+      access: "access-1",
+      refresh: "refresh-1",
+      expires: 123456789,
+    });
+    mocks.resolveGooglePersonalOAuthIdentity.mockResolvedValue({ email: "david@example.com" });
+    mocks.storeGmailOAuthCredentials.mockResolvedValue("google-gmail:david@example.com");
+    const { api, methods } = buildApi();
+
+    registerGmailGatewayMethods(api as never);
+    const response = await invoke(methods, "gmail.auth.exchange", {
+      code: "code-1",
+      verifier: "verifier-1",
+      redirectUri: "http://localhost:3000/overview",
+    });
+
+    expect(response.ok).toBe(true);
+    expect(mocks.exchangeGmailCodeForTokens).toHaveBeenCalledWith({
+      code: "code-1",
+      verifier: "verifier-1",
+      redirectUri: "http://localhost:3000/overview",
+    });
+    expect(mocks.storeGmailOAuthCredentials).toHaveBeenCalledWith({
+      agentDir: "/tmp/openclaw-agent",
+      access: "access-1",
+      refresh: "refresh-1",
+      expires: 123456789,
+      email: "david@example.com",
+    });
+    expect(response.result).toEqual({
+      providerId: "google-gmail",
+      profileId: "google-gmail:david@example.com",
+      email: "david@example.com",
+      expires: 123456789,
+    });
+  });
+
+  it("sends a message through the resolved Gmail profile", async () => {
+    mocks.resolveStoredGmailCredential.mockReturnValue({
+      profileId: "google-gmail:david@example.com",
+      credential: {
+        type: "oauth",
+        provider: "google-gmail",
+        access: "access-1",
+        refresh: "refresh-1",
+        expires: Date.now() + 60_000,
+      },
+    });
+    const sendMessage = vi.fn().mockResolvedValue({ id: "sent-1", threadId: "thread-1" });
+    mocks.createGmailClient.mockReturnValue({ sendMessage });
+    const { api, methods } = buildApi();
+
+    registerGmailGatewayMethods(api as never);
+    const response = await invoke(methods, "gmail.messages.send", {
+      to: "alex@example.com",
+      subject: "Hello",
+      textBody: "Sent body",
+      threadId: "thread-1",
+    });
+
+    expect(response.ok).toBe(true);
+    expect(sendMessage).toHaveBeenCalledWith({
+      to: "alex@example.com",
+      subject: "Hello",
+      textBody: "Sent body",
+      threadId: "thread-1",
+    });
+    expect(response.result).toEqual({
+      profileId: "google-gmail:david@example.com",
+      message: { id: "sent-1", threadId: "thread-1" },
+    });
+  });
+
+  it("lists messages through the resolved Gmail profile", async () => {
+    mocks.resolveStoredGmailCredential.mockReturnValue({
+      profileId: "google-gmail:david@example.com",
+      credential: {
+        type: "oauth",
+        provider: "google-gmail",
+        access: "access-1",
+        refresh: "refresh-1",
+        expires: Date.now() + 60_000,
+      },
+    });
+    const listMessages = vi.fn().mockResolvedValue({ messages: [{ id: "m1", threadId: "t1" }] });
+    mocks.createGmailClient.mockReturnValue({ listMessages });
+    const { api, methods } = buildApi();
+
+    registerGmailGatewayMethods(api as never);
+    const response = await invoke(methods, "gmail.messages.list", { maxResults: 5 });
+
+    expect(response.ok).toBe(true);
+    expect(listMessages).toHaveBeenCalledWith({
+      maxResults: 5,
+      pageToken: undefined,
+      query: undefined,
+      labelIds: undefined,
+      includeSpamTrash: undefined,
+    });
+    expect(response.result).toEqual({
+      profileId: "google-gmail:david@example.com",
+      messages: [{ id: "m1", threadId: "t1" }],
+    });
+  });
+});

--- a/extensions/google/gmail-gateway.ts
+++ b/extensions/google/gmail-gateway.ts
@@ -1,0 +1,380 @@
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { resolveOpenClawAgentDir } from "openclaw/plugin-sdk/provider-auth";
+import {
+  GMAIL_PROVIDER_ID,
+  listGmailStoredProfiles,
+  persistGmailRefresh,
+  resolveStoredGmailCredential,
+  storeGmailOAuthCredentials,
+} from "./gmail-auth-store.js";
+import { createGmailClient } from "./gmail-client.js";
+import { buildGmailAuthUrl, exchangeGmailCodeForTokens } from "./gmail-oauth.js";
+import type { GmailDraftMessageInput, GmailSearchParams } from "./gmail-types.js";
+import { resolveGooglePersonalOAuthIdentity } from "./oauth.project.js";
+
+const READ_SCOPE = "operator.read" as const;
+const WRITE_SCOPE = "operator.write" as const;
+
+type GatewayMethodContext = Parameters<
+  Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1]
+>[0];
+type GatewayRespond = GatewayMethodContext["respond"];
+
+function readStringParam(params: Record<string, unknown>, key: string): string | undefined;
+function readStringParam(
+  params: Record<string, unknown>,
+  key: string,
+  options: { required: true },
+): string;
+function readStringParam(
+  params: Record<string, unknown>,
+  key: string,
+  options?: { required?: boolean },
+): string | undefined {
+  const value = params[key];
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  if (options?.required) {
+    throw new Error(`${key} is required.`);
+  }
+  return undefined;
+}
+
+function readNumberParam(params: Record<string, unknown>, key: string): number | undefined {
+  const value = params[key];
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+function readBooleanParam(params: Record<string, unknown>, key: string): boolean | undefined {
+  const value = params[key];
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (value === "true") {
+    return true;
+  }
+  if (value === "false") {
+    return false;
+  }
+  return undefined;
+}
+
+function readStringArrayParam(params: Record<string, unknown>, key: string): string[] | undefined {
+  const value = params[key];
+  if (Array.isArray(value)) {
+    return value.filter(
+      (item): item is string => typeof item === "string" && item.trim().length > 0,
+    );
+  }
+  if (typeof value === "string" && value.trim()) {
+    return value
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+  return undefined;
+}
+
+function respondError(respond: GatewayRespond, error: unknown) {
+  respond(false, undefined, { code: "internal_error", message: formatErrorMessage(error) });
+}
+
+async function withGmailClient<T>(params: {
+  agentDir: string;
+  profileId?: string;
+  run: (client: ReturnType<typeof createGmailClient>, resolvedProfileId: string) => Promise<T>;
+}): Promise<T> {
+  const resolved = resolveStoredGmailCredential({
+    agentDir: params.agentDir,
+    profileId: params.profileId,
+  });
+
+  const client = createGmailClient({
+    auth: {
+      accessToken: resolved.credential.access,
+      refreshToken: resolved.credential.refresh,
+      expiresAt: resolved.credential.expires,
+    },
+    onTokenRefresh: async (refreshed) => {
+      await persistGmailRefresh({
+        agentDir: params.agentDir,
+        profileId: resolved.profileId,
+        credential: {
+          ...resolved.credential,
+          access: refreshed.access,
+          refresh: refreshed.refresh,
+          expires: refreshed.expires,
+          ...(refreshed.email ? { email: refreshed.email } : {}),
+        },
+      });
+    },
+  });
+
+  return await params.run(client, resolved.profileId);
+}
+
+function readSearchParams(params: Record<string, unknown>): GmailSearchParams {
+  return {
+    ...(readStringParam(params, "query") ? { query: readStringParam(params, "query") } : {}),
+    ...(readStringParam(params, "from") ? { from: readStringParam(params, "from") } : {}),
+    ...(readStringParam(params, "to") ? { to: readStringParam(params, "to") } : {}),
+    ...(readStringParam(params, "subject") ? { subject: readStringParam(params, "subject") } : {}),
+    ...(readStringParam(params, "label") ? { label: readStringParam(params, "label") } : {}),
+    ...(readStringParam(params, "after") ? { after: readStringParam(params, "after") } : {}),
+    ...(readStringParam(params, "before") ? { before: readStringParam(params, "before") } : {}),
+    ...(readBooleanParam(params, "isUnread") !== undefined
+      ? { isUnread: readBooleanParam(params, "isUnread") }
+      : {}),
+    ...(readBooleanParam(params, "inInbox") !== undefined
+      ? { inInbox: readBooleanParam(params, "inInbox") }
+      : {}),
+    ...(readBooleanParam(params, "hasAttachment") !== undefined
+      ? { hasAttachment: readBooleanParam(params, "hasAttachment") }
+      : {}),
+  };
+}
+
+function readDraftInput(params: Record<string, unknown>): GmailDraftMessageInput {
+  return {
+    to: readStringParam(params, "to", { required: true }),
+    subject: readStringParam(params, "subject", { required: true }),
+    ...(readStringParam(params, "textBody")
+      ? { textBody: readStringParam(params, "textBody") }
+      : {}),
+    ...(readStringParam(params, "htmlBody")
+      ? { htmlBody: readStringParam(params, "htmlBody") }
+      : {}),
+    ...(readStringArrayParam(params, "cc") ? { cc: readStringArrayParam(params, "cc") } : {}),
+    ...(readStringArrayParam(params, "bcc") ? { bcc: readStringArrayParam(params, "bcc") } : {}),
+    ...(readStringParam(params, "threadId")
+      ? { threadId: readStringParam(params, "threadId") }
+      : {}),
+    ...(readStringParam(params, "inReplyTo")
+      ? { inReplyTo: readStringParam(params, "inReplyTo") }
+      : {}),
+    ...(readStringArrayParam(params, "references")
+      ? { references: readStringArrayParam(params, "references") }
+      : {}),
+  };
+}
+
+export function registerGmailGatewayMethods(api: OpenClawPluginApi) {
+  const agentDir = resolveOpenClawAgentDir();
+
+  api.registerGatewayMethod(
+    "gmail.auth.status",
+    async ({ respond }) => {
+      try {
+        const profiles = listGmailStoredProfiles(agentDir);
+        respond(true, {
+          providerId: GMAIL_PROVIDER_ID,
+          connected: profiles.length > 0,
+          profiles,
+        });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: READ_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "gmail.auth.url",
+    async ({ params, respond }) => {
+      try {
+        const challenge = readStringParam(params, "challenge", { required: true });
+        const state = readStringParam(params, "state", { required: true });
+        const redirectUri = readStringParam(params, "redirectUri");
+        respond(true, {
+          providerId: GMAIL_PROVIDER_ID,
+          url: buildGmailAuthUrl({ challenge, state, redirectUri }),
+        });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "gmail.auth.exchange",
+    async ({ params, respond }) => {
+      try {
+        const code = readStringParam(params, "code", { required: true });
+        const verifier = readStringParam(params, "verifier", { required: true });
+        const redirectUri = readStringParam(params, "redirectUri");
+        const token = await exchangeGmailCodeForTokens({ code, verifier, redirectUri });
+        const identity = await resolveGooglePersonalOAuthIdentity(token.access);
+        const profileId = await storeGmailOAuthCredentials({
+          agentDir,
+          access: token.access,
+          refresh: token.refresh,
+          expires: token.expires,
+          email: identity.email,
+        });
+        respond(true, {
+          providerId: GMAIL_PROVIDER_ID,
+          profileId,
+          email: identity.email,
+          expires: token.expires,
+        });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "gmail.messages.list",
+    async ({ params, respond }) => {
+      try {
+        const result = await withGmailClient({
+          agentDir,
+          profileId: readStringParam(params, "profileId"),
+          run: async (client, resolvedProfileId) => ({
+            profileId: resolvedProfileId,
+            ...(await client.listMessages({
+              maxResults: readNumberParam(params, "maxResults"),
+              pageToken: readStringParam(params, "pageToken"),
+              query: readStringParam(params, "query"),
+              labelIds: readStringArrayParam(params, "labelIds"),
+              includeSpamTrash: readBooleanParam(params, "includeSpamTrash"),
+            })),
+          }),
+        });
+        respond(true, result);
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: READ_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "gmail.messages.search",
+    async ({ params, respond }) => {
+      try {
+        const result = await withGmailClient({
+          agentDir,
+          profileId: readStringParam(params, "profileId"),
+          run: async (client, resolvedProfileId) => ({
+            profileId: resolvedProfileId,
+            ...(await client.searchMessages({
+              ...readSearchParams(params),
+              maxResults: readNumberParam(params, "maxResults"),
+              pageToken: readStringParam(params, "pageToken"),
+            })),
+          }),
+        });
+        respond(true, result);
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: READ_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "gmail.messages.get",
+    async ({ params, respond }) => {
+      try {
+        const result = await withGmailClient({
+          agentDir,
+          profileId: readStringParam(params, "profileId"),
+          run: async (client, resolvedProfileId) => ({
+            profileId: resolvedProfileId,
+            message: await client.getMessage(
+              readStringParam(params, "id", { required: true }),
+              (readStringParam(params, "format") as
+                | "full"
+                | "metadata"
+                | "minimal"
+                | "raw"
+                | undefined) ?? "full",
+            ),
+          }),
+        });
+        respond(true, result);
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: READ_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "gmail.threads.get",
+    async ({ params, respond }) => {
+      try {
+        const result = await withGmailClient({
+          agentDir,
+          profileId: readStringParam(params, "profileId"),
+          run: async (client, resolvedProfileId) => ({
+            profileId: resolvedProfileId,
+            thread: await client.getThread(
+              readStringParam(params, "id", { required: true }),
+              (readStringParam(params, "format") as "full" | "metadata" | "minimal" | undefined) ??
+                "full",
+            ),
+          }),
+        });
+        respond(true, result);
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: READ_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "gmail.drafts.create",
+    async ({ params, respond }) => {
+      try {
+        const result = await withGmailClient({
+          agentDir,
+          profileId: readStringParam(params, "profileId"),
+          run: async (client, resolvedProfileId) => ({
+            profileId: resolvedProfileId,
+            draft: await client.createDraft(readDraftInput(params)),
+          }),
+        });
+        respond(true, result);
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "gmail.messages.send",
+    async ({ params, respond }) => {
+      try {
+        const result = await withGmailClient({
+          agentDir,
+          profileId: readStringParam(params, "profileId"),
+          run: async (client, resolvedProfileId) => ({
+            profileId: resolvedProfileId,
+            message: await client.sendMessage(readDraftInput(params)),
+          }),
+        });
+        respond(true, result);
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
+  );
+}

--- a/extensions/google/gmail-oauth.test.ts
+++ b/extensions/google/gmail-oauth.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./oauth.credentials.js", () => ({
+  resolveOAuthClientConfig: () => ({
+    clientId: "client-id-123",
+    clientSecret: "client-secret-456",
+  }),
+}));
+
+import { buildGmailAuthUrl, GMAIL_OAUTH_SCOPES } from "./gmail-oauth.js";
+
+describe("buildGmailAuthUrl", () => {
+  it("includes Gmail scopes and offline consent params", () => {
+    const url = new URL(buildGmailAuthUrl({ challenge: "challenge-1", state: "state-1" }));
+
+    expect(url.origin + url.pathname).toBe("https://accounts.google.com/o/oauth2/v2/auth");
+    expect(url.searchParams.get("client_id")).toBe("client-id-123");
+    expect(url.searchParams.get("code_challenge")).toBe("challenge-1");
+    expect(url.searchParams.get("state")).toBe("state-1");
+    expect(url.searchParams.get("access_type")).toBe("offline");
+    expect(url.searchParams.get("prompt")).toBe("consent");
+    expect(url.searchParams.get("scope")).toBe(GMAIL_OAUTH_SCOPES.join(" "));
+  });
+});

--- a/extensions/google/gmail-oauth.ts
+++ b/extensions/google/gmail-oauth.ts
@@ -1,0 +1,121 @@
+import { resolveOAuthClientConfig } from "./oauth.credentials.js";
+import { fetchWithTimeout } from "./oauth.http.js";
+import { AUTH_URL, DEFAULT_FETCH_TIMEOUT_MS, REDIRECT_URI, TOKEN_URL } from "./oauth.shared.js";
+
+export const GMAIL_OAUTH_SCOPES = [
+  "https://www.googleapis.com/auth/gmail.modify",
+  "https://www.googleapis.com/auth/gmail.compose",
+  "https://www.googleapis.com/auth/userinfo.email",
+  "https://www.googleapis.com/auth/userinfo.profile",
+] as const;
+
+export type GmailOAuthCredentials = {
+  access: string;
+  refresh: string;
+  expires: number;
+  email?: string;
+  scope?: string;
+  tokenType?: string;
+};
+
+export function buildGmailAuthUrl(params: {
+  challenge: string;
+  state: string;
+  redirectUri?: string;
+}): string {
+  const { clientId } = resolveOAuthClientConfig();
+  const redirectUri = params.redirectUri?.trim() || REDIRECT_URI;
+  const query = new URLSearchParams({
+    client_id: clientId,
+    response_type: "code",
+    redirect_uri: redirectUri,
+    scope: GMAIL_OAUTH_SCOPES.join(" "),
+    code_challenge: params.challenge,
+    code_challenge_method: "S256",
+    state: params.state,
+    access_type: "offline",
+    prompt: "consent",
+    include_granted_scopes: "true",
+  });
+  return `${AUTH_URL}?${query.toString()}`;
+}
+
+type TokenResponse = {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  scope?: string;
+  token_type?: string;
+};
+
+async function exchangeToken(body: URLSearchParams): Promise<TokenResponse> {
+  const { clientId, clientSecret } = resolveOAuthClientConfig();
+  body.set("client_id", clientId);
+  if (clientSecret) {
+    body.set("client_secret", clientSecret);
+  }
+  const response = await fetchWithTimeout(
+    TOKEN_URL,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+        Accept: "application/json",
+      },
+      body,
+    },
+    DEFAULT_FETCH_TIMEOUT_MS,
+  );
+
+  if (!response.ok) {
+    throw new Error(`Gmail OAuth token exchange failed: ${await response.text()}`);
+  }
+
+  return (await response.json()) as TokenResponse;
+}
+
+export async function exchangeGmailCodeForTokens(params: {
+  code: string;
+  verifier: string;
+  redirectUri?: string;
+}): Promise<GmailOAuthCredentials> {
+  const token = await exchangeToken(
+    new URLSearchParams({
+      code: params.code,
+      grant_type: "authorization_code",
+      redirect_uri: params.redirectUri?.trim() || REDIRECT_URI,
+      code_verifier: params.verifier,
+    }),
+  );
+
+  if (!token.refresh_token) {
+    throw new Error("No Gmail refresh token received. Please try again.");
+  }
+
+  return {
+    access: token.access_token,
+    refresh: token.refresh_token,
+    expires: Date.now() + token.expires_in * 1000 - 5 * 60 * 1000,
+    scope: token.scope,
+    tokenType: token.token_type,
+  };
+}
+
+export async function refreshGmailAccessToken(params: {
+  refreshToken: string;
+}): Promise<GmailOAuthCredentials> {
+  const token = await exchangeToken(
+    new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: params.refreshToken,
+    }),
+  );
+
+  return {
+    access: token.access_token,
+    refresh: params.refreshToken,
+    expires: Date.now() + token.expires_in * 1000 - 5 * 60 * 1000,
+    scope: token.scope,
+    tokenType: token.token_type,
+  };
+}

--- a/extensions/google/gmail-types.ts
+++ b/extensions/google/gmail-types.ts
@@ -1,0 +1,93 @@
+export type GmailLabelId = string;
+
+export type GmailMessageHeader = {
+  name: string;
+  value: string;
+};
+
+export type GmailMessagePartBody = {
+  attachmentId?: string;
+  data?: string;
+  size?: number;
+};
+
+export type GmailMessagePart = {
+  partId?: string;
+  mimeType?: string;
+  filename?: string;
+  headers?: GmailMessageHeader[];
+  body?: GmailMessagePartBody;
+  parts?: GmailMessagePart[];
+};
+
+export type GmailMessage = {
+  id: string;
+  threadId: string;
+  labelIds?: GmailLabelId[];
+  snippet?: string;
+  historyId?: string;
+  internalDate?: string;
+  payload?: GmailMessagePart;
+  raw?: string;
+  sizeEstimate?: number;
+};
+
+export type GmailThread = {
+  id: string;
+  historyId?: string;
+  messages?: GmailMessage[];
+  snippet?: string;
+};
+
+export type GmailListMessagesResponse = {
+  messages?: Array<Pick<GmailMessage, "id" | "threadId">>;
+  nextPageToken?: string;
+  resultSizeEstimate?: number;
+};
+
+export type GmailListThreadsResponse = {
+  threads?: Array<Pick<GmailThread, "id"> & { snippet?: string; historyId?: string }>;
+  nextPageToken?: string;
+  resultSizeEstimate?: number;
+};
+
+export type GmailDraftMessageInput = {
+  from?: string;
+  to: string | string[];
+  cc?: string | string[];
+  bcc?: string | string[];
+  subject: string;
+  textBody?: string;
+  htmlBody?: string;
+  inReplyTo?: string;
+  references?: string | string[];
+  threadId?: string;
+};
+
+export type GmailEncodedMessageRequest = {
+  raw: string;
+  threadId?: string;
+};
+
+export type GmailDraftCreateRequest = {
+  message: GmailEncodedMessageRequest;
+};
+
+export type GmailDraft = {
+  id: string;
+  message?: GmailMessage;
+};
+
+export type GmailSentMessage = GmailMessage;
+
+export type GmailSearchParams = {
+  query?: string;
+  labels?: string[];
+  newerThanDays?: number;
+  unread?: boolean;
+  inInbox?: boolean;
+  from?: string;
+  to?: string;
+  subject?: string;
+  hasWords?: string[];
+};

--- a/extensions/google/index.ts
+++ b/extensions/google/index.ts
@@ -17,6 +17,7 @@ import {
   createGoogleMusicGenerationProviderMetadata,
   createGoogleVideoGenerationProviderMetadata,
 } from "./generation-provider-metadata.js";
+import { registerGmailGatewayMethods } from "./gmail-gateway.js";
 import { geminiMemoryEmbeddingProviderAdapter } from "./memory-embedding-adapter.js";
 import { registerGoogleProvider } from "./provider-registration.js";
 import { buildGoogleSpeechProvider } from "./speech-provider.js";
@@ -342,6 +343,7 @@ export default definePluginEntry({
     api.registerCliBackend(buildGoogleGeminiCliBackend());
     registerGoogleGeminiCliProvider(api);
     registerGoogleProvider(api);
+    registerGmailGatewayMethods(api);
     api.registerMemoryEmbeddingProvider(geminiMemoryEmbeddingProviderAdapter);
     api.registerImageGenerationProvider(createLazyGoogleImageGenerationProvider());
     api.registerMediaUnderstandingProvider(createLazyGoogleMediaUnderstandingProvider());

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -44,6 +44,11 @@ import {
   pruneExecApprovalQueue,
   removeExecApproval,
 } from "./controllers/exec-approval.ts";
+import {
+  loadGmailAuthStatus,
+  maybeCompleteGmailOAuthRedirect,
+  type GmailAuthState,
+} from "./controllers/gmail-auth.ts";
 import { loadHealthState, type HealthState } from "./controllers/health.ts";
 import { loadNodes, type NodesState } from "./controllers/nodes.ts";
 import {
@@ -545,6 +550,11 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
       void loadHealthState(host as unknown as HealthState);
       void loadNodes(host as unknown as NodesState, { quiet: true });
       void loadDevices(host as unknown as DevicesState, { quiet: true });
+      void maybeCompleteGmailOAuthRedirect(host as unknown as GmailAuthState).then((completed) => {
+        if (!completed) {
+          void loadGmailAuthStatus(host as unknown as GmailAuthState);
+        }
+      });
       void loadAgentsThenRefreshActiveTab(host);
       // Re-run push reconciliation now that the gateway client is available.
       void host.reconcileWebPushState?.();

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1642,6 +1642,27 @@ export function renderApp(state: AppViewState) {
               lastChannelsRefresh: state.channelsLastSuccess,
               warnQueryToken,
               modelAuthStatus: state.modelAuthStatusResult,
+              gmailAuthStatus: state.gmailAuthStatus,
+              gmailAuthLoading: state.gmailAuthLoading,
+              gmailAuthConnectPending: state.gmailAuthConnectPending,
+              gmailAuthError: state.gmailAuthError,
+              gmailInboxLoading: state.gmailInboxLoading,
+              gmailInboxError: state.gmailInboxError,
+              gmailInboxItems: state.gmailInboxItems,
+              gmailInboxQuery: state.gmailInboxQuery,
+              gmailInboxUnreadOnly: state.gmailInboxUnreadOnly,
+              gmailSelectedThreadId: state.gmailSelectedThreadId,
+              gmailThreadLoading: state.gmailThreadLoading,
+              gmailThreadError: state.gmailThreadError,
+              gmailSelectedThread: state.gmailSelectedThread,
+              gmailDraftForm: state.gmailDraftForm,
+              gmailDraftSaving: state.gmailDraftSaving,
+              gmailDraftError: state.gmailDraftError,
+              gmailDraftSuccess: state.gmailDraftSuccess,
+              gmailSendConfirmOpen: state.gmailSendConfirmOpen,
+              gmailSendPending: state.gmailSendPending,
+              gmailSendError: state.gmailSendError,
+              gmailSendSuccess: state.gmailSendSuccess,
               usageResult: state.usageResult,
               sessionsResult: state.sessionsResult,
               skillsReport: state.skillsReport,
@@ -1667,6 +1688,48 @@ export function renderApp(state: AppViewState) {
               onRefresh: () => state.loadOverview({ refresh: true }),
               onNavigate: (tab) => state.setTab(tab as import("./navigation.ts").Tab),
               onRefreshLogs: () => state.loadOverview({ refresh: true }),
+              onGmailConnect: () => {
+                void state.startGmailOAuthConnect();
+              },
+              onGmailRefresh: () => {
+                void (async () => {
+                  await state.loadGmailAuthStatus();
+                  await state.loadGmailInbox();
+                })();
+              },
+              onGmailInboxFiltersChange: (patch) => {
+                state.updateGmailInboxFilters(patch);
+              },
+              onGmailInboxSearch: () => {
+                void state.loadGmailInbox();
+              },
+              onGmailSelectThread: (threadId) => {
+                void (async () => {
+                  await state.selectGmailThread(threadId);
+                  state.populateReplyDraftFromThread();
+                })();
+              },
+              onGmailDraftFieldChange: (patch) => {
+                state.updateGmailDraftForm(patch);
+              },
+              onGmailDraftReply: () => {
+                state.populateReplyDraftFromThread();
+              },
+              onGmailDraftReset: () => {
+                state.resetGmailDraftForm();
+              },
+              onGmailDraftSave: () => {
+                void state.createGmailDraft();
+              },
+              onGmailSendOpenConfirm: () => {
+                state.openGmailSendConfirm();
+              },
+              onGmailSendCloseConfirm: () => {
+                state.closeGmailSendConfirm();
+              },
+              onGmailSendConfirm: () => {
+                void state.sendGmailMessage();
+              },
             })
           : nothing}
         ${state.tab === "channels"

--- a/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
+++ b/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
@@ -21,6 +21,8 @@ const mocks = vi.hoisted(() => ({
   loadDebugMock: vi.fn(async () => {}),
   loadDevicesMock: vi.fn(async () => {}),
   loadExecApprovalsMock: vi.fn(async () => {}),
+  loadGmailAuthStatusMock: vi.fn(async () => {}),
+  loadGmailInboxMock: vi.fn(async () => {}),
   loadLogsMock: vi.fn(async () => {}),
   loadModelAuthStatusStateMock: vi.fn(async () => {}),
   loadNodesMock: vi.fn(async () => {}),
@@ -70,6 +72,12 @@ vi.mock("./controllers/devices.ts", () => ({
 }));
 vi.mock("./controllers/exec-approvals.ts", () => ({
   loadExecApprovals: mocks.loadExecApprovalsMock,
+}));
+vi.mock("./controllers/gmail-auth.ts", () => ({
+  loadGmailAuthStatus: mocks.loadGmailAuthStatusMock,
+}));
+vi.mock("./controllers/gmail-inbox.ts", () => ({
+  loadGmailInbox: mocks.loadGmailInboxMock,
 }));
 vi.mock("./controllers/logs.ts", () => ({
   loadLogs: mocks.loadLogsMock,

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -42,6 +42,8 @@ import {
   type DreamingState,
 } from "./controllers/dreaming.ts";
 import { loadExecApprovals, type ExecApprovalsState } from "./controllers/exec-approvals.ts";
+import { loadGmailAuthStatus, type GmailAuthState } from "./controllers/gmail-auth.ts";
+import { loadGmailInbox, type GmailInboxState } from "./controllers/gmail-inbox.ts";
 import { loadLogs, type LogsState } from "./controllers/logs.ts";
 import {
   loadModelAuthStatusState,
@@ -131,6 +133,8 @@ type SettingsAppHost = SettingsHost &
   CronState &
   DebugState &
   DevicesState &
+  GmailAuthState &
+  GmailInboxState &
   DreamingState &
   ExecApprovalsState &
   LogsState &
@@ -655,6 +659,10 @@ export async function loadOverview(host: SettingsHost, opts?: { refresh?: boolea
     // `refresh: true` bypasses the gateway's 60s auth-status cache so a
     // user-initiated refresh surfaces post-re-auth state immediately.
     loadModelAuthStatusState(app, { refresh: opts?.refresh }),
+    (async () => {
+      await loadGmailAuthStatus(app);
+      await loadGmailInbox(app);
+    })(),
   ]).then((results) => {
     if (!isCurrentOverviewRefresh()) {
       return;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -8,6 +8,9 @@ import type { CronModelSuggestionsState, CronState } from "./controllers/cron.ts
 import type { DevicePairingList } from "./controllers/devices.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
 import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
+import type { GmailAuthStatusResult } from "./controllers/gmail-auth.ts";
+import type { GmailDraftForm } from "./controllers/gmail-draft.ts";
+import type { GmailInboxItem, GmailThreadView } from "./controllers/gmail-inbox.ts";
 import type {
   ClawHubSearchResult,
   ClawHubSkillDetail,
@@ -137,6 +140,27 @@ export type AppViewState = {
   devicesLoading: boolean;
   devicesError: string | null;
   devicesList: DevicePairingList | null;
+  gmailAuthLoading: boolean;
+  gmailAuthConnectPending: boolean;
+  gmailAuthStatus: GmailAuthStatusResult | null;
+  gmailAuthError: string | null;
+  gmailInboxLoading: boolean;
+  gmailInboxError: string | null;
+  gmailInboxItems: GmailInboxItem[];
+  gmailInboxQuery: string;
+  gmailInboxUnreadOnly: boolean;
+  gmailSelectedThreadId: string | null;
+  gmailThreadLoading: boolean;
+  gmailThreadError: string | null;
+  gmailSelectedThread: GmailThreadView | null;
+  gmailDraftForm: GmailDraftForm;
+  gmailDraftSaving: boolean;
+  gmailDraftError: string | null;
+  gmailDraftSuccess: string | null;
+  gmailSendConfirmOpen: boolean;
+  gmailSendPending: boolean;
+  gmailSendError: string | null;
+  gmailSendSuccess: string | null;
   execApprovalsLoading: boolean;
   execApprovalsSaving: boolean;
   execApprovalsDirty: boolean;
@@ -430,6 +454,18 @@ export type AppViewState = {
     loadOverview: (opts?: { refresh?: boolean }) => Promise<void>;
     loadAssistantIdentity: () => Promise<void>;
     loadCron: () => Promise<void>;
+    loadGmailAuthStatus: () => Promise<void>;
+    startGmailOAuthConnect: () => Promise<void>;
+    loadGmailInbox: () => Promise<void>;
+    updateGmailInboxFilters: (patch: { query?: string; unreadOnly?: boolean }) => void;
+    selectGmailThread: (threadId: string) => Promise<void>;
+    updateGmailDraftForm: (patch: Partial<GmailDraftForm>) => void;
+    populateReplyDraftFromThread: () => void;
+    resetGmailDraftForm: () => void;
+    openGmailSendConfirm: () => void;
+    closeGmailSendConfirm: () => void;
+    createGmailDraft: () => Promise<void>;
+    sendGmailMessage: () => Promise<void>;
     handleWhatsAppStart: (force: boolean) => Promise<void>;
     handleWhatsAppWait: () => Promise<void>;
     handleWhatsAppLogout: () => Promise<void>;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -81,6 +81,28 @@ import type {
 } from "./controllers/dreaming.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
 import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
+import {
+  loadGmailAuthStatus as loadGmailAuthStatusInternal,
+  startGmailOAuthConnect as startGmailOAuthConnectInternal,
+  type GmailAuthStatusResult,
+} from "./controllers/gmail-auth.ts";
+import {
+  closeGmailSendConfirm as closeGmailSendConfirmInternal,
+  createGmailDraft as createGmailDraftInternal,
+  openGmailSendConfirm as openGmailSendConfirmInternal,
+  populateReplyDraftFromThread as populateReplyDraftFromThreadInternal,
+  resetGmailDraftForm as resetGmailDraftFormInternal,
+  sendGmailMessage as sendGmailMessageInternal,
+  updateGmailDraftForm as updateGmailDraftFormInternal,
+  type GmailDraftForm,
+} from "./controllers/gmail-draft.ts";
+import {
+  loadGmailInbox as loadGmailInboxInternal,
+  selectGmailThread as selectGmailThreadInternal,
+  updateGmailInboxFilters as updateGmailInboxFiltersInternal,
+  type GmailInboxItem,
+  type GmailThreadView,
+} from "./controllers/gmail-inbox.ts";
 import type {
   ClawHubSearchResult,
   ClawHubSkillDetail,
@@ -254,6 +276,31 @@ export class OpenClawApp extends LitElement {
   @state() devicesLoading = false;
   @state() devicesError: string | null = null;
   @state() devicesList: DevicePairingList | null = null;
+  @state() gmailAuthLoading = false;
+  @state() gmailAuthConnectPending = false;
+  @state() gmailAuthStatus: GmailAuthStatusResult | null = null;
+  @state() gmailAuthError: string | null = null;
+  @state() gmailInboxLoading = false;
+  @state() gmailInboxError: string | null = null;
+  @state() gmailInboxItems: GmailInboxItem[] = [];
+  @state() gmailInboxQuery = "";
+  @state() gmailInboxUnreadOnly = false;
+  @state() gmailSelectedThreadId: string | null = null;
+  @state() gmailThreadLoading = false;
+  @state() gmailThreadError: string | null = null;
+  @state() gmailSelectedThread: GmailThreadView | null = null;
+  @state() gmailDraftForm: GmailDraftForm = {
+    to: "",
+    subject: "",
+    textBody: "",
+  };
+  @state() gmailDraftSaving = false;
+  @state() gmailDraftError: string | null = null;
+  @state() gmailDraftSuccess: string | null = null;
+  @state() gmailSendConfirmOpen = false;
+  @state() gmailSendPending = false;
+  @state() gmailSendError: string | null = null;
+  @state() gmailSendSuccess: string | null = null;
   @state() execApprovalsLoading = false;
   @state() execApprovalsSaving = false;
   @state() execApprovalsDirty = false;
@@ -904,6 +951,79 @@ export class OpenClawApp extends LitElement {
 
   async loadCron() {
     await loadCronInternal(this as unknown as Parameters<typeof loadCronInternal>[0]);
+  }
+
+  async loadGmailAuthStatus() {
+    await loadGmailAuthStatusInternal(
+      this as unknown as Parameters<typeof loadGmailAuthStatusInternal>[0],
+    );
+  }
+
+  async startGmailOAuthConnect() {
+    await startGmailOAuthConnectInternal(
+      this as unknown as Parameters<typeof startGmailOAuthConnectInternal>[0],
+    );
+  }
+
+  async loadGmailInbox() {
+    await loadGmailInboxInternal(this as unknown as Parameters<typeof loadGmailInboxInternal>[0]);
+  }
+
+  updateGmailInboxFilters(patch: { query?: string; unreadOnly?: boolean }) {
+    updateGmailInboxFiltersInternal(
+      this as unknown as Parameters<typeof updateGmailInboxFiltersInternal>[0],
+      patch,
+    );
+  }
+
+  async selectGmailThread(threadId: string) {
+    await selectGmailThreadInternal(
+      this as unknown as Parameters<typeof selectGmailThreadInternal>[0],
+      threadId,
+    );
+  }
+
+  updateGmailDraftForm(patch: Partial<GmailDraftForm>) {
+    updateGmailDraftFormInternal(
+      this as unknown as Parameters<typeof updateGmailDraftFormInternal>[0],
+      patch,
+    );
+  }
+
+  populateReplyDraftFromThread() {
+    populateReplyDraftFromThreadInternal(
+      this as unknown as Parameters<typeof populateReplyDraftFromThreadInternal>[0],
+    );
+  }
+
+  resetGmailDraftForm() {
+    resetGmailDraftFormInternal(
+      this as unknown as Parameters<typeof resetGmailDraftFormInternal>[0],
+    );
+  }
+
+  openGmailSendConfirm() {
+    openGmailSendConfirmInternal(
+      this as unknown as Parameters<typeof openGmailSendConfirmInternal>[0],
+    );
+  }
+
+  closeGmailSendConfirm() {
+    closeGmailSendConfirmInternal(
+      this as unknown as Parameters<typeof closeGmailSendConfirmInternal>[0],
+    );
+  }
+
+  async createGmailDraft() {
+    await createGmailDraftInternal(
+      this as unknown as Parameters<typeof createGmailDraftInternal>[0],
+    );
+  }
+
+  async sendGmailMessage() {
+    await sendGmailMessageInternal(
+      this as unknown as Parameters<typeof sendGmailMessageInternal>[0],
+    );
   }
 
   async handleAbortChat() {

--- a/ui/src/ui/controllers/gmail-auth.test.ts
+++ b/ui/src/ui/controllers/gmail-auth.test.ts
@@ -1,0 +1,86 @@
+/* @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  loadGmailAuthStatus,
+  maybeCompleteGmailOAuthRedirect,
+  type GmailAuthState,
+} from "./gmail-auth.ts";
+
+function createState(overrides: Partial<GmailAuthState> = {}): GmailAuthState {
+  return {
+    client: {
+      request: vi.fn(),
+    } as unknown as GmailAuthState["client"],
+    connected: true,
+    gmailAuthLoading: false,
+    gmailAuthConnectPending: false,
+    gmailAuthStatus: null,
+    gmailAuthError: null,
+    ...overrides,
+  };
+}
+
+describe("gmail auth controller", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    window.history.replaceState({}, "", "http://localhost:3000/overview");
+  });
+
+  it("loads gmail auth status from the gateway", async () => {
+    const state = createState();
+    const request = vi.mocked(state.client!.request);
+    request.mockResolvedValue({
+      providerId: "google-gmail",
+      connected: true,
+      profiles: [{ profileId: "google-gmail:david@example.com", email: "david@example.com" }],
+    });
+
+    await loadGmailAuthStatus(state);
+
+    expect(request).toHaveBeenCalledWith("gmail.auth.status", {});
+    expect(state.gmailAuthStatus?.connected).toBe(true);
+    expect(state.gmailAuthStatus?.profiles[0]?.email).toBe("david@example.com");
+  });
+
+  it("completes a gmail oauth redirect and clears the callback params", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "http://localhost:3000/overview?code=code-123&state=state-123&scope=email",
+    );
+    sessionStorage.setItem(
+      "openclaw:gmail-oauth:pending",
+      JSON.stringify({
+        state: "state-123",
+        verifier: "verifier-123",
+        redirectUri: "http://localhost:3000/overview",
+        createdAt: Date.now(),
+      }),
+    );
+    const state = createState();
+    const request = vi.mocked(state.client!.request);
+    request
+      .mockResolvedValueOnce({
+        providerId: "google-gmail",
+        profileId: "google-gmail:david@example.com",
+      })
+      .mockResolvedValueOnce({
+        providerId: "google-gmail",
+        connected: true,
+        profiles: [{ profileId: "google-gmail:david@example.com", email: "david@example.com" }],
+      });
+
+    const completed = await maybeCompleteGmailOAuthRedirect(state);
+
+    expect(completed).toBe(true);
+    expect(request).toHaveBeenNthCalledWith(1, "gmail.auth.exchange", {
+      code: "code-123",
+      verifier: "verifier-123",
+      redirectUri: "http://localhost:3000/overview",
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "gmail.auth.status", {});
+    expect(window.location.search).toBe("");
+    expect(sessionStorage.getItem("openclaw:gmail-oauth:pending")).toBeNull();
+  });
+});

--- a/ui/src/ui/controllers/gmail-auth.ts
+++ b/ui/src/ui/controllers/gmail-auth.ts
@@ -1,0 +1,213 @@
+import type { GatewayBrowserClient } from "../gateway.ts";
+
+const GMAIL_OAUTH_STORAGE_KEY = "openclaw:gmail-oauth:pending";
+
+export type GmailAuthProfile = {
+  profileId: string;
+  email?: string;
+  displayName?: string;
+  expires?: number;
+};
+
+export type GmailAuthStatusResult = {
+  providerId: string;
+  connected: boolean;
+  profiles: GmailAuthProfile[];
+};
+
+export type GmailAuthState = {
+  client: GatewayBrowserClient | null;
+  connected: boolean;
+  gmailAuthLoading: boolean;
+  gmailAuthConnectPending: boolean;
+  gmailAuthStatus: GmailAuthStatusResult | null;
+  gmailAuthError: string | null;
+};
+
+type PendingGmailOAuth = {
+  state: string;
+  verifier: string;
+  redirectUri: string;
+  createdAt: number;
+};
+
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+async function sha256Base64Url(input: string): Promise<string> {
+  const encoded = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", encoded);
+  return toBase64Url(new Uint8Array(digest));
+}
+
+function randomBase64Url(byteLength = 32): string {
+  const bytes = new Uint8Array(byteLength);
+  crypto.getRandomValues(bytes);
+  return toBase64Url(bytes);
+}
+
+function buildRedirectUri(): string {
+  const url = new URL(window.location.href);
+  for (const key of ["code", "state", "scope", "error", "error_subtype", "authuser", "prompt"]) {
+    url.searchParams.delete(key);
+  }
+  url.hash = "";
+  return url.toString();
+}
+
+function readPendingGmailOAuth(): PendingGmailOAuth | null {
+  try {
+    const raw = sessionStorage.getItem(GMAIL_OAUTH_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as Partial<PendingGmailOAuth>;
+    if (
+      typeof parsed?.state !== "string" ||
+      typeof parsed?.verifier !== "string" ||
+      typeof parsed?.redirectUri !== "string"
+    ) {
+      return null;
+    }
+    return {
+      state: parsed.state,
+      verifier: parsed.verifier,
+      redirectUri: parsed.redirectUri,
+      createdAt: typeof parsed.createdAt === "number" ? parsed.createdAt : Date.now(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writePendingGmailOAuth(value: PendingGmailOAuth | null) {
+  if (!value) {
+    sessionStorage.removeItem(GMAIL_OAUTH_STORAGE_KEY);
+    return;
+  }
+  sessionStorage.setItem(GMAIL_OAUTH_STORAGE_KEY, JSON.stringify(value));
+}
+
+function clearGmailOAuthParamsFromUrl() {
+  const url = new URL(window.location.href);
+  let changed = false;
+  for (const key of ["code", "state", "scope", "error", "error_subtype", "authuser", "prompt"]) {
+    if (url.searchParams.has(key)) {
+      url.searchParams.delete(key);
+      changed = true;
+    }
+  }
+  if (changed) {
+    window.history.replaceState({}, "", url.toString());
+  }
+}
+
+function readRedirectParams() {
+  const url = new URL(window.location.href);
+  const code = url.searchParams.get("code")?.trim() || "";
+  const state = url.searchParams.get("state")?.trim() || "";
+  const error = url.searchParams.get("error")?.trim() || "";
+  return {
+    code: code || null,
+    state: state || null,
+    error: error || null,
+  };
+}
+
+export async function loadGmailAuthStatus(state: GmailAuthState): Promise<void> {
+  if (!state.client || !state.connected || state.gmailAuthLoading) {
+    return;
+  }
+  state.gmailAuthLoading = true;
+  state.gmailAuthError = null;
+  try {
+    state.gmailAuthStatus = await state.client.request<GmailAuthStatusResult>(
+      "gmail.auth.status",
+      {},
+    );
+  } catch (error) {
+    state.gmailAuthError = error instanceof Error ? error.message : String(error);
+    state.gmailAuthStatus = null;
+  } finally {
+    state.gmailAuthLoading = false;
+  }
+}
+
+export async function startGmailOAuthConnect(state: GmailAuthState): Promise<void> {
+  if (!state.client || !state.connected || state.gmailAuthConnectPending) {
+    return;
+  }
+  state.gmailAuthConnectPending = true;
+  state.gmailAuthError = null;
+  try {
+    const verifier = randomBase64Url(32);
+    const challenge = await sha256Base64Url(verifier);
+    const oauthState = randomBase64Url(24);
+    const redirectUri = buildRedirectUri();
+    writePendingGmailOAuth({
+      state: oauthState,
+      verifier,
+      redirectUri,
+      createdAt: Date.now(),
+    });
+    const result = await state.client.request<{ url: string }>("gmail.auth.url", {
+      challenge,
+      state: oauthState,
+      redirectUri,
+    });
+    if (!result?.url) {
+      throw new Error("Gmail auth URL was not returned.");
+    }
+    window.location.assign(result.url);
+  } catch (error) {
+    writePendingGmailOAuth(null);
+    state.gmailAuthConnectPending = false;
+    state.gmailAuthError = error instanceof Error ? error.message : String(error);
+  }
+}
+
+export async function maybeCompleteGmailOAuthRedirect(state: GmailAuthState): Promise<boolean> {
+  if (!state.client || !state.connected || state.gmailAuthConnectPending) {
+    return false;
+  }
+  const redirect = readRedirectParams();
+  if (!redirect.code && !redirect.error) {
+    return false;
+  }
+
+  state.gmailAuthConnectPending = true;
+  state.gmailAuthError = null;
+  try {
+    if (redirect.error) {
+      throw new Error(`Gmail OAuth failed: ${redirect.error}`);
+    }
+    const pending = readPendingGmailOAuth();
+    if (!pending) {
+      throw new Error("Missing pending Gmail OAuth session.");
+    }
+    if (!redirect.state || redirect.state !== pending.state) {
+      throw new Error("Gmail OAuth state mismatch.");
+    }
+    await state.client.request("gmail.auth.exchange", {
+      code: redirect.code,
+      verifier: pending.verifier,
+      redirectUri: pending.redirectUri,
+    });
+    writePendingGmailOAuth(null);
+    clearGmailOAuthParamsFromUrl();
+    await loadGmailAuthStatus(state);
+    return true;
+  } catch (error) {
+    writePendingGmailOAuth(null);
+    clearGmailOAuthParamsFromUrl();
+    state.gmailAuthError = error instanceof Error ? error.message : String(error);
+    return false;
+  } finally {
+    state.gmailAuthConnectPending = false;
+  }
+}

--- a/ui/src/ui/controllers/gmail-draft.test.ts
+++ b/ui/src/ui/controllers/gmail-draft.test.ts
@@ -1,0 +1,112 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  createGmailDraft,
+  openGmailSendConfirm,
+  populateReplyDraftFromThread,
+  sendGmailMessage,
+  type GmailDraftState,
+} from "./gmail-draft.ts";
+
+function createState(): GmailDraftState {
+  return {
+    client: {
+      request: vi.fn(),
+    } as unknown as GmailDraftState["client"],
+    connected: true,
+    gmailDraftForm: {
+      to: "",
+      subject: "",
+      textBody: "",
+    },
+    gmailDraftSaving: false,
+    gmailDraftError: null,
+    gmailDraftSuccess: null,
+    gmailSendConfirmOpen: false,
+    gmailSendPending: false,
+    gmailSendError: null,
+    gmailSendSuccess: null,
+    gmailSelectedThread: {
+      id: "thread-1",
+      messages: [
+        {
+          id: "msg-1",
+          subject: "Project update",
+          from: "Taylor <taylor@example.com>",
+          to: "David <david@example.com>",
+          date: "Wed, 7 May 2026 10:00:00 -0500",
+          snippet: "Wanted to send a quick update",
+          bodyText: "Latest body",
+          unread: true,
+          messageId: "<msg-1@example.com>",
+          references: ["<root@example.com>"],
+        },
+      ],
+    },
+  };
+}
+
+describe("gmail draft controller", () => {
+  it("prefills a reply draft from the selected thread", () => {
+    const state = createState();
+
+    populateReplyDraftFromThread(state);
+
+    expect(state.gmailDraftForm.to).toBe("taylor@example.com");
+    expect(state.gmailDraftForm.subject).toBe("Re: Project update");
+    expect(state.gmailDraftForm.threadId).toBe("thread-1");
+    expect(state.gmailDraftForm.inReplyTo).toBe("<msg-1@example.com>");
+  });
+
+  it("opens send confirmation for a valid message", () => {
+    const state = createState();
+    populateReplyDraftFromThread(state);
+    state.gmailDraftForm.textBody = "Looks good.";
+
+    openGmailSendConfirm(state);
+
+    expect(state.gmailSendConfirmOpen).toBe(true);
+  });
+
+  it("creates a draft via the gateway", async () => {
+    const state = createState();
+    populateReplyDraftFromThread(state);
+    state.gmailDraftForm.textBody = "Sounds good — I’ll review it today.";
+    const request = vi.mocked(state.client!.request);
+    request.mockResolvedValue({ draft: { id: "draft-123" } });
+
+    await createGmailDraft(state);
+
+    expect(request).toHaveBeenCalledWith("gmail.drafts.create", {
+      to: "taylor@example.com",
+      subject: "Re: Project update",
+      textBody: "Sounds good — I’ll review it today.",
+      threadId: "thread-1",
+      inReplyTo: "<msg-1@example.com>",
+      references: ["<root@example.com>"],
+    });
+    expect(state.gmailDraftSuccess).toContain("draft-123");
+    expect(state.gmailDraftForm.textBody).toBe("");
+  });
+
+  it("sends a message via the gateway", async () => {
+    const state = createState();
+    populateReplyDraftFromThread(state);
+    state.gmailDraftForm.textBody = "Sending this now.";
+    const request = vi.mocked(state.client!.request);
+    request.mockResolvedValue({ message: { id: "sent-123" } });
+
+    await sendGmailMessage(state);
+
+    expect(request).toHaveBeenCalledWith("gmail.messages.send", {
+      to: "taylor@example.com",
+      subject: "Re: Project update",
+      textBody: "Sending this now.",
+      threadId: "thread-1",
+      inReplyTo: "<msg-1@example.com>",
+      references: ["<root@example.com>"],
+    });
+    expect(state.gmailSendSuccess).toContain("sent-123");
+  });
+});

--- a/ui/src/ui/controllers/gmail-draft.ts
+++ b/ui/src/ui/controllers/gmail-draft.ts
@@ -1,0 +1,194 @@
+import type { GatewayBrowserClient } from "../gateway.ts";
+import type { GmailThreadView } from "./gmail-inbox.ts";
+
+export type GmailDraftForm = {
+  to: string;
+  subject: string;
+  textBody: string;
+  threadId?: string;
+  inReplyTo?: string;
+  references?: string[];
+};
+
+export type GmailDraftState = {
+  client: GatewayBrowserClient | null;
+  connected: boolean;
+  gmailDraftForm: GmailDraftForm;
+  gmailDraftSaving: boolean;
+  gmailDraftError: string | null;
+  gmailDraftSuccess: string | null;
+  gmailSendConfirmOpen: boolean;
+  gmailSendPending: boolean;
+  gmailSendError: string | null;
+  gmailSendSuccess: string | null;
+  gmailSelectedThread: GmailThreadView | null;
+};
+
+function normalizeSubjectForReply(subject: string): string {
+  const trimmed = subject.trim();
+  if (!trimmed) {
+    return "Re:";
+  }
+  return /^re:/i.test(trimmed) ? trimmed : `Re: ${trimmed}`;
+}
+
+function parseEmailAddress(value: string): string {
+  const match = value.match(/<([^>]+)>/);
+  if (match?.[1]) {
+    return match[1].trim();
+  }
+  return value.trim();
+}
+
+function validateDraftFields(
+  state: GmailDraftState,
+): { to: string; subject: string; textBody: string } | null {
+  const to = state.gmailDraftForm.to.trim();
+  const subject = state.gmailDraftForm.subject.trim();
+  const textBody = state.gmailDraftForm.textBody.trim();
+  if (!to || !subject || !textBody) {
+    state.gmailDraftError = "To, subject, and body are required to save a draft.";
+    state.gmailDraftSuccess = null;
+    return null;
+  }
+  return { to, subject, textBody };
+}
+
+export function updateGmailDraftForm(state: GmailDraftState, patch: Partial<GmailDraftForm>): void {
+  state.gmailDraftForm = {
+    ...state.gmailDraftForm,
+    ...patch,
+  };
+  state.gmailDraftError = null;
+  state.gmailDraftSuccess = null;
+  state.gmailSendError = null;
+  state.gmailSendSuccess = null;
+}
+
+export function populateReplyDraftFromThread(state: GmailDraftState): void {
+  const lastMessage = state.gmailSelectedThread?.messages.at(-1) ?? null;
+  if (!lastMessage) {
+    return;
+  }
+  state.gmailDraftForm = {
+    to: parseEmailAddress(lastMessage.from),
+    subject: normalizeSubjectForReply(lastMessage.subject),
+    textBody:
+      state.gmailDraftForm.textBody || `\n\n---\n${lastMessage.bodyText || lastMessage.snippet}`,
+    threadId: state.gmailSelectedThread?.id,
+    inReplyTo: lastMessage.messageId || undefined,
+    references: lastMessage.references?.length ? lastMessage.references : undefined,
+  };
+  state.gmailDraftError = null;
+  state.gmailDraftSuccess = null;
+  state.gmailSendError = null;
+  state.gmailSendSuccess = null;
+}
+
+export function resetGmailDraftForm(state: GmailDraftState): void {
+  state.gmailDraftForm = {
+    to: "",
+    subject: "",
+    textBody: "",
+  };
+  state.gmailDraftError = null;
+  state.gmailDraftSuccess = null;
+  state.gmailSendConfirmOpen = false;
+  state.gmailSendError = null;
+  state.gmailSendSuccess = null;
+}
+
+export function openGmailSendConfirm(state: GmailDraftState): void {
+  const valid = validateDraftFields(state);
+  if (!valid) {
+    state.gmailSendConfirmOpen = false;
+    return;
+  }
+  state.gmailSendError = null;
+  state.gmailSendSuccess = null;
+  state.gmailSendConfirmOpen = true;
+}
+
+export function closeGmailSendConfirm(state: GmailDraftState): void {
+  state.gmailSendConfirmOpen = false;
+  state.gmailSendError = null;
+}
+
+export async function createGmailDraft(state: GmailDraftState): Promise<void> {
+  if (!state.client || !state.connected || state.gmailDraftSaving) {
+    return;
+  }
+  const valid = validateDraftFields(state);
+  if (!valid) {
+    return;
+  }
+
+  state.gmailDraftSaving = true;
+  state.gmailDraftError = null;
+  state.gmailDraftSuccess = null;
+  try {
+    const result = await state.client.request<{ draft?: { id?: string } }>("gmail.drafts.create", {
+      to: valid.to,
+      subject: valid.subject,
+      textBody: valid.textBody,
+      ...(state.gmailDraftForm.threadId ? { threadId: state.gmailDraftForm.threadId } : {}),
+      ...(state.gmailDraftForm.inReplyTo ? { inReplyTo: state.gmailDraftForm.inReplyTo } : {}),
+      ...(state.gmailDraftForm.references?.length
+        ? { references: state.gmailDraftForm.references }
+        : {}),
+    });
+    state.gmailDraftSuccess = result?.draft?.id
+      ? `Draft saved (${result.draft.id}).`
+      : "Draft saved.";
+    state.gmailDraftForm = {
+      ...state.gmailDraftForm,
+      textBody: "",
+    };
+  } catch (error) {
+    state.gmailDraftError = error instanceof Error ? error.message : String(error);
+  } finally {
+    state.gmailDraftSaving = false;
+  }
+}
+
+export async function sendGmailMessage(state: GmailDraftState): Promise<void> {
+  if (!state.client || !state.connected || state.gmailSendPending) {
+    return;
+  }
+  const valid = validateDraftFields(state);
+  if (!valid) {
+    state.gmailSendConfirmOpen = false;
+    return;
+  }
+
+  state.gmailSendPending = true;
+  state.gmailSendError = null;
+  state.gmailSendSuccess = null;
+  try {
+    const result = await state.client.request<{ message?: { id?: string } }>(
+      "gmail.messages.send",
+      {
+        to: valid.to,
+        subject: valid.subject,
+        textBody: valid.textBody,
+        ...(state.gmailDraftForm.threadId ? { threadId: state.gmailDraftForm.threadId } : {}),
+        ...(state.gmailDraftForm.inReplyTo ? { inReplyTo: state.gmailDraftForm.inReplyTo } : {}),
+        ...(state.gmailDraftForm.references?.length
+          ? { references: state.gmailDraftForm.references }
+          : {}),
+      },
+    );
+    state.gmailSendSuccess = result?.message?.id
+      ? `Message sent (${result.message.id}).`
+      : "Message sent.";
+    state.gmailSendConfirmOpen = false;
+    state.gmailDraftForm = {
+      ...state.gmailDraftForm,
+      textBody: "",
+    };
+  } catch (error) {
+    state.gmailSendError = error instanceof Error ? error.message : String(error);
+  } finally {
+    state.gmailSendPending = false;
+  }
+}

--- a/ui/src/ui/controllers/gmail-inbox.test.ts
+++ b/ui/src/ui/controllers/gmail-inbox.test.ts
@@ -1,0 +1,120 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from "vitest";
+import { loadGmailInbox, updateGmailInboxFilters, type GmailInboxState } from "./gmail-inbox.ts";
+
+function createState(): GmailInboxState {
+  return {
+    client: {
+      request: vi.fn(),
+    } as unknown as GmailInboxState["client"],
+    connected: true,
+    gmailAuthStatus: {
+      providerId: "google-gmail",
+      connected: true,
+      profiles: [{ profileId: "google-gmail:david@example.com", email: "david@example.com" }],
+    },
+    gmailInboxLoading: false,
+    gmailInboxError: null,
+    gmailInboxItems: [],
+    gmailInboxQuery: "",
+    gmailInboxUnreadOnly: false,
+    gmailSelectedThreadId: null,
+    gmailThreadLoading: false,
+    gmailThreadError: null,
+    gmailSelectedThread: null,
+  };
+}
+
+describe("gmail inbox controller", () => {
+  it("loads inbox messages and auto-selects the first thread", async () => {
+    const state = createState();
+    const request = vi.mocked(state.client!.request);
+    request.mockImplementation(async (method: string, params?: Record<string, unknown>) => {
+      if (method === "gmail.messages.list") {
+        return {
+          messages: [{ id: "msg-1", threadId: "thread-1" }],
+        };
+      }
+      if (method === "gmail.messages.get") {
+        return {
+          message: {
+            id: String(params?.id),
+            threadId: "thread-1",
+            snippet: "Preview text",
+            internalDate: String(Date.now()),
+            labelIds: ["INBOX", "UNREAD"],
+            payload: {
+              headers: [
+                { name: "Subject", value: "Inbox subject" },
+                { name: "From", value: "Taylor <taylor@example.com>" },
+              ],
+            },
+          },
+        };
+      }
+      if (method === "gmail.threads.get") {
+        return {
+          thread: {
+            id: "thread-1",
+            messages: [
+              {
+                id: "msg-1",
+                threadId: "thread-1",
+                snippet: "Preview text",
+                labelIds: ["INBOX", "UNREAD"],
+                payload: {
+                  headers: [
+                    { name: "Subject", value: "Inbox subject" },
+                    { name: "From", value: "Taylor <taylor@example.com>" },
+                    { name: "To", value: "David <david@example.com>" },
+                  ],
+                  mimeType: "text/plain",
+                  body: { data: "SGVsbG8gRGF2aWQ" },
+                },
+              },
+            ],
+          },
+        };
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    await loadGmailInbox(state);
+
+    expect(request).toHaveBeenCalledWith("gmail.messages.list", {
+      labelIds: ["INBOX"],
+      maxResults: 12,
+    });
+    expect(state.gmailInboxItems[0]?.subject).toBe("Inbox subject");
+    expect(state.gmailSelectedThreadId).toBe("thread-1");
+    expect(state.gmailSelectedThread?.messages[0]?.bodyText).toContain("Hello David");
+  });
+
+  it("uses gmail search when filters are set", async () => {
+    const state = createState();
+    updateGmailInboxFilters(state, { query: "invoice", unreadOnly: true });
+    const request = vi.mocked(state.client!.request);
+    request.mockImplementation(async (method: string, params?: Record<string, unknown>) => {
+      if (method === "gmail.messages.search") {
+        expect(params).toMatchObject({
+          query: "invoice",
+          inInbox: true,
+          isUnread: true,
+          maxResults: 12,
+        });
+        return { messages: [] };
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    await loadGmailInbox(state);
+
+    expect(request).toHaveBeenCalledWith("gmail.messages.search", {
+      query: "invoice",
+      inInbox: true,
+      isUnread: true,
+      maxResults: 12,
+    });
+  });
+});

--- a/ui/src/ui/controllers/gmail-inbox.ts
+++ b/ui/src/ui/controllers/gmail-inbox.ts
@@ -1,0 +1,271 @@
+import type { GatewayBrowserClient } from "../gateway.ts";
+import type { GmailAuthStatusResult } from "./gmail-auth.ts";
+
+export type GmailInboxItem = {
+  id: string;
+  threadId: string;
+  subject: string;
+  from: string;
+  snippet: string;
+  internalDate: number | null;
+  unread: boolean;
+};
+
+export type GmailThreadMessage = {
+  id: string;
+  subject: string;
+  from: string;
+  to: string;
+  date: string;
+  snippet: string;
+  bodyText: string;
+  unread: boolean;
+  messageId: string;
+  references: string[];
+};
+
+export type GmailThreadView = {
+  id: string;
+  messages: GmailThreadMessage[];
+};
+
+type GmailMessagePart = {
+  mimeType?: string;
+  body?: { data?: string };
+  parts?: GmailMessagePart[];
+};
+
+type GmailMessageRecord = {
+  id: string;
+  threadId: string;
+  snippet?: string;
+  internalDate?: string;
+  labelIds?: string[];
+  payload?: GmailMessagePart;
+};
+
+type GmailThreadRecord = {
+  id: string;
+  messages?: GmailMessageRecord[];
+};
+
+type GmailListResponse = {
+  messages?: Array<{ id?: string; threadId?: string }>;
+};
+
+export type GmailInboxState = {
+  client: GatewayBrowserClient | null;
+  connected: boolean;
+  gmailAuthStatus: GmailAuthStatusResult | null;
+  gmailInboxLoading: boolean;
+  gmailInboxError: string | null;
+  gmailInboxItems: GmailInboxItem[];
+  gmailInboxQuery: string;
+  gmailInboxUnreadOnly: boolean;
+  gmailSelectedThreadId: string | null;
+  gmailThreadLoading: boolean;
+  gmailThreadError: string | null;
+  gmailSelectedThread: GmailThreadView | null;
+};
+
+export function updateGmailInboxFilters(
+  state: GmailInboxState,
+  patch: { query?: string; unreadOnly?: boolean },
+): void {
+  if (typeof patch.query === "string") {
+    state.gmailInboxQuery = patch.query;
+  }
+  if (typeof patch.unreadOnly === "boolean") {
+    state.gmailInboxUnreadOnly = patch.unreadOnly;
+  }
+  state.gmailInboxError = null;
+}
+
+function decodeBase64Url(value: string): string {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized + "=".repeat((4 - (normalized.length % 4 || 4)) % 4);
+  try {
+    return decodeURIComponent(
+      Array.from(atob(padded))
+        .map((char) => `%${char.charCodeAt(0).toString(16).padStart(2, "0")}`)
+        .join(""),
+    );
+  } catch {
+    try {
+      return atob(padded);
+    } catch {
+      return "";
+    }
+  }
+}
+
+function extractHeader(message: GmailMessageRecord, name: string): string {
+  const headers = (
+    message.payload as { headers?: Array<{ name?: string; value?: string }> } | undefined
+  )?.headers;
+  const match = headers?.find((header) => header.name?.toLowerCase() === name.toLowerCase());
+  return match?.value?.trim() ?? "";
+}
+
+function stripHtml(value: string): string {
+  return value
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+\n/g, "\n")
+    .replace(/\n\s+/g, "\n")
+    .replace(/[ \t]{2,}/g, " ")
+    .trim();
+}
+
+function collectBodyTexts(part: GmailMessagePart | undefined, output: string[]) {
+  if (!part) {
+    return;
+  }
+  const data = part.body?.data;
+  if (data && typeof part.mimeType === "string") {
+    if (part.mimeType.startsWith("text/plain")) {
+      const decoded = decodeBase64Url(data).trim();
+      if (decoded) {
+        output.push(decoded);
+      }
+    } else if (part.mimeType.startsWith("text/html")) {
+      const decoded = stripHtml(decodeBase64Url(data));
+      if (decoded) {
+        output.push(decoded);
+      }
+    }
+  }
+  if (Array.isArray(part.parts)) {
+    for (const child of part.parts) {
+      collectBodyTexts(child, output);
+    }
+  }
+}
+
+function summarizeMessage(message: GmailMessageRecord): GmailInboxItem {
+  return {
+    id: message.id,
+    threadId: message.threadId,
+    subject: extractHeader(message, "subject") || "(no subject)",
+    from: extractHeader(message, "from") || "Unknown sender",
+    snippet: message.snippet?.trim() || "",
+    internalDate: message.internalDate ? Number(message.internalDate) || null : null,
+    unread: Array.isArray(message.labelIds) && message.labelIds.includes("UNREAD"),
+  };
+}
+
+function mapThreadMessage(message: GmailMessageRecord): GmailThreadMessage {
+  const bodyParts: string[] = [];
+  collectBodyTexts(message.payload, bodyParts);
+  const references = extractHeader(message, "references")
+    .split(/\s+/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return {
+    id: message.id,
+    subject: extractHeader(message, "subject") || "(no subject)",
+    from: extractHeader(message, "from") || "Unknown sender",
+    to: extractHeader(message, "to"),
+    date: extractHeader(message, "date"),
+    snippet: message.snippet?.trim() || "",
+    bodyText: bodyParts.join("\n\n").trim(),
+    unread: Array.isArray(message.labelIds) && message.labelIds.includes("UNREAD"),
+    messageId: extractHeader(message, "message-id"),
+    references,
+  };
+}
+
+export async function loadGmailInbox(state: GmailInboxState): Promise<void> {
+  if (!state.client || !state.connected || state.gmailInboxLoading) {
+    return;
+  }
+  if (!state.gmailAuthStatus?.connected) {
+    state.gmailInboxItems = [];
+    state.gmailSelectedThread = null;
+    state.gmailSelectedThreadId = null;
+    state.gmailInboxError = null;
+    state.gmailThreadError = null;
+    return;
+  }
+  state.gmailInboxLoading = true;
+  state.gmailInboxError = null;
+  try {
+    const trimmedQuery = state.gmailInboxQuery.trim();
+    const useSearch = trimmedQuery.length > 0 || state.gmailInboxUnreadOnly;
+    const list = useSearch
+      ? await state.client.request<GmailListResponse>("gmail.messages.search", {
+          query: trimmedQuery || undefined,
+          inInbox: true,
+          isUnread: state.gmailInboxUnreadOnly || undefined,
+          maxResults: 12,
+        })
+      : await state.client.request<GmailListResponse>("gmail.messages.list", {
+          labelIds: ["INBOX"],
+          maxResults: 12,
+        });
+    const ids = Array.isArray(list.messages)
+      ? list.messages
+          .map((message) => (typeof message?.id === "string" ? message.id : null))
+          .filter((id): id is string => Boolean(id))
+      : [];
+    const messages = await Promise.all(
+      ids.map(async (id) => {
+        const result = await state.client!.request<{ message: GmailMessageRecord }>(
+          "gmail.messages.get",
+          { id, format: "full" },
+        );
+        return result.message;
+      }),
+    );
+    state.gmailInboxItems = messages
+      .map((message) => summarizeMessage(message))
+      .sort((left, right) => (right.internalDate ?? 0) - (left.internalDate ?? 0));
+
+    const nextThreadId =
+      state.gmailSelectedThreadId &&
+      state.gmailInboxItems.some((item) => item.threadId === state.gmailSelectedThreadId)
+        ? state.gmailSelectedThreadId
+        : (state.gmailInboxItems[0]?.threadId ?? null);
+    state.gmailSelectedThreadId = nextThreadId;
+    if (nextThreadId) {
+      await selectGmailThread(state, nextThreadId);
+    } else {
+      state.gmailSelectedThread = null;
+      state.gmailThreadError = null;
+    }
+  } catch (error) {
+    state.gmailInboxError = error instanceof Error ? error.message : String(error);
+    state.gmailInboxItems = [];
+  } finally {
+    state.gmailInboxLoading = false;
+  }
+}
+
+export async function selectGmailThread(state: GmailInboxState, threadId: string): Promise<void> {
+  if (!state.client || !state.connected || !threadId) {
+    return;
+  }
+  state.gmailSelectedThreadId = threadId;
+  state.gmailThreadLoading = true;
+  state.gmailThreadError = null;
+  try {
+    const result = await state.client.request<{ thread: GmailThreadRecord }>("gmail.threads.get", {
+      id: threadId,
+      format: "full",
+    });
+    const messages = Array.isArray(result.thread?.messages)
+      ? result.thread.messages.map((message) => mapThreadMessage(message))
+      : [];
+    state.gmailSelectedThread = {
+      id: result.thread.id,
+      messages,
+    };
+  } catch (error) {
+    state.gmailThreadError = error instanceof Error ? error.message : String(error);
+    state.gmailSelectedThread = null;
+  } finally {
+    state.gmailThreadLoading = false;
+  }
+}

--- a/ui/src/ui/views/overview.render.test.ts
+++ b/ui/src/ui/views/overview.render.test.ts
@@ -37,6 +37,31 @@ function createOverviewProps(overrides: Partial<OverviewProps> = {}): OverviewPr
     cronNext: null,
     lastChannelsRefresh: null,
     modelAuthStatus: null,
+    gmailAuthStatus: null,
+    gmailAuthLoading: false,
+    gmailAuthConnectPending: false,
+    gmailAuthError: null,
+    gmailInboxLoading: false,
+    gmailInboxError: null,
+    gmailInboxItems: [],
+    gmailInboxQuery: "",
+    gmailInboxUnreadOnly: false,
+    gmailSelectedThreadId: null,
+    gmailThreadLoading: false,
+    gmailThreadError: null,
+    gmailSelectedThread: null,
+    gmailDraftForm: {
+      to: "",
+      subject: "",
+      textBody: "",
+    },
+    gmailDraftSaving: false,
+    gmailDraftError: null,
+    gmailDraftSuccess: null,
+    gmailSendConfirmOpen: false,
+    gmailSendPending: false,
+    gmailSendError: null,
+    gmailSendSuccess: null,
     usageResult: null,
     sessionsResult: null,
     skillsReport: null,
@@ -56,6 +81,18 @@ function createOverviewProps(overrides: Partial<OverviewProps> = {}): OverviewPr
     onRefresh: () => undefined,
     onNavigate: () => undefined,
     onRefreshLogs: () => undefined,
+    onGmailConnect: () => undefined,
+    onGmailRefresh: () => undefined,
+    onGmailInboxFiltersChange: () => undefined,
+    onGmailInboxSearch: () => undefined,
+    onGmailSelectThread: () => undefined,
+    onGmailDraftFieldChange: () => undefined,
+    onGmailDraftReply: () => undefined,
+    onGmailDraftReset: () => undefined,
+    onGmailDraftSave: () => undefined,
+    onGmailSendOpenConfirm: () => undefined,
+    onGmailSendCloseConfirm: () => undefined,
+    onGmailSendConfirm: () => undefined,
     ...overrides,
   };
 }
@@ -90,6 +127,72 @@ describe("overview view rendering", () => {
     expect(select?.selectedOptions[0]?.textContent?.trim()).toBe("简体中文 (简体中文)");
 
     await i18n.setLocale("en");
+  });
+
+  it("renders the gmail connect controls in the overview access card", async () => {
+    const container = document.createElement("div");
+
+    render(renderOverview(createOverviewProps()), container);
+    await Promise.resolve();
+
+    expect(container.textContent).toContain("Connect Gmail");
+    expect(container.textContent).toContain("Refresh Gmail");
+  });
+
+  it("renders the gmail inbox and selected thread when connected", async () => {
+    const container = document.createElement("div");
+
+    render(
+      renderOverview(
+        createOverviewProps({
+          gmailAuthStatus: {
+            providerId: "google-gmail",
+            connected: true,
+            profiles: [{ profileId: "google-gmail:david@example.com", email: "david@example.com" }],
+          },
+          gmailInboxItems: [
+            {
+              id: "msg-1",
+              threadId: "thread-1",
+              subject: "Hello David",
+              from: "Taylor <taylor@example.com>",
+              snippet: "Just checking in about the project",
+              internalDate: Date.now(),
+              unread: true,
+            },
+          ],
+          gmailSelectedThreadId: "thread-1",
+          gmailSelectedThread: {
+            id: "thread-1",
+            messages: [
+              {
+                id: "msg-1",
+                subject: "Hello David",
+                from: "Taylor <taylor@example.com>",
+                to: "David <david@example.com>",
+                date: "Wed, 7 May 2026 10:00:00 -0500",
+                snippet: "Just checking in about the project",
+                bodyText: "Full body preview",
+                unread: true,
+                messageId: "<msg-1@example.com>",
+                references: ["<root@example.com>"],
+              },
+            ],
+          },
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    expect(container.textContent).toContain("Gmail inbox");
+    expect(container.textContent).toContain("Search inbox");
+    expect(container.textContent).toContain("Unread only");
+    expect(container.textContent).toContain("Hello David");
+    expect(container.textContent).toContain("Full body preview");
+    expect(container.textContent).toContain("Draft reply");
+    expect(container.textContent).toContain("Send…");
+    expect(container.textContent).toContain("Save draft");
   });
 
   it("renders a dedicated scope-upgrade approval hint with the exact approve command", async () => {

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -1,6 +1,9 @@
 import { html, nothing } from "lit";
 import { t, i18n, SUPPORTED_LOCALES, type Locale, isSupportedLocale } from "../../i18n/index.ts";
 import type { EventLogEntry } from "../app-events.ts";
+import type { GmailAuthStatusResult } from "../controllers/gmail-auth.ts";
+import type { GmailDraftForm } from "../controllers/gmail-draft.ts";
+import type { GmailInboxItem, GmailThreadView } from "../controllers/gmail-inbox.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../external-link.ts";
 import { formatRelativeTimestamp, formatDurationHuman } from "../format.ts";
 import type { GatewayHelloOk } from "../gateway.ts";
@@ -43,6 +46,27 @@ export type OverviewProps = {
   warnQueryToken: boolean;
   // New dashboard data
   modelAuthStatus: ModelAuthStatusResult | null;
+  gmailAuthStatus: GmailAuthStatusResult | null;
+  gmailAuthLoading: boolean;
+  gmailAuthConnectPending: boolean;
+  gmailAuthError: string | null;
+  gmailInboxLoading: boolean;
+  gmailInboxError: string | null;
+  gmailInboxItems: GmailInboxItem[];
+  gmailInboxQuery: string;
+  gmailInboxUnreadOnly: boolean;
+  gmailSelectedThreadId: string | null;
+  gmailThreadLoading: boolean;
+  gmailThreadError: string | null;
+  gmailSelectedThread: GmailThreadView | null;
+  gmailDraftForm: GmailDraftForm;
+  gmailDraftSaving: boolean;
+  gmailDraftError: string | null;
+  gmailDraftSuccess: string | null;
+  gmailSendConfirmOpen: boolean;
+  gmailSendPending: boolean;
+  gmailSendError: string | null;
+  gmailSendSuccess: string | null;
   usageResult: SessionsUsageResult | null;
   sessionsResult: SessionsListResult | null;
   skillsReport: SkillStatusReport | null;
@@ -62,6 +86,18 @@ export type OverviewProps = {
   onRefresh: () => void;
   onNavigate: (tab: string) => void;
   onRefreshLogs: () => void;
+  onGmailConnect: () => void;
+  onGmailRefresh: () => void;
+  onGmailInboxFiltersChange: (patch: { query?: string; unreadOnly?: boolean }) => void;
+  onGmailInboxSearch: () => void;
+  onGmailSelectThread: (threadId: string) => void;
+  onGmailDraftFieldChange: (patch: Partial<GmailDraftForm>) => void;
+  onGmailDraftReply: () => void;
+  onGmailDraftReset: () => void;
+  onGmailDraftSave: () => void;
+  onGmailSendOpenConfirm: () => void;
+  onGmailSendCloseConfirm: () => void;
+  onGmailSendConfirm: () => void;
 };
 
 const PAIRING_HINT_COPY: Record<
@@ -374,6 +410,47 @@ export function renderOverview(props: OverviewProps) {
               : t("overview.access.connectHint")}</span
           >
         </div>
+        <div
+          style="margin-top: 16px; padding-top: 16px; border-top: 1px solid var(--border, rgba(255,255,255,0.08));"
+        >
+          <div
+            style="display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap;"
+          >
+            <div>
+              <div class="card-title" style="font-size: 15px; margin: 0;">Gmail</div>
+              <div class="muted" style="margin-top: 4px;">
+                ${props.gmailAuthStatus?.connected
+                  ? (props.gmailAuthStatus.profiles[0]?.email ?? "Connected")
+                  : props.gmailAuthLoading
+                    ? "Checking Gmail connection…"
+                    : "Connect Gmail for inbox, search, threads, and drafts."}
+              </div>
+            </div>
+            <div class="row" style="gap: 8px;">
+              <button
+                class="btn"
+                ?disabled=${props.gmailAuthLoading}
+                @click=${() => props.onGmailRefresh()}
+              >
+                Refresh Gmail
+              </button>
+              <button
+                class="btn btn--primary"
+                ?disabled=${!props.connected || props.gmailAuthConnectPending}
+                @click=${() => props.onGmailConnect()}
+              >
+                ${props.gmailAuthConnectPending
+                  ? "Connecting Gmail…"
+                  : props.gmailAuthStatus?.connected
+                    ? "Reconnect Gmail"
+                    : "Connect Gmail"}
+              </button>
+            </div>
+          </div>
+          ${props.gmailAuthError
+            ? html`<div class="pill danger" style="margin-top: 10px;">${props.gmailAuthError}</div>`
+            : nothing}
+        </div>
         ${!props.connected
           ? html`
               <div class="login-gate__help" style="margin-top: 16px;">
@@ -451,6 +528,268 @@ export function renderOverview(props: OverviewProps) {
 
     <div class="ov-section-divider"></div>
 
+    ${props.gmailAuthStatus?.connected
+      ? html`
+          <div class="card">
+            <div
+              style="display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap;"
+            >
+              <div>
+                <div class="card-title">Gmail inbox</div>
+                <div class="card-sub">Recent inbox threads from the connected Gmail account.</div>
+              </div>
+              <button
+                class="btn"
+                ?disabled=${props.gmailInboxLoading}
+                @click=${() => props.onGmailRefresh()}
+              >
+                ${props.gmailInboxLoading ? "Refreshing…" : "Refresh inbox"}
+              </button>
+            </div>
+            <div style="display:flex; gap:10px; flex-wrap:wrap; margin-top:14px; align-items:end;">
+              <label class="field" style="flex:1 1 260px;">
+                <span>Search inbox</span>
+                <input
+                  .value=${props.gmailInboxQuery}
+                  @input=${(e: Event) =>
+                    props.onGmailInboxFiltersChange({
+                      query: (e.target as HTMLInputElement).value,
+                    })}
+                  @keydown=${(e: KeyboardEvent) => {
+                    if (e.key === "Enter") {
+                      props.onGmailInboxSearch();
+                    }
+                  }}
+                  placeholder="from:, subject:, keywords…"
+                />
+              </label>
+              <label
+                class="field"
+                style="display:flex; align-items:center; gap:8px; min-height:36px;"
+              >
+                <input
+                  type="checkbox"
+                  .checked=${props.gmailInboxUnreadOnly}
+                  @change=${(e: Event) =>
+                    props.onGmailInboxFiltersChange({
+                      unreadOnly: (e.target as HTMLInputElement).checked,
+                    })}
+                />
+                <span>Unread only</span>
+              </label>
+              <button
+                class="btn"
+                ?disabled=${props.gmailInboxLoading}
+                @click=${() => props.onGmailInboxSearch()}
+              >
+                Search
+              </button>
+            </div>
+            ${props.gmailInboxError
+              ? html`<div class="pill danger" style="margin-top: 12px;">
+                  ${props.gmailInboxError}
+                </div>`
+              : nothing}
+            <div
+              style="display:grid; grid-template-columns:minmax(280px, 360px) minmax(0, 1fr); gap:16px; margin-top:16px; align-items:start;"
+            >
+              <div style="display:flex; flex-direction:column; gap:8px;">
+                ${props.gmailInboxItems.length === 0
+                  ? html`<div class="muted">
+                      ${props.gmailInboxLoading
+                        ? "Loading inbox…"
+                        : "No inbox messages loaded yet."}
+                    </div>`
+                  : props.gmailInboxItems.map(
+                      (item) => html`
+                        <button
+                          class="btn"
+                          style="text-align:left; display:block; padding:12px; border:${props.gmailSelectedThreadId ===
+                          item.threadId
+                            ? "1px solid var(--accent, #6ea8fe)"
+                            : "1px solid var(--border, rgba(255,255,255,0.08))"}; background:${props.gmailSelectedThreadId ===
+                          item.threadId
+                            ? "rgba(110,168,254,0.08)"
+                            : "transparent"};"
+                          @click=${() => props.onGmailSelectThread(item.threadId)}
+                        >
+                          <div
+                            style="display:flex; align-items:center; justify-content:space-between; gap:8px;"
+                          >
+                            <strong style="font-size:13px;">${item.subject}</strong>
+                            ${item.unread ? html`<span class="pill">Unread</span>` : nothing}
+                          </div>
+                          <div class="muted" style="margin-top:4px; font-size:12px;">
+                            ${item.from}
+                          </div>
+                          <div style="margin-top:6px; font-size:13px;">
+                            ${item.snippet || "No preview available."}
+                          </div>
+                        </button>
+                      `,
+                    )}
+              </div>
+              <div>
+                ${props.gmailThreadError
+                  ? html`<div class="pill danger">${props.gmailThreadError}</div>`
+                  : props.gmailThreadLoading
+                    ? html`<div class="muted">Loading thread…</div>`
+                    : !props.gmailSelectedThread || props.gmailSelectedThread.messages.length === 0
+                      ? html`<div class="muted">Select a thread to read it here.</div>`
+                      : html`
+                          <div style="display:flex; flex-direction:column; gap:16px;">
+                            <div style="display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap;">
+                              <div>
+                                <div class="card-title" style="font-size: 15px; margin: 0;">Thread</div>
+                                <div class="muted" style="margin-top: 4px;">Read the thread, then save a reply draft below.</div>
+                              </div>
+                              <button class="btn" @click=${() => props.onGmailDraftReply()}>Reply as draft</button>
+                            </div>
+                            ${props.gmailSelectedThread.messages.map(
+                              (message) => html`
+                                <article
+                                  style="padding:14px; border:1px solid var(--border, rgba(255,255,255,0.08)); border-radius:12px;"
+                                >
+                                  <div
+                                    style="display:flex; align-items:center; justify-content:space-between; gap:8px; flex-wrap:wrap;"
+                                  >
+                                    <strong>${message.subject}</strong>
+                                    ${message.unread
+                                      ? html`<span class="pill">Unread</span>`
+                                      : nothing}
+                                  </div>
+                                  <div class="muted" style="margin-top:6px; font-size:12px;">
+                                    From:
+                                    ${message.from}${message.to
+                                      ? html`<span> · To: ${message.to}</span>`
+                                      : nothing}${message.date
+                                      ? html`<span> · ${message.date}</span>`
+                                      : nothing}
+                                  </div>
+                                  <div
+                                    style="margin-top:10px; white-space:pre-wrap; line-height:1.45; font-size:13px;"
+                                  >
+                                    ${message.bodyText ||
+                                    message.snippet ||
+                                    "No body preview available."}
+                                  </div>
+                                </article>
+                              `,
+                            )}
+                            <div style="padding:14px; border:1px solid var(--border, rgba(255,255,255,0.08)); border-radius:12px;">
+                              <div style="display:flex; align-items:center; justify-content:space-between; gap:8px; flex-wrap:wrap;">
+                                <div>
+                                  <div class="card-title" style="font-size: 15px; margin: 0;">Draft reply</div>
+                                  <div class="muted" style="margin-top: 4px;">Create a Gmail draft from this thread.</div>
+                                </div>
+                                <div class="row" style="gap:8px;">
+                                  <button class="btn" @click=${() => props.onGmailDraftReset()}>Clear</button>
+                                  <button class="btn" ?disabled=${props.gmailSendPending} @click=${() => props.onGmailSendOpenConfirm()}>
+                                    Send…
+                                  </button>
+                                  <button class="btn btn--primary" ?disabled=${props.gmailDraftSaving} @click=${() => props.onGmailDraftSave()}>
+                                    ${props.gmailDraftSaving ? "Saving draft…" : "Save draft"}
+                                  </button>
+                                </div>
+                              </div>
+                              ${
+                                props.gmailSendConfirmOpen
+                                  ? html`<div class="callout warn" style="margin-top:10px;">
+                                      <div><strong>Send this email now?</strong></div>
+                                      <div class="muted" style="margin-top:6px;">
+                                        This will send the message immediately from your Gmail
+                                        account.
+                                      </div>
+                                      <div class="row" style="gap:8px; margin-top:10px;">
+                                        <button
+                                          class="btn"
+                                          @click=${() => props.onGmailSendCloseConfirm()}
+                                        >
+                                          Cancel
+                                        </button>
+                                        <button
+                                          class="btn btn--primary"
+                                          ?disabled=${props.gmailSendPending}
+                                          @click=${() => props.onGmailSendConfirm()}
+                                        >
+                                          ${props.gmailSendPending ? "Sending…" : "Confirm send"}
+                                        </button>
+                                      </div>
+                                    </div>`
+                                  : nothing
+                              }
+                              </div>
+                              <div style="display:grid; gap:10px; margin-top:14px;">
+                                <label class="field">
+                                  <span>To</span>
+                                  <input
+                                    .value=${props.gmailDraftForm.to}
+                                    @input=${(e: Event) =>
+                                      props.onGmailDraftFieldChange({
+                                        to: (e.target as HTMLInputElement).value,
+                                      })}
+                                  />
+                                </label>
+                                <label class="field">
+                                  <span>Subject</span>
+                                  <input
+                                    .value=${props.gmailDraftForm.subject}
+                                    @input=${(e: Event) =>
+                                      props.onGmailDraftFieldChange({
+                                        subject: (e.target as HTMLInputElement).value,
+                                      })}
+                                  />
+                                </label>
+                                <label class="field">
+                                  <span>Body</span>
+                                  <textarea
+                                    rows="10"
+                                    .value=${props.gmailDraftForm.textBody}
+                                    @input=${(e: Event) =>
+                                      props.onGmailDraftFieldChange({
+                                        textBody: (e.target as HTMLTextAreaElement).value,
+                                      })}
+                                    style="width:100%; box-sizing:border-box; resize:vertical;"
+                                  ></textarea>
+                                </label>
+                              </div>
+                              ${
+                                props.gmailDraftError
+                                  ? html`<div class="pill danger" style="margin-top:10px;">
+                                      ${props.gmailDraftError}
+                                    </div>`
+                                  : nothing
+                              }
+                              ${
+                                props.gmailDraftSuccess
+                                  ? html`<div class="pill ok" style="margin-top:10px;">
+                                      ${props.gmailDraftSuccess}
+                                    </div>`
+                                  : nothing
+                              }
+                              ${
+                                props.gmailSendError
+                                  ? html`<div class="pill danger" style="margin-top:10px;">
+                                      ${props.gmailSendError}
+                                    </div>`
+                                  : nothing
+                              }
+                              ${
+                                props.gmailSendSuccess
+                                  ? html`<div class="pill ok" style="margin-top:10px;">
+                                      ${props.gmailSendSuccess}
+                                    </div>`
+                                  : nothing
+                              }
+                            </div>
+                          </div>
+                        `}
+              </div>
+            </div>
+          </div>
+          <div class="ov-section-divider"></div>
+        `
+      : nothing}
     ${renderOverviewCards({
       usageResult: props.usageResult,
       sessionsResult: props.sessionsResult,


### PR DESCRIPTION
## Summary

This PR adds an end-to-end Gmail integration to OpenClaw across the Google extension and the Overview UI.

It includes Gmail OAuth/profile persistence, gateway methods for inbox/thread/draft/send operations, and an Overview-embedded Gmail experience for connecting, browsing, drafting, searching, filtering, and sending with confirmation.

## Included

### Backend / gateway
- Gmail OAuth URL + code exchange
- persisted Gmail auth profiles + refresh handling
- Gmail client helpers for:
  - list/search messages
  - get message
  - get thread
  - create draft
  - send message
- Gmail gateway method registration in the Google extension

### UI
- Gmail auth controller + connect/reconnect state
- inbox list + thread reader
- reply-as-draft flow with prefill from selected thread
- send confirmation flow
- inbox search + unread-only filtering
- Overview rendering/state wiring for Gmail

## Validation

Passed:
- `corepack pnpm check --timed`
- focused Gmail/UI tests
- `corepack pnpm build:strict-smoke`

## Notes / scope
- This is an Overview-embedded Gmail experience, not a standalone mail app
- Watch/push-driven Gmail updates are not included
- Labels/archive actions are not included

## Reviewer notes
Main things to review:
1. Gmail gateway/API surface in `extensions/google/*`
2. Overview UI/state wiring in `ui/src/ui/*`
3. Send flow safety (explicit confirmation before outbound send)
