### PR TITLE
fix(models): use effective auth health for status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Memory/QMD: warn with a manual stale collection removal hint when QMD reports a path/pattern conflict but `collection list` lacks verifiable metadata, avoiding unsafe stderr-only rebinds. Refs #71783. (#72297) Thanks @MonkeyLeeT.
+- Models/auth: make `openclaw models status --check` and dashboard auth health honor effective auth profile order while keeping stale profiles visible. (#79685) Thanks @nimbleenigma.
 - Docs/Subagents: correct the listed sub-agent bootstrap context files to include `SOUL.md`, `IDENTITY.md`, and `USER.md`. (#79470) Thanks @lastguru-net.
 - Backup: keep live backup archives from copying current agent session transcripts, cron run logs, and delivery queues while preserving workspace lock/temp files and keeping `--json` output parseable when volatile files are skipped. Fixes #72249. (#72251) Thanks @abnershang.
 - OpenAI/Codex: install the Codex runtime plugin from npm during OpenAI onboarding and load it automatically for implicit OpenAI model routes, while preserving manual PI runtime overrides. Fixes #79358.

--- a/src/agents/auth-health.test.ts
+++ b/src/agents/auth-health.test.ts
@@ -11,6 +11,10 @@ vi.mock("./cli-credentials.js", () => ({
   readMiniMaxCliCredentialsCached: () => null,
   resetCliCredentialCachesForTest: () => undefined,
 }));
+vi.mock("./provider-auth-aliases.js", () => ({
+  resolveProviderIdForAuth: (provider: string) =>
+    provider === "codex-cli" ? "openai-codex" : provider,
+}));
 
 import {
   buildAuthHealthSummary,
@@ -111,6 +115,80 @@ describe("buildAuthHealthSummary", () => {
 
     const provider = summary.providers.find((entry) => entry.provider === "anthropic");
     expect(provider?.status).toBe("expired");
+    expect(
+      provider?.profiles.find((profile) => profile.profileId === "anthropic:expired")?.status,
+    ).toBe("expired");
+  });
+
+  it("uses ordered usable profiles for provider health while keeping stale inventory visible", () => {
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const store = {
+      version: 1,
+      profiles: {
+        "openai-codex:default": {
+          type: "oauth" as const,
+          provider: "openai-codex",
+          access: "stale-access",
+          refresh: "stale-refresh",
+          expires: now - 10_000,
+        },
+        "openai-codex:named": {
+          type: "oauth" as const,
+          provider: "openai-codex",
+          access: "fresh-access",
+          refresh: "fresh-refresh",
+          expires: now + DEFAULT_OAUTH_WARN_MS + 60_000,
+        },
+      },
+      order: {
+        "openai-codex": ["openai-codex:named"],
+      },
+    };
+
+    const summary = buildAuthHealthSummary({
+      store,
+      warnAfterMs: DEFAULT_OAUTH_WARN_MS,
+    });
+
+    expect(profileStatuses(summary)).toMatchObject({
+      "openai-codex:default": "expired",
+      "openai-codex:named": "ok",
+    });
+    const provider = summary.providers.find((entry) => entry.provider === "openai-codex");
+    expect(provider?.status).toBe("ok");
+    expect(provider?.expiresAt).toBe(now + DEFAULT_OAUTH_WARN_MS + 60_000);
+    expect(provider?.profiles.map((profile) => profile.profileId)).toEqual([
+      "openai-codex:default",
+      "openai-codex:named",
+    ]);
+  });
+
+  it("honors canonical empty auth order for aliased stored profile providers", () => {
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const store = {
+      version: 1,
+      profiles: {
+        "codex-cli:legacy": {
+          type: "oauth" as const,
+          provider: "codex-cli",
+          access: "fresh-access",
+          refresh: "fresh-refresh",
+          expires: now + DEFAULT_OAUTH_WARN_MS + 60_000,
+        },
+      },
+      order: {
+        "openai-codex": [],
+      },
+    };
+
+    const summary = buildAuthHealthSummary({
+      store,
+      warnAfterMs: DEFAULT_OAUTH_WARN_MS,
+    });
+
+    const provider = summary.providers.find((entry) => entry.provider === "codex-cli");
+    expect(provider?.status).toBe("missing");
+    expect(provider?.profiles.map((profile) => profile.profileId)).toEqual(["codex-cli:legacy"]);
   });
 
   it("reports expired for OAuth without a refresh token", () => {

--- a/src/agents/auth-health.test.ts
+++ b/src/agents/auth-health.test.ts
@@ -157,6 +157,9 @@ describe("buildAuthHealthSummary", () => {
     const provider = summary.providers.find((entry) => entry.provider === "openai-codex");
     expect(provider?.status).toBe("ok");
     expect(provider?.expiresAt).toBe(now + DEFAULT_OAUTH_WARN_MS + 60_000);
+    expect(provider?.effectiveProfiles?.map((profile) => profile.profileId)).toEqual([
+      "openai-codex:named",
+    ]);
     expect(provider?.profiles.map((profile) => profile.profileId)).toEqual([
       "openai-codex:default",
       "openai-codex:named",
@@ -188,6 +191,7 @@ describe("buildAuthHealthSummary", () => {
 
     const provider = summary.providers.find((entry) => entry.provider === "codex-cli");
     expect(provider?.status).toBe("missing");
+    expect(provider?.effectiveProfiles).toEqual([]);
     expect(provider?.profiles.map((profile) => profile.profileId)).toEqual(["codex-cli:legacy"]);
   });
 
@@ -403,6 +407,7 @@ describe("buildAuthHealthSummary", () => {
       {
         provider: "zai",
         status: "static",
+        effectiveProfiles: summary.profiles,
         profiles: summary.profiles,
       },
     ]);

--- a/src/agents/auth-health.ts
+++ b/src/agents/auth-health.ts
@@ -7,7 +7,10 @@ import {
 } from "./auth-profiles/credential-state.js";
 import { resolveAuthProfileDisplayLabel } from "./auth-profiles/display.js";
 import { resolveEffectiveOAuthCredential } from "./auth-profiles/effective-oauth.js";
+import { resolveAuthProfileOrder } from "./auth-profiles/order.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./auth-profiles/types.js";
+import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
+import { findNormalizedProviderValue } from "./provider-id.js";
 import { normalizeProviderId } from "./provider-id.js";
 
 type AuthProfileSource = "store";
@@ -256,9 +259,50 @@ export function buildAuthHealthSummary(params: {
     }
   }
 
+  const resolveExplicitAuthOrder = (provider: string): string[] | undefined => {
+    const authProvider = resolveProviderIdForAuth(provider, { config: params.cfg });
+    return (
+      findNormalizedProviderValue(params.store.order, authProvider) ??
+      findNormalizedProviderValue(params.store.order, provider) ??
+      findNormalizedProviderValue(params.cfg?.auth?.order, authProvider) ??
+      findNormalizedProviderValue(params.cfg?.auth?.order, provider)
+    );
+  };
+
+  const resolveProviderStatusProfiles = (provider: AuthProviderHealth): AuthProfileHealth[] => {
+    const explicitOrder = resolveExplicitAuthOrder(provider.provider);
+    if (explicitOrder && explicitOrder.length === 0) {
+      return [];
+    }
+
+    const ordered = resolveAuthProfileOrder({
+      cfg: params.cfg,
+      store: params.store,
+      provider: provider.provider,
+    });
+    const orderedProfiles = ordered
+      .map((profileId) => provider.profiles.find((profile) => profile.profileId === profileId))
+      .filter((profile): profile is AuthProfileHealth => Boolean(profile));
+
+    if (orderedProfiles.length > 0) {
+      return orderedProfiles;
+    }
+
+    if (explicitOrder) {
+      return explicitOrder
+        .map((profileId) => provider.profiles.find((profile) => profile.profileId === profileId))
+        .filter((profile): profile is AuthProfileHealth => Boolean(profile));
+    }
+
+    return provider.profiles;
+  };
+
   for (const provider of providersMap.values()) {
-    if (provider.profiles.length === 0) {
+    const statusProfiles = resolveProviderStatusProfiles(provider);
+    if (statusProfiles.length === 0) {
       provider.status = "missing";
+      provider.expiresAt = undefined;
+      provider.remainingMs = undefined;
       continue;
     }
 
@@ -267,7 +311,7 @@ export function buildAuthHealthSummary(params: {
     let hasExpiredOrMissing = false;
     let hasExpiring = false;
     let earliestExpiry: number | undefined;
-    for (const profile of provider.profiles) {
+    for (const profile of statusProfiles) {
       if (profile.type === "api_key") {
         hasApiKeyProfile = true;
         continue;

--- a/src/agents/auth-health.ts
+++ b/src/agents/auth-health.ts
@@ -10,8 +10,7 @@ import { resolveEffectiveOAuthCredential } from "./auth-profiles/effective-oauth
 import { resolveAuthProfileOrder } from "./auth-profiles/order.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./auth-profiles/types.js";
 import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
-import { findNormalizedProviderValue } from "./provider-id.js";
-import { normalizeProviderId } from "./provider-id.js";
+import { findNormalizedProviderValue, normalizeProviderId } from "./provider-id.js";
 
 type AuthProfileSource = "store";
 
@@ -36,6 +35,11 @@ export type AuthProviderHealth = {
   status: AuthProviderHealthStatus;
   expiresAt?: number;
   remainingMs?: number;
+  /**
+   * Full credential inventory stays in `profiles`; provider rollups use this
+   * effective subset after auth order, aliases, and explicit exclusions apply.
+   */
+  effectiveProfiles?: AuthProfileHealth[];
   profiles: AuthProfileHealth[];
 };
 
@@ -298,8 +302,9 @@ export function buildAuthHealthSummary(params: {
   };
 
   for (const provider of providersMap.values()) {
-    const statusProfiles = resolveProviderStatusProfiles(provider);
-    if (statusProfiles.length === 0) {
+    const effectiveProfiles = resolveProviderStatusProfiles(provider);
+    provider.effectiveProfiles = effectiveProfiles;
+    if (effectiveProfiles.length === 0) {
       provider.status = "missing";
       provider.expiresAt = undefined;
       provider.remainingMs = undefined;
@@ -311,7 +316,7 @@ export function buildAuthHealthSummary(params: {
     let hasExpiredOrMissing = false;
     let hasExpiring = false;
     let earliestExpiry: number | undefined;
-    for (const profile of statusProfiles) {
+    for (const profile of effectiveProfiles) {
       if (profile.type === "api_key") {
         hasApiKeyProfile = true;
         continue;

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_OAUTH_WARN_MS,
   formatRemainingShort,
 } from "../../agents/auth-health.js";
+import { resolveAuthProfileOrder } from "../../agents/auth-profiles/order.js";
 import { resolveAuthStorePathForDisplay } from "../../agents/auth-profiles/paths.js";
 import { ensureAuthProfileStoreWithoutExternalProfiles as ensureAuthProfileStore } from "../../agents/auth-profiles/store.js";
 import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
@@ -20,13 +21,12 @@ import {
   resolveProviderEnvApiKeyCandidates,
   resolveProviderEnvAuthEvidence,
 } from "../../agents/model-auth-env-vars.js";
-import { resolveEnvApiKey } from "../../agents/model-auth.js";
+import { resolveEnvApiKey, resolveUsableCustomProviderApiKey } from "../../agents/model-auth.js";
 import {
   buildModelAliasIndex,
   isCliProvider,
   modelKey,
   normalizeProviderId,
-  parseModelRef,
   resolveConfiguredModelRef,
   resolveModelRefFromString,
 } from "../../agents/model-selection.js";
@@ -34,6 +34,7 @@ import {
   OPENAI_CODEX_PROVIDER_ID,
   openAIProviderUsesCodexRuntimeByDefault,
 } from "../../agents/openai-codex-routing.js";
+import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { createConfigIO } from "../../config/config.js";
 import {
@@ -249,25 +250,39 @@ export async function modelsStatusCommand(
       .map((p) => (typeof p === "string" ? normalizeProviderId(p) : ""))
       .filter(Boolean),
   );
+  const aliasIndex = buildModelAliasIndex({
+    cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+    ...DISPLAY_MODEL_PARSE_OPTIONS,
+  });
+  const resolveStatusModelRef = (raw: string | undefined) => {
+    const modelRef = raw?.trim();
+    if (!modelRef) {
+      return undefined;
+    }
+    return resolveModelRefFromString({
+      cfg,
+      raw: modelRef,
+      defaultProvider: DEFAULT_PROVIDER,
+      aliasIndex,
+      ...DISPLAY_MODEL_PARSE_OPTIONS,
+    })?.ref;
+  };
   const providersFromModels = new Set<string>();
   const providerUses: Array<{ provider: string; allowCodexRuntimeFallback: boolean }> = [];
   const addProviderUse = (raw: string | undefined, allowCodexRuntimeFallback: boolean) => {
-    const modelRef = raw?.trim();
-    if (!modelRef) {
-      return;
-    }
-    const parsed = parseModelRef(modelRef, DEFAULT_PROVIDER, DISPLAY_MODEL_PARSE_OPTIONS);
-    if (parsed?.provider) {
+    const ref = resolveStatusModelRef(raw);
+    if (ref?.provider) {
       providerUses.push({
-        provider: normalizeProviderId(parsed.provider),
+        provider: normalizeProviderId(ref.provider),
         allowCodexRuntimeFallback,
       });
     }
   };
   for (const raw of [defaultLabel, ...fallbacks, imageModel, ...imageFallbacks, ...allowed]) {
-    const parsed = parseModelRef(raw ?? "", DEFAULT_PROVIDER, DISPLAY_MODEL_PARSE_OPTIONS);
-    if (parsed?.provider) {
-      providersFromModels.add(normalizeProviderId(parsed.provider));
+    const ref = resolveStatusModelRef(raw);
+    if (ref?.provider) {
+      providersFromModels.add(normalizeProviderId(ref.provider));
     }
   }
   for (const raw of [defaultLabel, ...fallbacks]) {
@@ -310,12 +325,15 @@ export async function modelsStatusCommand(
         providerConfig: resolveProviderConfigForStatus(cfg, normalized),
       },
     });
+    if (!resolved) {
+      continue;
+    }
     syntheticAuthByProvider.set(normalized, {
       value: "plugin-owned",
-      source: resolved?.source ?? "plugin synthetic auth",
-      credential: resolved?.apiKey,
-      mode: resolved?.mode,
-      expiresAt: resolved?.expiresAt,
+      source: resolved.source,
+      credential: resolved.apiKey,
+      mode: resolved.mode,
+      expiresAt: resolved.expiresAt,
     });
   }
   const runtimeCredentialsByProvider = new Map(
@@ -361,11 +379,42 @@ export async function modelsStatusCommand(
       return hasAny;
     });
   const providerAuthMap = new Map(providerAuth.map((entry) => [entry.provider, entry]));
+  const resolveProviderAuthHealthId = (provider: string): string =>
+    resolveProviderIdForAuth(provider, { config: cfg, workspaceDir });
+  const hasUsableNonProfileAuth = (provider: string): boolean => {
+    const authProvider = resolveProviderAuthHealthId(provider);
+    for (const candidate of new Set([provider, authProvider])) {
+      const auth = providerAuthMap.get(candidate);
+      if (
+        auth?.env ||
+        auth?.syntheticAuth ||
+        syntheticAuthByProvider.has(candidate) ||
+        resolveUsableCustomProviderApiKey({ cfg, provider: candidate })
+      ) {
+        return true;
+      }
+    }
+    return false;
+  };
+  const hasUsableProviderAuth = (provider: string): boolean => {
+    const authProvider = resolveProviderAuthHealthId(provider);
+    for (const candidate of new Set([provider, authProvider])) {
+      const orderedProfiles = resolveAuthProfileOrder({
+        cfg,
+        store,
+        provider: candidate,
+      });
+      if (orderedProfiles.length > 0 || hasUsableNonProfileAuth(candidate)) {
+        return true;
+      }
+    }
+    return false;
+  };
   const hasUsableAuthForProviderInUse = (
     provider: string,
     options: { allowCodexRuntimeFallback: boolean },
   ): boolean => {
-    if (providerAuthMap.has(provider) || syntheticAuthByProvider.has(provider)) {
+    if (hasUsableProviderAuth(provider)) {
       return true;
     }
     if (!options.allowCodexRuntimeFallback) {
@@ -373,7 +422,7 @@ export async function modelsStatusCommand(
     }
     return (
       openAIProviderUsesCodexRuntimeByDefault({ provider, config: cfg }) &&
-      providerAuthMap.has(OPENAI_CODEX_PROVIDER_ID)
+      hasUsableProviderAuth(OPENAI_CODEX_PROVIDER_ID)
     );
   };
   const missingProvidersInUse = Array.from(
@@ -414,11 +463,6 @@ export async function modelsStatusCommand(
     throw new Error("--probe-max-tokens must be > 0.");
   }
 
-  const aliasIndex = buildModelAliasIndex({
-    cfg,
-    defaultProvider: DEFAULT_PROVIDER,
-    ...DISPLAY_MODEL_PARSE_OPTIONS,
-  });
   const rawCandidates = [
     rawModel || resolvedLabel,
     ...fallbacks,
@@ -522,10 +566,31 @@ export async function modelsStatusCommand(
   })();
 
   const checkStatus = (() => {
+    const providersInUse = new Set<string>();
+    for (const usage of providerUses) {
+      providersInUse.add(usage.provider);
+      providersInUse.add(resolveProviderAuthHealthId(usage.provider));
+      if (
+        usage.allowCodexRuntimeFallback &&
+        openAIProviderUsesCodexRuntimeByDefault({ provider: usage.provider, config: cfg }) &&
+        providerAuthMap.has(OPENAI_CODEX_PROVIDER_ID)
+      ) {
+        providersInUse.add(OPENAI_CODEX_PROVIDER_ID);
+      }
+    }
     const hasExpiredOrMissing =
-      oauthProfiles.some((profile) => ["expired", "missing"].includes(profile.status)) ||
-      missingProvidersInUse.length > 0;
-    const hasExpiring = oauthProfiles.some((profile) => profile.status === "expiring");
+      authHealth.providers.some(
+        (provider) =>
+          providersInUse.has(provider.provider) &&
+          ["expired", "missing"].includes(provider.status) &&
+          !hasUsableNonProfileAuth(provider.provider),
+      ) || missingProvidersInUse.length > 0;
+    const hasExpiring = authHealth.providers.some(
+      (provider) =>
+        providersInUse.has(provider.provider) &&
+        provider.status === "expiring" &&
+        !hasUsableNonProfileAuth(provider.provider),
+    );
     if (hasExpiredOrMissing) {
       return 1;
     }

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -573,7 +573,7 @@ export async function modelsStatusCommand(
       if (
         usage.allowCodexRuntimeFallback &&
         openAIProviderUsesCodexRuntimeByDefault({ provider: usage.provider, config: cfg }) &&
-        providerAuthMap.has(OPENAI_CODEX_PROVIDER_ID)
+        hasUsableProviderAuth(OPENAI_CODEX_PROVIDER_ID)
       ) {
         providersInUse.add(OPENAI_CODEX_PROVIDER_ID);
       }

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => {
         key: "abc123", // pragma: allowlist secret
       },
     } as Record<string, MockAuthProfile>,
+    order: undefined as Record<string, string[]> | undefined,
   };
 
   return {
@@ -207,6 +208,11 @@ vi.mock("../../agents/model-auth-env-vars.js", () => ({
   resolveProviderEnvAuthEvidence: mocks.resolveProviderEnvAuthEvidence,
   listKnownProviderEnvApiKeyNames: mocks.listKnownProviderEnvApiKeyNames,
 }));
+vi.mock("../../agents/provider-auth-aliases.js", () => ({
+  resolveProviderIdForAuth: vi.fn((provider: string) =>
+    provider === "codex-cli" ? "openai-codex" : provider,
+  ),
+}));
 vi.mock("../../agents/model-selection-cli.js", () => ({
   isCliProvider: vi.fn(
     (provider: string, cfg?: { agents?: { defaults?: { cliBackends?: object } } }) =>
@@ -235,11 +241,13 @@ vi.mock("../../plugins/provider-runtime.js", () => ({
   resolveProviderSyntheticAuthWithPlugin: mocks.resolveProviderSyntheticAuthWithPlugin,
 }));
 
+import { buildAuthHealthSummary } from "../../agents/auth-health.js";
 import { modelsStatusCommand } from "./list.status-command.js";
 
 const defaultResolveEnvApiKeyImpl:
   | ((provider: string) => { apiKey: string; source: string } | null)
   | undefined = mocks.resolveEnvApiKey.getMockImplementation();
+const buildAuthHealthSummaryMock = vi.mocked(buildAuthHealthSummary);
 
 const runtime = {
   log: vi.fn(),
@@ -463,6 +471,471 @@ describe("modelsStatusCommand auth overview", () => {
     }
   });
 
+  it("does not fail --check for stale Codex inventory when ordered provider health is usable", async () => {
+    const localRuntime = createRuntime();
+    const originalLoadConfig = mocks.loadConfig.getMockImplementation();
+    const originalProfiles = { ...mocks.store.profiles };
+    const originalOrder = mocks.store.order ? { ...mocks.store.order } : undefined;
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+    const originalHealthImpl = buildAuthHealthSummaryMock.getMockImplementation();
+    const expiredProfile = {
+      type: "oauth",
+      provider: "openai-codex",
+      access: "expired-access",
+      refresh: "expired-refresh",
+      expires: Date.now() - 60_000,
+    };
+    const usableProfile = {
+      type: "oauth",
+      provider: "openai-codex",
+      access: "usable-access",
+      refresh: "usable-refresh",
+      expires: Date.now() + 60_000,
+    };
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5", fallbacks: [] },
+          models: { "openai/gpt-5.5": {} },
+        },
+      },
+      models: { providers: {} },
+      env: { shellEnv: { enabled: true } },
+    });
+    mocks.store.profiles = {
+      "openai-codex:default": expiredProfile,
+      "openai-codex:named": usableProfile,
+    };
+    mocks.store.order = {
+      "openai-codex": ["openai-codex:named"],
+    };
+    mocks.resolveEnvApiKey.mockImplementation(() => null);
+    buildAuthHealthSummaryMock.mockReturnValue({
+      now: Date.now(),
+      warnAfterMs: 86_400_000,
+      profiles: [
+        {
+          profileId: "openai-codex:default",
+          provider: "openai-codex",
+          type: "oauth",
+          status: "expired",
+          source: "store",
+          label: "openai-codex:default",
+        },
+        {
+          profileId: "openai-codex:named",
+          provider: "openai-codex",
+          type: "oauth",
+          status: "ok",
+          expiresAt: Date.now() + 60_000,
+          remainingMs: 60_000,
+          source: "store",
+          label: "openai-codex:named",
+        },
+      ],
+      providers: [
+        {
+          provider: "openai-codex",
+          status: "ok",
+          expiresAt: Date.now() + 60_000,
+          remainingMs: 60_000,
+          profiles: [],
+        },
+      ],
+    });
+
+    try {
+      await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+      const payload = JSON.parse(String((localRuntime.log as Mock).mock.calls[0]?.[0]));
+      expect(payload.auth.missingProvidersInUse).toEqual([]);
+      expect(payload.auth.oauth.profiles).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            profileId: "openai-codex:default",
+            status: "expired",
+          }),
+          expect.objectContaining({
+            profileId: "openai-codex:named",
+            status: "ok",
+          }),
+        ]),
+      );
+      expect(payload.auth.oauth.providers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            provider: "openai-codex",
+            status: "ok",
+          }),
+        ]),
+      );
+      expect(localRuntime.exit).not.toHaveBeenCalledWith(1);
+    } finally {
+      mocks.store.profiles = originalProfiles;
+      mocks.store.order = originalOrder;
+      if (originalLoadConfig) {
+        mocks.loadConfig.mockImplementation(originalLoadConfig);
+      }
+      if (originalEnvImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+      } else if (defaultResolveEnvApiKeyImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(defaultResolveEnvApiKeyImpl);
+      } else {
+        mocks.resolveEnvApiKey.mockImplementation(() => null);
+      }
+      if (originalHealthImpl) {
+        buildAuthHealthSummaryMock.mockImplementation(originalHealthImpl);
+      }
+    }
+  });
+
+  it("fails --check when an in-use provider alias has expired canonical auth health", async () => {
+    const localRuntime = createRuntime();
+    const originalLoadConfig = mocks.loadConfig.getMockImplementation();
+    const originalProfiles = { ...mocks.store.profiles };
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+    const originalHealthImpl = buildAuthHealthSummaryMock.getMockImplementation();
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: { primary: "codex-cli/gpt-5.5", fallbacks: [] },
+          models: { "codex-cli/gpt-5.5": {} },
+          cliBackends: { "codex-cli": {} },
+        },
+      },
+      models: { providers: {} },
+      env: { shellEnv: { enabled: true } },
+    });
+    mocks.store.profiles = {
+      "openai-codex:default": {
+        type: "oauth",
+        provider: "openai-codex",
+        access: "expired-access",
+        refresh: "expired-refresh",
+        expires: Date.now() - 60_000,
+      },
+    };
+    mocks.resolveEnvApiKey.mockImplementation(() => null);
+    buildAuthHealthSummaryMock.mockReturnValue({
+      now: Date.now(),
+      warnAfterMs: 86_400_000,
+      profiles: [
+        {
+          profileId: "openai-codex:default",
+          provider: "openai-codex",
+          type: "oauth",
+          status: "expired",
+          source: "store",
+          label: "openai-codex:default",
+        },
+      ],
+      providers: [
+        {
+          provider: "openai-codex",
+          status: "expired",
+          expiresAt: Date.now() - 60_000,
+          remainingMs: -60_000,
+          profiles: [],
+        },
+      ],
+    });
+
+    try {
+      await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+      const payload = JSON.parse(String((localRuntime.log as Mock).mock.calls[0]?.[0]));
+      expect(payload.auth.missingProvidersInUse).toEqual([]);
+      expect(localRuntime.exit).toHaveBeenCalledWith(1);
+    } finally {
+      mocks.store.profiles = originalProfiles;
+      if (originalLoadConfig) {
+        mocks.loadConfig.mockImplementation(originalLoadConfig);
+      }
+      if (originalEnvImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+      } else if (defaultResolveEnvApiKeyImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(defaultResolveEnvApiKeyImpl);
+      } else {
+        mocks.resolveEnvApiKey.mockImplementation(() => null);
+      }
+      if (originalHealthImpl) {
+        buildAuthHealthSummaryMock.mockImplementation(originalHealthImpl);
+      }
+    }
+  });
+
+  it("uses resolved configured model aliases when filtering provider health", async () => {
+    const localRuntime = createRuntime();
+    const originalLoadConfig = mocks.loadConfig.getMockImplementation();
+    const originalProfiles = { ...mocks.store.profiles };
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+    const originalHealthImpl = buildAuthHealthSummaryMock.getMockImplementation();
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: { primary: "Opus", fallbacks: [] },
+          models: { "anthropic/claude-opus-4-6": { alias: "Opus" } },
+        },
+      },
+      models: { providers: {} },
+      env: { shellEnv: { enabled: true } },
+    });
+    mocks.store.profiles = {
+      "anthropic:default": {
+        type: "oauth",
+        provider: "anthropic",
+        access: "expired-access",
+        refresh: "expired-refresh",
+        expires: Date.now() - 60_000,
+      },
+      "openai:default": {
+        type: "api_key",
+        provider: "openai",
+        key: "abc123",
+      },
+    };
+    mocks.resolveEnvApiKey.mockImplementation((provider: string) =>
+      provider === "openai"
+        ? {
+            apiKey: "sk-openai-0123456789abcdefghijklmnopqrstuvwxyz",
+            source: "shell env: OPENAI_API_KEY",
+          }
+        : null,
+    );
+    buildAuthHealthSummaryMock.mockReturnValue({
+      now: Date.now(),
+      warnAfterMs: 86_400_000,
+      profiles: [
+        {
+          profileId: "anthropic:default",
+          provider: "anthropic",
+          type: "oauth",
+          status: "expired",
+          source: "store",
+          label: "anthropic:default",
+        },
+      ],
+      providers: [
+        {
+          provider: "anthropic",
+          status: "expired",
+          expiresAt: Date.now() - 60_000,
+          remainingMs: -60_000,
+          profiles: [],
+        },
+      ],
+    });
+
+    try {
+      await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+      const payload = JSON.parse(String((localRuntime.log as Mock).mock.calls[0]?.[0]));
+      expect(payload.resolvedDefault).toBe("anthropic/claude-opus-4-6");
+      expect(localRuntime.exit).toHaveBeenCalledWith(1);
+    } finally {
+      mocks.store.profiles = originalProfiles;
+      if (originalLoadConfig) {
+        mocks.loadConfig.mockImplementation(originalLoadConfig);
+      }
+      if (originalEnvImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+      } else if (defaultResolveEnvApiKeyImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(defaultResolveEnvApiKeyImpl);
+      } else {
+        mocks.resolveEnvApiKey.mockImplementation(() => null);
+      }
+      if (originalHealthImpl) {
+        buildAuthHealthSummaryMock.mockImplementation(originalHealthImpl);
+      }
+    }
+  });
+
+  it("does not fail --check when profile health is missing but non-profile auth is usable", async () => {
+    const localRuntime = createRuntime();
+    const originalLoadConfig = mocks.loadConfig.getMockImplementation();
+    const originalProfiles = { ...mocks.store.profiles };
+    const originalOrder = mocks.store.order ? { ...mocks.store.order } : undefined;
+    const originalHealthImpl = buildAuthHealthSummaryMock.getMockImplementation();
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6", fallbacks: [] },
+          models: { "anthropic/claude-opus-4-6": {} },
+        },
+      },
+      auth: {
+        order: {
+          anthropic: [],
+        },
+      },
+      models: { providers: {} },
+      env: { shellEnv: { enabled: true } },
+    });
+    mocks.store.profiles = {};
+    mocks.store.order = {
+      anthropic: [],
+    };
+    buildAuthHealthSummaryMock.mockReturnValue({
+      now: Date.now(),
+      warnAfterMs: 86_400_000,
+      profiles: [
+        {
+          profileId: "anthropic:default",
+          provider: "anthropic",
+          type: "oauth",
+          status: "ok",
+          source: "store",
+          label: "anthropic:default",
+        },
+      ],
+      providers: [
+        {
+          provider: "anthropic",
+          status: "missing",
+          profiles: [],
+        },
+      ],
+    });
+
+    try {
+      await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+      const payload = JSON.parse(String((localRuntime.log as Mock).mock.calls[0]?.[0]));
+      expect(payload.auth.providers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            provider: "anthropic",
+            env: expect.objectContaining({ source: "env: ANTHROPIC_OAUTH_TOKEN" }),
+          }),
+        ]),
+      );
+      expect(localRuntime.exit).not.toHaveBeenCalledWith(1);
+      expect(localRuntime.exit).not.toHaveBeenCalledWith(2);
+    } finally {
+      mocks.store.profiles = originalProfiles;
+      mocks.store.order = originalOrder;
+      if (originalLoadConfig) {
+        mocks.loadConfig.mockImplementation(originalLoadConfig);
+      }
+      if (originalHealthImpl) {
+        buildAuthHealthSummaryMock.mockImplementation(originalHealthImpl);
+      }
+    }
+  });
+
+  it("reports missing auth when explicit auth order disables stored profiles", async () => {
+    const localRuntime = createRuntime();
+    const originalLoadConfig = mocks.loadConfig.getMockImplementation();
+    const originalProfiles = { ...mocks.store.profiles };
+    const originalOrder = mocks.store.order ? { ...mocks.store.order } : undefined;
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6", fallbacks: [] },
+          models: { "anthropic/claude-opus-4-6": {} },
+        },
+      },
+      auth: {
+        order: {
+          anthropic: [],
+        },
+      },
+      models: { providers: {} },
+      env: { shellEnv: { enabled: true } },
+    });
+    mocks.store.profiles = {
+      "anthropic:default": {
+        type: "oauth",
+        provider: "anthropic",
+        access: "usable-access",
+        refresh: "usable-refresh",
+        expires: Date.now() + 60_000,
+      },
+    };
+    mocks.store.order = undefined;
+    mocks.resolveEnvApiKey.mockImplementation(() => null);
+
+    try {
+      await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+      const payload = JSON.parse(String((localRuntime.log as Mock).mock.calls[0]?.[0]));
+      expect(payload.auth.missingProvidersInUse).toEqual(["anthropic"]);
+      expect(localRuntime.exit).toHaveBeenCalledWith(1);
+    } finally {
+      mocks.store.profiles = originalProfiles;
+      mocks.store.order = originalOrder;
+      if (originalLoadConfig) {
+        mocks.loadConfig.mockImplementation(originalLoadConfig);
+      }
+      if (originalEnvImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+      } else if (defaultResolveEnvApiKeyImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(defaultResolveEnvApiKeyImpl);
+      } else {
+        mocks.resolveEnvApiKey.mockImplementation(() => null);
+      }
+    }
+  });
+
+  it("does fail --check when the only models.json auth is not resolvable", async () => {
+    const localRuntime = createRuntime();
+    const originalLoadConfig = mocks.loadConfig.getMockImplementation();
+    const originalProfiles = { ...mocks.store.profiles };
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+    const originalCustomKeyImpl = mocks.getCustomProviderApiKey.getMockImplementation();
+    const originalUsableCustomKeyImpl =
+      mocks.resolveUsableCustomProviderApiKey.getMockImplementation();
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6", fallbacks: [] },
+          models: { "anthropic/claude-opus-4-6": {} },
+        },
+      },
+      models: {
+        providers: {
+          anthropic: {
+            apiKey: "ANTHROPIC_API_KEY",
+          },
+        },
+      },
+      env: { shellEnv: { enabled: true } },
+    });
+    mocks.store.profiles = {};
+    mocks.resolveEnvApiKey.mockImplementation(() => null);
+    mocks.getCustomProviderApiKey.mockImplementation((provider: string) =>
+      provider === "anthropic" ? "ANTHROPIC_API_KEY" : undefined,
+    );
+    mocks.resolveUsableCustomProviderApiKey.mockImplementation(() => null);
+    try {
+      await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+      const payload = JSON.parse(String((localRuntime.log as Mock).mock.calls[0]?.[0]));
+      expect(payload.auth.missingProvidersInUse).toEqual(["anthropic"]);
+      expect(mocks.resolveUsableCustomProviderApiKey).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: "anthropic" }),
+      );
+      expect(localRuntime.exit).toHaveBeenCalledWith(1);
+    } finally {
+      mocks.store.profiles = originalProfiles;
+      if (originalLoadConfig) {
+        mocks.loadConfig.mockImplementation(originalLoadConfig);
+      }
+      if (originalEnvImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+      } else if (defaultResolveEnvApiKeyImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(defaultResolveEnvApiKeyImpl);
+      } else {
+        mocks.resolveEnvApiKey.mockImplementation(() => null);
+      }
+      if (originalCustomKeyImpl) {
+        mocks.getCustomProviderApiKey.mockImplementation(originalCustomKeyImpl);
+      } else {
+        mocks.getCustomProviderApiKey.mockReturnValue(undefined);
+      }
+      if (originalUsableCustomKeyImpl) {
+        mocks.resolveUsableCustomProviderApiKey.mockImplementation(originalUsableCustomKeyImpl);
+      } else {
+        mocks.resolveUsableCustomProviderApiKey.mockReturnValue(null);
+      }
+    }
+  });
+
   it("keeps Codex auth fallback scoped away from OpenAI image routes", async () => {
     const localRuntime = createRuntime();
     const originalLoadConfig = mocks.loadConfig.getMockImplementation();
@@ -661,6 +1134,62 @@ describe("modelsStatusCommand auth overview", () => {
       );
       expect(providers.map((entry) => entry.provider)).not.toContain("unused-synthetic");
     } finally {
+      if (originalLoadConfig) {
+        mocks.loadConfig.mockImplementation(originalLoadConfig);
+      }
+      if (originalEnvImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+      } else if (defaultResolveEnvApiKeyImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(defaultResolveEnvApiKeyImpl);
+      } else {
+        mocks.resolveEnvApiKey.mockImplementation(() => null);
+      }
+      if (originalSyntheticImpl) {
+        mocks.resolveRuntimeSyntheticAuthProviderRefs.mockImplementation(originalSyntheticImpl);
+      } else {
+        mocks.resolveRuntimeSyntheticAuthProviderRefs.mockReturnValue([]);
+      }
+      if (originalResolveSyntheticAuthImpl) {
+        mocks.resolveProviderSyntheticAuthWithPlugin.mockImplementation(
+          originalResolveSyntheticAuthImpl,
+        );
+      } else {
+        mocks.resolveProviderSyntheticAuthWithPlugin.mockReturnValue(undefined);
+      }
+    }
+  });
+
+  it("does not treat declared but unresolved synthetic auth as usable", async () => {
+    const localRuntime = createRuntime();
+    const originalLoadConfig = mocks.loadConfig.getMockImplementation();
+    const originalProfiles = { ...mocks.store.profiles };
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+    const originalSyntheticImpl =
+      mocks.resolveRuntimeSyntheticAuthProviderRefs.getMockImplementation();
+    const originalResolveSyntheticAuthImpl =
+      mocks.resolveProviderSyntheticAuthWithPlugin.getMockImplementation();
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: { primary: "codex/gpt-5.5", fallbacks: [] },
+          models: { "codex/gpt-5.5": {} },
+        },
+      },
+      models: { providers: {} },
+      env: { shellEnv: { enabled: false } },
+    });
+    mocks.store.profiles = {};
+    mocks.resolveEnvApiKey.mockImplementation(() => null);
+    mocks.resolveRuntimeSyntheticAuthProviderRefs.mockReturnValue(["codex"]);
+    mocks.resolveProviderSyntheticAuthWithPlugin.mockReturnValue(undefined);
+
+    try {
+      await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+      const payload = JSON.parse(String((localRuntime.log as Mock).mock.calls[0]?.[0]));
+      expect(payload.auth.missingProvidersInUse).toEqual(["codex"]);
+      expect(localRuntime.exit).toHaveBeenCalledWith(1);
+    } finally {
+      mocks.store.profiles = originalProfiles;
       if (originalLoadConfig) {
         mocks.loadConfig.mockImplementation(originalLoadConfig);
       }

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -548,6 +548,22 @@ describe("aggregateOAuthStatus", () => {
     expect(result.status).toBe("ok");
   });
 
+  it("uses effective OAuth profiles while keeping stale inventory visible", () => {
+    const healthy = oauth("ok", expiring + 10_000_000);
+    const stale = oauth("expired", NOW - 1);
+    const result = aggregateOAuthStatus(
+      {
+        provider: "openai-codex",
+        status: "ok",
+        effectiveProfiles: [healthy],
+        profiles: [stale, healthy],
+      },
+      NOW,
+    );
+    expect(result.status).toBe("ok");
+    expect(result.expiresAt).toBe(healthy.expiresAt);
+  });
+
   it("falls back to prov.status when no OAuth profiles exist", () => {
     const result = aggregateOAuthStatus(
       {

--- a/src/gateway/server-methods/models-auth-status.ts
+++ b/src/gateway/server-methods/models-auth-status.ts
@@ -106,6 +106,8 @@ function providerDisplayName(provider: string): string {
  * where a healthy OAuth sits alongside an expired/missing bearer token.
  * For the dashboard's OAuth-health signal, token profiles are a separate
  * concern — we want "is OAuth healthy?", not "is every credential healthy?"
+ * It also consumes the provider's effective profile subset when auth order
+ * excludes stale inventory from the runtime credential path.
  *
  * `expectsOAuth` surfaces the configured-OAuth-but-no-oauth-profile case as
  * `missing` instead of silently falling back to the provider's rollup (which
@@ -124,7 +126,8 @@ export function aggregateOAuthStatus(
   expiresAt?: number;
   remainingMs?: number;
 } {
-  const oauth = prov.profiles.filter((p) => p.type === "oauth");
+  const profiles = prov.effectiveProfiles ?? prov.profiles;
+  const oauth = profiles.filter((p) => p.type === "oauth");
   if (oauth.length === 0) {
     if (expectsOAuth) {
       return { status: "missing" };


### PR DESCRIPTION
## Summary
- compute provider OAuth/token status from the effective auth profile order instead of all stored inventory
- keep stale/excluded profiles visible in per-profile and probe output
- scope `models status --check` to resolved in-use providers/auth aliases while honoring env, resolved models.json, and resolved synthetic auth paths

## Real Behavior Proof
- **Behavior or issue addressed:** `models status --check` should not fail a provider because a stale stored OAuth profile exists when the effective auth order selects a different healthy profile for that provider.
- **Real environment tested:** Real local OpenClaw checkout on this PR branch, using a real local OpenClaw config/auth store with two `openai-codex` OAuth profiles. Profile names, local paths, and account identifiers are redacted.
- **Exact steps or command run after this patch:**

  ```sh
  OPENCLAW_HOME=<redacted> node dist/index.js models status --json --probe --probe-provider openai-codex --probe-timeout 30000 --probe-max-tokens 8 --check
  ```

- **Evidence after fix:** Terminal output was captured from the command above. The command exited `0`; redacted copied output excerpt:

  ```json
  {
    "auth": {
      "missingProvidersInUse": [],
      "provider": {
        "provider": "openai-codex",
        "effectiveKind": "profiles",
        "profileCount": 2,
        "oauthProfiles": 2
      },
      "health": {
        "provider": "openai-codex",
        "status": "ok",
        "profiles": [
          {
            "profileId": "openai-codex:default",
            "status": "expired",
            "source": "store"
          },
          {
            "profileId": "openai-codex:<redacted-ordered-profile>",
            "status": "ok",
            "source": "store"
          }
        ]
      },
      "probes": {
        "totalTargets": 1,
        "results": [
          {
            "provider": "openai-codex",
            "profileId": "openai-codex:default",
            "status": "unknown",
            "reasonCode": "excluded_by_auth_order",
            "mode": "oauth",
            "source": "profile",
            "latencyMs": null
          },
          {
            "provider": "openai-codex",
            "profileId": "openai-codex:<redacted-ordered-profile>",
            "status": "ok",
            "reasonCode": null,
            "mode": "oauth",
            "source": "profile",
            "latencyMs": 6672
          }
        ]
      }
    }
  }
  ```

- **Observed result after fix:** The stale `openai-codex:default` profile remains visible as `expired`, but it is excluded by effective auth order during probing. The ordered redacted OpenAI/Codex OAuth profile probes successfully, provider health is `ok`, `missingProvidersInUse` is empty, and `models status --check` exits `0`.
- **What was not tested:** Full `pnpm test` and maintainer-side non-draft CI were not run for this narrow draft PR.

## Validation
- `node scripts/test-projects.mjs src/commands/models/list.status.test.ts src/agents/auth-health.test.ts`
- `pnpm tsgo:prod`
- `git diff --check origin/main...HEAD`
- `codex review --base origin/main`

## Notes
- AI-assisted.
- Opened as draft for maintainer review before broader validation.
- Full `pnpm test` was intentionally not run for this narrow draft PR.