### PR TITLE
[AI-assisted] fix(qqbot): preserve framework command replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Telegram/Feishu: honor configured per-agent and global `reasoningDefault` values when deciding whether channel reasoning previews should stream or stay hidden, addressing the preview-default part of #73182. Thanks @anagnorisis2peripeteia.
+- QQBot: mark recognized framework slash commands as text-command turns before reply dispatch so `/models`, `/status`, and `/new` responses stay visible in QQ Bot C2C conversations. Fixes #79310. Thanks @rollingshmily.
 - Docker: run the runtime image under `tini` so long-lived containers reap orphaned child processes and forward signals correctly. (#77885) Thanks @VintageAyu.
 - Google/Gemini: normalize retired `google/gemini-3-pro-preview` and `google-gemini-cli/gemini-3-pro-preview` selections to `google/gemini-3.1-pro-preview` before they are written to model config.
 - Amazon Bedrock: support `serviceTier` parameter for Bedrock models, configurable via `agents.defaults.params.serviceTier` or per-model in `agents.defaults.models`. Valid values: `default`, `flex`, `priority`, `reserved`. (#64512) Thanks @mobilinkd.

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -98,6 +98,7 @@ function makeInbound(overrides: Partial<InboundContext> = {}): InboundContext {
 
 function makeRuntime(params: {
   onFinalize?: (ctx: Record<string, unknown>) => void;
+  isControlCommandMessage?: (text?: string, cfg?: unknown) => boolean;
   onDeliver?: (
     deliver: (
       payload: { text?: string; audioAsVoice?: boolean },
@@ -164,6 +165,9 @@ function makeRuntime(params: {
       text: {
         chunkMarkdownText: (text: string) => [text],
       },
+      commands: {
+        isControlCommandMessage: params.isControlCommandMessage ?? (() => false),
+      },
     },
     tts: {
       textToSpeech: vi.fn(async () => ({
@@ -227,5 +231,41 @@ describe("dispatchOutbound", () => {
       }),
     );
     expect(sendTextMock).not.toHaveBeenCalled();
+  });
+
+  it("marks recognized C2C framework slash commands as text commands", async () => {
+    let finalized: Record<string, unknown> | undefined;
+    const runtime = makeRuntime({
+      isControlCommandMessage: (text) => text === "/models",
+      onFinalize: (ctx) => (finalized = ctx),
+    });
+
+    await dispatchOutbound(
+      makeInbound({
+        event: {
+          type: "c2c",
+          senderId: "user-openid",
+          messageId: "msg-models",
+          content: "/models",
+          timestamp: "2026-04-25T00:00:00.000Z",
+        },
+        parsedContent: "/models",
+        userContent: "/models",
+        userMessage: "/models",
+        agentBody: "/models",
+        body: "/models",
+        commandAuthorized: true,
+      }),
+      { runtime, cfg: { commands: { text: true } }, account },
+    );
+
+    expect(finalized).toMatchObject({
+      CommandBody: "/models",
+      CommandAuthorized: true,
+      CommandSource: "text",
+      Provider: "qqbot",
+      Surface: "qqbot",
+      ChatType: "direct",
+    });
   });
 });

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
@@ -94,7 +94,7 @@ export async function dispatchOutbound(
   const sendErrorMessage = (errorText: string) => sendErrorToTarget(replyCtx, errorText);
 
   // ---- Build ctxPayload ----
-  const ctxPayload = buildCtxPayload(inbound, runtime);
+  const ctxPayload = buildCtxPayload(inbound, runtime, cfg);
 
   // ---- Deliver state ----
   let hasResponse = false;
@@ -512,11 +512,25 @@ export async function dispatchOutbound(
 
 // ============ ctxPayload builder ============
 
+function resolveCommandSource(
+  inbound: InboundContext,
+  runtime: GatewayPluginRuntime,
+  cfg: unknown,
+): "text" | undefined {
+  const commandBody = inbound.event.content;
+  if (!runtime.channel.commands?.isControlCommandMessage?.(commandBody, cfg)) {
+    return undefined;
+  }
+  return "text";
+}
+
 function buildCtxPayload(
   inbound: InboundContext,
   runtime: GatewayPluginRuntime,
+  cfg: unknown,
 ): FinalizedMsgContext {
   const { event } = inbound;
+  const commandSource = resolveCommandSource(inbound, runtime, cfg);
   return runtime.channel.reply.finalizeInboundContext({
     Body: inbound.body,
     BodyForAgent: inbound.agentBody,
@@ -546,6 +560,7 @@ function buildCtxPayload(
     QQVoiceAsrReferTexts: inbound.uniqueVoiceAsrReferTexts,
     QQVoiceInputStrategy: "prefer_audio_stt_then_asr_fallback",
     CommandAuthorized: inbound.commandAuthorized,
+    ...(commandSource ? { CommandSource: commandSource } : {}),
     ...(inbound.voiceMediaTypes.length > 0
       ? {
           MediaTypes: inbound.voiceMediaTypes,

--- a/extensions/qqbot/src/engine/gateway/types.ts
+++ b/extensions/qqbot/src/engine/gateway/types.ts
@@ -42,6 +42,9 @@ export interface GatewayPluginRuntime {
         peer: { kind: "group" | "direct"; id: string };
       }) => { sessionKey: string; accountId: string; agentId?: string };
     };
+    commands?: {
+      isControlCommandMessage?: (text?: string, cfg?: unknown) => boolean;
+    };
     reply: {
       dispatchReplyWithBufferedBlockDispatcher: (params: unknown) => Promise<unknown>;
       resolveEffectiveMessagesConfig: (


### PR DESCRIPTION
## Summary

Fixes #79310.

QQBot now tags recognized framework slash-command messages as `CommandSource: text` before they enter reply dispatch. That preserves the existing core visibility policy for authorized text commands, so `/models`, `/status`, `/new`, and similar framework command replies are not treated like ordinary message-tool-only turns on the QQBot C2C path.

## Validation

- `corepack pnpm test extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts`
- `corepack pnpm test extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts extensions/qqbot/src/engine/commands/slash-command-handler.test.ts extensions/qqbot/src/bridge/commands/framework-registration.test.ts extensions/qqbot/src/channel.message-adapter.test.ts`
- `corepack pnpm test src/auto-reply/reply/commands-models.test.ts src/auto-reply/reply/commands-status.test.ts`
- `corepack pnpm exec oxfmt --check --threads=1 CHANGELOG.md extensions/qqbot/src/engine/gateway/types.ts extensions/qqbot/src/engine/gateway/outbound-dispatch.ts extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts`
- `corepack pnpm check:changelog-attributions`
- `corepack pnpm check:changed`
- `corepack pnpm tsgo:extensions`
- `git diff --check origin/main...HEAD`
- `codex review --base origin/main -c model_reasoning_effort=medium`

Note: `corepack pnpm tsgo:extensions:test` was attempted but is currently blocked by unrelated existing OpenRouter test errors in `extensions/openrouter/video-generation-provider.test.ts` (`video.buffer` possibly undefined at lines 254 and 338). The production extension typecheck above passes.

## Real behavior proof

Behavior or issue addressed: QQBot C2C framework slash commands should return visible command replies instead of showing typing and then silently dropping the final response.

Real environment tested: Local OpenClaw checkout on Windows at branch `fix-qqbot-framework-commands-79310`, commit `3595442cbff62a13b3fe6858c8a2804ec95f722f`, using the QQBot outbound dispatcher with a QQBot C2C `/models` turn and the framework command detection hook.

Exact steps or command run after this patch: A local QQBot outbound runtime probe was executed with `corepack pnpm tsx -`, importing `dispatchOutbound`, feeding it a QQBot C2C `/models` inbound turn, and printing the finalized reply context after dispatch setup.

Evidence after fix: Terminal output from the patched checkout:

```json
{
  CommandBody: /models,
  CommandAuthorized: true,
  CommandSource: text,
  Provider: qqbot,
  Surface: qqbot,
  ChatType: direct
}
```

Observed result after fix: The QQBot C2C `/models` turn finalizes as an authorized text-command turn, which is the context shape core reply visibility uses for automatic visible command delivery.

What was not tested: Live end-to-end QQBot C2C delivery was not run on this machine because this checkout does not have QQBot credentials or a live QQBot channel configured.

