### PR TITLE
fix(gateway/health): surface model-pricing bootstrap error in health endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/health: surface model-pricing bootstrap failures in `openclaw health` output as `model-pricing: degraded (...)` and expose them via the `health` endpoint `modelPricingError` field so degraded pricing state is visible without manually parsing gateway logs. Fixes #79599.
 - CLI: make parser, startup, config, guardrail, channel, agent, task, session, and MCP failures explain what happened and point to the next recovery command.
 - GitHub Copilot: refresh the model catalog from `${baseUrl}/models` so per-account entitlement and accurate context windows surface at runtime; static manifest catalog (now including `gpt-5.5`) remains the fallback when discovery is disabled or the API is unreachable.
 - Active Memory: support concrete `plugins.entries.active-memory.config.toolsAllow` recall tool names for custom memory plugins while keeping the built-in memory-core default on `memory_search`/`memory_get` and preserving `memory_recall` automatically for `plugins.slots.memory: "memory-lancedb"`.

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
   evaluateChannelHealth,
 } from "../gateway/channel-health-policy.js";
+import { getGatewayModelPricingBootstrapError } from "../gateway/model-pricing-cache.js";
 import type { ChannelRuntimeSnapshot } from "../gateway/server-channel-runtime.types.js";
 import { info } from "../globals.js";
 import { isTruthyEnvValue } from "../infra/env.js";
@@ -508,12 +509,14 @@ export async function getHealthSnapshot(params?: {
   }
 
   const pluginHealth = buildPluginHealthSummary();
+  const modelPricingError = getGatewayModelPricingBootstrapError();
   const summary: HealthSummary = {
     ok: true,
     ts: Date.now(),
     durationMs: Date.now() - start,
     ...(params?.eventLoop ? { eventLoop: params.eventLoop } : {}),
     ...(pluginHealth ? { plugins: pluginHealth } : {}),
+    ...(modelPricingError != null ? { modelPricingError } : {}),
     channels,
     channelOrder,
     channelLabels,
@@ -700,6 +703,11 @@ export async function healthCommand(
     const eventLoopLine = formatEventLoopHealthLine(summary);
     if (eventLoopLine) {
       runtime.log(styleHealthChannelLine(eventLoopLine, rich));
+    }
+    if (summary.modelPricingError) {
+      runtime.log(
+        styleHealthChannelLine(`model-pricing: degraded (${summary.modelPricingError})`, rich),
+      );
     }
     for (const plugin of displayPlugins) {
       const channelSummary = summary.channels?.[plugin.id];

--- a/src/commands/health.types.ts
+++ b/src/commands/health.types.ts
@@ -41,6 +41,7 @@ export type HealthSummary = {
   durationMs: number;
   eventLoop?: import("../gateway/server/event-loop-health.js").GatewayEventLoopHealth;
   plugins?: PluginHealthSummary;
+  modelPricingError?: string;
   channels: Record<string, ChannelHealthSummary>;
   channelOrder: string[];
   channelLabels: Record<string, string>;

--- a/src/gateway/model-pricing-cache-state.ts
+++ b/src/gateway/model-pricing-cache-state.ts
@@ -22,6 +22,7 @@ export type CachedModelPricing = {
 
 let cachedPricing = new Map<string, CachedModelPricing>();
 let cachedAt = 0;
+let lastBootstrapError: string | null = null;
 
 function modelPricingCacheKey(provider: string, model: string): string {
   const providerId = normalizeProviderId(provider);
@@ -47,6 +48,15 @@ export function replaceGatewayModelPricingCache(
 export function clearGatewayModelPricingCacheState(): void {
   cachedPricing = new Map();
   cachedAt = 0;
+  lastBootstrapError = null;
+}
+
+export function setGatewayModelPricingBootstrapError(error: string | null): void {
+  lastBootstrapError = error;
+}
+
+export function getGatewayModelPricingBootstrapError(): string | null {
+  return lastBootstrapError;
 }
 
 export function getCachedGatewayModelPricing(params: {

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -26,8 +26,10 @@ import { normalizeOptionalString, resolvePrimaryStringValue } from "../shared/st
 import {
   clearGatewayModelPricingCacheState,
   getCachedGatewayModelPricing,
+  getGatewayModelPricingBootstrapError,
   getGatewayModelPricingCacheMeta as getGatewayModelPricingCacheMetaState,
   replaceGatewayModelPricingCache,
+  setGatewayModelPricingBootstrapError,
   type CachedModelPricing,
   type CachedPricingTier,
 } from "./model-pricing-cache-state.js";
@@ -73,7 +75,7 @@ type ExternalPricingSourcePolicy = {
   modelIdTransforms: readonly PluginManifestModelPricingModelIdTransform[];
 };
 
-export { getCachedGatewayModelPricing };
+export { getCachedGatewayModelPricing, getGatewayModelPricingBootstrapError };
 
 type PricingModelNormalizationOptions = {
   allowManifestNormalization: boolean;
@@ -1317,6 +1319,7 @@ export async function refreshGatewayModelPricingCache(
       return;
     }
     replaceGatewayModelPricingCache(nextPricing);
+    setGatewayModelPricingBootstrapError(null);
     scheduleRefresh({ ...params, fetchImpl });
   })();
 
@@ -1342,7 +1345,9 @@ export function startGatewayModelPricingRefresh(
     }
     void refreshGatewayModelPricingCache({ ...params, signal: abortController.signal }).catch(
       (error: unknown) => {
-        log.warn(`pricing bootstrap failed: ${String(error)}`);
+        const message = String(error);
+        log.warn(`pricing bootstrap failed: ${message}`);
+        setGatewayModelPricingBootstrapError(message);
       },
     );
   });


### PR DESCRIPTION
## Summary

When the background pricing catalog fetch fails on cold gateway start, the failure is logged at WARN level only (`pricing bootstrap failed: TypeError: fetch failed`) but never surfaced in `openclaw health` output, the `/health` gateway endpoint, or `openclaw gateway status`. Users have no way to know pricing data is unavailable without manually parsing gateway JSON logs.

## Fix

Three-layer additive change:

**`model-pricing-cache-state.ts`** — add `lastBootstrapError: string | null` module-level state with `setGatewayModelPricingBootstrapError(error)` (called on failure) and `getGatewayModelPricingBootstrapError()` (read by health). Cleared to `null` on successful refresh. `clearGatewayModelPricingCacheState` also resets it.

**`model-pricing-cache.ts`** — in `startGatewayModelPricingRefresh`, call `setGatewayModelPricingBootstrapError(message)` on catch and `setGatewayModelPricingBootstrapError(null)` after a successful `replaceGatewayModelPricingCache`. Re-export `getGatewayModelPricingBootstrapError` from the public module surface.

**`health.types.ts` + `health.ts`** — add optional `modelPricingError?: string` to `HealthSummary`. In `getHealthSnapshot`, call `getGatewayModelPricingBootstrapError()` and include it if non-null. In `healthCommand` output, render `model-pricing: degraded (${summary.modelPricingError})` alongside the event-loop line so it appears in plain and JSON output alike.

## Behavior proof

**Before:** cold start with network blocked → `pricing bootstrap failed: TypeError: fetch failed` in gateway log → `openclaw health` shows no pricing warning → users assume pricing works.

**After:** same scenario → `health` endpoint returns `{ "modelPricingError": "TypeError: fetch failed", ... }` → `openclaw health` prints `model-pricing: degraded (TypeError: fetch failed)` → degradation is immediately visible. Successful subsequent fetch clears the error.

No liveness semantics change: `ok: true` is preserved — this is a non-fatal degraded subsystem warning only.

## Test plan

- `pnpm test src/gateway/model-pricing-cache.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/gateway/model-pricing-cache-state.ts src/gateway/model-pricing-cache.ts src/commands/health.types.ts src/commands/health.ts CHANGELOG.md`

Fixes #79599.