### PR TITLE
fix(gateway): do not mark event-loop degraded from ELU/CPU without actual delay evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway: stop marking `eventLoop.degraded` from ELU or CPU saturation when no actual event-loop delay is present, fixing false-positive health warnings on idle gateways with no blocking. Fixes #79017. Thanks @1yihui.
 - Telegram: preserve the channel-specific 10-option poll cap in the unified outbound adapter so over-limit polls are rejected before send. (#78762) Thanks @obviyus.
 - Runtime/install: raise the supported Node 22 floor to `22.16+` so native SQLite query handling can rely on the `node:sqlite` statement metadata API while continuing to recommend Node 24. (#78921)
 - Discord/voice: stream ElevenLabs TTS directly into Discord playback and send ElevenLabs latency optimization as the documented query parameter so spoken replies can start sooner.

--- a/src/gateway/server/event-loop-health.test.ts
+++ b/src/gateway/server/event-loop-health.test.ts
@@ -80,10 +80,16 @@ describe("createGatewayEventLoopHealthMonitor", () => {
     expect(harness.cpuUsage).toHaveBeenCalledTimes(1);
     expect(harness.eventLoopUtilization).toHaveBeenCalledTimes(1);
 
+    // With no delay evidence (delayMaxMs=0), ELU=1.0 and cpuCoreRatio=1.0 must NOT
+    // trigger degraded. perf_hooks.eventLoopUtilization() saturates at 1.0 whenever
+    // the loop is kept busy with frequent short async work, even when it never
+    // blocks. cpuCoreRatio is aggregated across all cores and can exceed 1.0 without
+    // indicating single-core saturation. Both require actual delay to be meaningful.
+    // See: https://github.com/openclaw/openclaw/issues/79017
     harness.setNow(1_000);
     expect(harness.monitor.snapshot()).toMatchObject({
-      degraded: true,
-      reasons: ["event_loop_utilization", "cpu"],
+      degraded: false,
+      reasons: [],
       intervalMs: 1_000,
       delayP99Ms: 0,
       delayMaxMs: 0,
@@ -103,6 +109,24 @@ describe("createGatewayEventLoopHealthMonitor", () => {
       intervalMs: 42,
       delayP99Ms: 0,
       delayMaxMs: 1_500,
+    });
+  });
+
+  it("reports utilization and cpu reasons only when delay evidence also present", () => {
+    const harness = createMonitorHarness();
+    harness.setDelay({ maxMs: 1_200 }); // delay above EVENT_LOOP_DELAY_WARN_MS (1000)
+    harness.setNow(1_000);
+
+    // With utilization=1, cpuCoreRatio=1 AND delay evidence present → degraded with
+    // all three reasons.
+    expect(harness.monitor.snapshot()).toMatchObject({
+      degraded: true,
+      reasons: ["event_loop_delay", "event_loop_utilization", "cpu"],
+      intervalMs: 1_000,
+      delayP99Ms: 0,
+      delayMaxMs: 1_200,
+      utilization: 1,
+      cpuCoreRatio: 1,
     });
   });
 

--- a/src/gateway/server/event-loop-health.ts
+++ b/src/gateway/server/event-loop-health.ts
@@ -66,10 +66,24 @@ function resolveGatewayEventLoopHealthReasons(params: {
   ) {
     reasons.push("event_loop_delay");
   }
-  if (hasSustainedLoadWindow && params.utilization >= EVENT_LOOP_UTILIZATION_WARN) {
+  // Require actual event-loop delay evidence before attributing degradation to
+  // utilization or CPU saturation. perf_hooks.eventLoopUtilization() returns 1.0
+  // whenever the loop is kept busy with frequent short async work (websocket
+  // keepalives, libuv microtasks) even when it never blocks. Similarly,
+  // cpuCoreRatio is aggregated across all cores and can exceed 1.0 on
+  // multi-core systems without indicating actual saturation. Neither is
+  // sufficient grounds for a degraded flag on its own.
+  // See: https://github.com/openclaw/openclaw/issues/79017
+  const hasDelayEvidence =
+    params.delayP99Ms >= EVENT_LOOP_DELAY_WARN_MS || params.delayMaxMs >= EVENT_LOOP_DELAY_WARN_MS;
+  if (
+    hasSustainedLoadWindow &&
+    params.utilization >= EVENT_LOOP_UTILIZATION_WARN &&
+    hasDelayEvidence
+  ) {
     reasons.push("event_loop_utilization");
   }
-  if (hasSustainedLoadWindow && params.cpuCoreRatio >= CPU_CORE_RATIO_WARN) {
+  if (hasSustainedLoadWindow && params.cpuCoreRatio >= CPU_CORE_RATIO_WARN && hasDelayEvidence) {
     reasons.push("cpu");
   }
 

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -303,13 +303,31 @@ function sampleDiagnosticLiveness(now: number): DiagnosticLivenessSample | null 
   ) {
     reasons.push("event_loop_delay");
   }
-  if (eventLoopUtilizationRatio >= DEFAULT_LIVENESS_EVENT_LOOP_UTILIZATION_WARN) {
+  // Require actual event-loop delay evidence before attributing the warning to
+  // utilization or CPU saturation. perf_hooks.eventLoopUtilization() saturates at
+  // 1.0 whenever the loop is kept busy with frequent short async work even when it
+  // never blocks. cpuCoreRatio is aggregated across all cores and can exceed 1.0
+  // without indicating single-core saturation. Both require delay evidence to be
+  // meaningful degradation signals.
+  // Corresponds to: https://github.com/openclaw/openclaw/issues/79017
+  const hasDelayEvidence =
+    eventLoopDelayP99Ms >= DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS ||
+    eventLoopDelayMaxMs >= DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS;
+  if (
+    hasDelayEvidence &&
+    eventLoopUtilizationRatio >= DEFAULT_LIVENESS_EVENT_LOOP_UTILIZATION_WARN
+  ) {
     reasons.push("event_loop_utilization");
   }
-  if (cpuCoreRatio >= DEFAULT_LIVENESS_CPU_CORE_RATIO_WARN) {
+  if (hasDelayEvidence && cpuCoreRatio >= DEFAULT_LIVENESS_CPU_CORE_RATIO_WARN) {
     reasons.push("cpu");
   }
-  if (reasons.length === 0) {
+  const hasAnyMetric =
+    eventLoopDelayP99Ms >= DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS ||
+    eventLoopDelayMaxMs >= DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS ||
+    eventLoopUtilizationRatio >= DEFAULT_LIVENESS_EVENT_LOOP_UTILIZATION_WARN ||
+    cpuCoreRatio >= DEFAULT_LIVENESS_CPU_CORE_RATIO_WARN;
+  if (!hasAnyMetric) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

Fix false positive in event-loop health monitoring where idle gateways with no event-loop blocking were incorrectly flagged as degraded.

## Root cause

`perf_hooks.eventLoopUtilization()` returns 1.0 whenever the loop is kept busy with frequent short async work (websocket keepalives, libuv microtasks) even when it never blocks. Similarly, `cpuCoreRatio` is aggregated across all cores and can exceed 1.0 on multi-core systems without indicating actual single-core saturation. Neither is sufficient grounds for a `degraded` flag on its own.

## Fix

Require actual event-loop delay evidence (`delayMaxMs` or `delayP99Ms >= 1000ms`) before adding `event_loop_utilization` or `cpu` reasons to the degraded state. The `event_loop_delay` reason continues to fire independently based on actual blocking evidence.

Files changed:
- `src/gateway/server/event-loop-health.ts` — add `hasDelayEvidence` guard before ELU/CPU reasons
- `src/gateway/server/event-loop-health.test.ts` — fix existing test; add new case for delay+ELU+CPU combination
- `src/logging/diagnostic.ts` — same fix for the liveness warning path (scoped to preserve CPU-only telemetry)
- `CHANGELOG.md` — add fix entry

**Review fixes applied:**
- Removed unrelated `data/gh-issues-*.json` files
- Added CHANGELOG.md entry  
- Scoped diagnostic change to preserve CPU-only telemetry samples

Corresponds to: https://github.com/openclaw/openclaw/issues/79017
