### PR TITLE
fix(markdown): exclude trailing paragraph separator from blockquote style span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Markdown/Telegram: trim trailing paragraph separator from blockquote style span so `<blockquote>` elements no longer include an extra blank line on Telegram. (#79646)
 - Gateway/maintenance: prune dedupe overflow against a stable excess count and keep active agent retries from starting duplicate runs after cache eviction. (#73841) Thanks @thesomewhatyou.
 - Control UI/subagents: suppress internal `subagent_announce` handoff prompts from requester transcripts and hide legacy inter-session wrapper rows so completed subagent results no longer surface runtime context in WebChat history. (#79618) Thanks @joshavant.
 - Discord: preserve username target resolution for Discord outbound sends. (#79076) Thanks @vincentkoc.

--- a/src/markdown/ir.blockquote-spacing.test.ts
+++ b/src/markdown/ir.blockquote-spacing.test.ts
@@ -174,6 +174,43 @@ describe("blockquote spacing", () => {
   });
 });
 
+describe("blockquote style span boundaries (#79646)", () => {
+  it("should not include trailing paragraph separator in blockquote style span", () => {
+    const input = "> `gpt`\n\nbody";
+    const result = markdownToIR(input);
+
+    // Text should be correct
+    expect(result.text).toBe("gpt\n\nbody");
+
+    // The blockquote style span should NOT include the \n\n
+    const bqStyle = result.styles.find((s) => s.style === "blockquote");
+    expect(bqStyle).toBeDefined();
+    // Blockquote span should end at "gpt" (position 3), not at "gpt\n\n" (position 5)
+    expect(bqStyle!.end).toBe(3);
+  });
+
+  it("should not include trailing separator in multi-paragraph blockquote style span", () => {
+    const input = "> first\n>\n> second\n\nfollowing";
+    const result = markdownToIR(input);
+
+    const bqStyle = result.styles.find((s) => s.style === "blockquote");
+    expect(bqStyle).toBeDefined();
+    // Blockquote should cover "first\n\nsecond" but not the trailing \n\n
+    const bqText = result.text.slice(bqStyle!.start, bqStyle!.end);
+    expect(bqText).not.toMatch(/\n\n$/);
+  });
+
+  it("should handle blockquote at end of document without trailing separator", () => {
+    const input = "paragraph\n\n> quote";
+    const result = markdownToIR(input);
+
+    const bqStyle = result.styles.find((s) => s.style === "blockquote");
+    expect(bqStyle).toBeDefined();
+    const bqText = result.text.slice(bqStyle!.start, bqStyle!.end);
+    expect(bqText).toBe("quote");
+  });
+});
+
 describe("comparison with other block elements (control group)", () => {
   it("paragraphs should have double newline separation", () => {
     const input = "paragraph 1\n\nparagraph 2";

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -679,9 +679,17 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         }
         openStyle(state, "blockquote");
         break;
-      case "blockquote_close":
+      case "blockquote_close": {
+        // Trim trailing paragraph separator before closing the style so the
+        // blockquote span boundary does not include the \n\n, which would
+        // cause an extra blank line inside <blockquote> on Telegram (#79646).
+        const target = resolveRenderTarget(state);
+        const hadTrailingSep = target.text.endsWith("\n\n");
+        if (hadTrailingSep) target.text = target.text.slice(0, -2);
         closeStyle(state, "blockquote");
+        if (hadTrailingSep) target.text += "\n\n";
         break;
+      }
       case "bullet_list_open":
         // Add newline before nested list starts (so nested items appear on new line)
         if (state.env.listStack.length > 0) {


### PR DESCRIPTION
## Summary

Fixes #79646 — blockquote style spans include the trailing `\n\n` from `paragraph_close`, causing an extra blank line inside `<blockquote>` elements on Telegram.

## Root Cause

In `ir.ts`, `paragraph_close` calls `appendParagraphSeparator()` which appends `\n\n` to `state.text` **before** `blockquote_close` calls `closeStyle()`. Since `closeStyle` uses `target.text.length` as the span end, the `\n\n` gets included inside the blockquote style span.

## Fix

In the `blockquote_close` handler, trim any trailing `\n\n` before closing the style, then re-add it afterward. This ensures the blockquote style span ends at the actual content boundary, not after the paragraph separator.

```diff
- case "blockquote_close":
-   closeStyle(state, "blockquote");
-   break;
+ case "blockquote_close": {
+   const target = resolveRenderTarget(state);
+   const hadTrailingSep = target.text.endsWith("\n\n");
+   if (hadTrailingSep) target.text = target.text.slice(0, -2);
+   closeStyle(state, "blockquote");
+   if (hadTrailingSep) target.text += "\n\n";
+   break;
+ }
```

## Testing

- Added 3 new tests to `ir.blockquote-spacing.test.ts` that verify style span boundaries do not include trailing separators
- All 22 blockquote spacing tests pass
- All 84 markdown tests pass (9 test files)

## Changes

- `src/markdown/ir.ts` — trim trailing paragraph separator before closing blockquote style
- `src/markdown/ir.blockquote-spacing.test.ts` — 3 new style span boundary tests
- `CHANGELOG.md` — added fix entry