### PR TITLE
fix(auto-reply): bridge CLI-backend assistant deltas to onPartialReply

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -40,7 +40,7 @@ import {
   updateSessionStore,
 } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
-import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
+import { emitAgentEvent, onAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
@@ -1439,6 +1439,47 @@ export async function runAgentTurnWithFallback(params: {
               provider: params.sessionCtx.Provider,
             });
             return (async () => {
+              // Bridge intermediate assistant deltas from the CLI backend into the
+              // turn's onPartialReply callback so channels (Telegram preview edits,
+              // Discord drafts, etc.) can render progressive text updates for
+              // CLI-backed agents the same way runEmbeddedPiAgent already does.
+              //
+              // Without this, CLI backends emit granular text_delta events (claude
+              // CLI does this when spawned with --include-partial-messages) onto
+              // the global agent-event bus, but nothing forwards them to the
+              // channel preview layer -- so users see a single block at turn end
+              // instead of a live-edited draft.
+              const cliAssistantDeltaUnsub = onAgentEvent((evt) => {
+                if (evt.runId !== runId) {
+                  return;
+                }
+                if (evt.stream !== "assistant") {
+                  return;
+                }
+                const data = evt.data;
+                const delta = typeof data?.delta === "string" ? data.delta : "";
+                if (!delta) {
+                  return;
+                }
+                const onPartialReply = params.opts?.onPartialReply;
+                if (typeof onPartialReply !== "function") {
+                  return;
+                }
+                try {
+                  Promise.resolve(
+                    onPartialReply({
+                      text: typeof data.text === "string" ? data.text : "",
+                      mediaUrls: Array.isArray(data.mediaUrls)
+                        ? (data.mediaUrls as string[])
+                        : undefined,
+                    }),
+                  ).catch(() => {
+                    /* swallow downstream errors */
+                  });
+                } catch {
+                  /* swallow */
+                }
+              });
               let lifecycleTerminalEmitted = false;
               try {
                 const result = await runCliAgent({
@@ -1486,9 +1527,12 @@ export async function runAgentTurnWithFallback(params: {
                   result.meta?.systemPromptReport,
                 );
 
-                // CLI backends don't emit streaming assistant events, so we need to
-                // emit one with the final text so server-chat can populate its buffer
-                // and send the response to TUI/WebSocket clients.
+                // Intermediate assistant text deltas from the CLI backend were
+                // forwarded to params.opts.onPartialReply via the
+                // cliAssistantDeltaUnsub listener above. Emit a single assistant
+                // event with the final accumulated text so server-chat
+                // (TUI/WebSocket) can populate its buffer with the canonical turn
+                // output.
                 const cliText = normalizeOptionalString(result.payloads?.[0]?.text);
                 if (cliText) {
                   emitAgentEvent({
@@ -1534,6 +1578,11 @@ export async function runAgentTurnWithFallback(params: {
                 lifecycleTerminalEmitted = true;
                 throw err;
               } finally {
+                try {
+                  cliAssistantDeltaUnsub();
+                } catch {
+                  /* swallow */
+                }
                 // Defensive backstop: never let a CLI run complete without a terminal
                 // lifecycle event, otherwise downstream consumers can hang.
                 if (!lifecycleTerminalEmitted) {


### PR DESCRIPTION
# fix(auto-reply): bridge CLI-backend assistant deltas to onPartialReply

## Summary

Channels that support live-draft UX (Telegram preview edits, Discord
drafts, Mattermost streaming blocks, etc.) do not render progressive
text updates for CLI-backed agents (claude-cli, codex-cli, gemini-cli).
The user sees a single block at turn-end instead of a live-edited draft.

Same-day-turn agents that go through `runEmbeddedPiAgent` stream
correctly because that path wires `onPartialReply` through the embedded
pi inference loop. `runCliAgent` is called without any streaming
callbacks and its delta events are never forwarded to the channel
preview layer.

This PR bridges CLI assistant deltas to `onPartialReply` so the existing
draft-stream machinery renders them.

## Reproduction

1. Configure a claude-cli backend and an agent whose primary model uses
   the `claude-cli/` prefix (or the agent-runtime alias).
2. Send the agent a message via Telegram in a group with forum topics.
3. Observe: the bot types for the whole turn, then posts one final
   message. No progressive edits.

Gateway log shows the claude live session is healthy (`rawLines` grows
as deltas arrive) and the spawn command already includes
`--include-partial-messages` so claude CLI is emitting
`stream_event:content_block_delta` with `text_delta` payloads. The
events land on the global agent-event bus via
`emitAgentEvent({ runId, stream: "assistant", data: { text, delta } })`
from `claude-live-session`'s `onAssistantDelta`, but nothing downstream
of the CLI dispatch subscribes to them.

## Root cause

In `src/auto-reply/reply/agent-runner-execution.ts`, the
`runCliAgent({...})` call inside the `isCliProvider` branch does not
receive any streaming-delta plumbing. Compared with the
`runEmbeddedPiAgent({...})` call a few blocks later (which receives
`onPartialReply`, `onAssistantMessageStart`, `onReasoningStream`,
`onReasoningEnd`, and `onAgentEvent`), the CLI branch only handles the
final `result.payloads[0].text`.

The inline comment said:

```ts
// CLI backends don't emit streaming assistant events, so we need to
// emit one with the final text so server-chat can populate its buffer
// and send the response to TUI/WebSocket clients.
```

That assumption is incorrect for CLI backends configured with streaming
flags. `claude CLI` under `--include-partial-messages` emits full
`stream_event:*` JSONL (verified by dumping the spawned process's
stdout during a live OpenClaw turn). The runtime accepts and parses
those deltas (`parseClaudeCliStreamingDelta` in `claude-live-session`),
emits them to the global bus, and then the trail goes cold -- the
channel layer never sees them because only
`selection.ts` fires `onPartialReply`, and the CLI branch bypasses
`selection.ts`.

## Fix

Wrap the `runCliAgent` call with an `onAgentEvent` subscriber that:

1. Filters by the turn's `runId`.
2. Catches `stream: "assistant"` events carrying a non-empty `delta`.
3. Forwards them to `params.opts.onPartialReply({ text, mediaUrls })`
   (the same callback `runEmbeddedPiAgent` invokes through its
   inference loop).
4. Swallows downstream errors so a broken channel handler cannot
   destabilise the CLI run.
5. Unsubscribes in the `finally` block.

The final `emitAgentEvent({ stream: "assistant", data: { text } })`
after `runCliAgent` returns is preserved so `server-chat` (TUI,
WebSocket clients) still receives the canonical final text. Only the
misleading comment is updated to reflect the new wiring.

No new config knobs, no new feature flags. Existing channel streaming
configuration (`channels.telegram.streaming.mode`, `preview.toolProgress`,
etc.) now takes effect for CLI-backed agents automatically.

## Impact

Any user running a claude-cli, codex-cli, or similar CLI runtime on a
channel that supports live-draft rendering (Telegram forum topics,
Discord, Mattermost block/progress, etc.) will get live preview edits
as text streams in, matching the UX of non-CLI backends.

Users who do not use streaming-capable CLI backends or streaming-capable
channels are unaffected -- the subscriber's filter short-circuits on
events without a non-empty delta or when `onPartialReply` is not
provided.

## Test plan

- `pnpm check` passes (typecheck prod, lint, policy guards, import
  cycles, etc.).
- `pnpm vitest run src/auto-reply/reply/agent-runner-execution.test.ts`
  -- 68 tests pass.
- `pnpm vitest run src/agents/cli-runner.before-agent-reply-cron.test.ts`
  -- 14 tests pass.
- End-to-end on openclaw `2026.5.7` with the claude-cli backend driving
  `anthropic/claude-opus-4-7` (Bedrock via `~/.claude/settings.json`):
  Telegram preview message is now edited progressively as text streams
  in, and tool-progress labels render in partial mode. Before the
  patch, each turn arrived as a single `sendMessage` at turn-end.

Happy to add a targeted vitest covering the new subscriber if
maintainers point me at the right fixture pattern -- the existing
`agent-runner-execution` suite mocks `runCliAgent` but doesn't
currently exercise delta forwarding.

## Not included

- Subagent / isolated-agent CLI paths (`src/cron/isolated-agent/*`,
  `src/agents/cli-runner.ts:567`, and the Crestodian planner invocation
  at `src/crestodian/assistant.ts:189`) were not touched. They might
  benefit from the same bridge if they surface to chat channels; I
  left them out because they weren't part of the reproduction and the
  scope here is the agent-runner CLI dispatch that Telegram /
  Discord / etc. ride.
- No changes to `runCliAgent`'s signature. The bridge is purely
  additive at the caller site. If the maintainers prefer to thread
  `onPartialReply` through `runCliAgent`'s params and invoke it from
  the `onAssistantDelta` handler inside `execute.runtime`, I'm happy
  to refactor -- that keeps the streaming concern inside the CLI
  runner module rather than at the caller.
