### PR TITLE
fix(telegram): start partial draft previews immediately

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -442,7 +442,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       expect.objectContaining({
         chatId: 123,
         thread: { id: 777, scope: "dm" },
-        minInitialChars: 30,
+        minInitialChars: 0,
       }),
     );
     expect(draftStream.update).toHaveBeenCalledWith("Hello");
@@ -466,6 +466,41 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
     expect(editMessageTelegram).not.toHaveBeenCalled();
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends direct model partials through the Telegram draft transport before final delivery", async () => {
+    const { createTelegramDraftStream: createRealTelegramDraftStream } =
+      await vi.importActual<typeof import("./draft-stream.js")>("./draft-stream.js");
+    const bot = createBot();
+    createTelegramDraftStream.mockImplementation((params) => createRealTelegramDraftStream(params));
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Hi" });
+        await vi.waitFor(() =>
+          expect(bot.api.sendMessage).toHaveBeenCalledWith(
+            123,
+            "Hi",
+            expect.objectContaining({ message_thread_id: 777 }),
+          ),
+        );
+        expect(deliverReplies).not.toHaveBeenCalled();
+
+        await dispatcherOptions.deliver({ text: "Hi there" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({ context: createContext(), bot });
+
+    await vi.waitFor(() =>
+      expect(bot.api.editMessageText).toHaveBeenCalledWith(
+        123,
+        777,
+        "Hi there",
+        expect.objectContaining({ parse_mode: "HTML" }),
+      ),
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
   });
 
   it("keeps retained overflow draft previews", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -428,7 +428,7 @@ export const dispatchTelegramMessage = async ({
     replyToMode !== "off" && typeof msg.message_id === "number"
       ? (replyQuoteMessageId ?? msg.message_id)
       : undefined;
-  const draftMinInitialChars = streamMode === "progress" ? 0 : DRAFT_MIN_INITIAL_CHARS;
+  const draftMinInitialChars = streamMode === "block" ? DRAFT_MIN_INITIAL_CHARS : 0;
   const progressSeed = `${route.accountId}:${chatId}:${threadSpec.id ?? ""}`;
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {


### PR DESCRIPTION
## Summary

Fixes #79605.

Telegram partial preview mode now starts the draft preview immediately instead of applying the block-streaming first-message debounce. That preserves the debounce for block previews, while allowing direct model partial text to create the live Telegram preview before final delivery.

The regression test uses the real Telegram draft stream transport from the dispatcher test, emits a short direct partial (`Hi`), verifies the draft transport sends the preview before final delivery, then verifies the final answer edits that preview instead of falling back to the normal final-send path.

## Root Cause

`dispatchTelegramMessage` passed `DRAFT_MIN_INITIAL_CHARS` to the draft stream for both `partial` and `block` modes. Short direct model partials in `partial` mode could stay below the 30-character initial threshold, so no visible Telegram preview was created even though partial callbacks reached the lane.

## Real behavior proof

From `extensions/telegram/src/bot-message-dispatch.test.ts`:

- A direct model partial `Hi` is emitted through `replyOptions.onPartialReply`.
- The real Telegram draft transport calls `bot.api.sendMessage(123, "Hi", ...)` before any final delivery.
- The final answer `Hi there` calls `bot.api.editMessageText(123, 777, "Hi there", ...)`.
- `deliverReplies` is not called, proving the turn stayed on the preview/edit path instead of sending only a final Telegram message.

## Validation

- `pnpm test extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/draft-stream.test.ts src/plugin-sdk/channel-streaming.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- `git diff --check`
- `pnpm check:changed --base upstream/main`