### PR TITLE
fix(google): retry stalled Gemini first response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Codex: auto-enable the Codex harness plugin for one-shot OpenAI model overrides so `openclaw agent --local --model openai/...` does not fail with an unregistered `codex` harness.
 - Gateway/live tests: avoid full model-registry enumeration for explicit provider-qualified live model filters, preventing `.profile` OpenAI gateway profile runs from hanging before provider dispatch.
 - Gateway/status: surface CLI and gateway runtime versions, warn about stale PATH/global wrappers when they differ, and add stale-wrapper checks to the newer-config warning. Refs #79091. Thanks @RamaAditya49 and @sallyom.
+- Google/Gemini: retry stalled Gemini 3 preview direct API-key streams with a lean first-response payload and share Gemini tool-schema cleanup across direct Google and Gemini CLI providers, so main sessions with coding tools can recover before the LLM idle watchdog fires. (#79668) Thanks @joshavant.
 - Providers: preserve non-OK `text/event-stream` response bodies so provider HTTP errors keep their JSON detail instead of collapsing to generic streaming failures. Fixes #78180.
 - Gateway/auth: make explicit `trusted-proxy` mode fail closed instead of accepting local password fallback credentials after trusted-proxy identity checks fail. Fixes #78684.
 - Active memory: treat Google Chat `spaces/...` conversation ids as scoped targets instead of runnable channel names so recall runs no longer fail bundled-plugin dirName validation. Fixes #78918.

--- a/extensions/google/gemini-cli-provider.ts
+++ b/extensions/google/gemini-cli-provider.ts
@@ -5,7 +5,6 @@ import type {
 } from "openclaw/plugin-sdk/plugin-entry";
 import { buildOauthProviderAuthResult } from "openclaw/plugin-sdk/provider-auth-result";
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
-import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
 import { fetchGeminiUsage } from "openclaw/plugin-sdk/provider-usage";
 import { formatGoogleOauthApiKey, parseGoogleUsageToken } from "./oauth-token-shared.js";
 import { GOOGLE_GEMINI_PROVIDER_HOOKS } from "./provider-hooks.js";
@@ -20,11 +19,6 @@ const ENV_VARS = [
   "GEMINI_CLI_OAUTH_CLIENT_ID",
   "GEMINI_CLI_OAUTH_CLIENT_SECRET",
 ] as const;
-
-const GOOGLE_GEMINI_CLI_PROVIDER_HOOKS = {
-  ...GOOGLE_GEMINI_PROVIDER_HOOKS,
-  ...buildProviderToolCompatFamilyHooks("gemini"),
-};
 
 async function fetchGeminiCliUsage(ctx: ProviderFetchUsageSnapshotContext) {
   return await fetchGeminiUsage(ctx.token, ctx.timeoutMs, ctx.fetchFn, PROVIDER_ID);
@@ -125,7 +119,7 @@ export function buildGoogleGeminiCliProvider(): ProviderPlugin {
         providerId: PROVIDER_ID,
         ctx,
       }),
-    ...GOOGLE_GEMINI_CLI_PROVIDER_HOOKS,
+    ...GOOGLE_GEMINI_PROVIDER_HOOKS,
     isModernModelRef: ({ modelId }) => isModernGoogleModel(modelId),
     formatApiKey: (cred) => formatGoogleOauthApiKey(cred),
     resolveUsageAuth: async (ctx) => {

--- a/extensions/google/index.test.ts
+++ b/extensions/google/index.test.ts
@@ -94,51 +94,54 @@ describe("google provider plugin hooks", () => {
     expect(customEntries[0]?.customType).toBe("google-turn-ordering-bootstrap");
   });
 
-  it("owns Gemini CLI tool schema normalization", async () => {
+  it("owns Gemini tool schema normalization for direct and CLI providers", async () => {
     const { providers } = await registerProviderPlugin({
       plugin: googleProviderPlugin,
       id: "google",
       name: "Google Provider",
     });
-    const provider = requireRegisteredProvider(providers, "google-gemini-cli");
+    const providerIds = ["google", "google-gemini-cli"] as const;
 
-    const [tool] =
-      provider.normalizeToolSchemas?.({
-        provider: "google-gemini-cli",
-        tools: [
-          {
-            name: "write_file",
-            description: "Write a file",
-            parameters: {
-              type: "object",
-              additionalProperties: false,
-              properties: {
-                path: { type: "string", pattern: "^src/" },
+    for (const providerId of providerIds) {
+      const provider = requireRegisteredProvider(providers, providerId);
+      const [tool] =
+        provider.normalizeToolSchemas?.({
+          provider: providerId,
+          tools: [
+            {
+              name: "write_file",
+              description: "Write a file",
+              parameters: {
+                type: "object",
+                additionalProperties: false,
+                properties: {
+                  path: { type: "string", pattern: "^src/" },
+                },
               },
             },
-          },
-        ],
-      } as never) ?? [];
+          ],
+        } as never) ?? [];
 
-    expect(tool).toMatchObject({
-      name: "write_file",
-      parameters: {
-        type: "object",
-        properties: {
-          path: { type: "string" },
+      expect(tool).toMatchObject({
+        name: "write_file",
+        parameters: {
+          type: "object",
+          properties: {
+            path: { type: "string" },
+          },
         },
-      },
-    });
-    expect(tool?.parameters).not.toHaveProperty("additionalProperties");
-    expect(
-      (tool?.parameters as { properties?: { path?: Record<string, unknown> } })?.properties?.path,
-    ).not.toHaveProperty("pattern");
-    expect(
-      provider.inspectToolSchemas?.({
-        provider: "google-gemini-cli",
-        tools: [tool],
-      } as never),
-    ).toStrictEqual([]);
+      });
+      expect(tool?.parameters).not.toHaveProperty("additionalProperties");
+      expect(
+        (tool?.parameters as { properties?: { path?: Record<string, unknown> } })?.properties?.path,
+      ).not.toHaveProperty("pattern");
+      expect(
+        provider.inspectToolSchemas?.({
+          provider: providerId,
+          tools: [tool],
+        } as never),
+      ).toEqual([]);
+    }
   });
 
   it("wires google-thinking stream hooks for direct and Gemini CLI providers", async () => {

--- a/extensions/google/provider-hooks.ts
+++ b/extensions/google/provider-hooks.ts
@@ -3,12 +3,14 @@ import type {
   ProviderThinkingProfile,
 } from "openclaw/plugin-sdk/core";
 import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
+import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
 import { createGoogleThinkingStreamWrapper, isGoogleGemini3ProModel } from "./thinking-api.js";
 
 export const GOOGLE_GEMINI_PROVIDER_HOOKS = {
   ...buildProviderReplayFamilyHooks({
     family: "google-gemini",
   }),
+  ...buildProviderToolCompatFamilyHooks("gemini"),
   resolveThinkingProfile: ({ modelId }: ProviderDefaultThinkingPolicyContext) =>
     ({
       levels: isGoogleGemini3ProModel(modelId)

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -86,6 +86,35 @@ function buildSseResponse(events: unknown[]): Response {
   });
 }
 
+function buildDelayedSecondSseResponse(params: {
+  first: unknown;
+  second: unknown;
+  delayMs: number;
+}): Response {
+  const encoder = new TextEncoder();
+  const first = `data: ${JSON.stringify(params.first)}\n\n`;
+  const second = `data: ${JSON.stringify(params.second)}\n\ndata: [DONE]\n\n`;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(first));
+      timeout = setTimeout(() => {
+        controller.enqueue(encoder.encode(second));
+        controller.close();
+      }, params.delayMs);
+    },
+    cancel() {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
 describe("google transport stream", () => {
   beforeAll(async () => {
     ({
@@ -332,6 +361,40 @@ describe("google transport stream", () => {
       thinkingLevel: "LOW",
     });
     expect(retryBody.tools).toEqual(firstBody.tools);
+  });
+
+  it("keeps streaming after the first Gemini 3 chunk arrives before the retry deadline", async () => {
+    vi.stubEnv("OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS", "10");
+    guardedFetchMock.mockResolvedValueOnce(
+      buildDelayedSecondSseResponse({
+        first: {
+          candidates: [{ content: { parts: [{ text: "first " }] } }],
+        },
+        second: {
+          candidates: [{ content: { parts: [{ text: "second" }] }, finishReason: "STOP" }],
+        },
+        delayMs: 25,
+      }),
+    );
+
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as never,
+        { reasoning: "high" } as never,
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.content).toEqual([{ type: "text", text: "first second" }]);
+    expect(guardedFetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("uses bearer auth when the Google api key is an OAuth JSON payload", async () => {

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -15,6 +15,7 @@ vi.mock("openclaw/plugin-sdk/provider-transport-runtime", async (importOriginal)
 }));
 
 let buildGoogleGenerativeAiParams: typeof import("./transport-stream.js").buildGoogleGenerativeAiParams;
+let buildGoogleGemini3FirstResponseRetryParams: typeof import("./transport-stream.js").buildGoogleGemini3FirstResponseRetryParams;
 let createGoogleGenerativeAiTransportStreamFn: typeof import("./transport-stream.js").createGoogleGenerativeAiTransportStreamFn;
 let createGoogleVertexTransportStreamFn: typeof import("./transport-stream.js").createGoogleVertexTransportStreamFn;
 let hasGoogleVertexAuthorizedUserAdcSync: typeof import("./vertex-adc.js").hasGoogleVertexAuthorizedUserAdcSync;
@@ -89,6 +90,7 @@ describe("google transport stream", () => {
   beforeAll(async () => {
     ({
       buildGoogleGenerativeAiParams,
+      buildGoogleGemini3FirstResponseRetryParams,
       createGoogleGenerativeAiTransportStreamFn,
       createGoogleVertexTransportStreamFn,
     } = await import("./transport-stream.js"));
@@ -246,6 +248,90 @@ describe("google transport stream", () => {
         },
       ],
     });
+  });
+
+  it("builds a lean Gemini 3 first-response retry payload", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+    const retryPayload = buildGoogleGemini3FirstResponseRetryParams({
+      model,
+      request: {
+        contents: [{ role: "user", parts: [{ text: "hello" }] }],
+        generationConfig: {
+          thinkingConfig: {
+            includeThoughts: true,
+            thinkingLevel: "HIGH",
+          },
+        },
+      },
+    });
+
+    expect(retryPayload?.generationConfig).toEqual({
+      thinkingConfig: {
+        thinkingLevel: "LOW",
+      },
+    });
+  });
+
+  it("retries Gemini 3 requests with lean thinking when the first attempt has no first response", async () => {
+    vi.stubEnv("OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS", "10");
+    guardedFetchMock
+      .mockImplementationOnce(
+        (_url: string, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => {
+              reject(init.signal?.reason ?? new Error("aborted"));
+            });
+          }),
+      )
+      .mockResolvedValueOnce(
+        buildSseResponse([
+          {
+            candidates: [{ content: { parts: [{ text: "recovered" }] }, finishReason: "STOP" }],
+          },
+        ]),
+      );
+
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+          tools: [
+            {
+              name: "lookup",
+              description: "Look up a value",
+              parameters: {
+                type: "object",
+                properties: { q: { type: "string" } },
+              },
+            },
+          ],
+        } as never,
+        { reasoning: "high" } as never,
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.content).toEqual([{ type: "text", text: "recovered" }]);
+    expect(guardedFetchMock).toHaveBeenCalledTimes(2);
+    const firstBody = JSON.parse(guardedFetchMock.mock.calls[0]?.[1]?.body as string);
+    const retryBody = JSON.parse(guardedFetchMock.mock.calls[1]?.[1]?.body as string);
+    expect(firstBody.generationConfig.thinkingConfig).toMatchObject({
+      includeThoughts: true,
+      thinkingLevel: "HIGH",
+    });
+    expect(retryBody.generationConfig.thinkingConfig).toEqual({
+      thinkingLevel: "LOW",
+    });
+    expect(retryBody.tools).toEqual(firstBody.tools);
   });
 
   it("uses bearer auth when the Google api key is an OAuth JSON payload", async () => {

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -752,13 +752,18 @@ function createChildSignal(parent: AbortSignal | undefined, timeoutMs: number) {
     }, timeoutMs);
     timeout.unref?.();
   }
+  const clearDeadline = () => {
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = undefined;
+    }
+  };
   return {
     signal: controller.signal,
     timedOut: () => timedOut,
+    clearDeadline,
     cleanup: () => {
-      if (timeout) {
-        clearTimeout(timeout);
-      }
+      clearDeadline();
       parent?.removeEventListener("abort", abortFromParent);
     },
   };
@@ -819,6 +824,7 @@ async function openGoogleSseAttempt(params: {
     const chunks = parseGoogleSseChunks(response, signal);
     const iterator = chunks[Symbol.asyncIterator]();
     const first = await iterator.next();
+    attemptSignal?.clearDeadline();
     if (first.done) {
       return {
         type: "ready",

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -74,6 +74,9 @@ type GoogleGenerateContentRequest = {
   toolConfig?: Record<string, unknown>;
 };
 
+const GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_DEFAULT_MS = 45_000;
+const GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_ENV = "OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS";
+
 type GoogleTransportContentBlock =
   | { type: "text"; text: string; textSignature?: string }
   | { type: "thinking"; thinking: string; thinkingSignature?: string }
@@ -646,6 +649,277 @@ function buildGoogleTransportRequestUrl(
     : buildGoogleGenerativeAiRequestUrl(model);
 }
 
+function isOfficialGoogleGenerativeAiBaseUrl(baseUrl: string | undefined): boolean {
+  if (!baseUrl) {
+    return true;
+  }
+  try {
+    return new URL(baseUrl).hostname === "generativelanguage.googleapis.com";
+  } catch {
+    return false;
+  }
+}
+
+function resolveGoogleGemini3FirstResponseRetryMs(env = process.env): number {
+  const raw = env[GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_ENV];
+  if (raw === undefined || raw.trim() === "") {
+    return GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_DEFAULT_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_DEFAULT_MS;
+  }
+  return Math.floor(parsed);
+}
+
+function shouldRetryGoogleGemini3FirstResponse(params: {
+  kind: GoogleTransportApi;
+  model: GoogleTransportModel;
+}): boolean {
+  if (params.kind !== "google-generative-ai") {
+    return false;
+  }
+  if (!isOfficialGoogleGenerativeAiBaseUrl(params.model.baseUrl)) {
+    return false;
+  }
+  return isGoogleGemini3ProModel(params.model.id) || isGoogleGemini3FlashModel(params.model.id);
+}
+
+function resolveGoogleGemini3RetryThinkingLevel(modelId: string): GoogleThinkingLevel | undefined {
+  if (isGoogleGemini3ProModel(modelId)) {
+    return "LOW";
+  }
+  if (isGoogleGemini3FlashModel(modelId)) {
+    return "MINIMAL";
+  }
+  return undefined;
+}
+
+function cloneGoogleGenerateContentRequest(
+  params: GoogleGenerateContentRequest,
+): GoogleGenerateContentRequest {
+  return JSON.parse(JSON.stringify(params)) as GoogleGenerateContentRequest;
+}
+
+export function buildGoogleGemini3FirstResponseRetryParams(params: {
+  model: GoogleTransportModel;
+  request: GoogleGenerateContentRequest;
+}): GoogleGenerateContentRequest | undefined {
+  const thinkingLevel = resolveGoogleGemini3RetryThinkingLevel(params.model.id);
+  if (!thinkingLevel) {
+    return undefined;
+  }
+  const retryRequest = cloneGoogleGenerateContentRequest(params.request);
+  const generationConfig =
+    retryRequest.generationConfig && typeof retryRequest.generationConfig === "object"
+      ? retryRequest.generationConfig
+      : {};
+  const thinkingConfig =
+    generationConfig.thinkingConfig && typeof generationConfig.thinkingConfig === "object"
+      ? { ...(generationConfig.thinkingConfig as Record<string, unknown>) }
+      : {};
+
+  // Gemini 3 defaults to dynamic high thinking when the request omits an
+  // explicit level. On a zero-output stall, retry with the smallest supported
+  // native level and suppress thought streaming so the recovery call prioritizes
+  // producing a visible first token.
+  delete thinkingConfig.thinkingBudget;
+  delete thinkingConfig.includeThoughts;
+  thinkingConfig.thinkingLevel = thinkingLevel;
+  generationConfig.thinkingConfig = thinkingConfig;
+  retryRequest.generationConfig = generationConfig;
+  return retryRequest;
+}
+
+function createChildSignal(parent: AbortSignal | undefined, timeoutMs: number) {
+  const controller = new AbortController();
+  let timedOut = false;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const abortFromParent = () => {
+    controller.abort(parent?.reason);
+  };
+  if (parent) {
+    if (parent.aborted) {
+      abortFromParent();
+    } else {
+      parent.addEventListener("abort", abortFromParent, { once: true });
+    }
+  }
+  if (timeoutMs > 0) {
+    timeout = setTimeout(() => {
+      timedOut = true;
+      controller.abort(new Error("Google Gemini first response retry deadline reached"));
+    }, timeoutMs);
+    timeout.unref?.();
+  }
+  return {
+    signal: controller.signal,
+    timedOut: () => timedOut,
+    cleanup: () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      parent?.removeEventListener("abort", abortFromParent);
+    },
+  };
+}
+
+function iteratorToAsyncGenerator<T>(
+  iterator: AsyncIterator<T>,
+  cleanup?: () => void,
+): AsyncGenerator<T> {
+  return (async function* () {
+    try {
+      for (;;) {
+        const next = await iterator.next();
+        if (next.done) {
+          return;
+        }
+        yield next.value;
+      }
+    } finally {
+      cleanup?.();
+      await iterator.return?.();
+    }
+  })();
+}
+
+type GoogleSseAttempt =
+  | {
+      type: "ready";
+      firstChunk?: GoogleSseChunk;
+      chunks: AsyncGenerator<GoogleSseChunk>;
+    }
+  | { type: "timeout" };
+
+async function openGoogleSseAttempt(params: {
+  guardedFetch: ReturnType<typeof buildGuardedModelFetch>;
+  url: string;
+  headers: Record<string, string>;
+  request: GoogleGenerateContentRequest;
+  parentSignal?: AbortSignal;
+  firstResponseTimeoutMs: number;
+  errorPrefix: string;
+}): Promise<GoogleSseAttempt> {
+  const attemptSignal =
+    params.firstResponseTimeoutMs > 0
+      ? createChildSignal(params.parentSignal, params.firstResponseTimeoutMs)
+      : undefined;
+  const signal = attemptSignal?.signal ?? params.parentSignal;
+  try {
+    const response = await params.guardedFetch(params.url, {
+      method: "POST",
+      headers: params.headers,
+      body: JSON.stringify(params.request),
+      signal,
+    });
+    if (!response.ok) {
+      throw await createProviderHttpError(response, params.errorPrefix);
+    }
+    const chunks = parseGoogleSseChunks(response, signal);
+    const iterator = chunks[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    if (first.done) {
+      return {
+        type: "ready",
+        chunks: iteratorToAsyncGenerator(iterator, attemptSignal?.cleanup),
+      };
+    }
+    return {
+      type: "ready",
+      firstChunk: first.value,
+      chunks: iteratorToAsyncGenerator(iterator, attemptSignal?.cleanup),
+    };
+  } catch (error) {
+    attemptSignal?.cleanup();
+    if (attemptSignal?.timedOut() && !params.parentSignal?.aborted) {
+      return { type: "timeout" };
+    }
+    throw error;
+  }
+}
+
+async function openGoogleSseChunks(params: {
+  kind: GoogleTransportApi;
+  model: GoogleTransportModel;
+  options: GoogleTransportOptions | undefined;
+  guardedFetch: ReturnType<typeof buildGuardedModelFetch>;
+  url: string;
+  headers: Record<string, string>;
+  request: GoogleGenerateContentRequest;
+}): Promise<Extract<GoogleSseAttempt, { type: "ready" }>> {
+  const errorPrefix =
+    params.kind === "google-vertex"
+      ? "Google Vertex AI API error"
+      : "Google Generative AI API error";
+  if (!shouldRetryGoogleGemini3FirstResponse({ kind: params.kind, model: params.model })) {
+    const response = await params.guardedFetch(params.url, {
+      method: "POST",
+      headers: params.headers,
+      body: JSON.stringify(params.request),
+      signal: params.options?.signal,
+    });
+    if (!response.ok) {
+      throw await createProviderHttpError(response, errorPrefix);
+    }
+    return {
+      type: "ready",
+      chunks: parseGoogleSseChunks(response, params.options?.signal),
+    };
+  }
+
+  const retryMs = resolveGoogleGemini3FirstResponseRetryMs();
+  const retryRequest =
+    retryMs > 0
+      ? buildGoogleGemini3FirstResponseRetryParams({
+          model: params.model,
+          request: params.request,
+        })
+      : undefined;
+  if (!retryRequest) {
+    const response = await params.guardedFetch(params.url, {
+      method: "POST",
+      headers: params.headers,
+      body: JSON.stringify(params.request),
+      signal: params.options?.signal,
+    });
+    if (!response.ok) {
+      throw await createProviderHttpError(response, errorPrefix);
+    }
+    return {
+      type: "ready",
+      chunks: parseGoogleSseChunks(response, params.options?.signal),
+    };
+  }
+
+  const firstAttempt = await openGoogleSseAttempt({
+    guardedFetch: params.guardedFetch,
+    url: params.url,
+    headers: params.headers,
+    request: params.request,
+    parentSignal: params.options?.signal,
+    firstResponseTimeoutMs: retryMs,
+    errorPrefix,
+  });
+  if (firstAttempt.type === "ready") {
+    return firstAttempt;
+  }
+
+  const retryAttempt = await openGoogleSseAttempt({
+    guardedFetch: params.guardedFetch,
+    url: params.url,
+    headers: params.headers,
+    request: retryRequest,
+    parentSignal: params.options?.signal,
+    firstResponseTimeoutMs: 0,
+    errorPrefix,
+  });
+  if (retryAttempt.type === "timeout") {
+    throw new Error("Google Gemini first response retry timed out unexpectedly");
+  }
+  return retryAttempt;
+}
+
 async function buildGoogleTransportHeaders(params: {
   kind: GoogleTransportApi;
   model: GoogleTransportModel;
@@ -782,29 +1056,33 @@ function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
         if (nextParams !== undefined) {
           params = nextParams as GoogleGenerateContentRequest;
         }
-        const response = await guardedFetch(buildGoogleTransportRequestUrl(kind, model, options), {
-          method: "POST",
-          headers: await buildGoogleTransportHeaders({
-            kind,
-            model,
-            apiKey,
-            optionHeaders: options?.headers,
-            fetchImpl: (options as { fetch?: typeof fetch } | undefined)?.fetch,
-          }),
-          body: JSON.stringify(params),
-          signal: options?.signal,
+        const requestUrl = buildGoogleTransportRequestUrl(kind, model, options);
+        const requestHeaders = await buildGoogleTransportHeaders({
+          kind,
+          model,
+          apiKey,
+          optionHeaders: options?.headers,
+          fetchImpl: (options as { fetch?: typeof fetch } | undefined)?.fetch,
         });
-        if (!response.ok) {
-          throw await createProviderHttpError(
-            response,
-            kind === "google-vertex"
-              ? "Google Vertex AI API error"
-              : "Google Generative AI API error",
-          );
-        }
+        const sse = await openGoogleSseChunks({
+          kind,
+          model,
+          options,
+          guardedFetch,
+          url: requestUrl,
+          headers: requestHeaders,
+          request: params,
+        });
         stream.push({ type: "start", partial: output as never });
         let currentBlockIndex = -1;
-        for await (const chunk of parseGoogleSseChunks(response, options?.signal)) {
+        const chunks =
+          sse.firstChunk === undefined
+            ? sse.chunks
+            : (async function* (firstChunk: GoogleSseChunk) {
+                yield firstChunk;
+                yield* sse.chunks;
+              })(sse.firstChunk);
+        for await (const chunk of chunks) {
           output.responseId ||= chunk.responseId;
           updateUsage(output, model, chunk);
           const candidate = chunk.candidates?.[0];


### PR DESCRIPTION
## Summary

- Problem: Direct Google Gemini 3.1 Pro / 3 Flash main-session runs can stall before the first model response when high thinking and the full coding tool profile are present.
- Why it matters: The direct Google API-key path can hit the OpenClaw LLM idle watchdog even though direct provider calls and isolated/simple paths may work.
- What changed: Add a Google native transport first-response retry for Gemini 3 Pro/Flash families that retries once with a lean thinking payload while preserving tools/content, and move Gemini tool-schema normalization into the shared Google provider hooks so direct Google and Gemini CLI paths both receive it.
- What did NOT change (scope boundary): No changelog entry, no Vertex retry behavior, no Gemini 2.5 retry policy change, and no generic agent idle-timeout policy change.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78502
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Direct Google Gemini main-session idle timeout before a reply with high thinking and coding tools.
- Real environment tested: macOS local checkout, Node 22+, direct Google Generative AI API key from a private env file, isolated OpenClaw HOME/state/config/workspace/trajectory dirs.
- Exact steps or command run after this patch: `node dist/entry.js agent --local --session-id <case> --message "Reply exactly <marker> and nothing else." --model <google model> --thinking high --timeout 240 --json` with `tools.profile: "coding"` and direct `google-generative-ai` provider config.
- Evidence after fix: copied live output from fresh runs below.
- Observed result after fix: Gemini 3.1 Pro and Gemini 3 Flash return final text and trajectory `session.ended` success with `idleTimedOut:false`.
- What was not tested: Human chat-channel delivery; Vertex-specific Google path.
- Before evidence: Earlier A/B on the same issue reproduced `LLM idle timeout` on the main-session direct Google path for Gemini 3.1 Pro / Gemini 3 Flash with coding tools.

Live results on the current fix branch:

```text
current_g31_high_coding: google/gemini-3.1-pro-preview, exit 0, 20s, text CURRENT_G31_HIGH_CODING_OK, trajectory success, idleTimedOut:false
current_g3flash_high_coding: google/gemini-3-flash-preview, exit 0, 52s, text CURRENT_G3FLASH_HIGH_CODING_OK, trajectory success, idleTimedOut:false
current_g25pro_high_coding_control: google/gemini-2.5-pro, exit 0, 11s, live response, trajectory success, idleTimedOut:false
```

Live results with the same code patch applied to `v2026.5.7`:

```text
rel57_g31_high_coding: google/gemini-3.1-pro-preview, exit 0, 52s, text REL57_G31_HIGH_CODING_OK, trajectory success, idleTimedOut:false
rel57_g3flash_high_coding: google/gemini-3-flash-preview, exit 0, 52s, text REL57_G3FLASH_HIGH_CODING_OK, trajectory success, idleTimedOut:false
rel57_g25pro_high_coding_control: google/gemini-2.5-pro, exit 0, 159s, final success after existing same-model retry; one first-attempt internal idle timeout was observed before recovery
```

## Root Cause (if applicable)

- Root cause: Gemini 3 preview direct API requests can accept the full main-session/coding-tool payload but fail to produce the first SSE chunk before OpenClaw's idle watchdog. The direct Google provider also missed the Gemini tool-schema compatibility hook that Gemini CLI already had.
- Missing detection / guardrail: No transport-level test covered zero-first-response Gemini 3 SSE stalls, and hook tests only asserted Gemini CLI schema normalization.
- Contributing context (if known): The issue appears sensitive to the direct Google API surface, Gemini 3 preview families, high thinking, and full main-session/coding-tool payload shape.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/google/transport-stream.test.ts`, `extensions/google/index.test.ts`, plus live `openclaw agent --local` validation.
- Scenario the test should lock in: Gemini 3 first attempt hangs before first SSE chunk, then transport retries once with lean thinking and preserved tools; direct Google and Gemini CLI both expose Gemini tool schema normalization hooks.
- Why this is the smallest reliable guardrail: The transport test controls the exact no-first-response failure deterministically; live proof covers the user-visible main-session behavior.
- Existing test that already covers this (if any): None before this patch.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Direct Google Gemini 3 preview main-session calls that stall before the first response now retry once with a lean first-response payload instead of waiting for the outer idle timeout.

## Diagram (if applicable)

```text
Before:
main session -> direct Google Gemini 3 high-thinking request -> no first SSE chunk -> OpenClaw idle timeout

After:
main session -> direct Google Gemini 3 high-thinking request -> no first SSE chunk by retry deadline -> lean retry -> final reply
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: A retry may make one additional request to the same official Google Generative AI endpoint for Gemini 3 Pro/Flash only after no first response. It preserves the same auth and request content, and is not enabled for Vertex or custom base URLs.

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: Node 22+, local built OpenClaw runtime
- Model/provider: Direct Google Generative AI API key; `google/gemini-3.1-pro-preview`, `google/gemini-3-flash-preview`, `google/gemini-2.5-pro`
- Integration/channel (if any): `openclaw agent --local` main session, isolated state/config/workspace/trajectory dirs
- Relevant config (redacted): Google provider configured as `api: "google-generative-ai"`, official `https://generativelanguage.googleapis.com/v1beta`, `tools.profile: "coding"`, high thinking

### Steps

1. Configure isolated OpenClaw state with direct Google provider and coding tools.
2. Run `node dist/entry.js agent --local ... --model google/gemini-3.1-pro-preview --thinking high --json`.
3. Run the same shape for `google/gemini-3-flash-preview`.
4. Inspect JSON output and trajectory `session.ended` events.

### Expected

- Gemini 3.1 Pro / Gemini 3 Flash produce a final assistant reply without an OpenClaw idle-timeout failure.

### Actual

- Both Gemini 3 cases produced final marker replies on current branch and on a patched `v2026.5.7` worktree.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Direct Google Gemini 3.1 Pro and Gemini 3 Flash high-thinking coding-tool main-session live runs on current branch; same code patch applied to `v2026.5.7`; Gemini 2.5 Pro control.
- Edge cases checked: Official Google API only; direct Google and Gemini CLI provider hook wiring; transport retry preserves tools and strips only retry thinking fields.
- What you did **not** verify: Vertex live path; chat-channel delivery path.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes
- Migration needed? No
- If yes, exact upgrade steps: No migration. Optional diagnostic/tuning env `OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS` can override the default 45s first-response retry deadline.

## Risks and Mitigations

- Risk: Retrying a request that might still later produce a response could duplicate provider work.
  - Mitigation: The retry is limited to Gemini 3 Pro/Flash, direct official Google Generative AI API, no first response/no first SSE chunk only, and a single retry.
- Risk: Lean retry could alter model output quality.
  - Mitigation: It only runs after the original high-thinking request has produced no visible response; tools/content are preserved, and the retry uses the smallest supported Gemini 3 thinking level to recover a reply.
