### PR TITLE
fix: hide subagent announce handoff prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/maintenance: prune dedupe overflow against a stable excess count and keep active agent retries from starting duplicate runs after cache eviction. (#73841) Thanks @thesomewhatyou.
+- Control UI/subagents: suppress internal `subagent_announce` handoff prompts from requester transcripts and hide legacy inter-session wrapper rows so completed subagent results no longer surface runtime context in WebChat history. Fixes #79071. Thanks @CjTruHeart and @COOLBGT.
 - Discord: preserve username target resolution for Discord outbound sends. (#79076) Thanks @vincentkoc.
 - Gateway/sessions: rotate generated transcript paths when gateway sessions reset, complementing the daily-rollover transcript persistence. (#79076) Thanks @vincentkoc.
 - Dependencies: pin the transitive `fast-uri` production dependency to `3.1.2` so the production dependency audit no longer resolves the vulnerable `<=3.1.1` range. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,7 +203,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/maintenance: prune dedupe overflow against a stable excess count and keep active agent retries from starting duplicate runs after cache eviction. (#73841) Thanks @thesomewhatyou.
-- Control UI/subagents: suppress internal `subagent_announce` handoff prompts from requester transcripts and hide legacy inter-session wrapper rows so completed subagent results no longer surface runtime context in WebChat history. Fixes #79071. Thanks @CjTruHeart and @COOLBGT.
+- Control UI/subagents: suppress internal `subagent_announce` handoff prompts from requester transcripts and hide legacy inter-session wrapper rows so completed subagent results no longer surface runtime context in WebChat history. (#79618) Thanks @joshavant.
 - Discord: preserve username target resolution for Discord outbound sends. (#79076) Thanks @vincentkoc.
 - Gateway/sessions: rotate generated transcript paths when gateway sessions reset, complementing the daily-rollover transcript persistence. (#79076) Thanks @vincentkoc.
 - Dependencies: pin the transitive `fast-uri` production dependency to `3.1.2` so the production dependency audit no longer resolves the vulnerable `<=3.1.1` range. Thanks @shakkernerd.

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -804,6 +804,38 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(attemptCalls[1]?.suppressPromptPersistenceOnRetry).toBe(true);
   });
 
+  it("suppresses prompt persistence for internal handoffs on every fallback attempt", async () => {
+    type AttemptCall = {
+      suppressPromptPersistenceOnRetry?: boolean;
+    };
+    const attemptCalls: AttemptCall[] = [];
+    state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
+      const first = await params.run(params.provider, params.model);
+      const result = await params.run(params.provider, params.model);
+      return {
+        result,
+        provider: params.provider,
+        model: params.model,
+        attempts: [first],
+      };
+    });
+    state.runAgentAttemptMock.mockImplementation(async (attemptParams: AttemptCall) => {
+      attemptCalls.push(attemptParams);
+      return makeSuccessResult("openai", "gpt-5.4");
+    });
+
+    await agentCommand({
+      message: "internal handoff",
+      to: "+1234567890",
+      senderIsOwner: true,
+      suppressPromptPersistence: true,
+    });
+
+    expect(attemptCalls).toHaveLength(2);
+    expect(attemptCalls[0]?.suppressPromptPersistenceOnRetry).toBe(true);
+    expect(attemptCalls[1]?.suppressPromptPersistenceOnRetry).toBe(true);
+  });
+
   it("propagates non-switch errors without retrying and emits lifecycle error", async () => {
     state.runWithModelFallbackMock.mockRejectedValueOnce(new Error("provider down"));
 

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1046,7 +1046,9 @@ async function agentCommandInternal(
               allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
               sessionHasHistory:
                 !isNewSession || (await attemptExecutionRuntime.sessionFileHasContent(sessionFile)),
-              suppressPromptPersistenceOnRetry: isFallbackRetry && currentTurnUserMessagePersisted,
+              suppressPromptPersistenceOnRetry:
+                opts.suppressPromptPersistence === true ||
+                (isFallbackRetry && currentTurnUserMessagePersisted),
               onUserMessagePersisted: () => {
                 currentTurnUserMessagePersisted = true;
               },

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -118,6 +118,8 @@ export type AgentCommandOpts = {
   promptMode?: PromptMode;
   /** Internal ACP-ready session turn source. Manual spawn turns bypass only the dispatch gate. */
   acpTurnSource?: AcpTurnSource;
+  /** Internal handoffs can feed the model without writing the synthetic prompt to transcript. */
+  suppressPromptPersistence?: boolean;
 };
 
 export type AgentCommandIngressOpts = Omit<

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -1,6 +1,10 @@
 import { isHeartbeatOkResponse, isHeartbeatUserMessage } from "../auto-reply/heartbeat-filter.js";
 import { HEARTBEAT_PROMPT } from "../auto-reply/heartbeat.js";
 import {
+  INTER_SESSION_PROMPT_PREFIX_BASE,
+  normalizeInputProvenance,
+} from "../sessions/input-provenance.js";
+import {
   parseAssistantTextSignature,
   resolveAssistantMessagePhase,
 } from "../shared/chat-message-content.js";
@@ -505,10 +509,44 @@ function isEmptyTextOnlyContent(content: unknown): boolean {
   return sawText;
 }
 
+function extractProjectedText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const text = (block as { text?: unknown }).text;
+    if (typeof text === "string") {
+      parts.push(text);
+    }
+  }
+  return parts.join("\n");
+}
+
+function isSubagentAnnounceInterSessionUserMessage(message: Record<string, unknown>): boolean {
+  const provenance = normalizeInputProvenance(message.provenance);
+  if (provenance?.kind === "inter_session" && provenance.sourceTool === "subagent_announce") {
+    return true;
+  }
+  const text = extractProjectedText(message.content ?? message.text);
+  return (
+    text.includes(INTER_SESSION_PROMPT_PREFIX_BASE) && text.includes("sourceTool=subagent_announce")
+  );
+}
+
 function shouldHideProjectedHistoryMessage(message: Record<string, unknown>): boolean {
   const roleContent = asRoleContentMessage(message);
   if (!roleContent) {
     return false;
+  }
+  if (roleContent.role === "user" && isSubagentAnnounceInterSessionUserMessage(message)) {
+    return true;
   }
   if (roleContent.role === "user" && isEmptyTextOnlyContent(message.content ?? message.text)) {
     return true;

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1061,6 +1061,49 @@ describe("gateway agent handler", () => {
     resetTimeConfig();
   });
 
+  it("suppresses persisted prompts for subagent announce task-completion handoffs", async () => {
+    primeMainAgentRun({ cfg: mocks.loadConfigReturn });
+    mocks.agentCommand.mockClear();
+
+    await invokeAgent(
+      {
+        message: "runtime-only announce bookkeeping",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: "agent:main:subagent:child",
+          sourceTool: "subagent_announce",
+        },
+        internalEvents: [
+          {
+            type: "task_completion",
+            source: "subagent",
+            childSessionKey: "agent:main:subagent:child",
+            childSessionId: "child-session-id",
+            announceType: "completion",
+            taskLabel: "child task",
+            status: "ok",
+            statusLabel: "completed",
+            result: "child result",
+            statsLine: "tokens=10",
+            replyInstruction: "Deliver the child result.",
+          },
+        ],
+        idempotencyKey: "test-subagent-announce-suppress-prompt",
+      },
+      { reqId: "subagent-announce-suppress-prompt" },
+    );
+
+    const callArgs = await waitForAgentCommandCall<{
+      suppressPromptPersistence?: boolean;
+      message?: string;
+    }>();
+    expect(callArgs.suppressPromptPersistence).toBe(true);
+    expect(callArgs.message).toMatch(/^\[Inter-session message\]/);
+    expect(callArgs.message).toContain("sourceTool=subagent_announce");
+  });
+
   it("rejects public transcriptMessage overrides", async () => {
     primeMainAgentRun({ cfg: mocks.loadConfigReturn });
     mocks.agentCommand.mockClear();

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -9,6 +9,7 @@ import {
   resolveAgentAvatar,
   resolvePublicAgentAvatarSource,
 } from "../../agents/identity-avatar.js";
+import { AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION } from "../../agents/internal-event-contract.js";
 import type { AgentInternalEvent } from "../../agents/internal-events.js";
 import { resolveTrustedGroupId } from "../../agents/pi-tools.policy.js";
 import { resolveSandboxConfigForAgent } from "../../agents/sandbox/config.js";
@@ -509,6 +510,24 @@ function dispatchAgentRunFromGateway(params: {
         params.context.chatAbortControllers.delete(params.runId);
       }
     });
+}
+
+function shouldSuppressAgentPromptPersistence(params: {
+  inputProvenance?: InputProvenance;
+  internalEvents?: AgentInternalEvent[];
+}): boolean {
+  if (
+    params.inputProvenance?.kind !== "inter_session" ||
+    params.inputProvenance.sourceTool !== "subagent_announce"
+  ) {
+    return false;
+  }
+  return (
+    params.internalEvents?.some(
+      (event) =>
+        event.type === AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION && event.source === "subagent",
+    ) === true
+  );
 }
 
 function yieldAfterAgentAcceptedAck(): Promise<void> {
@@ -1414,6 +1433,10 @@ export const agentHandlers: GatewayRequestHandlers = {
             acpTurnSource: request.acpTurnSource,
             internalEvents: request.internalEvents,
             inputProvenance,
+            suppressPromptPersistence: shouldSuppressAgentPromptPersistence({
+              inputProvenance,
+              internalEvents: request.internalEvents,
+            }),
             cleanupBundleMcpOnRunEnd: request.cleanupBundleMcpOnRunEnd,
             abortSignal: activeRunAbort.controller.signal,
             // Internal-only: allow workspace override for spawned subagent runs.

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -205,6 +205,47 @@ describe("SessionHistorySseState", () => {
     ]);
   });
 
+  test("drops subagent announce inter-session user messages from projected history", () => {
+    const snapshot = buildSessionHistorySnapshot({
+      rawMessages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: [
+                "[Inter-session message] sourceSession=agent:main:subagent:child sourceChannel=webchat sourceTool=subagent_announce isUser=false",
+                "This content was routed by OpenClaw from another session or internal tool.",
+                "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+                "subagent completion payload",
+                "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+              ].join("\n"),
+            },
+          ],
+          provenance: {
+            kind: "inter_session",
+            sourceSessionKey: "agent:main:subagent:child",
+            sourceTool: "subagent_announce",
+          },
+          __openclaw: { seq: 1 },
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "clean child result" }],
+          __openclaw: { seq: 2 },
+        },
+      ],
+    });
+
+    expect(snapshot.history.messages).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "clean child result" }],
+        __openclaw: { seq: 2 },
+      },
+    ]);
+  });
+
   test("hides heartbeat prompt and ok acknowledgements from visible history", () => {
     const snapshot = buildSessionHistorySnapshot({
       rawMessages: [


### PR DESCRIPTION
## Summary

- Problem: subagent completion announces were persisted as requester `user` turns and could surface `[Inter-session message] ... sourceTool=subagent_announce` runtime context in Control UI/WebChat history.
- Why it matters: completed subagent results should reach the requester without exposing internal handoff metadata or polluting the requester transcript.
- What changed: suppress transcript persistence for internal subagent task-completion handoff prompts, and filter legacy subagent announce inter-session rows from `chat.history` projection.
- What did NOT change (scope boundary): normal user-authored inter-session messages, subagent child transcripts, and assistant completion delivery remain intact.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #79071
- Related #62306
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: live `sessions_spawn` completion announce into a requester WebChat session.
- Real environment tested: local contained Gateway, live OpenAI Responses model `openai/gpt-5.4-mini`, branch `release/2026.5.7` at `abffed82d8` before and after applying this patch.
- Exact steps or command run after this patch: started Gateway with contained state/config, connected over Gateway WebSocket as an operator client, created a dashboard session, sent a parent prompt that calls `sessions_spawn` with an isolated child and then `sessions_yield`, then inspected both raw JSONL transcript messages and `chat.history`.
- Evidence after fix (copied live output):

```json
{
  "marker": "CHILD-79071-RELEASE-FIX",
  "chatSendOk": true,
  "rawMessageCount": 10,
  "rawUserCount": 1,
  "historyCount": 8,
  "rawUserHasInternalBegin": false,
  "rawUserHasInterSession": false,
  "rawUserHasSubagentAnnounce": false,
  "rawAssistantHasChildToken": true,
  "historyHasInternalBegin": false,
  "historyHasInterSession": false,
  "historyHasSubagentAnnounce": false,
  "historyAssistantHasChildToken": true,
  "rawUserSnippets": [],
  "historySnippets": []
}
```

- Observed result after fix: child result delivered to the requester, while neither the raw requester transcript nor `chat.history` contains the internal announce wrapper.
- What was not tested: Discord thread-bound UI rendering and non-OpenAI providers.
- Before evidence:

```json
{
  "marker": "CHILD-79071-RELEASE-BASE",
  "chatSendOk": true,
  "rawMessageCount": 11,
  "rawUserCount": 2,
  "historyCount": 9,
  "rawUserHasInternalBegin": true,
  "rawUserHasInterSession": true,
  "rawUserHasSubagentAnnounce": true,
  "rawAssistantHasChildToken": true,
  "historyHasInternalBegin": false,
  "historyHasInterSession": true,
  "historyHasSubagentAnnounce": true,
  "historyAssistantHasChildToken": true
}
```

## Root Cause (if applicable)

- Root cause: the subagent announce path handed runtime-generated task-completion context back through the requester agent as a normal prompt, so Pi persisted it as a requester `user` message; `chat.history` then projected the persisted inter-session wrapper.
- Missing detection / guardrail: tests covered delivery mechanics but not the transcript/display hygiene for internal `subagent_announce` completion handoffs.
- Contributing context (if known): older affected transcripts may already contain these wrapper rows, so display projection also needs a legacy filter.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-methods/agent.test.ts`, `src/gateway/session-history-state.test.ts`, `src/agents/agent-command.live-model-switch.test.ts`.
- Scenario the test should lock in: internal subagent task-completion announces set prompt persistence suppression, legacy subagent announce rows are hidden from history projection, and fallback/model-switch retries preserve suppression.
- Why this is the smallest reliable guardrail: it covers the Gateway handoff seam, the persisted-history projection seam, and the agent-command retry seam without requiring a live model for every CI run.
- Existing test that already covers this (if any): `src/agents/session-tool-result-guard.test.ts` remains adjacent guard coverage for tool result/session handling.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Completed subagent results still appear, but internal `subagent_announce` handoff prompts no longer appear as requester user turns in WebChat history.

## Diagram (if applicable)

```text
Before:
subagent completion -> internal announce prompt -> requester transcript user row -> WebChat wrapper leak

After:
subagent completion -> internal announce prompt -> requester assistant result, no persisted internal user row
legacy stored wrapper row -> chat.history projection filter -> hidden from WebChat
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local host
- Runtime/container: local Gateway with contained state/config; release branch validation used `release/2026.5.7` at `abffed82d8`
- Model/provider: OpenAI Responses, `openai/gpt-5.4-mini`
- Integration/channel (if any): WebChat/Gateway WebSocket; channels disabled for isolation
- Relevant config (redacted): token-auth loopback Gateway, coding tool profile, `sessions_spawn` available, OpenAI API key supplied via redacted env file

### Steps

1. Start Gateway from `release/2026.5.7` without this patch and connect over WebSocket.
2. Create a dashboard session and send a parent prompt that calls `sessions_spawn` with an isolated child and then `sessions_yield`.
3. Confirm the child marker reaches the requester.
4. Inspect the raw requester transcript and `chat.history` for `sourceTool=subagent_announce` / `[Inter-session message]`.
5. Apply this patch to the same release worktree and repeat the same live flow with fresh contained state.

### Expected

- Child result reaches the requester.
- Raw requester transcript has no internal `subagent_announce` user prompt after the initial user turn.
- `chat.history` has no inter-session wrapper row for the subagent announce.

### Actual

- Before patch: raw transcript and `chat.history` exposed the internal announce wrapper.
- After patch: child result delivered; no internal announce wrapper in raw transcript or `chat.history`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified:

- Focused tests: `pnpm test src/gateway/server-methods/agent.test.ts src/gateway/session-history-state.test.ts src/agents/agent-command.live-model-switch.test.ts src/agents/session-tool-result-guard.test.ts`
- Formatting: `pnpm exec oxfmt --check --threads=1 src/gateway/server-methods/agent.ts src/agents/command/types.ts src/agents/agent-command.ts src/gateway/chat-display-projection.ts src/gateway/server-methods/agent.test.ts src/gateway/session-history-state.test.ts src/agents/agent-command.live-model-switch.test.ts`
- Changelog attribution: `pnpm check:changelog-attributions`
- Changed gate: `pnpm check:changed` in Blacksmith Testbox, run https://github.com/openclaw/openclaw/actions/runs/25589137355
- Live validation on current feature branch with OpenAI: passed with no internal announce wrapper in raw transcript or `chat.history`.
- Live validation on `release/2026.5.7`: reproduced before patch, passed after patch.

Edge cases checked:

- Legacy persisted subagent announce row filtering.
- Fallback/model-switch retry path keeps prompt persistence suppression.
- Assistant completion still reaches the requester.

What I did not verify:

- Full `pnpm check` / full `pnpm test` after the final rebase.
- Discord thread-bound UI rendering.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: filtering too broadly could hide legitimate inter-session user content.
  - Mitigation: suppression and display filtering are scoped to `sourceTool=subagent_announce` plus subagent task-completion provenance, not all inter-session messages.
- Risk: suppressing persistence could drop child results.
  - Mitigation: live tests verify child assistant result still reaches requester, and regression tests cover the handoff/retry seams.
