### PR TITLE
fix(matrix): keep joined-room discovery alive when m.direct mapping is stale (#79514)

### DIFF
--- a/extensions/matrix/src/matrix/direct-management.test.ts
+++ b/extensions/matrix/src/matrix/direct-management.test.ts
@@ -22,6 +22,29 @@ function createClient(overrides: Partial<MatrixClient> = {}): MatrixClient {
 }
 
 describe("inspectMatrixDirectRooms", () => {
+  it("discovers newer strict joined DM rooms even when an older strict m.direct mapping exists", async () => {
+    // Regression for openclaw/openclaw#79514: a stale `m.direct` mapping
+    // pointing at an older strict DM room must not suppress discovery of
+    // newer joined strict 2-member DM rooms with the same remote user.
+    const client = createClient({
+      getAccountData: vi.fn(async () => ({
+        "@alice:example.org": ["!old:example.org"],
+      })),
+      getJoinedRooms: vi.fn(async () => ["!old:example.org", "!new:example.org"]),
+      getJoinedRoomMembers: vi.fn(async () => ["@bot:example.org", "@alice:example.org"]),
+    });
+
+    const result = await inspectMatrixDirectRooms({
+      client,
+      remoteUserId: "@alice:example.org",
+    });
+
+    // Existing strict mapped room still wins for activeRoomId (preserves
+    // prior preference), but the newer strict joined room is now surfaced.
+    expect(result.activeRoomId).toBe("!old:example.org");
+    expect(result.discoveredStrictRoomIds).toEqual(["!new:example.org"]);
+  });
+
   it("prefers strict mapped rooms over discovered rooms", async () => {
     const client = createClient({
       getAccountData: vi.fn(async () => ({
@@ -188,6 +211,37 @@ describe("repairMatrixDirectRooms", () => {
       EventType.Direct,
       expect.objectContaining({
         "@alice:example.org": ["!created:example.org"],
+      }),
+    );
+  });
+
+  it("surfaces newer strict joined DM rooms into m.direct alongside the existing mapping", async () => {
+    // Regression for openclaw/openclaw#79514: repair must promote
+    // newly-discovered strict joined DM rooms into m.direct so downstream
+    // DM detection (client.dms.isDm) recognises them, instead of leaving
+    // them invisible because an older strict mapping already exists.
+    const setAccountData = vi.fn(async () => undefined);
+    const client = createClient({
+      getAccountData: vi.fn(async () => ({
+        "@alice:example.org": ["!old:example.org"],
+      })),
+      getJoinedRooms: vi.fn(async () => ["!old:example.org", "!new:example.org"]),
+      getJoinedRoomMembers: vi.fn(async () => ["@bot:example.org", "@alice:example.org"]),
+      setAccountData,
+    });
+
+    const result = await repairMatrixDirectRooms({
+      client,
+      remoteUserId: "@alice:example.org",
+    });
+
+    expect(result.activeRoomId).toBe("!old:example.org");
+    expect(result.createdRoomId).toBeNull();
+    expect(result.discoveredStrictRoomIds).toEqual(["!new:example.org"]);
+    expect(setAccountData).toHaveBeenCalledWith(
+      EventType.Direct,
+      expect.objectContaining({
+        "@alice:example.org": ["!old:example.org", "!new:example.org"],
       }),
     );
   });

--- a/extensions/matrix/src/matrix/direct-management.ts
+++ b/extensions/matrix/src/matrix/direct-management.ts
@@ -100,14 +100,6 @@ function normalizeRoomIdList(values: readonly string[]): string[] {
   return normalized;
 }
 
-function hasPrimaryMatrixDirectRoomMapping(params: {
-  directContent: MatrixDirectAccountData;
-  remoteUserId: string;
-  roomId: string;
-}): boolean {
-  return normalizeMappedRoomIds(params.directContent, params.remoteUserId)[0] === params.roomId;
-}
-
 function resolveDirectAccountDataWriteQueue(client: MatrixClient): KeyedAsyncQueue {
   const existing = directAccountDataWriteQueues.get(client);
   if (existing) {
@@ -123,6 +115,18 @@ async function writeMatrixDirectRoomMapping(params: {
   remoteUserId: string;
   roomId: string;
 }): Promise<MatrixDirectRoomMappingWriteResult> {
+  return await writeMatrixDirectRoomMappings({
+    client: params.client,
+    remoteUserId: params.remoteUserId,
+    roomIds: [params.roomId],
+  });
+}
+
+async function writeMatrixDirectRoomMappings(params: {
+  client: MatrixClient;
+  remoteUserId: string;
+  roomIds: readonly string[];
+}): Promise<MatrixDirectRoomMappingWriteResult> {
   return await resolveDirectAccountDataWriteQueue(params.client).enqueue(
     DIRECT_ACCOUNT_DATA_QUEUE_KEY,
     async () => {
@@ -130,13 +134,13 @@ async function writeMatrixDirectRoomMapping(params: {
       const directContentAfter = buildNextDirectContent({
         directContent: directContentBefore,
         remoteUserId: params.remoteUserId,
-        roomId: params.roomId,
+        roomIds: params.roomIds,
       });
-      const changed = !hasPrimaryMatrixDirectRoomMapping({
-        directContent: directContentBefore,
-        remoteUserId: params.remoteUserId,
-        roomId: params.roomId,
-      });
+      const beforeRooms = normalizeMappedRoomIds(directContentBefore, params.remoteUserId);
+      const afterRooms = normalizeMappedRoomIds(directContentAfter, params.remoteUserId);
+      const changed =
+        beforeRooms.length !== afterRooms.length ||
+        beforeRooms.some((roomId, index) => roomId !== afterRooms[index]);
       if (changed) {
         await params.client.setAccountData(EventType.Direct, directContentAfter);
       }
@@ -178,10 +182,10 @@ async function classifyDirectRoomCandidate(params: {
 function buildNextDirectContent(params: {
   directContent: MatrixDirectAccountData;
   remoteUserId: string;
-  roomId: string;
+  roomIds: readonly string[];
 }): MatrixDirectAccountData {
   const current = normalizeMappedRoomIds(params.directContent, params.remoteUserId);
-  const nextRooms = normalizeRoomIdList([params.roomId, ...current]);
+  const nextRooms = normalizeRoomIdList([...params.roomIds, ...current]);
   return {
     ...params.directContent,
     [params.remoteUserId]: nextRooms,
@@ -276,8 +280,12 @@ export async function inspectMatrixDirectRooms(params: {
   );
   const mappedStrict = mappedRooms.find((room) => room.strict);
 
+  // Always discover joined strict DM rooms, even when a mapped strict room
+  // already exists. A stale `m.direct` mapping must not suppress discovery
+  // of newer valid strict 2-member DM rooms with the same remote user (see
+  // openclaw/openclaw#79514).
   let joinedRooms: string[] = [];
-  if (!mappedStrict && typeof params.client.getJoinedRooms === "function") {
+  if (typeof params.client.getJoinedRooms === "function") {
     try {
       const resolved = await params.client.getJoinedRooms();
       joinedRooms = Array.isArray(resolved) ? resolved : [];
@@ -331,10 +339,14 @@ export async function repairMatrixDirectRooms(params: {
       encrypted: params.encrypted === true,
     }));
   const createdRoomId = inspected.activeRoomId ? null : activeRoomId;
-  const mappingWrite = await writeMatrixDirectRoomMapping({
+  // Persist the active room first (preserves primary-mapping semantics) and
+  // also surface any newly-discovered strict joined DM rooms into m.direct so
+  // downstream DM detection (client.dms.isDm) recognises them as DMs without
+  // requiring another repair pass (see openclaw/openclaw#79514).
+  const mappingWrite = await writeMatrixDirectRoomMappings({
     client: params.client,
     remoteUserId,
-    roomId: activeRoomId,
+    roomIds: [activeRoomId, ...inspected.discoveredStrictRoomIds],
   });
   return {
     ...inspected,


### PR DESCRIPTION
Fixes #79514

## Root cause

`inspectMatrixDirectRooms()` only ran joined-room discovery when no mapped strict `m.direct` room existed (`extensions/matrix/src/matrix/direct-management.ts`). With `channels.matrix.dm.sessionScope: "per-room"`, a stale `m.direct` mapping pointing at an older strict 1:1 DM room therefore hid every newer strict joined DM room with the same remote user, so replies into the newer DM never landed and `matrix direct repair` could not surface the new room either.

## Fix

- Always invoke joined-room discovery in `inspectMatrixDirectRooms()`, even when a mapped strict room is present, so additional strict joined DM rooms with the same remote user populate `discoveredStrictRoomIds`. The mapped strict room still wins for `activeRoomId` (no broad return to "any 2-member room is a DM" — the local `is_direct: false`, named/aliased/configured-room and post-cache-seed safeguards from #57124 are untouched).
- `repairMatrixDirectRooms()` now folds the freshly discovered strict joined DM rooms into `m.direct` alongside the existing mapping (kept as the primary). Downstream DM detection (`client.dms.isDm`) recognises them on the next sync without requiring a second repair pass.

## Tests

Adds two focused regression tests in `extensions/matrix/src/matrix/direct-management.test.ts` covering the stale-mapping + newer-strict-room scenario for both `inspect` and `repair`. Existing tests (mapped-strict preference, local `is_direct: false` rejection, concurrent write serialization, etc.) continue to pass.

## Out of scope

Runtime DM acceptance in `monitor/direct.ts` and the 30s startup readiness path are deliberately untouched — the source-reproducible failure mode flagged by the ClawSweeper review is the discovery short-circuit, and broader changes to runtime acceptance risk reintroducing the false-positive class addressed by #57124.