### PR TITLE
docs: update stale sub-agent context injection details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Docs/Subagents: correct the listed sub-agent bootstrap context files to include `SOUL.md`, `IDENTITY.md`, and `USER.md`. (#79470) Thanks @lastguru-net.
 - OpenAI/Codex: install the Codex runtime plugin from npm during OpenAI onboarding and load it automatically for implicit OpenAI model routes, while preserving manual PI runtime overrides. Fixes #79358.
 - OpenAI/realtime voice: defer `response.create` while a realtime response is still active, retry after `response.done`/`response.cancelled`, and align GA input transcription/noise-reduction defaults with the Codex realtime reference so Discord/Voice Call consult results can resume speaking instead of tripping the active-response race.
 - OpenAI/realtime voice: avoid duplicate barge-in cancellation requests, log realtime model interruption/cutoff events in Discord voice logs, and treat OpenAI's no-active-response cancellation reply as a completed cancel so Discord voice sessions do not wedge pending speech after fast interruptions.

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -547,7 +547,7 @@ still need normal device approval for scope upgrades.
 - Sub-agent announce is **best-effort**. If the gateway restarts, pending "announce back" work is lost.
 - Sub-agents still share the same gateway process resources; treat `maxConcurrent` as a safety valve.
 - `sessions_spawn` is always non-blocking: it returns `{ status: "accepted", runId, childSessionKey }` immediately.
-- Sub-agent context only injects `AGENTS.md` + `TOOLS.md` (no `SOUL.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, or `BOOTSTRAP.md`).
+- Sub-agent context only injects `AGENTS.md`, `TOOLS.md`, `SOUL.md`, `IDENTITY.md` and `USER.md` (no `MEMORY.md`, `HEARTBEAT.md`, or `BOOTSTRAP.md`).
 - Maximum nesting depth is 5 (`maxSpawnDepth` range: 1–5). Depth 2 is recommended for most use cases.
 - `maxChildrenPerAgent` caps active children per session (default `5`, range `1–20`).
 


### PR DESCRIPTION
## Summary

The sub-agents documentation incorrectly states that they only get `AGENTS.md` and `TOOLS.md` files injected in their context. Commit https://github.com/openclaw/openclaw/commit/8d2035633b89e560132406b90d86f5cbfff602d2 added `SOUL.md`, `IDENTITY.md`, and `USER.md` in sub-agent context, but did not update this documentation line.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Related #8d20356

## Real behavior proof

- **Behavior or issue addressed:** `docs/tools/subagents.md` listed stale sub-agent context injection behavior. Runtime source now allows `AGENTS.md`, `TOOLS.md`, `SOUL.md`, `IDENTITY.md`, and `USER.md`, while excluding `MEMORY.md`, `HEARTBEAT.md`, and `BOOTSTRAP.md`.
- **Real environment tested:** Current OpenClaw source on `main` and the PR branch after this patch; verified against `src/agents/workspace.ts` and the existing `filterBootstrapFilesForSession` regression tests.
- **Exact steps or command run after this patch:** Source inspection of `src/agents/workspace.ts` plus docs render proof screenshots below; CI `check-docs` also passed on the PR branch.
- **Evidence after fix:** After-fix rendered docs screenshot: ![After fix screenshot](https://github.com/user-attachments/assets/7bece4ca-56f1-4bcf-9195-db4d8aeb6f41)
- **Observed result after fix:** The rendered docs line now lists `AGENTS.md`, `TOOLS.md`, `SOUL.md`, `IDENTITY.md`, and `USER.md`, and excludes `MEMORY.md`, `HEARTBEAT.md`, and `BOOTSTRAP.md`, matching the current source allowlist.
- **What was not tested:** No additional runtime sub-agent flow was run for this docs-only change; runtime behavior is already covered by existing source tests.

Before source/runtime evidence:
<img width="866" height="280" alt="Screenshot 2026-05-08 at 20 31 22" src="https://github.com/user-attachments/assets/ea88277e-eddb-4369-b7eb-3e8013c33f55" />

Before the fix the documentation is wrong:
<img width="1015" height="254" alt="Screenshot 2026-05-08 at 20 39 48" src="https://github.com/user-attachments/assets/a6585c6a-7902-4959-ae60-271fd569424c" />
