### PR TITLE
[Fix] Scope session resolve store loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway: scope `sessions.resolve` sessionId and label store loads to the requested agent so large unrelated agent stores are not parsed for scoped lookups. Fixes #51264. (#79474) Thanks @samzong.
 - Browser: report Chrome MCP existing-session page readiness in browser status without letting status probes exceed the client timeout. Fixes #80268. (#80280) Thanks @ai-hpc.
 - Memory: reject symlinked directory components in configured extra memory paths before reading Markdown files. (#80331) Thanks @samzong.
 - Sessions/transcripts: replace whole-file `readFile` scans with shared streaming helpers (`streamSessionTranscriptLines` and `streamSessionTranscriptLinesReverse`) for idempotency lookup, latest/tail assistant text reads, delivery-mirror dedupe, and compaction fork loading, so long-running sessions no longer materialize the full transcript in memory. Forward scans use `readline` over a bounded `createReadStream`; reverse scans read bounded chunks from the file end and decode complete JSONL lines newest-first without a fixed tail cap. Synthetic 200 MiB transcript: peak RSS delta drops from +252 MiB to +27 MiB while preserving malformed-line tolerance and idempotency-key return semantics. Fixes #54296. Thanks @jack-stormentswe.

--- a/src/cli/completion-cli.write-state.test.ts
+++ b/src/cli/completion-cli.write-state.test.ts
@@ -94,7 +94,7 @@ describe("completion-cli write-state", () => {
     await program.parseAsync(["completion", "--write-state"], { from: "user" });
 
     const cacheDir = path.join(stateDir, "completions");
-    expect((await fs.readdir(cacheDir)).sort()).toEqual([
+    expect((await fs.readdir(cacheDir)).toSorted()).toEqual([
       "openclaw.bash",
       "openclaw.fish",
       "openclaw.ps1",
@@ -137,7 +137,7 @@ describe("completion-cli write-state", () => {
         [program, "qa", process.argv, { purpose: "completion" }],
       ]);
       expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
-      expect((await fs.readdir(path.join(stateDir, "completions"))).sort()).toEqual([
+      expect((await fs.readdir(path.join(stateDir, "completions"))).toSorted()).toEqual([
         "openclaw.bash",
         "openclaw.fish",
         "openclaw.ps1",

--- a/src/gateway/sessions-resolve-store.test.ts
+++ b/src/gateway/sessions-resolve-store.test.ts
@@ -40,6 +40,101 @@ describe("resolveSessionKeyFromResolveParams store canonicalization", () => {
     });
   });
 
+  it("does not resolve another agent store when agentId is scoped", async () => {
+    await withStateDirEnv("openclaw-sessions-resolve-agent-scope-", async () => {
+      const cfg: OpenClawConfig = {
+        agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+      };
+      const workStorePath = resolveStorePath(cfg.session?.store, { agentId: "work" });
+      await saveSessionStore(workStorePath, {
+        "agent:work:target": {
+          sessionId: "sess-shared",
+          label: "shared-label",
+          updatedAt: freshUpdatedAt(),
+        },
+      });
+
+      await expect(
+        resolveSessionKeyFromResolveParams({
+          cfg,
+          p: { sessionId: "sess-shared", agentId: "main" },
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        error: {
+          code: ErrorCodes.INVALID_REQUEST,
+          message: "No session found: sess-shared",
+        },
+      });
+
+      await expect(
+        resolveSessionKeyFromResolveParams({
+          cfg,
+          p: { label: "shared-label", agentId: "main" },
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        error: {
+          code: ErrorCodes.INVALID_REQUEST,
+          message: "No session found with label: shared-label",
+        },
+      });
+    });
+  });
+
+  it("preserves cross-agent ambiguity when agentId is absent", async () => {
+    await withStateDirEnv("openclaw-sessions-resolve-cross-agent-", async () => {
+      const cfg: OpenClawConfig = {
+        agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+      };
+      const updatedAt = freshUpdatedAt();
+      await saveSessionStore(resolveStorePath(cfg.session?.store, { agentId: "main" }), {
+        "main-target": {
+          sessionId: "sess-shared",
+          label: "shared-label",
+          updatedAt,
+        },
+      });
+      await saveSessionStore(resolveStorePath(cfg.session?.store, { agentId: "work" }), {
+        "work-target": {
+          sessionId: "sess-shared",
+          label: "shared-label",
+          updatedAt,
+        },
+      });
+
+      const sessionIdResult = await resolveSessionKeyFromResolveParams({
+        cfg,
+        p: { sessionId: "sess-shared" },
+      });
+      expect(sessionIdResult.ok).toBe(false);
+      if (sessionIdResult.ok) {
+        throw new Error("expected ambiguous sessionId result");
+      }
+      expect(sessionIdResult.error.code).toBe(ErrorCodes.INVALID_REQUEST);
+      expect(sessionIdResult.error.message).toContain(
+        "Multiple sessions found for sessionId: sess-shared",
+      );
+      expect(sessionIdResult.error.message).toContain("agent:main:main-target");
+      expect(sessionIdResult.error.message).toContain("agent:work:work-target");
+
+      const labelResult = await resolveSessionKeyFromResolveParams({
+        cfg,
+        p: { label: "shared-label" },
+      });
+      expect(labelResult.ok).toBe(false);
+      if (labelResult.ok) {
+        throw new Error("expected ambiguous label result");
+      }
+      expect(labelResult.error.code).toBe(ErrorCodes.INVALID_REQUEST);
+      expect(labelResult.error.message).toContain(
+        "Multiple sessions found with label: shared-label",
+      );
+      expect(labelResult.error.message).toContain("agent:main:main-target");
+      expect(labelResult.error.message).toContain("agent:work:work-target");
+    });
+  });
+
   it("still rejects non-alias agent:main matches when main is no longer configured", async () => {
     await withStateDirEnv("openclaw-sessions-resolve-stale-main-", async ({ stateDir }) => {
       const storePath = path.join(stateDir, "sessions.json");

--- a/src/gateway/sessions-resolve.test.ts
+++ b/src/gateway/sessions-resolve.test.ts
@@ -218,12 +218,16 @@ describe("resolveSessionKeyFromResolveParams", () => {
       throw new Error("session rows should not be materialized for exact sessionId lookup");
     });
 
+    const cfg = {};
     const result = await resolveSessionKeyFromResolveParams({
-      cfg: {},
-      p: { sessionId: "sess-target" },
+      cfg,
+      p: { sessionId: "sess-target", agentId: "main" },
     });
 
     expect(result).toEqual({ ok: true, key: "agent:main:target" });
+    expect(hoisted.loadCombinedSessionStoreForGatewayMock).toHaveBeenCalledWith(cfg, {
+      agentId: "main",
+    });
     expect(hoisted.listSessionsFromStoreMock).not.toHaveBeenCalled();
   });
 
@@ -238,11 +242,15 @@ describe("resolveSessionKeyFromResolveParams", () => {
     });
     hoisted.listAgentIdsMock.mockReturnValue(["main"]);
 
+    const cfg = {};
     const result = await resolveSessionKeyFromResolveParams({
-      cfg: {},
-      p: { label: "my-label" },
+      cfg,
+      p: { label: "my-label", agentId: "main" },
     });
 
+    expect(hoisted.loadCombinedSessionStoreForGatewayMock).toHaveBeenCalledWith(cfg, {
+      agentId: "main",
+    });
     expect(result).toEqual({
       ok: false,
       error: {

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -166,7 +166,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
   }
 
   if (hasSessionId) {
-    const { store } = loadCombinedSessionStoreForGateway(cfg);
+    const { store } = loadCombinedSessionStoreForGateway(cfg, { agentId: p.agentId });
     const matches = findVisibleSessionIdMatches({ store, p, sessionId });
     const selection = resolveSessionIdMatchSelection(matches, sessionId);
     if (selection.kind === "none") {
@@ -200,7 +200,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
     };
   }
 
-  const { storePath, store } = loadCombinedSessionStoreForGateway(cfg);
+  const { storePath, store } = loadCombinedSessionStoreForGateway(cfg, { agentId: p.agentId });
   const list = listSessionsFromStore({
     cfg,
     storePath,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Fixes #51264: `sessions.resolve` loaded combined session stores across all agents for `sessionId` and `label` lookups even when the request already provided an `agentId`.
- Why it matters: scoped Gateway session resolution should not read unrelated agent stores on this hot path.
- What changed: pass the requested `agentId` into `loadCombinedSessionStoreForGateway` for `sessionId` and `label` resolution, and add regression coverage for scoped and unscoped behavior.
- What did NOT change (scope boundary): key-based resolution, public protocol shape, session store format, and unscoped cross-agent ambiguity behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #51264
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: scoped `sessions.resolve` with `agentId: "main"` must not resolve sessions that exist only in another agent store, while unscoped resolution still sees that store.
- Real environment tested: local OpenClaw repo on macOS, Node v24.14.0, temporary `OPENCLAW_STATE_DIR` with real on-disk Gateway session stores.
- Exact steps or command run after this patch:

```bash
pnpm exec tsx -e 'import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"; import { tmpdir } from "node:os"; import path from "node:path"; import { resolveSessionKeyFromResolveParams } from "./src/gateway/sessions-resolve.ts"; import { resolveStorePath } from "./src/config/sessions.ts"; void (async () => { const stateDir = await mkdtemp(path.join(tmpdir(), "openclaw-real-resolve-")); const previous = process.env.OPENCLAW_STATE_DIR; process.env.OPENCLAW_STATE_DIR = stateDir; try { const cfg = { agents: { list: [{ id: "main", default: true }, { id: "work" }] } }; const workStorePath = resolveStorePath(cfg.session?.store, { agentId: "work" }); await mkdir(path.dirname(workStorePath), { recursive: true }); await writeFile(workStorePath, JSON.stringify({ "work-target": { sessionId: "sess-shared", label: "shared-label", updatedAt: Date.now() } }), "utf8"); const scopedSession = await resolveSessionKeyFromResolveParams({ cfg, p: { sessionId: "sess-shared", agentId: "main" } }); const scopedLabel = await resolveSessionKeyFromResolveParams({ cfg, p: { label: "shared-label", agentId: "main" } }); const unscopedSession = await resolveSessionKeyFromResolveParams({ cfg, p: { sessionId: "sess-shared" } }); console.log(JSON.stringify({ scopedSession, scopedLabel, unscopedSession }, null, 2)); if (scopedSession.ok || scopedSession.error.message !== "No session found: sess-shared") throw new Error("scoped sessionId resolved another agent store"); if (scopedLabel.ok || scopedLabel.error.message !== "No session found with label: shared-label") throw new Error("scoped label resolved another agent store"); if (!unscopedSession.ok || unscopedSession.key !== "agent:work:work-target") throw new Error("unscoped resolve did not see the work agent store"); } finally { if (previous === undefined) delete process.env.OPENCLAW_STATE_DIR; else process.env.OPENCLAW_STATE_DIR = previous; await rm(stateDir, { recursive: true, force: true }); } })();'
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "scopedSession": {
    "ok": false,
    "error": {
      "code": "INVALID_REQUEST",
      "message": "No session found: sess-shared"
    }
  },
  "scopedLabel": {
    "ok": false,
    "error": {
      "code": "INVALID_REQUEST",
      "message": "No session found with label: shared-label"
    }
  },
  "unscopedSession": {
    "ok": true,
    "key": "agent:work:work-target"
  }
}
```

- Observed result after fix: scoped `main` lookups do not resolve the `work` store session; unscoped lookup still resolves `agent:work:work-target`.
- What was not tested: full Gateway WebSocket RPC flow and remote Testbox lanes were not run for this narrow resolver/store change.
- Before evidence (optional but encouraged): Not captured; the after-fix terminal output above is the real behavior proof for this patch.

## Root Cause (if applicable)

- Root cause: `resolveSessionKeyFromResolveParams` had the requested `agentId` in `SessionsResolveParams`, but did not pass it into the combined store loader for `sessionId` or `label` lookup paths.
- Missing detection / guardrail: existing tests checked resolver output after visibility filtering, but did not assert scoped loader arguments or on-disk scoped-store behavior.
- Contributing context (if known): combined stores preserve unscoped cross-agent lookup behavior, so scoped and unscoped loader paths need separate coverage.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/sessions-resolve.test.ts`; `src/gateway/sessions-resolve-store.test.ts`
- Scenario the test should lock in: scoped `agentId` lookups pass `{ agentId }` to the combined store loader and do not resolve another agent's store; unscoped lookups still preserve cross-agent ambiguity.
- Why this is the smallest reliable guardrail: direct unit assertions catch the hot-path loader contract, while the store test proves the real on-disk store behavior without a full Gateway server.
- Existing test that already covers this (if any): none covered the loader argument contract before this change.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
[sessions.resolve with agentId] -> [load all agent stores] -> [filter to requested agent]

After:
[sessions.resolve with agentId] -> [load requested agent store] -> [resolve within requested agent]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: session resolve now narrows scoped store reads to the requested agent for `sessionId` and `label` lookups; unscoped behavior remains covered by tests.

## Repro + Verification

### Environment

- OS: macOS (Darwin 25.4.0)
- Runtime/container: Node v24.14.0, local repo checkout
- Model/provider: N/A
- Integration/channel (if any): Gateway session resolver
- Relevant config (redacted): temporary `OPENCLAW_STATE_DIR`; agents `main` and `work`

### Steps

1. Create a temporary OpenClaw state directory.
2. Write a real `work` agent session store containing `sessionId: "sess-shared"` and `label: "shared-label"`.
3. Resolve by `sessionId` and `label` with `agentId: "main"`, then resolve by `sessionId` without `agentId`.

### Expected

- Scoped `main` lookups return not found for the `work`-only session.
- Unscoped lookup still resolves `agent:work:work-target`.

### Actual

- Scoped `main` lookups returned not found.
- Unscoped lookup returned `agent:work:work-target`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Additional verification:

```bash
pnpm docs:list
pnpm test src/gateway/sessions-resolve.test.ts src/gateway/sessions-resolve-store.test.ts
git diff --check HEAD
/pre-ship --committed
```

Results:

- `pnpm test src/gateway/sessions-resolve.test.ts src/gateway/sessions-resolve-store.test.ts`: 2 files passed, 13 tests passed.
- `git diff --check HEAD`: passed.
- `/pre-ship --committed`: passed with no MUST-FIX findings and no deferred findings.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: real on-disk scoped `agentId` session resolve for `sessionId` and `label`; unscoped lookup still sees the other agent store.
- Edge cases checked: cross-agent duplicate `sessionId` and `label` ambiguity remains covered when `agentId` is absent.
- What you did **not** verify: full Gateway WebSocket RPC flow, remote CI/Testbox lanes.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: accidentally narrowing unscoped resolution behavior.
  - Mitigation: added regression coverage proving unscoped cross-agent ambiguity is preserved when `agentId` is absent.