### PR TITLE
test(agents/bundle-mcp): cover configured MCP request-boundary path

### DIFF
--- a/scripts/e2e/pi-bundle-mcp-tools-docker-client.ts
+++ b/scripts/e2e/pi-bundle-mcp-tools-docker-client.ts
@@ -12,6 +12,7 @@ import {
   getOrCreateSessionMcpRuntime,
 } from "../../dist/agents/pi-bundle-mcp-runtime.js";
 import { applyFinalEffectiveToolPolicy } from "../../dist/agents/pi-embedded-runner/effective-tool-policy.js";
+import { splitSdkTools } from "../../dist/agents/pi-embedded-runner/tool-split.js";
 import type { OpenClawConfig } from "../../dist/config/types.openclaw.js";
 import { getPluginToolMeta } from "../../dist/plugins/tools.js";
 
@@ -136,6 +137,37 @@ async function main() {
     });
     assert(denied.tools.length === 0, "expected tools.deny bundle-mcp to filter MCP tools");
 
+    // The disputed boundary on #76063 is what reaches the SDK as `customTools`,
+    // since that is the exact value serialized to the outbound provider request.
+    // Prove the live stdio probe survives the materialize -> filter -> split chain
+    // through `splitSdkTools` for the same four profiles already asserted above.
+    const codingCustom = splitSdkTools({ tools: coding.tools, sandboxEnabled: false }).customTools;
+    const messagingCustom = splitSdkTools({
+      tools: messaging.tools,
+      sandboxEnabled: false,
+    }).customTools;
+    const minimalCustom = splitSdkTools({
+      tools: minimal.tools,
+      sandboxEnabled: false,
+    }).customTools;
+    const deniedCustom = splitSdkTools({ tools: denied.tools, sandboxEnabled: false }).customTools;
+    assert(
+      codingCustom.some((tool) => tool.name === probeTool.name),
+      "expected coding profile customTools to include bundle MCP tools",
+    );
+    assert(
+      messagingCustom.some((tool) => tool.name === probeTool.name),
+      "expected messaging profile customTools to include bundle MCP tools",
+    );
+    assert(
+      minimalCustom.length === 0,
+      "expected minimal profile customTools to exclude bundle MCP tools",
+    );
+    assert(
+      deniedCustom.length === 0,
+      "expected tools.deny bundle-mcp customTools to exclude bundle MCP tools",
+    );
+
     process.stdout.write(
       JSON.stringify(
         {
@@ -146,6 +178,18 @@ async function main() {
             messaging: messaging.tools.length,
             minimal: minimal.tools.length,
             denied: denied.tools.length,
+          },
+          customToolsCounts: {
+            coding: codingCustom.length,
+            messaging: messagingCustom.length,
+            minimal: minimalCustom.length,
+            denied: deniedCustom.length,
+          },
+          customToolNames: {
+            coding: codingCustom.map((tool) => tool.name),
+            messaging: messagingCustom.map((tool) => tool.name),
+            minimal: minimalCustom.map((tool) => tool.name),
+            denied: deniedCustom.map((tool) => tool.name),
           },
         },
         null,

--- a/src/agents/pi-bundle-mcp-tools.request-boundary.test.ts
+++ b/src/agents/pi-bundle-mcp-tools.request-boundary.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  createBundleMcpToolRuntime,
+  materializeBundleMcpToolsForRun,
+} from "./pi-bundle-mcp-materialize.js";
+import type { McpCatalogTool, SessionMcpRuntime } from "./pi-bundle-mcp-types.js";
+import { applyFinalEffectiveToolPolicy } from "./pi-embedded-runner/effective-tool-policy.js";
+import { splitSdkTools } from "./pi-embedded-runner/tool-split.js";
+
+// Regression coverage for #76063. The reporter's evidence was a captured
+// outbound provider request body that contained only built-in OpenClaw tools
+// and no `server__*` MCP tool definitions, even though `cfg.mcp.servers`
+// declared healthy stdio servers. The materialize/policy/split units each
+// have their own focused tests, but ClawSweeper noted that the full request-
+// boundary path was uncovered: configured (`cfg.mcp.servers.<name>`) tools
+// must materialize, survive `applyFinalEffectiveToolPolicy`, and reach
+// `splitSdkTools().customTools` (the value passed to the SDK as
+// `customTools`, which is what the provider receives). This test asserts
+// that boundary behavior with a fake session MCP runtime so it can run
+// against current main without booting a real stdio child.
+
+function makeConfiguredRuntime(
+  params: {
+    serverName?: string;
+    toolNames?: string[];
+  } = {},
+): SessionMcpRuntime {
+  const serverName = params.serverName ?? "userMcp";
+  const toolNames = params.toolNames ?? ["list_inbox", "send_reply"];
+  const tools: McpCatalogTool[] = toolNames.map((toolName) => ({
+    serverName,
+    safeServerName: serverName,
+    toolName,
+    description: `${serverName}.${toolName}`,
+    inputSchema: { type: "object", properties: {} },
+    fallbackDescription: `${serverName}.${toolName}`,
+  }));
+  return {
+    sessionId: "session-request-boundary",
+    workspaceDir: "/workspace",
+    configFingerprint: "fingerprint",
+    createdAt: 0,
+    lastUsedAt: 0,
+    markUsed: () => {},
+    getCatalog: async () => ({
+      version: 1,
+      generatedAt: 0,
+      servers: {
+        [serverName]: {
+          serverName,
+          launchSummary: serverName,
+          toolCount: tools.length,
+        },
+      },
+      tools,
+    }),
+    callTool: async () => ({
+      content: [{ type: "text", text: "FROM-CONFIG" }],
+      isError: false,
+    }),
+    dispose: async () => {},
+  };
+}
+
+async function buildConfiguredMcpToolNamesAtRequestBoundary(params: {
+  cfg: OpenClawConfig;
+}): Promise<string[]> {
+  const runtime = await createBundleMcpToolRuntime({
+    workspaceDir: "/workspace",
+    cfg: params.cfg,
+    createRuntime: () => makeConfiguredRuntime(),
+  });
+  const filtered = applyFinalEffectiveToolPolicy({
+    bundledTools: runtime.tools,
+    config: params.cfg,
+    warn: () => {},
+  });
+  const { customTools } = splitSdkTools({ tools: filtered, sandboxEnabled: false });
+  return customTools.map((tool) => tool.name);
+}
+
+describe("configured MCP tools reach the request boundary (#76063)", () => {
+  it("includes server__* tools in customTools under the coding profile", async () => {
+    const names = await buildConfiguredMcpToolNamesAtRequestBoundary({
+      cfg: {
+        tools: { profile: "coding" },
+        mcp: {
+          servers: {
+            userMcp: {
+              command: "node",
+              args: ["user-mcp.mjs"],
+            },
+          },
+        },
+      },
+    });
+
+    expect(names).toEqual(["userMcp__list_inbox", "userMcp__send_reply"]);
+  });
+
+  it("includes server__* tools in customTools under the messaging profile", async () => {
+    const names = await buildConfiguredMcpToolNamesAtRequestBoundary({
+      cfg: {
+        tools: { profile: "messaging" },
+        mcp: {
+          servers: {
+            userMcp: {
+              command: "node",
+              args: ["user-mcp.mjs"],
+            },
+          },
+        },
+      },
+    });
+
+    expect(names).toEqual(["userMcp__list_inbox", "userMcp__send_reply"]);
+  });
+
+  it("removes configured server__* tools from customTools under the minimal profile", async () => {
+    const names = await buildConfiguredMcpToolNamesAtRequestBoundary({
+      cfg: {
+        tools: { profile: "minimal" },
+        mcp: {
+          servers: {
+            userMcp: {
+              command: "node",
+              args: ["user-mcp.mjs"],
+            },
+          },
+        },
+      },
+    });
+
+    expect(names).toEqual([]);
+  });
+
+  it("respects an explicit tools.deny: ['bundle-mcp'] entry under the coding profile", async () => {
+    const names = await buildConfiguredMcpToolNamesAtRequestBoundary({
+      cfg: {
+        tools: { profile: "coding", deny: ["bundle-mcp"] },
+        mcp: {
+          servers: {
+            userMcp: {
+              command: "node",
+              args: ["user-mcp.mjs"],
+            },
+          },
+        },
+      },
+    });
+
+    expect(names).toEqual([]);
+  });
+
+  it("preserves materialize ordering at the request boundary so prompt cache keys stay stable", async () => {
+    const runtime = await materializeBundleMcpToolsForRun({
+      runtime: makeConfiguredRuntime({
+        toolNames: ["zeta_tool", "alpha_tool", "mu_tool"],
+      }),
+    });
+    const filtered = applyFinalEffectiveToolPolicy({
+      bundledTools: runtime.tools,
+      config: { tools: { profile: "coding" } },
+      warn: () => {},
+    });
+    const { customTools } = splitSdkTools({ tools: filtered, sandboxEnabled: false });
+
+    expect(customTools.map((tool) => tool.name)).toEqual([
+      "userMcp__alpha_tool",
+      "userMcp__mu_tool",
+      "userMcp__zeta_tool",
+    ]);
+  });
+});


### PR DESCRIPTION
Refs #76063.

Adds regression coverage for configured MCP tools reaching the Pi request boundary. This is test-only: it covers the production materialize -> final effective tool policy -> splitSdkTools().customTools path, and extends the Docker MCP harness so live stdio materialized tools are asserted at the customTools boundary.

This does not claim to fix #76063 outright. Additional maintainer proof captured after review shows current main with forced Pi does include configured stdio MCP tools in the outbound provider request body, so the still-open bug likely lives in runtime selection, toolsAllow filtering, gateway/session config freshness, or a non-Pi/native harness path.

## Verification

- pnpm test src/agents/pi-bundle-mcp-tools.request-boundary.test.ts
- pnpm exec oxfmt --check --threads=1 src/agents/pi-bundle-mcp-tools.request-boundary.test.ts scripts/e2e/pi-bundle-mcp-tools-docker-client.ts
- Blacksmith Testbox tbx_01krapsvn0rz48jf9rqxteaz3b / https://github.com/openclaw/openclaw/actions/runs/25651404782: fake OpenAI Responses provider captured /v1/responses, with repro__probe_tool present in the request tools and in systemPromptReport.tools.entries.

Pure test addition; no CHANGELOG entry.
