### PR TITLE
docs: document Codex harness model availability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,7 @@ Telegraph style. Root rules only. Read scoped `AGENTS.md` before subtree work.
 ## Docs / Changelog
 
 - Docs change with behavior/API. Use docs list/read_when hints; docs links per `docs/AGENTS.md`.
+- When upgrading the bundled Codex harness (`@openai/codex` in `extensions/codex/package.json`), refresh the model availability snapshot in `docs/plugins/codex-harness.md` from the new harness's `model/list` result.
 - Docs final answers: when doc files changed, end with the relevant full `https://docs.openclaw.ai/...` URL(s).
 - Changelog user-facing only; fixing an issue or landing/merging a PR needs one unless pure test/internal.
 - Changelog placement: active version `### Changes`/`### Fixes`; contributor-facing added entries should include at least one `Thanks @author` attribution, using credited human GitHub username(s). Never add `Thanks @codex`, `Thanks @openclaw`, `Thanks @clawsweeper`, or `Thanks @steipete`; if the real credited human is unknown, leave attribution blank instead of guessing or adding a random person.

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -396,12 +396,33 @@ and lets the next turn resolve the harness from current config again.
 
 ## Model discovery
 
-By default, the Codex plugin asks the app-server for available models. If
-discovery fails or times out, it uses a bundled fallback catalog for:
+By default, the Codex plugin asks the app-server for available models. Model
+availability is owned by the Codex app-server harness, so the list can change
+when OpenClaw upgrades the bundled `@openai/codex` version or when a deployment
+points `appServer.command` at a different Codex binary. Availability can also be
+account-scoped. Use `/codex models` on a running gateway to see the live catalog
+for that harness and account.
+
+If discovery fails or times out, OpenClaw uses a bundled fallback catalog for:
 
 - GPT-5.5
 - GPT-5.4 mini
 - GPT-5.2
+
+The current bundled harness is `@openai/codex` `0.129.0`. A `model/list` probe
+against that bundled app-server returned:
+
+| Model id            | Default | Hidden | Input modalities | Reasoning efforts        |
+| ------------------- | ------- | ------ | ---------------- | ------------------------ |
+| `gpt-5.5`           | Yes     | No     | text, image      | low, medium, high, xhigh |
+| `gpt-5.4`           | No      | No     | text, image      | low, medium, high, xhigh |
+| `gpt-5.4-mini`      | No      | No     | text, image      | low, medium, high, xhigh |
+| `gpt-5.3-codex`     | No      | No     | text, image      | low, medium, high, xhigh |
+| `gpt-5.2`           | No      | No     | text, image      | low, medium, high, xhigh |
+| `codex-auto-review` | No      | Yes    | text, image      | low, medium, high, xhigh |
+
+Hidden models are returned by the app-server catalog for internal or specialized
+flows, but they are not normal model-picker choices.
 
 You can tune discovery under `plugins.entries.codex.config.discovery`:
 


### PR DESCRIPTION
## Summary

- Document that Codex model availability comes from the bundled app-server harness version and selected account.
- Add the current `@openai/codex` `0.129.0` model availability snapshot to the Codex harness docs.
- Add an `AGENTS.md` reminder to refresh that snapshot when upgrading the bundled harness.

## Verification

- `pnpm docs:list`
- `git diff --check -- AGENTS.md docs/plugins/codex-harness.md`
- `pnpm check:docs`

Note: local Node is `v22.15.1`, so pnpm prints the repo engine warning for `>=22.16.0`; the docs checks passed after dependency/cache setup.

## Real behavior proof

Behavior or issue addressed: the Codex harness docs now say model availability depends on the Codex app-server harness version/account, and the docs include the current bundled harness model snapshot.

Real environment tested: local OpenClaw checkout using the bundled `@openai/codex` `0.129.0` app-server harness.

Exact steps or command run after this patch: called the bundled Codex app-server `model/list` JSON-RPC with hidden models included, then updated `docs/plugins/codex-harness.md` to match that result. Ran `pnpm check:docs` after the docs edit.

Evidence after fix:

```text
openclaw bundled codex app-server
calledAt: 2026-05-09T00:44:34.047Z
gpt-5.5           default=true  hidden=false  input=text,image  efforts=low,medium,high,xhigh
gpt-5.4           default=false hidden=false  input=text,image  efforts=low,medium,high,xhigh
gpt-5.4-mini      default=false hidden=false  input=text,image  efforts=low,medium,high,xhigh
gpt-5.3-codex     default=false hidden=false  input=text,image  efforts=low,medium,high,xhigh
gpt-5.2           default=false hidden=false  input=text,image  efforts=low,medium,high,xhigh
codex-auto-review default=false hidden=true   input=text,image  efforts=low,medium,high,xhigh

pnpm check:docs
Docs formatting clean (608 files).
Summary: 0 error(s)
Docs MDX check passed (623 files, 2411ms).
checked_internal_links=4218
broken_links=0
```

Observed result after fix: `docs/plugins/codex-harness.md` lists the same six model ids for the current bundled harness and tells operators to use `/codex models` for the live harness/account catalog.

What was not tested: no gateway runtime turn was executed because this is a documentation-only change.
