### PR TITLE
Fix skill source links and ClawHub update action

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -120,6 +120,7 @@ import {
   saveSkillApiKey,
   searchClawHub,
   setClawHubSearchQuery,
+  updateFromClawHub,
   updateSkillEdit,
   updateSkillEnabled,
 } from "./controllers/skills.ts";
@@ -2330,6 +2331,7 @@ export function renderApp(state: AppViewState) {
                 onClawHubDetailOpen: (slug) => loadClawHubDetail(state, slug),
                 onClawHubDetailClose: () => closeClawHubDetail(state),
                 onClawHubInstall: (slug) => installFromClawHub(state, slug),
+                onClawHubUpdate: (skillKey, slug) => updateFromClawHub(state, skillKey, slug),
               }),
             )
           : nothing}

--- a/ui/src/ui/controllers/skills.ts
+++ b/ui/src/ui/controllers/skills.ts
@@ -278,3 +278,40 @@ export async function installFromClawHub(state: SkillsState, slug: string) {
     state.clawhubInstallSlug = null;
   }
 }
+
+export async function updateFromClawHub(state: SkillsState, skillKey: string, slug: string) {
+  await runSkillMutation(state, skillKey, async (client) => {
+    const result = await client.request<{
+      config?: {
+        source?: "clawhub";
+        results?: Array<{
+          ok: boolean;
+          slug?: string;
+          previousVersion?: string | null;
+          version?: string;
+          changed?: boolean;
+          error?: string;
+        }>;
+      };
+    }>("skills.update", { source: "clawhub", slug });
+    const update = result?.config?.results?.find((entry) => entry.slug === slug);
+    if (update?.changed) {
+      return {
+        kind: "success",
+        message: `Updated ${slug}${update.previousVersion ? ` from v${update.previousVersion}` : ""}${
+          update.version ? ` to v${update.version}` : ""
+        }`,
+      };
+    }
+    if (update?.version) {
+      return {
+        kind: "success",
+        message: `${slug} is already up to date at v${update.version}`,
+      };
+    }
+    return {
+      kind: "success",
+      message: `Checked ${slug} for updates`,
+    };
+  });
+}

--- a/ui/src/ui/views/skills.test.ts
+++ b/ui/src/ui/views/skills.test.ts
@@ -86,6 +86,7 @@ function createProps(overrides: Partial<SkillsProps> = {}): SkillsProps {
     onClawHubDetailOpen: () => undefined,
     onClawHubDetailClose: () => undefined,
     onClawHubInstall: () => undefined,
+    onClawHubUpdate: () => undefined,
     ...overrides,
   };
 }
@@ -249,6 +250,52 @@ describe("renderSkills", () => {
     expect(onClawHubInstall).toHaveBeenCalledTimes(1);
     expect(onClawHubInstall).toHaveBeenCalledWith("github");
   });
+
+  it("renders ClawHub skill sources as external links and routes update checks", async () => {
+    const container = document.createElement("div");
+    const showModal = vi.fn(function (this: HTMLDialogElement) {
+      this.setAttribute("open", "");
+    });
+    const onClawHubUpdate = vi.fn();
+
+    installDialogMethod("showModal", showModal);
+
+    render(
+      renderSkills(
+        createProps({
+          detailKey: "repo-skill",
+          onClawHubUpdate,
+          report: {
+            workspaceDir: "/tmp/workspace",
+            managedSkillsDir: "/tmp/skills",
+            skills: [
+              createSkill({
+                source: "https://clawhub.ai/skills/self-improving-agent",
+              }),
+            ],
+          },
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    const sourceLink = container.querySelector<HTMLAnchorElement>(
+      'a[href="https://clawhub.ai/skills/self-improving-agent"]',
+    );
+    expect(sourceLink?.target).toBe("_blank");
+    expect(sourceLink?.rel).toContain("noopener");
+    expect(sourceLink?.rel).toContain("noreferrer");
+
+    const updateButton = [...container.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => normalizeText(button).includes("Check for updates"),
+    );
+    updateButton?.click();
+
+    expect(onClawHubUpdate).toHaveBeenCalledTimes(1);
+    expect(onClawHubUpdate).toHaveBeenCalledWith("repo-skill", "self-improving-agent");
+  });
+
 });
 
 function installDialogMethod(

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -75,6 +75,7 @@ export type SkillsProps = {
   onClawHubDetailOpen: (slug: string) => void;
   onClawHubDetailClose: () => void;
   onClawHubInstall: (slug: string) => void;
+  onClawHubUpdate: (skillKey: string, slug: string) => void;
 };
 
 type StatusTabDef = { id: SkillsStatusFilter; label: string };
@@ -105,6 +106,41 @@ function skillStatusClass(skill: SkillStatusEntry): string {
     return "muted";
   }
   return skill.eligible ? "ok" : "warn";
+}
+
+function resolveClawHubSlugFromSource(source: string): string | null {
+  const trimmed = source.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const clawhubPrefix = "clawhub:";
+  if (trimmed.toLowerCase().startsWith(clawhubPrefix)) {
+    const slug = trimmed.slice(clawhubPrefix.length).trim();
+    return slug || null;
+  }
+  try {
+    const url = new URL(trimmed, window.location.href);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return null;
+    }
+    if (url.hostname !== "clawhub.ai" && !url.hostname.endsWith(".clawhub.ai")) {
+      return null;
+    }
+    const [, section, slug] = url.pathname.split("/");
+    if (section !== "skills") {
+      return null;
+    }
+    return slug ? decodeURIComponent(slug) : null;
+  } catch {
+    return null;
+  }
+}
+
+function renderSkillSource(source: string) {
+  const href = safeExternalHref(source);
+  return href
+    ? html`<a href="${href}" target="_blank" rel="noopener noreferrer">${source}</a>`
+    : source;
 }
 
 export function renderSkills(props: SkillsProps) {
@@ -429,6 +465,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
   const message = props.messages[skill.skillKey] ?? null;
   const canInstall = skill.install.length > 0 && skill.missing.bins.length > 0;
   const showBundledBadge = Boolean(skill.bundled && skill.source !== "openclaw-bundled");
+  const clawhubSlug = resolveClawHubSlugFromSource(skill.source);
   const missing = computeSkillMissing(skill);
   const reasons = computeSkillReasons(skill);
 
@@ -559,7 +596,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
           <div
             style="border-top: 1px solid var(--border); padding-top: 12px; display: grid; gap: 6px; font-size: 12px; color: var(--muted);"
           >
-            <div><span style="font-weight: 600;">Source:</span> ${skill.source}</div>
+            <div><span style="font-weight: 600;">Source:</span> ${renderSkillSource(skill.source)}</div>
             <div style="font-family: var(--mono); word-break: break-all;">${skill.filePath}</div>
             ${(() => {
               const safeHref = safeExternalHref(skill.homepage);
@@ -571,6 +608,17 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
                   </div>`
                 : nothing;
             })()}
+            ${clawhubSlug
+              ? html`<div style="margin-top: 6px;">
+                  <button
+                    class="btn btn--sm"
+                    ?disabled=${busy}
+                    @click=${() => props.onClawHubUpdate(skill.skillKey, clawhubSlug)}
+                  >
+                    ${busy ? "Checking…" : "Check for updates"}
+                  </button>
+                </div>`
+              : nothing}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- render installed skill source URLs as safe external links that open in a new tab
- add a working ClawHub update action for installed ClawHub-backed skills
- cover source link/update routing in the Skills view test

## Verification
- git diff --check
- pnpm install --frozen-lockfile *(blocked: packageExtensionsChecksum config mismatch with lockfile)*