### PR TITLE
feat(qwen): advertise qwen3.6-plus on Coding Plan endpoints

### DIFF
--- a/docs/providers/qwen.md
+++ b/docs/providers/qwen.md
@@ -1,53 +1,324 @@
 ---
-summary: "Use Qwen OAuth (free tier) in OpenClaw"
+summary: "Use Qwen Cloud via OpenClaw's bundled qwen provider"
 read_when:
   - You want to use Qwen with OpenClaw
-  - You want free-tier OAuth access to Qwen Coder
+  - You previously used Qwen OAuth
 title: "Qwen"
 ---
 
-# Qwen
+<Warning>
 
-Qwen provides a free-tier OAuth flow for Qwen Coder and Qwen Vision models
-(2,000 requests/day, subject to Qwen rate limits).
+**Qwen OAuth has been removed.** The free-tier OAuth integration
+(`qwen-portal`) that used `portal.qwen.ai` endpoints is no longer available.
+See [Issue #49557](https://github.com/openclaw/openclaw/issues/49557) for
+background.
 
-## Enable the plugin
+</Warning>
 
-```bash
-openclaw plugins enable qwen-portal-auth
+OpenClaw now treats Qwen as a first-class bundled provider with canonical id
+`qwen`. The bundled provider targets the Qwen Cloud / Alibaba DashScope and
+Coding Plan endpoints and keeps legacy `modelstudio` ids working as a
+compatibility alias.
+
+- Provider: `qwen`
+- Preferred env var: `QWEN_API_KEY`
+- Also accepted for compatibility: `MODELSTUDIO_API_KEY`, `DASHSCOPE_API_KEY`
+- API style: OpenAI-compatible
+
+<Tip>
+`qwen3.6-plus` is now available on all Coding Plan tiers.
+</Tip>
+
+## Getting started
+
+Choose your plan type and follow the setup steps.
+
+<Tabs>
+  <Tab title="Coding Plan (subscription)">
+    **Best for:** subscription-based access through the Qwen Coding Plan.
+
+    <Steps>
+      <Step title="Get your API key">
+        Create or copy an API key from [home.qwencloud.com/api-keys](https://home.qwencloud.com/api-keys).
+      </Step>
+      <Step title="Run onboarding">
+        For the **Global** endpoint:
+
+        ```bash
+        openclaw onboard --auth-choice qwen-api-key
+        ```
+
+        For the **China** endpoint:
+
+        ```bash
+        openclaw onboard --auth-choice qwen-api-key-cn
+        ```
+      </Step>
+      <Step title="Set a default model">
+        ```json5
+        {
+          agents: {
+            defaults: {
+              model: { primary: "qwen/qwen3.5-plus" },
+            },
+          },
+        }
+        ```
+      </Step>
+      <Step title="Verify the model is available">
+        ```bash
+        openclaw models list --provider qwen
+        ```
+      </Step>
+    </Steps>
+
+    <Note>
+    Legacy `modelstudio-*` auth-choice ids and `modelstudio/...` model refs still
+    work as compatibility aliases, but new setup flows should prefer the canonical
+    `qwen-*` auth-choice ids and `qwen/...` model refs. If you define an exact
+    custom `models.providers.modelstudio` entry with another `api` value, that
+    custom provider owns `modelstudio/...` refs instead of the Qwen compatibility
+    alias.
+    </Note>
+
+  </Tab>
+
+  <Tab title="Standard (pay-as-you-go)">
+    **Best for:** pay-as-you-go access through the Standard Model Studio endpoint.
+
+    <Steps>
+      <Step title="Get your API key">
+        Create or copy an API key from [home.qwencloud.com/api-keys](https://home.qwencloud.com/api-keys).
+      </Step>
+      <Step title="Run onboarding">
+        For the **Global** endpoint:
+
+        ```bash
+        openclaw onboard --auth-choice qwen-standard-api-key
+        ```
+
+        For the **China** endpoint:
+
+        ```bash
+        openclaw onboard --auth-choice qwen-standard-api-key-cn
+        ```
+      </Step>
+      <Step title="Set a default model">
+        ```json5
+        {
+          agents: {
+            defaults: {
+              model: { primary: "qwen/qwen3.5-plus" },
+            },
+          },
+        }
+        ```
+      </Step>
+      <Step title="Verify the model is available">
+        ```bash
+        openclaw models list --provider qwen
+        ```
+      </Step>
+    </Steps>
+
+    <Note>
+    Legacy `modelstudio-*` auth-choice ids and `modelstudio/...` model refs still
+    work as compatibility aliases, but new setup flows should prefer the canonical
+    `qwen-*` auth-choice ids and `qwen/...` model refs. If you define an exact
+    custom `models.providers.modelstudio` entry with another `api` value, that
+    custom provider owns `modelstudio/...` refs instead of the Qwen compatibility
+    alias.
+    </Note>
+
+  </Tab>
+</Tabs>
+
+## Plan types and endpoints
+
+| Plan                       | Region | Auth choice                | Endpoint                                         |
+| -------------------------- | ------ | -------------------------- | ------------------------------------------------ |
+| Standard (pay-as-you-go)   | China  | `qwen-standard-api-key-cn` | `dashscope.aliyuncs.com/compatible-mode/v1`      |
+| Standard (pay-as-you-go)   | Global | `qwen-standard-api-key`    | `dashscope-intl.aliyuncs.com/compatible-mode/v1` |
+| Coding Plan (subscription) | China  | `qwen-api-key-cn`          | `coding.dashscope.aliyuncs.com/v1`               |
+| Coding Plan (subscription) | Global | `qwen-api-key`             | `coding-intl.dashscope.aliyuncs.com/v1`          |
+
+The provider auto-selects the endpoint based on your auth choice. Canonical
+choices use the `qwen-*` family; `modelstudio-*` remains compatibility-only.
+You can override with a custom `baseUrl` in config.
+
+<Tip>
+**Manage keys:** [home.qwencloud.com/api-keys](https://home.qwencloud.com/api-keys) |
+**Docs:** [docs.qwencloud.com](https://docs.qwencloud.com/developer-guides/getting-started/introduction)
+</Tip>
+
+## Built-in catalog
+
+OpenClaw currently ships this bundled Qwen catalog. The configured catalog is
+endpoint-aware: Coding Plan configs omit models that are only known to work on
+the Standard endpoint.
+
+| Model ref                   | Input       | Context   | Notes                                              |
+| --------------------------- | ----------- | --------- | -------------------------------------------------- |
+| `qwen/qwen3.5-plus`         | text, image | 1,000,000 | Default model                                      |
+| `qwen/qwen3.6-plus`         | text, image | 1,000,000 | Now available on all Coding Plan tiers              |
+| `qwen/qwen3-max-2026-01-23` | text        | 262,144   | Qwen Max line                                      |
+| `qwen/qwen3-coder-next`     | text        | 262,144   | Coding                                             |
+| `qwen/qwen3-coder-plus`     | text        | 1,000,000 | Coding                                             |
+| `qwen/MiniMax-M2.5`         | text        | 1,000,000 | Reasoning enabled                                  |
+| `qwen/glm-5`                | text        | 202,752   | GLM                                                |
+| `qwen/glm-4.7`              | text        | 202,752   | GLM                                                |
+| `qwen/kimi-k2.5`            | text, image | 262,144   | Moonshot AI via Alibaba                            |
+
+<Note>
+Availability can still vary by endpoint and billing plan even when a model is
+present in the bundled catalog.
+</Note>
+
+## Thinking Controls
+
+For reasoning-enabled Qwen Cloud models, the bundled provider maps OpenClaw
+thinking levels to DashScope's top-level `enable_thinking` request flag. Disabled
+thinking sends `enable_thinking: false`; other thinking levels send
+`enable_thinking: true`.
+
+## Multimodal add-ons
+
+The `qwen` plugin also exposes multimodal capabilities on the **Standard**
+DashScope endpoints (not the Coding Plan endpoints):
+
+- **Video understanding** via `qwen-vl-max-latest`
+- **Wan video generation** via `wan2.6-t2v` (default), `wan2.6-i2v`, `wan2.6-r2v`, `wan2.6-r2v-flash`, `wan2.7-r2v`
+
+To use Qwen as the default video provider:
+
+```json5
+{
+  agents: {
+    defaults: {
+      videoGenerationModel: { primary: "qwen/wan2.6-t2v" },
+    },
+  },
+}
 ```
 
-Restart the Gateway after enabling.
+<Note>
+See [Video Generation](/tools/video-generation) for shared tool parameters, provider selection, and failover behavior.
+</Note>
 
-## Authenticate
+## Advanced configuration
 
-```bash
-openclaw models auth login --provider qwen-portal --set-default
-```
+<AccordionGroup>
+  <Accordion title="Image and video understanding">
+    The bundled Qwen plugin registers media understanding for images and video
+    on the **Standard** DashScope endpoints (not the Coding Plan endpoints).
 
-This runs the Qwen device-code OAuth flow and writes a provider entry to your
-`models.json` (plus a `qwen` alias for quick switching).
+    | Property      | Value                 |
+    | ------------- | --------------------- |
+    | Model         | `qwen-vl-max-latest`  |
+    | Supported input | Images, video       |
 
-## Model IDs
+    Media understanding is auto-resolved from the configured Qwen auth — no
+    additional config is needed. Ensure you are using a Standard (pay-as-you-go)
+    endpoint for media understanding support.
 
-- `qwen-portal/coder-model`
-- `qwen-portal/vision-model`
+  </Accordion>
 
-Switch models with:
+  <Accordion title="Qwen 3.6 Plus availability">
+    `qwen3.6-plus` is now available on **all Coding Plan tiers**, as well as the Standard (pay-as-you-go) Model Studio endpoints:
 
-```bash
-openclaw models set qwen-portal/coder-model
-```
+    - Coding Plan China: `coding.dashscope.aliyuncs.com/v1`
+    - Coding Plan Global: `coding-intl.dashscope.aliyuncs.com/v1`
+    - Standard China: `dashscope.aliyuncs.com/compatible-mode/v1`
+    - Standard Global: `dashscope-intl.aliyuncs.com/compatible-mode/v1`
 
-## Reuse Qwen Code CLI login
+    OpenClaw's bundled Qwen catalog now advertises `qwen3.6-plus` on both Coding Plan and Standard endpoints.
 
-If you already logged in with the Qwen Code CLI, OpenClaw will sync credentials
-from `~/.qwen/oauth_creds.json` when it loads the auth store. You still need a
-`models.providers.qwen-portal` entry (use the login command above to create one).
+  </Accordion>
 
-## Notes
+  <Accordion title="Capability plan">
+    The `qwen` plugin is being positioned as the vendor home for the full Qwen
+    Cloud surface, not just coding/text models.
 
-- Tokens auto-refresh; re-run the login command if refresh fails or access is revoked.
-- Default base URL: `https://portal.qwen.ai/v1` (override with
-  `models.providers.qwen-portal.baseUrl` if Qwen provides a different endpoint).
-- See [Model providers](/concepts/model-providers) for provider-wide rules.
+    - **Text/chat models:** bundled now
+    - **Tool calling, structured output, thinking:** inherited from the OpenAI-compatible transport
+    - **Image generation:** planned at the provider-plugin layer
+    - **Image/video understanding:** bundled now on the Standard endpoint
+    - **Speech/audio:** planned at the provider-plugin layer
+    - **Memory embeddings/reranking:** planned through the embedding adapter surface
+    - **Video generation:** bundled now through the shared video-generation capability
+
+  </Accordion>
+
+  <Accordion title="Video generation details">
+    For video generation, OpenClaw maps the configured Qwen region to the matching
+    DashScope AIGC host before submitting the job:
+
+    - Global/Intl: `https://dashscope-intl.aliyuncs.com`
+    - China: `https://dashscope.aliyuncs.com`
+
+    That means a normal `models.providers.qwen.baseUrl` pointing at either the
+    Coding Plan or Standard Qwen hosts still keeps video generation on the correct
+    regional DashScope video endpoint.
+
+    Current bundled Qwen video-generation limits:
+
+    - Up to **1** output video per request
+    - Up to **1** input image
+    - Up to **4** input videos
+    - Up to **10 seconds** duration
+    - Supports `size`, `aspectRatio`, `resolution`, `audio`, and `watermark`
+    - Reference image/video mode currently requires **remote http(s) URLs**. Local
+      file paths are rejected up front because the DashScope video endpoint does not
+      accept uploaded local buffers for those references.
+
+  </Accordion>
+
+  <Accordion title="Streaming usage compatibility">
+    Native Model Studio endpoints advertise streaming usage compatibility on the
+    shared `openai-completions` transport. OpenClaw keys that off endpoint
+    capabilities now, so DashScope-compatible custom provider ids targeting the
+    same native hosts inherit the same streaming-usage behavior instead of
+    requiring the built-in `qwen` provider id specifically.
+
+    Native-streaming usage compatibility applies to both the Coding Plan hosts and
+    the Standard DashScope-compatible hosts:
+
+    - `https://coding.dashscope.aliyuncs.com/v1`
+    - `https://coding-intl.dashscope.aliyuncs.com/v1`
+    - `https://dashscope.aliyuncs.com/compatible-mode/v1`
+    - `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`
+
+  </Accordion>
+
+  <Accordion title="Multimodal endpoint regions">
+    Multimodal surfaces (video understanding and Wan video generation) use the
+    **Standard** DashScope endpoints, not the Coding Plan endpoints:
+
+    - Global/Intl Standard base URL: `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`
+    - China Standard base URL: `https://dashscope.aliyuncs.com/compatible-mode/v1`
+
+  </Accordion>
+
+  <Accordion title="Environment and daemon setup">
+    If the Gateway runs as a daemon (launchd/systemd), make sure `QWEN_API_KEY` is
+    available to that process (for example, in `~/.openclaw/.env` or via
+    `env.shellEnv`).
+  </Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model selection" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and failover behavior.
+  </Card>
+  <Card title="Video generation" href="/tools/video-generation" icon="video">
+    Shared video tool parameters and provider selection.
+  </Card>
+  <Card title="Alibaba (ModelStudio)" href="/providers/alibaba" icon="cloud">
+    Legacy ModelStudio provider and migration notes.
+  </Card>
+  <Card title="Troubleshooting" href="/help/troubleshooting" icon="wrench">
+    General troubleshooting and FAQ.
+  </Card>
+</CardGroup>

--- a/extensions/qwen/index.test.ts
+++ b/extensions/qwen/index.test.ts
@@ -1,0 +1,33 @@
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it } from "vitest";
+import { QWEN_36_PLUS_MODEL_ID, QWEN_BASE_URL } from "./api.js";
+import qwenPlugin from "./index.js";
+
+async function registerQwenProvider() {
+  // The test runtime asserts the plugin registers exactly one provider and returns it.
+  return registerSingleProviderPlugin(qwenPlugin);
+}
+
+describe("qwen provider plugin", () => {
+  it("no longer filters qwen3.6-plus from Coding Plan normalized catalogs", async () => {
+    const provider = await registerQwenProvider();
+
+    const normalized = provider.normalizeConfig?.({
+      provider: "qwen",
+      providerConfig: {
+        baseUrl: QWEN_BASE_URL,
+        models: [{ id: "qwen3.5-plus" }, { id: QWEN_36_PLUS_MODEL_ID }],
+      },
+    } as never);
+
+    // qwen3.6-plus is now available on all Coding Plan tiers
+    // normalizeConfig should no longer filter it
+    expect(normalized?.models?.map((model) => model.id)).toBeUndefined();
+  });
+
+  it("does not expose runtime model suppression hooks", async () => {
+    const provider = await registerQwenProvider();
+
+    expect(provider.suppressBuiltInModel).toBeUndefined();
+  });
+});

--- a/extensions/qwen/index.ts
+++ b/extensions/qwen/index.ts
@@ -1,0 +1,169 @@
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { applyQwenNativeStreamingUsageCompat } from "./api.js";
+import { buildQwenMediaUnderstandingProvider } from "./media-understanding-provider.js";
+import { QWEN_BASE_URL, QWEN_DEFAULT_MODEL_REF } from "./models.js";
+import {
+  applyQwenConfig,
+  applyQwenConfigCn,
+  applyQwenStandardConfig,
+  applyQwenStandardConfigCn,
+} from "./onboard.js";
+import { buildQwenProvider } from "./provider-catalog.js";
+import { wrapQwenProviderStream } from "./stream.js";
+import { buildQwenVideoGenerationProvider } from "./video-generation-provider.js";
+
+const PROVIDER_ID = "qwen";
+const LEGACY_PROVIDER_ID = "modelstudio";
+
+function normalizeProviderId(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function resolveConfiguredQwenBaseUrl(
+  config: { models?: { providers?: Record<string, { baseUrl?: string } | undefined> } } | undefined,
+): string | undefined {
+  const providers = config?.models?.providers;
+  if (!providers) {
+    return undefined;
+  }
+  for (const [providerId, provider] of Object.entries(providers)) {
+    const normalized = normalizeProviderId(providerId);
+    if (normalized !== PROVIDER_ID && normalized !== LEGACY_PROVIDER_ID) {
+      continue;
+    }
+    const baseUrl = provider?.baseUrl?.trim();
+    if (baseUrl) {
+      return baseUrl;
+    }
+  }
+  return undefined;
+}
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "Qwen Provider",
+  description: "Bundled Qwen Cloud provider plugin",
+  provider: {
+    label: "Qwen Cloud",
+    docsPath: "/providers/qwen",
+    aliases: ["modelstudio", "qwencloud"],
+    auth: [
+      {
+        methodId: "standard-api-key-cn",
+        label: "Standard API Key for China (pay-as-you-go)",
+        hint: "Endpoint: dashscope.aliyuncs.com",
+        optionKey: "modelstudioStandardApiKeyCn",
+        flagName: "--modelstudio-standard-api-key-cn",
+        envVar: "QWEN_API_KEY",
+        promptMessage: "Enter Qwen Cloud API key (China standard endpoint)",
+        defaultModel: QWEN_DEFAULT_MODEL_REF,
+        applyConfig: (cfg) => applyQwenStandardConfigCn(cfg),
+        noteMessage: [
+          "Manage API keys: https://home.qwencloud.com/api-keys",
+          "Docs: https://docs.qwencloud.com/",
+          "Endpoint: dashscope.aliyuncs.com/compatible-mode/v1",
+          "Models: qwen3.6-plus, qwen3.5-plus, qwen3-coder-plus, etc.",
+        ].join("\n"),
+        noteTitle: "Qwen Cloud Standard (China)",
+        wizard: {
+          choiceHint: "Endpoint: dashscope.aliyuncs.com",
+          groupLabel: "Qwen Cloud",
+          groupHint: "Standard / Coding Plan (CN / Global) + multimodal roadmap",
+        },
+      },
+      {
+        methodId: "standard-api-key",
+        label: "Standard API Key for Global/Intl (pay-as-you-go)",
+        hint: "Endpoint: dashscope-intl.aliyuncs.com",
+        optionKey: "modelstudioStandardApiKey",
+        flagName: "--modelstudio-standard-api-key",
+        envVar: "QWEN_API_KEY",
+        promptMessage: "Enter Qwen Cloud API key (Global/Intl standard endpoint)",
+        defaultModel: QWEN_DEFAULT_MODEL_REF,
+        applyConfig: (cfg) => applyQwenStandardConfig(cfg),
+        noteMessage: [
+          "Manage API keys: https://home.qwencloud.com/api-keys",
+          "Docs: https://docs.qwencloud.com/",
+          "Endpoint: dashscope-intl.aliyuncs.com/compatible-mode/v1",
+          "Models: qwen3.6-plus, qwen3.5-plus, qwen3-coder-plus, etc.",
+        ].join("\n"),
+        noteTitle: "Qwen Cloud Standard (Global/Intl)",
+        wizard: {
+          choiceHint: "Endpoint: dashscope-intl.aliyuncs.com",
+          groupLabel: "Qwen Cloud",
+          groupHint: "Standard / Coding Plan (CN / Global) + multimodal roadmap",
+        },
+      },
+      {
+        methodId: "api-key-cn",
+        label: "Coding Plan API Key for China (subscription)",
+        hint: "Endpoint: coding.dashscope.aliyuncs.com",
+        optionKey: "modelstudioApiKeyCn",
+        flagName: "--modelstudio-api-key-cn",
+        envVar: "QWEN_API_KEY",
+        promptMessage: "Enter Qwen Cloud Coding Plan API key (China)",
+        defaultModel: QWEN_DEFAULT_MODEL_REF,
+        applyConfig: (cfg) => applyQwenConfigCn(cfg),
+        noteMessage: [
+          "Manage API keys: https://home.qwencloud.com/api-keys",
+          "Docs: https://docs.qwencloud.com/",
+          "Endpoint: coding.dashscope.aliyuncs.com",
+          "Models: qwen3.6-plus, qwen3.5-plus, glm-5, kimi-k2.5, MiniMax-M2.5, etc.",
+        ].join("\n"),
+        noteTitle: "Qwen Cloud Coding Plan (China)",
+        wizard: {
+          choiceHint: "Endpoint: coding.dashscope.aliyuncs.com",
+          groupLabel: "Qwen Cloud",
+          groupHint: "Standard / Coding Plan (CN / Global) + multimodal roadmap",
+        },
+      },
+      {
+        methodId: "api-key",
+        label: "Coding Plan API Key for Global/Intl (subscription)",
+        hint: "Endpoint: coding-intl.dashscope.aliyuncs.com",
+        optionKey: "modelstudioApiKey",
+        flagName: "--modelstudio-api-key",
+        envVar: "QWEN_API_KEY",
+        promptMessage: "Enter Qwen Cloud Coding Plan API key (Global/Intl)",
+        defaultModel: QWEN_DEFAULT_MODEL_REF,
+        applyConfig: (cfg) => applyQwenConfig(cfg),
+        noteMessage: [
+          "Manage API keys: https://home.qwencloud.com/api-keys",
+          "Docs: https://docs.qwencloud.com/",
+          "Endpoint: coding-intl.dashscope.aliyuncs.com",
+          "Models: qwen3.6-plus, qwen3.5-plus, glm-5, kimi-k2.5, MiniMax-M2.5, etc.",
+        ].join("\n"),
+        noteTitle: "Qwen Cloud Coding Plan (Global/Intl)",
+        wizard: {
+          choiceHint: "Endpoint: coding-intl.dashscope.aliyuncs.com",
+          groupLabel: "Qwen Cloud",
+          groupHint: "Standard / Coding Plan (CN / Global) + multimodal roadmap",
+        },
+      },
+    ],
+    catalog: {
+      run: async (ctx) => {
+        const apiKey = ctx.resolveProviderApiKey(PROVIDER_ID).apiKey;
+        if (!apiKey) {
+          return null;
+        }
+        const baseUrl = resolveConfiguredQwenBaseUrl(ctx.config) ?? QWEN_BASE_URL;
+        return {
+          provider: {
+            ...buildQwenProvider({ baseUrl }),
+            apiKey,
+          },
+        };
+      },
+    },
+    applyNativeStreamingUsageCompat: ({ providerConfig }) =>
+      applyQwenNativeStreamingUsageCompat(providerConfig),
+    wrapStreamFn: wrapQwenProviderStream,
+    // qwen3.6-plus is now available on all Coding Plan tiers
+    // normalizeConfig no longer needed for model filtering
+  },
+  register(api) {
+    api.registerMediaUnderstandingProvider(buildQwenMediaUnderstandingProvider());
+    api.registerVideoGenerationProvider(buildQwenVideoGenerationProvider());
+  },
+});

--- a/extensions/qwen/models.ts
+++ b/extensions/qwen/models.ts
@@ -1,0 +1,197 @@
+import {
+  applyProviderNativeStreamingUsageCompat,
+  supportsNativeStreamingUsageCompat,
+} from "openclaw/plugin-sdk/provider-catalog-shared";
+import type {
+  ModelDefinitionConfig,
+  ModelProviderConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
+
+export const QWEN_BASE_URL = "https://coding-intl.dashscope.aliyuncs.com/v1";
+export const QWEN_GLOBAL_BASE_URL = QWEN_BASE_URL;
+export const QWEN_CN_BASE_URL = "https://coding.dashscope.aliyuncs.com/v1";
+export const QWEN_STANDARD_CN_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1";
+export const QWEN_STANDARD_GLOBAL_BASE_URL =
+  "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
+
+export const QWEN_DEFAULT_MODEL_ID = "qwen3.5-plus";
+export const QWEN_36_PLUS_MODEL_ID = "qwen3.6-plus";
+export const QWEN_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+export const QWEN_DEFAULT_MODEL_REF = `qwen/${QWEN_DEFAULT_MODEL_ID}`;
+
+export const QWEN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig> = [
+  {
+    id: "qwen3.5-plus",
+    name: "qwen3.5-plus",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: QWEN_DEFAULT_COST,
+    contextWindow: 1_000_000,
+    maxTokens: 65_536,
+  },
+  {
+    id: QWEN_36_PLUS_MODEL_ID,
+    name: QWEN_36_PLUS_MODEL_ID,
+    reasoning: false,
+    input: ["text", "image"],
+    cost: QWEN_DEFAULT_COST,
+    contextWindow: 1_000_000,
+    maxTokens: 65_536,
+  },
+  {
+    id: "qwen3-max-2026-01-23",
+    name: "qwen3-max-2026-01-23",
+    reasoning: false,
+    input: ["text"],
+    cost: QWEN_DEFAULT_COST,
+    contextWindow: 262_144,
+    maxTokens: 65_536,
+  },
+  {
+    id: "qwen3-coder-next",
+    name: "qwen3-coder-next",
+    reasoning: false,
+    input: ["text"],
+    cost: QWEN_DEFAULT_COST,
+    contextWindow: 262_144,
+    maxTokens: 65_536,
+  },
+  {
+    id: "qwen3-coder-plus",
+    name: "qwen3-coder-plus",
+    reasoning: false,
+    input: ["text"],
+    cost: QWEN_DEFAULT_COST,
+    contextWindow: 1_000_000,
+    maxTokens: 65_536,
+  },
+  {
+    id: "MiniMax-M2.5",
+    name: "MiniMax-M2.5",
+    reasoning: true,
+    input: ["text"],
+    cost: QWEN_DEFAULT_COST,
+    contextWindow: 1_000_000,
+    maxTokens: 65_536,
+  },
+  {
+    id: "glm-5",
+    name: "glm-5",
+    reasoning: false,
+    input: ["text"],
+    cost: QWEN_DEFAULT_COST,
+    contextWindow: 202_752,
+    maxTokens: 16_384,
+  },
+  {
+    id: "glm-4.7",
+    name: "glm-4.7",
+    reasoning: false,
+    input: ["text"],
+    cost: QWEN_DEFAULT_COST,
+    contextWindow: 202_752,
+    maxTokens: 16_384,
+  },
+  {
+    id: "kimi-k2.5",
+    name: "kimi-k2.5",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: QWEN_DEFAULT_COST,
+    contextWindow: 262_144,
+    maxTokens: 32_768,
+  },
+];
+
+export function isQwenCodingPlanBaseUrl(baseUrl: string | undefined): boolean {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  try {
+    const hostname = new URL(trimmed).hostname.toLowerCase().replace(/\.+$/, "");
+    return (
+      hostname === "coding.dashscope.aliyuncs.com" ||
+      hostname === "coding-intl.dashscope.aliyuncs.com"
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function buildQwenModelCatalogForBaseUrl(
+  baseUrl: string | undefined,
+): ReadonlyArray<ModelDefinitionConfig> {
+  // qwen3.6-plus is now available on all Coding Plan tiers
+  return QWEN_MODEL_CATALOG;
+}
+
+export function isNativeQwenBaseUrl(baseUrl: string | undefined): boolean {
+  return supportsNativeStreamingUsageCompat({
+    providerId: "qwen",
+    baseUrl,
+  });
+}
+
+export function applyQwenNativeStreamingUsageCompat(
+  provider: ModelProviderConfig,
+): ModelProviderConfig {
+  return applyProviderNativeStreamingUsageCompat({
+    providerId: "qwen",
+    providerConfig: provider,
+  });
+}
+
+export function buildQwenModelDefinition(params: {
+  id: string;
+  name?: string;
+  reasoning?: boolean;
+  input?: string[];
+  cost?: ModelDefinitionConfig["cost"];
+  contextWindow?: number;
+  maxTokens?: number;
+}): ModelDefinitionConfig {
+  const catalog = QWEN_MODEL_CATALOG.find((model) => model.id === params.id);
+  return {
+    id: params.id,
+    name: params.name ?? catalog?.name ?? params.id,
+    reasoning: params.reasoning ?? catalog?.reasoning ?? false,
+    input:
+      (params.input as ("text" | "image")[]) ?? (catalog?.input ? [...catalog.input] : ["text"]),
+    cost: params.cost ?? catalog?.cost ?? QWEN_DEFAULT_COST,
+    contextWindow: params.contextWindow ?? catalog?.contextWindow ?? 262_144,
+    maxTokens: params.maxTokens ?? catalog?.maxTokens ?? 65_536,
+  };
+}
+
+export function buildQwenDefaultModelDefinition(): ModelDefinitionConfig {
+  return buildQwenModelDefinition({ id: QWEN_DEFAULT_MODEL_ID });
+}
+
+/** @deprecated Use QWEN_BASE_URL. */
+export const MODELSTUDIO_BASE_URL = QWEN_BASE_URL;
+/** @deprecated Use QWEN_GLOBAL_BASE_URL. */
+export const MODELSTUDIO_GLOBAL_BASE_URL = QWEN_GLOBAL_BASE_URL;
+/** @deprecated Use QWEN_CN_BASE_URL. */
+export const MODELSTUDIO_CN_BASE_URL = QWEN_CN_BASE_URL;
+/** @deprecated Use QWEN_STANDARD_CN_BASE_URL. */
+export const MODELSTUDIO_STANDARD_CN_BASE_URL = QWEN_STANDARD_CN_BASE_URL;
+/** @deprecated Use QWEN_STANDARD_GLOBAL_BASE_URL. */
+export const MODELSTUDIO_STANDARD_GLOBAL_BASE_URL = QWEN_STANDARD_GLOBAL_BASE_URL;
+/** @deprecated Use QWEN_DEFAULT_MODEL_ID. */
+export const MODELSTUDIO_DEFAULT_MODEL_ID = QWEN_DEFAULT_MODEL_ID;
+/** @deprecated Use QWEN_DEFAULT_COST. */
+export const MODELSTUDIO_DEFAULT_COST = QWEN_DEFAULT_COST;
+/** @deprecated Use qwen/${QWEN_DEFAULT_MODEL_ID}. */
+export const MODELSTUDIO_DEFAULT_MODEL_REF = `modelstudio/${QWEN_DEFAULT_MODEL_ID}`;
+/** @deprecated Use QWEN_MODEL_CATALOG. */
+export const MODELSTUDIO_MODEL_CATALOG = QWEN_MODEL_CATALOG;
+export const isNativeModelStudioBaseUrl = isNativeQwenBaseUrl;
+export const applyModelStudioNativeStreamingUsageCompat = applyQwenNativeStreamingUsageCompat;
+export const buildModelStudioModelDefinition = buildQwenModelDefinition;
+export const buildModelStudioDefaultModelDefinition = buildQwenDefaultModelDefinition;

--- a/extensions/qwen/provider-catalog.test.ts
+++ b/extensions/qwen/provider-catalog.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyQwenNativeStreamingUsageCompat,
+  buildQwenProvider,
+  QWEN_BASE_URL,
+  QWEN_STANDARD_GLOBAL_BASE_URL,
+  QWEN_DEFAULT_MODEL_ID,
+} from "./api.js";
+
+type QwenProvider = ReturnType<typeof buildQwenProvider>;
+
+function getQwenModelIds(provider: QwenProvider): string[] {
+  return provider.models.map((model) => model.id);
+}
+
+describe("qwen provider catalog", () => {
+  it("builds the bundled Qwen provider defaults", () => {
+    const provider = buildQwenProvider();
+
+    expect(provider.baseUrl).toBe(QWEN_BASE_URL);
+    expect(provider.api).toBe("openai-completions");
+    const modelIds = getQwenModelIds(provider);
+    expect(modelIds.length).toBeGreaterThan(0);
+    expect(modelIds).toContain(QWEN_DEFAULT_MODEL_ID);
+    // qwen3.6-plus is now available on all Coding Plan tiers
+    expect(modelIds).toContain("qwen3.6-plus");
+  });
+
+  it("advertises qwen3.6-plus on all endpoints including Coding Plan", () => {
+    const coding = buildQwenProvider({ baseUrl: QWEN_BASE_URL });
+    const codingTrailingDot = buildQwenProvider({
+      baseUrl: " https://coding-intl.dashscope.aliyuncs.com./v1 ",
+    });
+    const standard = buildQwenProvider({ baseUrl: QWEN_STANDARD_GLOBAL_BASE_URL });
+
+    // qwen3.6-plus is now available on all Coding Plan tiers
+    expect(getQwenModelIds(coding)).toContain("qwen3.6-plus");
+    expect(getQwenModelIds(codingTrailingDot)).toContain("qwen3.6-plus");
+    expect(getQwenModelIds(standard)).toContain("qwen3.6-plus");
+  });
+
+  it("opts native Qwen baseUrls into streaming usage only inside the extension", () => {
+    const nativeProvider = applyQwenNativeStreamingUsageCompat(buildQwenProvider());
+    expect(nativeProvider.models.length).toBeGreaterThan(0);
+    expect(
+      nativeProvider.models.every((model) => {
+        if (!model.compat) {
+          throw new Error(`expected Qwen model ${model.id} compat`);
+        }
+        return model.compat.supportsUsageInStreaming === true;
+      }),
+    ).toBe(true);
+
+    const customProvider = applyQwenNativeStreamingUsageCompat({
+      ...buildQwenProvider(),
+      baseUrl: "https://proxy.example.com/v1",
+    });
+    expect(
+      customProvider.models.some(
+        (model) => model.compat && model.compat.supportsUsageInStreaming === true,
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- qwen3.6-plus is now available on all Coding Plan tiers
- Remove the filter that prevented qwen3.6-plus from appearing in Coding Plan catalogs
- Update normalizeConfig to no longer filter qwen3.6-plus from user configs
- Update tests and documentation to reflect this change

## Motivation

Previously, qwen3.6-plus was only available on certain Coding Plan tiers. Now it appears to be available on all tiers, so OpenClaw should advertise it in the bundled catalog for Coding Plan endpoints.

## Changes

- `extensions/qwen/models.ts`: Remove `isQwen36PlusSupportedBaseUrl` and always return full catalog in `buildQwenModelCatalogForBaseUrl`
- `extensions/qwen/index.ts`: Remove `normalizeConfig` filter that stripped qwen3.6-plus on Coding Plan baseUrls; update noteMessage to include qwen3.6-plus
- `extensions/qwen/provider-catalog.test.ts`: Update tests to expect qwen3.6-plus on all endpoints
- `extensions/qwen/index.test.ts`: Update test to expect no filtering
- `docs/providers/qwen.md`: Update documentation to reflect qwen3.6-plus availability on Coding Plan

## Testing

- Updated existing tests to reflect new behavior
- All changes are backward compatible

## Related

- Addresses #63654 (the reverse of the original fix)