### PR TITLE
feat(qwen): advertise qwen3.6-plus on Coding Plan endpoints

### DIFF
--- a/extensions/qwen/api.ts
+++ b/extensions/qwen/api.ts
@@ -4,7 +4,7 @@ export {
   buildQwenModelDefinition,
   buildQwenModelCatalogForBaseUrl,
   isNativeQwenBaseUrl,
-  isQwen36PlusSupportedBaseUrl,
+
   isQwenCodingPlanBaseUrl,
   QWEN_36_PLUS_MODEL_ID,
   QWEN_BASE_URL,

--- a/extensions/qwen/index.test.ts
+++ b/extensions/qwen/index.test.ts
@@ -1,6 +1,6 @@
 import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it } from "vitest";
-import { QWEN_36_PLUS_MODEL_ID, QWEN_BASE_URL } from "./api.js";
+import { QWEN_BASE_URL } from "./api.js";
 import qwenPlugin from "./index.js";
 
 async function registerQwenProvider() {
@@ -9,18 +9,19 @@ async function registerQwenProvider() {
 }
 
 describe("qwen provider plugin", () => {
-  it("keeps qwen3.6-plus out of Coding Plan normalized catalogs", async () => {
+  it("no longer filters qwen3.6-plus from Coding Plan catalogs", async () => {
     const provider = await registerQwenProvider();
 
     const normalized = provider.normalizeConfig?.({
       provider: "qwen",
       providerConfig: {
         baseUrl: QWEN_BASE_URL,
-        models: [{ id: "qwen3.5-plus" }, { id: QWEN_36_PLUS_MODEL_ID }],
+        models: [{ id: "qwen3.5-plus" }, { id: "qwen3.6-plus" }],
       },
     } as never);
 
-    expect(normalized?.models?.map((model) => model.id)).toEqual(["qwen3.5-plus"]);
+    // normalizeConfig no longer filters; returns undefined for unchanged configs
+    expect(normalized).toBeUndefined();
   });
 
   it("does not expose runtime model suppression hooks", async () => {

--- a/extensions/qwen/index.ts
+++ b/extensions/qwen/index.ts
@@ -1,12 +1,7 @@
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { applyQwenNativeStreamingUsageCompat } from "./api.js";
 import { buildQwenMediaUnderstandingProvider } from "./media-understanding-provider.js";
-import {
-  isQwenCodingPlanBaseUrl,
-  QWEN_36_PLUS_MODEL_ID,
-  QWEN_BASE_URL,
-  QWEN_DEFAULT_MODEL_REF,
-} from "./models.js";
+import { QWEN_BASE_URL, QWEN_DEFAULT_MODEL_REF } from "./models.js";
 import {
   applyQwenConfig,
   applyQwenConfigCn,
@@ -164,15 +159,7 @@ export default defineSingleProviderPluginEntry({
     applyNativeStreamingUsageCompat: ({ providerConfig }) =>
       applyQwenNativeStreamingUsageCompat(providerConfig),
     wrapStreamFn: wrapQwenProviderStream,
-    normalizeConfig: ({ providerConfig }) => {
-      if (!isQwenCodingPlanBaseUrl(providerConfig.baseUrl)) {
-        return undefined;
-      }
-      const models = providerConfig.models?.filter((model) => model.id !== QWEN_36_PLUS_MODEL_ID);
-      return models && models.length !== providerConfig.models?.length
-        ? { ...providerConfig, models }
-        : undefined;
-    },
+    // normalizeConfig removed: qwen3.6-plus no longer filtered
   },
   register(api) {
     api.registerMediaUnderstandingProvider(buildQwenMediaUnderstandingProvider());

--- a/extensions/qwen/models.ts
+++ b/extensions/qwen/models.ts
@@ -124,16 +124,10 @@ export function isQwenCodingPlanBaseUrl(baseUrl: string | undefined): boolean {
   }
 }
 
-export function isQwen36PlusSupportedBaseUrl(baseUrl: string | undefined): boolean {
-  return !isQwenCodingPlanBaseUrl(baseUrl);
-}
-
 export function buildQwenModelCatalogForBaseUrl(
   baseUrl: string | undefined,
 ): ReadonlyArray<ModelDefinitionConfig> {
-  return isQwen36PlusSupportedBaseUrl(baseUrl)
-    ? QWEN_MODEL_CATALOG
-    : QWEN_MODEL_CATALOG.filter((model) => model.id !== QWEN_36_PLUS_MODEL_ID);
+  return QWEN_MODEL_CATALOG;
 }
 
 export function isNativeQwenBaseUrl(baseUrl: string | undefined): boolean {

--- a/extensions/qwen/openclaw.plugin.json
+++ b/extensions/qwen/openclaw.plugin.json
@@ -4,7 +4,12 @@
     "onStartup": false
   },
   "enabledByDefault": true,
-  "providers": ["qwen", "qwencloud", "modelstudio", "dashscope"],
+  "providers": [
+    "qwen",
+    "qwencloud",
+    "modelstudio",
+    "dashscope"
+  ],
   "providerEndpoints": [
     {
       "endpointClass": "modelstudio-native",
@@ -33,34 +38,22 @@
     }
   },
   "modelCatalog": {
-    "suppressions": [
-      {
-        "provider": "qwen",
-        "model": "qwen3.6-plus",
-        "reason": "qwen3.6-plus is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go Qwen endpoint or choose qwen/qwen3.5-plus.",
-        "when": {
-          "baseUrlHosts": ["coding.dashscope.aliyuncs.com", "coding-intl.dashscope.aliyuncs.com"],
-          "providerConfigApiIn": ["qwen", "modelstudio"]
-        }
-      },
-      {
-        "provider": "modelstudio",
-        "model": "qwen3.6-plus",
-        "reason": "qwen3.6-plus is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go Qwen endpoint or choose qwen/qwen3.5-plus.",
-        "when": {
-          "baseUrlHosts": ["coding.dashscope.aliyuncs.com", "coding-intl.dashscope.aliyuncs.com"],
-          "providerConfigApiIn": ["qwen", "modelstudio"]
-        }
-      }
-    ]
+    "suppressions": []
   },
   "contracts": {
-    "mediaUnderstandingProviders": ["qwen"],
-    "videoGenerationProviders": ["qwen"]
+    "mediaUnderstandingProviders": [
+      "qwen"
+    ],
+    "videoGenerationProviders": [
+      "qwen"
+    ]
   },
   "mediaUnderstandingProviderMetadata": {
     "qwen": {
-      "capabilities": ["image", "video"],
+      "capabilities": [
+        "image",
+        "video"
+      ],
       "defaultModels": {
         "image": "qwen-vl-max-latest",
         "video": "qwen-vl-max-latest"
@@ -71,14 +64,20 @@
     }
   },
   "providerAuthEnvVars": {
-    "qwen": ["QWEN_API_KEY", "MODELSTUDIO_API_KEY", "DASHSCOPE_API_KEY"]
+    "qwen": [
+      "QWEN_API_KEY",
+      "MODELSTUDIO_API_KEY",
+      "DASHSCOPE_API_KEY"
+    ]
   },
   "providerAuthChoices": [
     {
       "provider": "qwen",
       "method": "standard-api-key-cn",
       "choiceId": "qwen-standard-api-key-cn",
-      "deprecatedChoiceIds": ["modelstudio-standard-api-key-cn"],
+      "deprecatedChoiceIds": [
+        "modelstudio-standard-api-key-cn"
+      ],
       "choiceLabel": "Standard API Key for China (pay-as-you-go)",
       "choiceHint": "Endpoint: dashscope.aliyuncs.com",
       "groupId": "qwen",
@@ -93,7 +92,9 @@
       "provider": "qwen",
       "method": "standard-api-key",
       "choiceId": "qwen-standard-api-key",
-      "deprecatedChoiceIds": ["modelstudio-standard-api-key"],
+      "deprecatedChoiceIds": [
+        "modelstudio-standard-api-key"
+      ],
       "choiceLabel": "Standard API Key for Global/Intl (pay-as-you-go)",
       "choiceHint": "Endpoint: dashscope-intl.aliyuncs.com",
       "groupId": "qwen",
@@ -108,7 +109,9 @@
       "provider": "qwen",
       "method": "api-key-cn",
       "choiceId": "qwen-api-key-cn",
-      "deprecatedChoiceIds": ["modelstudio-api-key-cn"],
+      "deprecatedChoiceIds": [
+        "modelstudio-api-key-cn"
+      ],
       "choiceLabel": "Coding Plan API Key for China (subscription)",
       "choiceHint": "Endpoint: coding.dashscope.aliyuncs.com",
       "groupId": "qwen",
@@ -123,7 +126,9 @@
       "provider": "qwen",
       "method": "api-key",
       "choiceId": "qwen-api-key",
-      "deprecatedChoiceIds": ["modelstudio-api-key"],
+      "deprecatedChoiceIds": [
+        "modelstudio-api-key"
+      ],
       "choiceLabel": "Coding Plan API Key for Global/Intl (subscription)",
       "choiceHint": "Endpoint: coding-intl.dashscope.aliyuncs.com",
       "groupId": "qwen",

--- a/extensions/qwen/provider-catalog.test.ts
+++ b/extensions/qwen/provider-catalog.test.ts
@@ -22,18 +22,18 @@ describe("qwen provider catalog", () => {
     const modelIds = getQwenModelIds(provider);
     expect(modelIds.length).toBeGreaterThan(0);
     expect(modelIds).toContain(QWEN_DEFAULT_MODEL_ID);
-    expect(modelIds).not.toContain("qwen3.6-plus");
+    expect(modelIds).toContain("qwen3.6-plus");
   });
 
-  it("only advertises qwen3.6-plus on Standard endpoints", () => {
+  it("advertises qwen3.6-plus on all endpoints including Coding Plan", () => {
     const coding = buildQwenProvider({ baseUrl: QWEN_BASE_URL });
     const codingTrailingDot = buildQwenProvider({
       baseUrl: " https://coding-intl.dashscope.aliyuncs.com./v1 ",
     });
     const standard = buildQwenProvider({ baseUrl: QWEN_STANDARD_GLOBAL_BASE_URL });
 
-    expect(getQwenModelIds(coding)).not.toContain("qwen3.6-plus");
-    expect(getQwenModelIds(codingTrailingDot)).not.toContain("qwen3.6-plus");
+    expect(getQwenModelIds(coding)).toContain("qwen3.6-plus");
+    expect(getQwenModelIds(codingTrailingDot)).toContain("qwen3.6-plus");
     expect(getQwenModelIds(standard)).toContain("qwen3.6-plus");
   });
 


### PR DESCRIPTION
## Summary

qwen3.6-plus is now available on all Coding Plan tiers. Remove the catalog filter that prevented it from appearing on Coding Plan endpoints.

## Changes

- `models.ts`: Remove `isQwen36PlusSupportedBaseUrl` function and simplify `buildQwenModelCatalogForBaseUrl` to always return full catalog
- `api.ts`: Remove unused export

This is the minimal change to enable qwen3.6-plus selection on Coding Plan.