### PR TITLE
fix(onboard): use safe custom provider context window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Custom onboarding: default new OpenAI-compatible custom models to the documented 200k context window while only repairing known generated low defaults, preserving explicit small local-model limits.
 - Memory: close temp SQLite handles before failed atomic reindex cleanup and retry Windows EBUSY/EPERM/EACCES temp file removals, so `memory index --force` does not abort or leave temp sidecars on locked filesystems. Fixes #79708. Thanks @LobsterFarmerAmp and @hclsys.
 - Agents/CLI: add an explicit `reseedFromRawTranscriptWhenUncompacted` backend opt-in so safe invalidated CLI sessions can reseed from a bounded raw OpenClaw transcript tail before compaction while auth-boundary resets remain no-raw. Fixes #79713. (#79764) Thanks @hclsys.
 - Agents/CLI: handle resumed CLI JSONL output and bound supervisor output buffering so resumed runs stay readable without letting noisy child output grow unbounded.

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -477,23 +477,23 @@ describe("QmdMemoryManager", () => {
       },
     } as OpenClawConfig;
 
-    let releaseUpdate: (() => void) | null = null;
+    const updateControl: { release?: () => void } = {};
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "update") {
         const child = createMockChild({ autoClose: false });
-        releaseUpdate = () => child.closeWith(0);
+        updateControl.release = () => child.closeWith(0);
         return child;
       }
       return createMockChild();
     });
 
     const { manager } = await createManager({ mode: "full" });
-    (
-      releaseUpdate ??
-      (() => {
-        throw new Error("Expected qmd update release callback");
-      })
-    )();
+    expect(updateControl.release).toBeTypeOf("function");
+    const completeUpdate = updateControl.release;
+    if (!completeUpdate) {
+      throw new Error("expected background qmd update to start");
+    }
+    completeUpdate();
     await manager?.close();
   });
 

--- a/src/commands/onboard-custom-config.test.ts
+++ b/src/commands/onboard-custom-config.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import { CONTEXT_WINDOW_HARD_MIN_TOKENS } from "../agents/context-window-guard.js";
-import { DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR } from "../agents/pi-settings.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   applyCustomApiConfig,
@@ -112,17 +111,27 @@ describe("applyCustomApiConfig", () => {
       expectedContextWindow: 200000,
     },
     {
-      name: "upgrades existing custom model context window when below the compaction reserve floor",
+      name: "upgrades invalid existing custom model context window",
       existingContextWindow: 2048,
       expectedContextWindow: 200000,
     },
     {
-      name: "upgrades existing custom model context window when equal to the compaction reserve floor",
-      existingContextWindow: DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR,
+      name: "upgrades existing custom model context window from the generated hard-minimum default",
+      existingContextWindow: CONTEXT_WINDOW_HARD_MIN_TOKENS,
       expectedContextWindow: 200000,
     },
     {
-      name: "preserves existing custom model context window when already above the reserve floor",
+      name: "upgrades existing custom model context window from the generated max-tokens default",
+      existingContextWindow: 4096,
+      expectedContextWindow: 200000,
+    },
+    {
+      name: "preserves explicit small custom model context windows",
+      existingContextWindow: 8192,
+      expectedContextWindow: 8192,
+    },
+    {
+      name: "preserves existing custom model context window when already above the generated defaults",
       existingContextWindow: 131072,
       expectedContextWindow: 131072,
     },

--- a/src/commands/onboard-custom-config.test.ts
+++ b/src/commands/onboard-custom-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { CONTEXT_WINDOW_HARD_MIN_TOKENS } from "../agents/context-window-guard.js";
+import { DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR } from "../agents/pi-settings.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   applyCustomApiConfig,
@@ -106,17 +107,22 @@ it("uses expanded max_tokens for anthropic verification probes", () => {
 describe("applyCustomApiConfig", () => {
   it.each([
     {
-      name: "uses hard-min context window for newly added custom models",
+      name: "uses documented default context window for newly added custom models",
       existingContextWindow: undefined,
-      expectedContextWindow: CONTEXT_WINDOW_HARD_MIN_TOKENS,
+      expectedContextWindow: 200000,
     },
     {
-      name: "upgrades existing custom model context window when below hard minimum",
+      name: "upgrades existing custom model context window when below the compaction reserve floor",
       existingContextWindow: 2048,
-      expectedContextWindow: CONTEXT_WINDOW_HARD_MIN_TOKENS,
+      expectedContextWindow: 200000,
     },
     {
-      name: "preserves existing custom model context window when already above minimum",
+      name: "upgrades existing custom model context window when equal to the compaction reserve floor",
+      existingContextWindow: DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR,
+      expectedContextWindow: 200000,
+    },
+    {
+      name: "preserves existing custom model context window when already above the reserve floor",
       existingContextWindow: 131072,
       expectedContextWindow: 131072,
     },

--- a/src/commands/onboard-custom-config.ts
+++ b/src/commands/onboard-custom-config.ts
@@ -1,7 +1,6 @@
 import { CONTEXT_WINDOW_HARD_MIN_TOKENS } from "../agents/context-window-guard.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { buildModelAliasIndex, modelKey } from "../agents/model-selection.js";
-import { DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR } from "../agents/pi-settings.js";
 import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isSecretRef, type SecretInput } from "../config/types.secrets.js";
@@ -16,6 +15,7 @@ import { normalizeAlias } from "./models/alias-name.js";
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
 const DEFAULT_MAX_TOKENS = 4096;
+const GENERATED_LOW_CONTEXT_WINDOWS = new Set([CONTEXT_WINDOW_HARD_MIN_TOKENS, DEFAULT_MAX_TOKENS]);
 // Azure OpenAI uses the Responses API which supports larger defaults
 const AZURE_DEFAULT_CONTEXT_WINDOW = 400_000;
 const AZURE_DEFAULT_MAX_TOKENS = 16_384;
@@ -27,13 +27,10 @@ export type CustomModelImageInputInference = {
 
 function normalizeContextWindowForCustomModel(value: unknown): number {
   const parsed = typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : 0;
-  if (
-    parsed >= CONTEXT_WINDOW_HARD_MIN_TOKENS &&
-    parsed > DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR
-  ) {
-    return parsed;
+  if (parsed < CONTEXT_WINDOW_HARD_MIN_TOKENS || GENERATED_LOW_CONTEXT_WINDOWS.has(parsed)) {
+    return DEFAULT_CONTEXT_WINDOW;
   }
-  return DEFAULT_CONTEXT_WINDOW;
+  return parsed;
 }
 
 function customModelInputs(supportsImageInput: boolean): CustomModelInput[] {

--- a/src/commands/onboard-custom-config.ts
+++ b/src/commands/onboard-custom-config.ts
@@ -1,6 +1,7 @@
 import { CONTEXT_WINDOW_HARD_MIN_TOKENS } from "../agents/context-window-guard.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { buildModelAliasIndex, modelKey } from "../agents/model-selection.js";
+import { DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR } from "../agents/pi-settings.js";
 import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isSecretRef, type SecretInput } from "../config/types.secrets.js";
@@ -13,7 +14,7 @@ import {
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
 import { normalizeAlias } from "./models/alias-name.js";
 
-const DEFAULT_CONTEXT_WINDOW = CONTEXT_WINDOW_HARD_MIN_TOKENS;
+const DEFAULT_CONTEXT_WINDOW = 200_000;
 const DEFAULT_MAX_TOKENS = 4096;
 // Azure OpenAI uses the Responses API which supports larger defaults
 const AZURE_DEFAULT_CONTEXT_WINDOW = 400_000;
@@ -26,7 +27,13 @@ export type CustomModelImageInputInference = {
 
 function normalizeContextWindowForCustomModel(value: unknown): number {
   const parsed = typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : 0;
-  return parsed >= CONTEXT_WINDOW_HARD_MIN_TOKENS ? parsed : CONTEXT_WINDOW_HARD_MIN_TOKENS;
+  if (
+    parsed >= CONTEXT_WINDOW_HARD_MIN_TOKENS &&
+    parsed > DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR
+  ) {
+    return parsed;
+  }
+  return DEFAULT_CONTEXT_WINDOW;
 }
 
 function customModelInputs(supportsImageInput: boolean): CustomModelInput[] {


### PR DESCRIPTION
## Summary

- Default new non-Azure custom provider models to the documented `200000` token context window instead of the 4,000-token hard minimum.
- Heal existing custom-provider model entries only when their context window is invalid or a known generated low default such as `4000`/`4096`.
- Preserve explicit small custom context windows such as 8K/16K as user-provided model limits.

Fixes #79428.

## Real behavior proof

Behavior addressed: Custom provider onboarding no longer writes a 4,000-token context window that is below the default 20,000-token compaction reserve floor.

Real environment tested: OpenClaw source checkout on macOS with Node 22.22.2, running the actual `applyCustomApiConfig` onboarding config path for a DashScope-style custom provider.

Exact steps or command run after this patch:

```bash
PATH=/opt/homebrew/opt/node@22/bin:$PATH node --import tsx --input-type=module -e 'import { applyCustomApiConfig } from "./src/commands/onboard-custom-config.ts"; const first = applyCustomApiConfig({ config: {}, baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1", modelId: "qwen-plus", compatibility: "openai", providerId: "custom-dashscope" }); const model = first.config.models.providers["custom-dashscope"].models[0]; const repaired = applyCustomApiConfig({ config: { models: { providers: { "custom-dashscope": { baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1", api: "openai-completions", models: [{ id: "qwen-plus", name: "qwen-plus", contextWindow: 4000, maxTokens: 1024, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, reasoning: false }] } } } }, baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1", modelId: "qwen-plus", compatibility: "openai", providerId: "custom-dashscope" }); const repairedModel = repaired.config.models.providers["custom-dashscope"].models[0]; console.log(JSON.stringify({ newCustomProviderContextWindow: model.contextWindow, repairedExistingContextWindow: repairedModel.contextWindow, preservedMaxTokens: repairedModel.maxTokens }, null, 2));'
```

Evidence after fix: Terminal output from the live command above:

```json
{
  "newCustomProviderContextWindow": 200000,
  "repairedExistingContextWindow": 200000,
  "preservedMaxTokens": 1024
}
```

Observed result after fix: A newly configured DashScope-style custom provider receives `contextWindow: 200000`, and an existing custom provider entry with `contextWindow: 4000` is repaired to `200000` while preserving its `maxTokens`.

What was not tested: I did not run a full dashboard first-message flow against a live DashScope account; the proof exercises the OpenClaw onboarding config path that writes the bad value reported in #79428.

## Verification

- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npx pnpm@10.33.2 test src/commands/onboard-custom-config.test.ts` (36 passed)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npx pnpm@10.33.2 test src/commands/onboard-custom.test.ts` (8 passed)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npx pnpm@10.33.2 format:check src/commands/onboard-custom-config.ts src/commands/onboard-custom-config.test.ts`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npx pnpm@10.33.2 check:changed`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npx pnpm@10.33.2 build`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH /opt/homebrew/bin/pnpm check:test-types`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH /opt/homebrew/bin/pnpm test extensions/memory-core/src/memory/index.test.ts extensions/memory-core/src/memory/qmd-manager.test.ts extensions/memory-core/src/memory/manager.watcher-config.test.ts` (122 passed)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH /opt/homebrew/bin/pnpm format:check src/commands/onboard-custom-config.ts src/commands/onboard-custom-config.test.ts extensions/memory-core/src/memory/index.test.ts extensions/memory-core/src/memory/qmd-manager.test.ts extensions/memory-core/src/memory/manager.watcher-config.test.ts`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npx pnpm@10.33.2 test` ran the full suite; two unrelated failures appeared: an IPv6 loopback `ECONNRESET` in `src/gateway/server.plugin-node-capability-auth.test.ts`, and a local-timezone mismatch in `src/auto-reply/reply/inbound-meta.test.ts` under `Asia/Shanghai`.
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npx pnpm@10.33.2 test src/gateway/server.plugin-node-capability-auth.test.ts` passed on rerun (7 passed).
- `TZ=UTC PATH=/opt/homebrew/opt/node@22/bin:$PATH npx pnpm@10.33.2 test src/auto-reply/reply/inbound-meta.test.ts` passed on rerun (38 passed).

AI-assisted. I reviewed the change and ran the checks above.
