### PR TITLE
fix: stabilize native codex model state in telegram sessions

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -521,7 +521,11 @@ export async function initSessionState(params: {
       // must be cleared so /new and /reset actually return the session to
       // the configured default instead of staying pinned to the auto pick
       // (#69301).
-      const preservedSelection = resolveResetPreservedSelection({ entry });
+      const preservedSelection = resolveResetPreservedSelection({
+        entry,
+        cfg,
+        agentId,
+      });
       persistedModelOverride = preservedSelection.modelOverride;
       persistedProviderOverride = preservedSelection.providerOverride;
       persistedModelOverrideSource = preservedSelection.modelOverrideSource;

--- a/src/config/sessions/reset-preserved-selection.test.ts
+++ b/src/config/sessions/reset-preserved-selection.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../types.openclaw.js";
+import { resolveResetPreservedSelection } from "./reset-preserved-selection.js";
+
+describe("resolveResetPreservedSelection", () => {
+  it("preserves generic legacy user overrides without a source marker", () => {
+    const preserved = resolveResetPreservedSelection({
+      entry: {
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4-1",
+      },
+    });
+
+    expect(preserved).toMatchObject({
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-1",
+      modelOverrideSource: "user",
+    });
+  });
+
+  it("drops stale legacy openai-codex overrides when the agent now uses native codex", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          agentRuntime: { id: "codex" },
+          model: { primary: "openai/gpt-5.5" },
+        },
+      },
+    };
+
+    const preserved = resolveResetPreservedSelection({
+      cfg,
+      agentId: "main",
+      entry: {
+        providerOverride: "openai-codex",
+        modelOverride: "gpt-5.5",
+      },
+    });
+
+    expect(preserved.providerOverride).toBeUndefined();
+    expect(preserved.modelOverride).toBeUndefined();
+    expect(preserved.modelOverrideSource).toBeUndefined();
+  });
+});

--- a/src/config/sessions/reset-preserved-selection.ts
+++ b/src/config/sessions/reset-preserved-selection.ts
@@ -1,3 +1,7 @@
+import { resolveAgentRuntimeMetadata } from "../../agents/agent-runtime-metadata.js";
+import { parseModelRef } from "../../agents/model-selection-normalize.js";
+import { resolveDefaultModelForAgent } from "../../agents/model-selection.js";
+import type { OpenClawConfig } from "../types.openclaw.js";
 import type { SessionEntry } from "./types.js";
 
 export type ResetPreservedSelectionState = Pick<
@@ -21,8 +25,43 @@ export type ResetPreservedSelectionState = Pick<
  * treated as user-driven, matching the prior reset behavior so explicit
  * selections made before the source field existed are not silently dropped.
  */
+function isStaleLegacyOpenAICodexOverride(params: {
+  entry: SessionEntry;
+  cfg?: OpenClawConfig;
+  agentId?: string;
+}): boolean {
+  if (
+    !params.cfg ||
+    !params.entry.modelOverride ||
+    params.entry.modelOverrideSource !== undefined
+  ) {
+    return false;
+  }
+
+  const runtime = resolveAgentRuntimeMetadata(params.cfg, params.agentId ?? "").id;
+  if (runtime !== "codex") {
+    return false;
+  }
+
+  const selected = parseModelRef(params.entry.modelOverride, params.entry.providerOverride ?? "", {
+    allowPluginNormalization: false,
+  });
+  if (!selected || selected.provider !== "openai-codex") {
+    return false;
+  }
+
+  const configured = resolveDefaultModelForAgent({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    allowPluginNormalization: false,
+  });
+  return configured.provider === "openai" && configured.model === selected.model;
+}
+
 export function resolveResetPreservedSelection(params: {
   entry?: SessionEntry;
+  cfg?: OpenClawConfig;
+  agentId?: string;
 }): Partial<ResetPreservedSelectionState> {
   const { entry } = params;
   if (!entry) {
@@ -32,7 +71,13 @@ export function resolveResetPreservedSelection(params: {
   const preserved: Partial<ResetPreservedSelectionState> = {};
   const preserveLegacyUserModelOverride =
     entry.modelOverrideSource === "user" ||
-    (entry.modelOverrideSource === undefined && Boolean(entry.modelOverride));
+    (entry.modelOverrideSource === undefined &&
+      Boolean(entry.modelOverride) &&
+      !isStaleLegacyOpenAICodexOverride({
+        entry,
+        cfg: params.cfg,
+        agentId: params.agentId,
+      }));
   if (preserveLegacyUserModelOverride && entry.modelOverride) {
     preserved.providerOverride = entry.providerOverride;
     preserved.modelOverride = entry.modelOverride;

--- a/src/gateway/server.sessions.reset-models.test.ts
+++ b/src/gateway/server.sessions.reset-models.test.ts
@@ -105,6 +105,60 @@ test("sessions.reset preserves legacy explicit model overrides without modelOver
   expect(store["agent:main:main"]?.model).toBe("claude-opus-4-1");
 });
 
+test("sessions.reset drops stale legacy openai-codex overrides after native codex migration", async () => {
+  const { storePath } = await createSessionStoreDir();
+  testState.agentConfig = {
+    agentRuntime: {
+      id: "codex",
+    },
+    model: {
+      primary: "openai/gpt-5.5",
+    },
+  };
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-native-codex-migration", {
+        providerOverride: "openai-codex",
+        modelOverride: "gpt-5.5",
+        modelProvider: "openai-codex",
+        model: "gpt-5.5",
+      }),
+    },
+  });
+
+  const reset = await directSessionReq<{
+    ok: true;
+    key: string;
+    entry: {
+      providerOverride?: string;
+      modelOverride?: string;
+      modelProvider?: string;
+      model?: string;
+    };
+  }>("sessions.reset", { key: "main" });
+
+  expect(reset.ok).toBe(true);
+  expect(reset.payload?.entry.providerOverride).toBeUndefined();
+  expect(reset.payload?.entry.modelOverride).toBeUndefined();
+  expect(reset.payload?.entry.modelProvider).toBe("openai");
+  expect(reset.payload?.entry.model).toBe("gpt-5.5");
+
+  const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+    string,
+    {
+      providerOverride?: string;
+      modelOverride?: string;
+      modelProvider?: string;
+      model?: string;
+    }
+  >;
+  expect(store["agent:main:main"]?.providerOverride).toBeUndefined();
+  expect(store["agent:main:main"]?.modelOverride).toBeUndefined();
+  expect(store["agent:main:main"]?.modelProvider).toBe("openai");
+  expect(store["agent:main:main"]?.model).toBe("gpt-5.5");
+});
+
 test("sessions.reset clears fallback-pinned model overrides and restores the selected model", async () => {
   const { storePath } = await createSessionStoreDir();
   testState.agentConfig = {

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -542,6 +542,8 @@ export async function performGatewaySessionReset(params: {
     const sessionAgentId = normalizeAgentId(parsed?.agentId ?? resolveDefaultAgentId(cfg));
     const resetPreservedSelection = resolveResetPreservedSelection({
       entry: currentEntry,
+      cfg,
+      agentId: sessionAgentId,
     });
     const resetEntry = {
       ...stripRuntimeModelState(currentEntry),


### PR DESCRIPTION
## Summary
- stop preserving stale legacy `openai-codex` model overrides when a session resets after migrating to native Codex
- apply the reset fix through the shared preserved-selection helper so both gateway resets and chat `/reset` follow the configured `openai/gpt-5.5` + `agentRuntime.id="codex"` route
- add regression coverage for the helper and for `sessions.reset` on the native Codex migration path

## Testing
- `corepack pnpm exec tsx -e "import { resolveResetPreservedSelection } from './src/config/sessions/reset-preserved-selection.ts'; const generic = resolveResetPreservedSelection({ entry: { providerOverride: 'anthropic', modelOverride: 'claude-opus-4-1' } as any }); const stale = resolveResetPreservedSelection({ cfg: { agents: { defaults: { agentRuntime: { id: 'codex' }, model: { primary: 'openai/gpt-5.5' } } } } as any, agentId: 'main', entry: { providerOverride: 'openai-codex', modelOverride: 'gpt-5.5' } as any }); console.log(JSON.stringify({ generic, stale }, null, 2));"`
- `corepack pnpm exec tsx -e "(async () => { await import('./src/config/sessions/reset-preserved-selection.ts'); await import('./src/gateway/session-reset-service.ts'); await import('./src/auto-reply/reply/session.ts'); console.log('imports-ok'); })().catch((err) => { console.error(err); process.exit(1); });"`

Fixes openclaw/openclaw#79413