### PR TITLE
[Fix] Bound CLI runner supervisor output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,6 +355,7 @@ Docs: https://docs.openclaw.ai
 - Agents/failover: rotate auth profiles before deferred cooldown marking on rate-limit failures, so file-lock contention cannot stall profile failover. Fixes #57281. (#57283) Thanks @jeremyknows.
 - Gateway/sessions: when `session.dmScope: "main"` is configured, route a bare webchat `/new` against the agent's main session (`sessions.create` with `emitCommandHooks=true`) to an in-place reset instead of creating a parallel `dashboard:` child, matching `/new` behavior on Telegram/Discord. Fixes #77434. (#71170) Thanks @statxc.
 - Scripts/UI/Windows: launch `.cmd` and `.bat` UI runners through the shared cmd.exe escaping path with shell mode disabled, avoiding Node.js v24 DEP0190 warnings while preserving argument boundaries. (#62910) Thanks @nandanadileep.
+- Agents/CLI runner: disable supervisor stdout/stderr capture for prepared CLI runs while keeping bounded diagnostics and incremental JSONL output parsing, preventing long CLI output from being retained in memory. (#79617) Thanks @samzong.
 - Telegram: treat a DM binding that carries the chat id in both `conversationId` and `parentConversationId` as a direct conversation instead of a topic, so reverse delivery for Telegram DMs is not misrouted through a topic-shaped target. (#79700) Thanks @TSHOGX.
 
 ## 2026.5.7

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -388,14 +388,34 @@ export function createCliJsonlStreamingParser(params: {
   let assistantText = "";
   let sessionId: string | undefined;
   let usage: CliUsage | undefined;
+  let output: CliOutput | null = null;
+  const texts: string[] = [];
 
   const handleParsedRecord = (parsed: Record<string, unknown>) => {
     sessionId = pickCliSessionId(parsed, params.backend) ?? sessionId;
     if (!sessionId && typeof parsed.thread_id === "string") {
       sessionId = parsed.thread_id.trim();
     }
-    if (isRecord(parsed.usage)) {
-      usage = toCliUsage(parsed.usage) ?? usage;
+    usage = readCliUsage(parsed) ?? usage;
+
+    const result = parseClaudeCliJsonlResult({
+      backend: params.backend,
+      providerId: params.providerId,
+      parsed,
+      sessionId,
+      usage,
+    });
+    if (result) {
+      output = result;
+      return;
+    }
+
+    const item = isRecord(parsed.item) ? parsed.item : null;
+    if (item && typeof item.text === "string") {
+      const type = normalizeLowercaseStringOrEmpty(item.type);
+      if (!type || type.includes("message")) {
+        texts.push(item.text);
+      }
     }
 
     const delta = parseClaudeCliStreamingDelta({
@@ -451,6 +471,13 @@ export function createCliJsonlStreamingParser(params: {
     },
     finish() {
       flushLines(true);
+    },
+    getOutput() {
+      if (output) {
+        return output;
+      }
+      const text = texts.join("\n").trim();
+      return text ? { text, sessionId, usage } : null;
     },
   };
 }

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -768,27 +768,19 @@ describe("runCliAgent spawn path", () => {
           event: { type: "content_block_delta", delta: { type: "text_delta", text: " world" } },
         }) + "\n",
       );
+      input.onStdout?.(
+        JSON.stringify({
+          type: "result",
+          session_id: "session-123",
+          result: "Hello world",
+        }) + "\n",
+      );
       return createManagedRun({
         reason: "exit",
         exitCode: 0,
         exitSignal: null,
         durationMs: 50,
-        stdout: [
-          JSON.stringify({ type: "init", session_id: "session-123" }),
-          JSON.stringify({
-            type: "stream_event",
-            event: { type: "content_block_delta", delta: { type: "text_delta", text: "Hello" } },
-          }),
-          JSON.stringify({
-            type: "stream_event",
-            event: { type: "content_block_delta", delta: { type: "text_delta", text: " world" } },
-          }),
-          JSON.stringify({
-            type: "result",
-            session_id: "session-123",
-            result: "Hello world",
-          }),
-        ].join("\n"),
+        stdout: "",
         stderr: "",
         timedOut: false,
         noOutputTimedOut: false,

--- a/src/agents/cli-runner.test-support.ts
+++ b/src/agents/cli-runner.test-support.ts
@@ -38,8 +38,44 @@ const hoisted = vi.hoisted(
 
 setCliRunnerExecuteTestDeps({
   getProcessSupervisor: () => ({
-    spawn: (params: Parameters<SupervisorSpawnFn>[0]) =>
-      supervisorSpawnMock(params) as ReturnType<SupervisorSpawnFn>,
+    spawn: async (params: Parameters<SupervisorSpawnFn>[0]) => {
+      let stdoutDelivered = false;
+      let stderrDelivered = false;
+      const wrappedParams = {
+        ...params,
+        onStdout: params.onStdout
+          ? (chunk: string) => {
+              stdoutDelivered = true;
+              params.onStdout?.(chunk);
+            }
+          : undefined,
+        onStderr: params.onStderr
+          ? (chunk: string) => {
+              stderrDelivered = true;
+              params.onStderr?.(chunk);
+            }
+          : undefined,
+      };
+      const managedRun = (await supervisorSpawnMock(wrappedParams)) as Awaited<
+        ReturnType<SupervisorSpawnFn>
+      >;
+      const wait = managedRun.wait;
+      return {
+        ...managedRun,
+        wait: async () => {
+          const exit = await wait();
+          if (params.captureOutput === false) {
+            if (!stdoutDelivered && exit.stdout) {
+              params.onStdout?.(exit.stdout);
+            }
+            if (!stderrDelivered && exit.stderr) {
+              params.onStderr?.(exit.stderr);
+            }
+          }
+          return exit;
+        },
+      };
+    },
     cancel: vi.fn(),
     cancelScope: vi.fn(),
     reconcileOrphans: vi.fn(),

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -1,0 +1,247 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { onAgentEvent, resetAgentEventsForTest } from "../../infra/agent-events.js";
+import type { getProcessSupervisor } from "../../process/supervisor/index.js";
+import { createManagedRun, supervisorSpawnMock } from "../cli-runner.test-support.js";
+import { executePreparedCliRun } from "./execute.js";
+import type { PreparedCliRunContext } from "./types.js";
+
+type ProcessSupervisor = ReturnType<typeof getProcessSupervisor>;
+type SupervisorSpawnInput = Parameters<ProcessSupervisor["spawn"]>[0];
+
+function buildPreparedCliRunContext(params: {
+  output: "jsonl" | "text";
+  provider?: string;
+}): PreparedCliRunContext {
+  const provider = params.provider ?? "codex-cli";
+  const backend = {
+    command: "agent-cli",
+    args: [],
+    output: params.output,
+    input: "stdin" as const,
+    serialize: true,
+  };
+
+  return {
+    params: {
+      sessionId: "session-1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hi",
+      provider,
+      model: "model",
+      timeoutMs: 1_000,
+      runId: `run-${params.output}`,
+    },
+    started: Date.now(),
+    workspaceDir: "/tmp",
+    backendResolved: {
+      id: provider,
+      config: backend,
+      bundleMcp: false,
+    },
+    preparedBackend: {
+      backend,
+      env: {},
+    },
+    reusableCliSession: {},
+    modelId: "model",
+    normalizedModel: "model",
+    systemPrompt: "system",
+    systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
+    bootstrapPromptWarningLines: [],
+    authEpochVersion: 2,
+  };
+}
+
+beforeEach(() => {
+  resetAgentEventsForTest();
+  supervisorSpawnMock.mockReset();
+});
+
+describe("executePreparedCliRun supervisor output capture", () => {
+  it("disables supervisor capture without parsing from the diagnostic stdout tail", async () => {
+    const fullText = `start-${"x".repeat(80 * 1024)}-end`;
+
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as SupervisorSpawnInput;
+      input.onStdout?.(fullText);
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: input.captureOutput === false ? "" : fullText,
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    const result = await executePreparedCliRun(buildPreparedCliRunContext({ output: "text" }));
+    const spawnInput = supervisorSpawnMock.mock.calls[0]?.[0] as SupervisorSpawnInput;
+
+    expect(spawnInput.captureOutput).toBe(false);
+    expect(result.rawText).toBe(fullText);
+  });
+
+  it("rejects oversized successful stdout instead of parsing a truncated tail", async () => {
+    const noisyPrefix = "x".repeat(2 * 1024 * 1024);
+    const finalText = "final answer";
+
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as SupervisorSpawnInput;
+      input.onStdout?.(noisyPrefix);
+      input.onStdout?.(finalText);
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: input.captureOutput === false ? "" : `${noisyPrefix}${finalText}`,
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    await expect(
+      executePreparedCliRun(buildPreparedCliRunContext({ output: "text" })),
+    ).rejects.toThrow("CLI stdout exceeded");
+    const spawnInput = supervisorSpawnMock.mock.calls[0]?.[0] as SupervisorSpawnInput;
+
+    expect(spawnInput.captureOutput).toBe(false);
+  });
+
+  it("parses valid oversized JSONL output incrementally", async () => {
+    const largeToolEvent = `${JSON.stringify({
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        delta: { type: "tool_delta", text: "x".repeat(2 * 1024 * 1024) },
+      },
+    })}\n`;
+    const resultEvent = `${JSON.stringify({
+      type: "result",
+      session_id: "session-jsonl-large",
+      result: "final answer",
+    })}\n`;
+
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as SupervisorSpawnInput;
+      input.onStdout?.(largeToolEvent);
+      input.onStdout?.(resultEvent);
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: input.captureOutput === false ? "" : `${largeToolEvent}${resultEvent}`,
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    const result = await executePreparedCliRun(
+      buildPreparedCliRunContext({ output: "jsonl", provider: "claude-cli" }),
+    );
+
+    expect(result.text).toBe("final answer");
+    expect(result.sessionId).toBe("session-jsonl-large");
+  });
+
+  it("classifies failed stdout from the retained parse buffer before the diagnostic tail", async () => {
+    const errorPrefix = `${JSON.stringify({
+      type: "result",
+      is_error: true,
+      result: "429 rate limit exceeded",
+    })}\n`;
+    const noisyTail = "x".repeat(80 * 1024);
+
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as SupervisorSpawnInput;
+      input.onStdout?.(errorPrefix);
+      input.onStdout?.(noisyTail);
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 1,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: input.captureOutput === false ? "" : `${errorPrefix}${noisyTail}`,
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    await expect(
+      executePreparedCliRun(buildPreparedCliRunContext({ output: "text" })),
+    ).rejects.toMatchObject({
+      reason: "rate_limit",
+      status: 429,
+    });
+  });
+
+  it("still streams every JSONL stdout chunk with supervisor capture disabled", async () => {
+    const agentEvents: Array<{ text?: string; delta?: string }> = [];
+    const stop = onAgentEvent((event) => {
+      if (event.stream !== "assistant") {
+        return;
+      }
+      agentEvents.push({
+        text: typeof event.data.text === "string" ? event.data.text : undefined,
+        delta: typeof event.data.delta === "string" ? event.data.delta : undefined,
+      });
+    });
+    const chunks = [
+      `${JSON.stringify({ type: "init", session_id: "session-jsonl" })}\n`,
+      `${JSON.stringify({
+        type: "stream_event",
+        event: { type: "content_block_delta", delta: { type: "text_delta", text: "Hello" } },
+      })}\n`,
+      `not-json ${"x".repeat(80 * 1024)}\n`,
+      `${JSON.stringify({
+        type: "stream_event",
+        event: { type: "content_block_delta", delta: { type: "text_delta", text: " world" } },
+      })}\n`,
+      `${JSON.stringify({
+        type: "result",
+        session_id: "session-jsonl",
+        result: "Hello world",
+      })}\n`,
+    ];
+
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as SupervisorSpawnInput;
+      for (const chunk of chunks) {
+        input.onStdout?.(chunk);
+      }
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: input.captureOutput === false ? "" : chunks.join(""),
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    try {
+      const result = await executePreparedCliRun(
+        buildPreparedCliRunContext({ output: "jsonl", provider: "claude-cli" }),
+      );
+      const spawnInput = supervisorSpawnMock.mock.calls[0]?.[0] as SupervisorSpawnInput;
+
+      expect(spawnInput.captureOutput).toBe(false);
+      expect(result.text).toBe("Hello world");
+      expect(agentEvents).toEqual([
+        { text: "Hello", delta: "Hello" },
+        { text: "Hello world", delta: " world" },
+      ]);
+    } finally {
+      stop();
+    }
+  });
+});

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -150,6 +150,52 @@ describe("executePreparedCliRun supervisor output capture", () => {
     expect(result.sessionId).toBe("session-jsonl-large");
   });
 
+  it("parses oversized resume JSONL output from the effective resume output mode", async () => {
+    const largeToolEvent = `${JSON.stringify({
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        delta: { type: "tool_delta", text: "x".repeat(2 * 1024 * 1024) },
+      },
+    })}\n`;
+    const resultEvent = `${JSON.stringify({
+      type: "result",
+      session_id: "resume-jsonl-session",
+      result: "resumed answer",
+    })}\n`;
+    const context = buildPreparedCliRunContext({
+      output: "text",
+      provider: "resume-jsonl-cli",
+    });
+    Object.assign(context.preparedBackend.backend, {
+      jsonlDialect: "claude-stream-json" as const,
+      resumeArgs: ["resume", "{sessionId}"],
+      resumeOutput: "jsonl" as const,
+      sessionMode: "existing" as const,
+    });
+
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as SupervisorSpawnInput;
+      input.onStdout?.(largeToolEvent);
+      input.onStdout?.(resultEvent);
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: input.captureOutput === false ? "" : `${largeToolEvent}${resultEvent}`,
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    const result = await executePreparedCliRun(context, "resume-jsonl-session");
+
+    expect(result.text).toBe("resumed answer");
+    expect(result.sessionId).toBe("resume-jsonl-session");
+  });
+
   it("classifies failed stdout from the retained parse buffer before the diagnostic tail", async () => {
     const errorPrefix = `${JSON.stringify({
       type: "result",

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -45,6 +45,51 @@ const executeDeps = {
   requestHeartbeat: requestHeartbeatImpl,
 };
 
+const CLI_RUNNER_OUTPUT_TAIL_BYTES = 64 * 1024;
+const CLI_RUNNER_OUTPUT_PARSE_BYTES = 1024 * 1024;
+
+function appendCliOutputTail(tail: Buffer, chunk: string): Buffer {
+  if (!chunk) {
+    return tail;
+  }
+  const chunkBuffer = Buffer.from(chunk);
+  if (chunkBuffer.byteLength >= CLI_RUNNER_OUTPUT_TAIL_BYTES) {
+    return Buffer.from(chunkBuffer.subarray(chunkBuffer.byteLength - CLI_RUNNER_OUTPUT_TAIL_BYTES));
+  }
+  const next = Buffer.concat([tail, chunkBuffer], tail.byteLength + chunkBuffer.byteLength);
+  if (next.byteLength <= CLI_RUNNER_OUTPUT_TAIL_BYTES) {
+    return next;
+  }
+  return Buffer.from(next.subarray(next.byteLength - CLI_RUNNER_OUTPUT_TAIL_BYTES));
+}
+
+function appendCliOutputParseBuffer(
+  buffer: Buffer,
+  chunk: string,
+): { buffer: Buffer; exceeded: boolean } {
+  if (!chunk) {
+    return { buffer, exceeded: false };
+  }
+  const chunkBuffer = Buffer.from(chunk);
+  if (buffer.byteLength + chunkBuffer.byteLength > CLI_RUNNER_OUTPUT_PARSE_BYTES) {
+    const remainingBytes = CLI_RUNNER_OUTPUT_PARSE_BYTES - buffer.byteLength;
+    if (remainingBytes <= 0) {
+      return { buffer, exceeded: true };
+    }
+    return {
+      buffer: Buffer.concat(
+        [buffer, chunkBuffer.subarray(0, remainingBytes)],
+        CLI_RUNNER_OUTPUT_PARSE_BYTES,
+      ),
+      exceeded: true,
+    };
+  }
+  return {
+    buffer: Buffer.concat([buffer, chunkBuffer], buffer.byteLength + chunkBuffer.byteLength),
+    exceeded: false,
+  };
+}
+
 export function setCliRunnerExecuteTestDeps(overrides: Partial<typeof executeDeps>): void {
   Object.assign(executeDeps, overrides);
 }
@@ -476,6 +521,12 @@ export async function executePreparedCliRun(
           backendId: context.backendResolved.id,
           cliSessionId: useResume ? resolvedSessionId : undefined,
         });
+        let stdoutTail: Buffer = Buffer.alloc(0);
+        let stdoutParseBuffer: Buffer = Buffer.alloc(0);
+        let stdoutParseExceeded = false;
+        let stderrTail: Buffer = Buffer.alloc(0);
+        let stderrParseBuffer: Buffer = Buffer.alloc(0);
+        let stderrParseExceeded = false;
 
         const managedRun = await supervisor.spawn({
           sessionId: params.sessionId,
@@ -489,7 +540,24 @@ export async function executePreparedCliRun(
           cwd: context.workspaceDir,
           env,
           input: stdinPayload,
-          onStdout: streamingParser ? (chunk: string) => streamingParser.push(chunk) : undefined,
+          captureOutput: false,
+          onStdout: (chunk: string) => {
+            stdoutTail = appendCliOutputTail(stdoutTail, chunk);
+            if (!stdoutParseExceeded) {
+              const nextStdoutParse = appendCliOutputParseBuffer(stdoutParseBuffer, chunk);
+              stdoutParseBuffer = nextStdoutParse.buffer;
+              stdoutParseExceeded = nextStdoutParse.exceeded;
+            }
+            streamingParser?.push(chunk);
+          },
+          onStderr: (chunk: string) => {
+            stderrTail = appendCliOutputTail(stderrTail, chunk);
+            if (!stderrParseExceeded) {
+              const nextStderrParse = appendCliOutputParseBuffer(stderrParseBuffer, chunk);
+              stderrParseBuffer = nextStderrParse.buffer;
+              stderrParseExceeded = nextStderrParse.exceeded;
+            }
+          },
         });
         let replyBackendCompleted = false;
         const replyBackendHandle = params.replyOperation
@@ -526,22 +594,24 @@ export async function executePreparedCliRun(
           throw createCliAbortError();
         }
 
-        const stdout = result.stdout.trim();
-        const stderr = result.stderr.trim();
+        const stdout = stdoutParseBuffer.toString("utf8").trim();
+        const stdoutDiagnostic = stdoutTail.toString("utf8").trim();
+        const stderr = stderrParseBuffer.toString("utf8").trim();
+        const stderrDiagnostic = stderrTail.toString("utf8").trim();
         if (logOutputText) {
-          if (stdout) {
-            cliBackendLog.info(`cli stdout:\n${stdout}`);
+          if (stdoutDiagnostic) {
+            cliBackendLog.info(`cli stdout:\n${stdoutDiagnostic}`);
           }
-          if (stderr) {
-            cliBackendLog.info(`cli stderr:\n${stderr}`);
+          if (stderrDiagnostic) {
+            cliBackendLog.info(`cli stderr:\n${stderrDiagnostic}`);
           }
         }
         if (shouldLogVerbose()) {
-          if (stdout) {
-            cliBackendLog.debug(`cli stdout:\n${stdout}`);
+          if (stdoutDiagnostic) {
+            cliBackendLog.debug(`cli stdout:\n${stdoutDiagnostic}`);
           }
-          if (stderr) {
-            cliBackendLog.debug(`cli stderr:\n${stderr}`);
+          if (stderrDiagnostic) {
+            cliBackendLog.debug(`cli stderr:\n${stderrDiagnostic}`);
           }
         }
 
@@ -586,12 +656,27 @@ export async function executePreparedCliRun(
               status: resolveFailoverStatus("timeout"),
             });
           }
-          const primaryErrorText = stderr || stdout;
+          const errorCandidates = [stderr, stdout, stderrDiagnostic, stdoutDiagnostic].filter(
+            (candidate) => candidate.length > 0,
+          );
           const structuredError =
-            extractCliErrorMessage(primaryErrorText) ??
-            (stderr ? extractCliErrorMessage(stdout) : null);
-          const err = structuredError || primaryErrorText || "CLI failed.";
-          const reason = classifyFailoverReason(err, { provider: params.provider }) ?? "unknown";
+            errorCandidates.map((candidate) => extractCliErrorMessage(candidate)).find(Boolean) ??
+            null;
+          let classifiedErrorText = structuredError;
+          let reason = structuredError
+            ? classifyFailoverReason(structuredError, { provider: params.provider })
+            : null;
+          if (!reason) {
+            for (const candidate of errorCandidates) {
+              reason = classifyFailoverReason(candidate, { provider: params.provider });
+              if (reason) {
+                classifiedErrorText = candidate;
+                break;
+              }
+            }
+          }
+          const err = structuredError || classifiedErrorText || errorCandidates[0] || "CLI failed.";
+          reason = reason ?? "unknown";
           const status = resolveFailoverStatus(reason);
           throw new FailoverError(err, {
             reason,
@@ -603,13 +688,33 @@ export async function executePreparedCliRun(
           });
         }
 
-        const parsed = parseCliOutput({
-          raw: stdout,
-          backend,
-          providerId: context.backendResolved.id,
-          outputMode: useResume ? (backend.resumeOutput ?? backend.output) : backend.output,
-          fallbackSessionId: resolvedSessionId,
-        });
+        const outputMode = useResume ? (backend.resumeOutput ?? backend.output) : backend.output;
+        const streamedJsonlOutput =
+          outputMode === "jsonl" ? (streamingParser?.getOutput() ?? null) : null;
+
+        if (stdoutParseExceeded && !streamedJsonlOutput) {
+          throw new FailoverError(
+            `CLI stdout exceeded ${CLI_RUNNER_OUTPUT_PARSE_BYTES} bytes; refusing to parse truncated output.`,
+            {
+              reason: "format",
+              provider: params.provider,
+              model: context.modelId,
+              sessionId: params.sessionId,
+              lane: params.lane,
+              status: resolveFailoverStatus("format"),
+            },
+          );
+        }
+
+        const parsed =
+          streamedJsonlOutput ??
+          parseCliOutput({
+            raw: stdout,
+            backend,
+            providerId: context.backendResolved.id,
+            outputMode,
+            fallbackSessionId: resolvedSessionId,
+          });
         const rawText = parsed.text;
         return {
           ...parsed,

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -442,7 +442,8 @@ export async function executePreparedCliRun(
           useResume,
           trigger: params.trigger,
         });
-        const hasJsonlOutput = backend.output === "jsonl";
+        const outputMode = useResume ? (backend.resumeOutput ?? backend.output) : backend.output;
+        const hasJsonlOutput = outputMode === "jsonl";
         if (shouldUseClaudeLiveSession(context)) {
           if (!hasJsonlOutput) {
             throw new Error("Claude live session requires JSONL streaming parser");
@@ -688,7 +689,6 @@ export async function executePreparedCliRun(
           });
         }
 
-        const outputMode = useResume ? (backend.resumeOutput ?? backend.output) : backend.output;
         const streamedJsonlOutput =
           outputMode === "jsonl" ? (streamingParser?.getOutput() ?? null) : null;
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: prepared CLI runs spawned through the process supervisor without `captureOutput:false`, so the supervisor retained full stdout/stderr in memory until the run exited.
- Why it matters: verbose CLI backends can produce large JSONL/progress output and inflate Gateway heap even though the runner already streams output through callbacks.
- What changed: the CLI runner disables supervisor capture, keeps bounded diagnostic tails, keeps a bounded parse buffer for non-streaming output, and lets JSONL runs use the streaming parser's final output, including `resumeOutput: "jsonl"` backends.
- What did NOT change (scope boundary): supervisor defaults, plugin boundaries, CLI backend configuration, and unrelated CLI runner behavior were left unchanged except for deleting a duplicate test helper that blocked `tsgo:core:test`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related #79617
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: process supervisor output capture can retain full CLI stdout/stderr for prepared CLI runs instead of using the callback stream.
- Real environment tested: local OpenClaw checkout on Darwin 25.4.0 arm64, Node v24.14.0, pnpm 10.33.2 (proof re-run 2026-05-09T03:34:44Z).
- Exact steps or command run after this patch: ran a production `createProcessSupervisor()` child process that wrote 2 MiB to stdout and `"err-chunk"` to stderr, testing both `captureOutput:false` and `captureOutput:true` back to back.
- Evidence after fix (full dual-mode output):
  ```json
  [
    {
      "label": "captureOutput: false",
      "retainedStdoutBytes": 0,
      "streamedBytes": 2097152,
      "retainedStderr": ""
    },
    {
      "label": "captureOutput: true",
      "retainedStdoutBytes": 2097152,
      "streamedBytes": 2097152,
      "retainedStderr": "err-chunk"
    }
  ]
  ```
- Observed result after fix: with `captureOutput:false`, the supervisor retained zero stdout/stderr bytes in `RunExit`, while the callback stream received all 2,097,152 stdout bytes. With `captureOutput:true` (default), both retained and streamed bytes are 2,097,152, confirming no regression in the default path.
- What was not tested: a full live Gateway run against an external CLI provider; the touched runner path is covered by focused regression tests below.
- Before evidence (optional but encouraged): code inspection showed `src/process/supervisor/supervisor.ts` defaults `captureOutput` on and appends chunks into retained stdout/stderr; this prepared CLI runner spawn previously did not override that default.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the prepared CLI runner spawn path missed the `captureOutput:false` override already used by other long-running CLI/supervisor paths.
- Missing detection / guardrail: there was no regression test asserting that the prepared CLI runner disables supervisor capture while preserving streamed output.
- Contributing context (if known): the downstream success and failure handling still consumed `RunExit.stdout`/`stderr`, which made disabling capture require a small bounded parse/diagnostic buffer at the call site.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/cli-runner/execute.supervisor-capture.test.ts` plus existing CLI output and runner spawn tests.
- Scenario the test should lock in: prepared CLI runs pass `captureOutput:false`, keep bounded diagnostics, reject oversized non-streaming stdout instead of parsing a truncated tail, parse oversized JSONL incrementally for fresh and resumed output modes, classify failures from retained parse buffers, and keep streaming callbacks ordered.
- Why this is the smallest reliable guardrail: it exercises the prepared runner's supervisor seam directly without starting unrelated Gateway/channel/plugin runtime.
- Existing test that already covers this (if any): N/A; this PR adds the missing regression coverage.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Long, verbose prepared CLI runs no longer make the supervisor retain full stdout/stderr in Gateway heap. Oversized successful non-JSONL stdout is now rejected as a format error instead of being parsed from a truncated diagnostic tail.

## Diagram (if applicable)

```text
Before:
prepared CLI run -> supervisor capture enabled -> full stdout/stderr retained until exit

After:
prepared CLI run -> callback stream + bounded runner buffers -> no supervisor stdout/stderr retention
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Darwin 25.4.0 arm64
- Runtime/container: Node v24.14.0, pnpm 10.33.2
- Model/provider: N/A
- Integration/channel (if any): prepared CLI runner / process supervisor
- Relevant config (redacted): N/A

### Steps

1. Run a production process supervisor child process with `captureOutput:false` and a child that writes 2 MiB to stdout.
2. Run focused CLI output and CLI runner regression tests.
3. Run targeted formatter, linter, diff whitespace checks, changed-lane discovery, and local `check:changed`.
4. Run local Codex review; address actionable findings.

### Expected

- Supervisor `RunExit.stdout` stays empty when capture is disabled.
- Callback streaming still receives every output byte.
- Prepared CLI runner tests pass for bounded diagnostics, oversized JSONL, oversized resumed JSONL, oversized non-streaming stdout, failure classification, and streaming callback delivery.

### Actual

- Runtime proof output: `captureOutput:false` → `retainedStdoutBytes:0, streamedBytes:2097152`; `captureOutput:true` → `retainedStdoutBytes:2097152, streamedBytes:2097152, retainedStderr:"err-chunk"`.
- Focused tests passed.
- `pnpm check:changed` exit 0 (lanes: core, coreTests, docs).

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Supporting commands run:

- `node --import tsx supervisor-capture-proof.ts` (repo root): `captureOutput:false` → `retainedStdoutBytes:0, streamedBytes:2097152`; `captureOutput:true` → `retainedStdoutBytes:2097152, streamedBytes:2097152, retainedStderr:"err-chunk"`. PASS.
- `pnpm test src/agents/cli-runner/execute.supervisor-capture.test.ts src/agents/cli-output.test.ts src/agents/cli-runner.spawn.test.ts -- --reporter=verbose`: passed, 52 tests across 2 files (agents shard) + 15 tests (unit-fast shard).
- `pnpm test src/agents/cli-runner/execute.supervisor-capture.test.ts src/agents/cli-output.test.ts src/agents/cli-runner.reliability.test.ts -- --reporter=verbose`: passed, 25 tests across 2 files.
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/cli-runner.spawn.test.ts src/agents/cli-runner/execute.ts src/agents/cli-runner/execute.supervisor-capture.test.ts src/agents/cli-output.ts src/agents/cli-runner.test-support.ts`: passed.
- `node scripts/check-changelog-attributions.mjs`: passed.
- `git diff --check -- CHANGELOG.md src/agents/cli-runner.spawn.test.ts src/agents/cli-runner/execute.ts src/agents/cli-runner/execute.supervisor-capture.test.ts src/agents/cli-output.ts src/agents/cli-runner.test-support.ts`: passed.
- `pnpm changed:lanes --json`: lanes `core`, `coreTests`, `docs`.
- `pnpm check:changed`: exit 0 (conflict markers, changelog attributions, extension re-exports, plugin-sdk re-exports, duplicate coverage, tsgo:core, tsgo:core:test, lint:core, runtime sidecar loaders, import cycles, webhook body guard, pairing store guard, pairing account guard — all passed).

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: supervisor capture disabled with full callback streaming; default capture path retains full output (regression check); prepared CLI runner bounded diagnostic behavior; oversized successful stdout rejection; oversized fresh JSONL incremental parsing; oversized resumed JSONL incremental parsing; failure classification from parse buffer before diagnostic tail; existing CLI output parsing and runner spawn/reliability tests.
- Edge cases checked: 2 MiB stdout, JSONL final result after a 2 MiB tool delta, resumed JSONL final result after a 2 MiB tool delta, non-JSONL stdout over the parse limit, noisy failed stdout where the diagnostic tail does not contain the actionable error, callback streaming with capture disabled.
- What you did **not** verify: full live Gateway execution against an external CLI provider; `pnpm build` is not included in the final green set because a prior local build attempt hit an existing CLI bootstrap import guard for `json5` outside this diff.

AI-assisted: Yes. This change was implemented with Codex assistance; a local Codex review finding was addressed, and the final rerun was blocked by Codex usage limits.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No GitHub review conversations exist yet for this new PR.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: successful non-JSONL CLI output above the parse limit now fails instead of relying on retained full supervisor stdout.
  - Mitigation: JSONL output is parsed incrementally for large valid streamed runs, including resumed JSONL output, and non-JSONL oversized stdout cannot be safely parsed without reintroducing unbounded retention.
