### PR TITLE
feat(qwen): advertise qwen3.6-plus on Coding Plan endpoints

### DIFF
--- a/extensions/qwen/models.ts
+++ b/extensions/qwen/models.ts
@@ -124,16 +124,10 @@ export function isQwenCodingPlanBaseUrl(baseUrl: string | undefined): boolean {
   }
 }
 
-export function isQwen36PlusSupportedBaseUrl(baseUrl: string | undefined): boolean {
-  return !isQwenCodingPlanBaseUrl(baseUrl);
-}
-
 export function buildQwenModelCatalogForBaseUrl(
   baseUrl: string | undefined,
 ): ReadonlyArray<ModelDefinitionConfig> {
-  return isQwen36PlusSupportedBaseUrl(baseUrl)
-    ? QWEN_MODEL_CATALOG
-    : QWEN_MODEL_CATALOG.filter((model) => model.id !== QWEN_36_PLUS_MODEL_ID);
+  return QWEN_MODEL_CATALOG;
 }
 
 export function isNativeQwenBaseUrl(baseUrl: string | undefined): boolean {


### PR DESCRIPTION
## Summary

qwen3.6-plus is now available on all Coding Plan tiers. Remove the catalog filter that prevented it from appearing on Coding Plan endpoints.

## Changes

- Remove `isQwen36PlusSupportedBaseUrl` function (no longer needed)
- Simplify `buildQwenModelCatalogForBaseUrl` to always return the full catalog

This is the minimal change to enable qwen3.6-plus selection on Coding Plan.