### PR TITLE
fix(telegram): share bot api throttler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - CLI: make parser, startup, config, guardrail, channel, agent, task, session, and MCP failures explain what happened and point to the next recovery command.
 - GitHub Copilot: refresh the model catalog from `${baseUrl}/models` so per-account entitlement and accurate context windows surface at runtime; static manifest catalog (now including `gpt-5.5`) remains the fallback when discovery is disabled or the API is unreachable.
 - Active Memory: support concrete `plugins.entries.active-memory.config.toolsAllow` recall tool names for custom memory plugins while keeping the built-in memory-core default on `memory_search`/`memory_get` and preserving `memory_recall` automatically for `plugins.slots.memory: "memory-lancedb"`.
+- Telegram: share the grammY API throttler across polling and ad hoc send clients for the same bot token, so visible draft previews and CLI sends use one quota gate. Thanks @anagnorisis2peripeteia.
 - Telegram/Feishu: honor configured per-agent and global `reasoningDefault` values when deciding whether channel reasoning previews should stream or stay hidden, addressing the preview-default part of #73182. Thanks @anagnorisis2peripeteia.
 - Docker: run the runtime image under `tini` so long-lived containers reap orphaned child processes and forward signals correctly. (#77885) Thanks @VintageAyu.
 - Google/Gemini: normalize retired `google/gemini-3-pro-preview` and `google-gemini-cli/gemini-3-pro-preview` selections to `google/gemini-3.1-pro-preview` before they are written to model config.

--- a/extensions/telegram/src/account-throttler.test.ts
+++ b/extensions/telegram/src/account-throttler.test.ts
@@ -1,0 +1,17 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { clearAccountThrottlersForTest, getOrCreateAccountThrottler } from "./account-throttler.js";
+
+describe("getOrCreateAccountThrottler", () => {
+  beforeEach(() => {
+    clearAccountThrottlersForTest();
+  });
+
+  it("shares throttlers per bot token", () => {
+    const first = getOrCreateAccountThrottler("tok");
+    const second = getOrCreateAccountThrottler("tok");
+    const other = getOrCreateAccountThrottler("other");
+
+    expect(second).toBe(first);
+    expect(other).not.toBe(first);
+  });
+});

--- a/extensions/telegram/src/account-throttler.ts
+++ b/extensions/telegram/src/account-throttler.ts
@@ -1,0 +1,21 @@
+import { apiThrottler } from "./bot.runtime.js";
+
+type ApiThrottlerTransformer = ReturnType<typeof apiThrottler>;
+
+const throttlerByToken = new Map<string, ApiThrottlerTransformer>();
+
+export function getOrCreateAccountThrottler(
+  token: string,
+  createThrottler: () => ApiThrottlerTransformer = apiThrottler,
+): ApiThrottlerTransformer {
+  let throttler = throttlerByToken.get(token);
+  if (!throttler) {
+    throttler = createThrottler();
+    throttlerByToken.set(token, throttler);
+  }
+  return throttler;
+}
+
+export function clearAccountThrottlersForTest(): void {
+  throttlerByToken.clear();
+}

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -23,6 +23,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/text-runtime";
+import { getOrCreateAccountThrottler } from "./account-throttler.js";
 import { resolveTelegramAccount } from "./accounts.js";
 import { normalizeTelegramApiRoot } from "./api-root.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
@@ -353,7 +354,7 @@ export function createTelegramBotCore(
       ? { ...(client ? { client } : {}), ...(opts.botInfo ? { botInfo: opts.botInfo } : {}) }
       : undefined;
   const bot = new botRuntime.Bot(opts.token, botConfig);
-  bot.api.config.use(botRuntime.apiThrottler());
+  bot.api.config.use(getOrCreateAccountThrottler(opts.token, botRuntime.apiThrottler));
   // Catch all errors from bot middleware to prevent unhandled rejections
   bot.catch((err) => {
     runtime.error?.(danger(`telegram bot error: ${formatUncaughtError(err)}`));

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -47,6 +47,7 @@ const {
   getTelegramSequentialKey,
   setTelegramBotRuntimeForTest,
 } = await import("./bot-core.js");
+const { clearAccountThrottlersForTest } = await import("./account-throttler.js");
 const { resetTelegramForumFlagCacheForTest } = await import("./bot/helpers.js");
 let createTelegramBot: (
   opts: TelegramBotOptions,
@@ -173,6 +174,8 @@ describe("createTelegramBot", () => {
   });
   beforeEach(() => {
     resetTelegramForumFlagCacheForTest();
+    clearAccountThrottlersForTest();
+    throttlerSpy.mockReset();
     setTelegramBotRuntimeForTest(
       telegramBotRuntimeForTest as unknown as Parameters<typeof setTelegramBotRuntimeForTest>[0],
     );
@@ -189,6 +192,15 @@ describe("createTelegramBot", () => {
     createTelegramBot({ token: "tok" });
     expect(throttlerSpy).toHaveBeenCalledTimes(1);
     expect(useSpy).toHaveBeenCalledWith("throttler");
+  });
+
+  it("reuses the grammY throttler for the same token", () => {
+    createTelegramBot({ token: "tok" });
+    createTelegramBot({ token: "tok" });
+    createTelegramBot({ token: "other" });
+
+    expect(throttlerSpy).toHaveBeenCalledTimes(2);
+    expect(useSpy).toHaveBeenCalledTimes(3);
   });
 
   it("logs middleware errors through grammY catch without rethrowing", () => {

--- a/extensions/telegram/src/send.test-harness.ts
+++ b/extensions/telegram/src/send.test-harness.ts
@@ -8,7 +8,8 @@ import {
 import type { MockFn } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { beforeEach, vi } from "vitest";
 
-const { botApi, botCtorSpy } = vi.hoisted(() => ({
+const { botApi, botConfigUseSpy, botCtorSpy } = vi.hoisted(() => ({
+  botConfigUseSpy: vi.fn(),
   botApi: {
     deleteMessage: vi.fn(),
     editForumTopic: vi.fn(),
@@ -87,7 +88,8 @@ const {
 }));
 
 type TelegramSendTestMocks = {
-  botApi: Record<string, MockFn>;
+  botApi: typeof botApi;
+  botConfigUseSpy: MockFn;
   botCtorSpy: MockFn;
   loadConfig: MockFn;
   resolveStorePath: MockFn;
@@ -107,7 +109,12 @@ vi.mock("grammy", () => ({
     ALL_UPDATE_TYPES: ["message"],
   },
   Bot: class {
-    api = botApi;
+    api = {
+      ...botApi,
+      config: {
+        use: botConfigUseSpy,
+      },
+    };
     catch = vi.fn();
     constructor(
       public token: string,
@@ -171,6 +178,7 @@ vi.mock("./target-writeback.js", () => ({
 export function getTelegramSendTestMocks(): TelegramSendTestMocks {
   return {
     botApi,
+    botConfigUseSpy,
     botCtorSpy,
     loadConfig,
     resolveStorePath,
@@ -198,6 +206,7 @@ export function installTelegramSendTestHooks() {
     undiciEnvHttpProxyAgentCtor.mockClear();
     undiciProxyAgentCtor.mockClear();
     botCtorSpy.mockReset();
+    botConfigUseSpy.mockReset();
     for (const fn of Object.values(botApi)) {
       fn.mockReset();
     }

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -18,6 +18,7 @@ installTelegramSendTestHooks();
 
 const {
   botApi,
+  botConfigUseSpy,
   botCtorSpy,
   imageMetadata,
   loadConfig,
@@ -523,6 +524,14 @@ describe("sendMessageTelegram", () => {
         client: expect.objectContaining({ apiRoot: "https://api.telegram.org" }),
       }),
     );
+  });
+
+  it("installs the shared grammY throttler on send clients", async () => {
+    botApi.sendMessage.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
+
+    await sendMessageTelegram("123", "hi", { cfg: TELEGRAM_TEST_CFG, token: "tok" });
+
+    expect(botConfigUseSpy).toHaveBeenCalledWith(expect.any(Function));
   });
 
   it("falls back to plain text when Telegram rejects HTML and preserves send params", async () => {

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -8,6 +8,7 @@ import { createTelegramRetryRunner, type RetryConfig } from "openclaw/plugin-sdk
 import { createSubsystemLogger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString, redactSensitiveText } from "openclaw/plugin-sdk/text-runtime";
+import { getOrCreateAccountThrottler } from "./account-throttler.js";
 import { type ResolvedTelegramAccount, resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { normalizeTelegramApiRoot } from "./api-root.js";
@@ -447,7 +448,14 @@ function resolveTelegramApiContext(opts: {
   });
   const token = resolveToken(opts.token, account);
   const client = resolveTelegramClientOptions(account);
-  const api = (opts.api ?? new Bot(token, client ? { client } : undefined).api) as TelegramApi;
+  let api: TelegramApi;
+  if (opts.api) {
+    api = opts.api as TelegramApi;
+  } else {
+    const bot = new Bot(token, client ? { client } : undefined);
+    bot.api.config.use(getOrCreateAccountThrottler(token));
+    api = bot.api;
+  }
   return { cfg, account, api };
 }
 


### PR DESCRIPTION
## Summary

- Share one grammY `apiThrottler()` transformer per Telegram bot token.
- Install that shared throttler on both the long-running polling bot and ad hoc `send.ts` clients.
- Keep the fix scoped to outbound quota ownership; no custom send gate, auto-retry, overflow, QQBot, or generated docs changes.

Extracted from the throttle concern around #74508.

## Distill

Before: polling bots and CLI/ad hoc send clients each constructed their own API client throttle state, even when they used the same bot token.

Insight: Telegram Bot API quotas are token-scoped, so the token is the owner of the throttler. Bot instances are just callers.

After: every Telegram API client asks for the token's throttler and installs that same transformer.

Tradeoff: one small Telegram-owned helper map. No new dependency and no local rate-limit model duplicating grammY.

## Verification

- `pnpm test extensions/telegram/src/account-throttler.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/send.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md extensions/telegram/src/account-throttler.ts extensions/telegram/src/account-throttler.test.ts extensions/telegram/src/bot-core.ts extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/send.ts extensions/telegram/src/send.test.ts extensions/telegram/src/send.test-harness.ts`
- `pnpm check:test-types`
