### PR TITLE
[codex] Fix OpenAI API-key default runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway: avoid false degraded event-loop health during rapid health/readiness/status probes unless sustained load has delay co-evidence, while keeping hard delay detection immediate. (#77028) Thanks @rubencu.
+- OpenAI: pin OpenAI API-key onboarding's `openai/gpt-5.5` default to the PI runtime so fresh API-key installs use the saved `openai:default` profile instead of the implicit Codex harness. Fixes #79358. Thanks @pubnub-mrruby.
 - Gateway/agent: pass the session-key agent id into inline image attachment validation so the first image in a fresh per-agent session uses the agent's vision-capable model override instead of the text-only system default. Fixes #79407. Thanks @pandadev66.
 - Gateway/maintenance: prune dedupe overflow against a stable excess count and keep active agent retries from starting duplicate runs after cache eviction. (#73841) Thanks @thesomewhatyou.
 - Control UI/subagents: suppress internal `subagent_announce` handoff prompts from requester transcripts and hide legacy inter-session wrapper rows so completed subagent results no longer surface runtime context in WebChat history. (#79618) Thanks @joshavant.

--- a/extensions/openai/default-models.test.ts
+++ b/extensions/openai/default-models.test.ts
@@ -8,6 +8,28 @@ describe("openai default models", () => {
     expect(Object.keys(next.agents?.defaults?.models ?? {})).toContain(OPENAI_DEFAULT_MODEL);
   });
 
+  it("pins the default API-key model to PI runtime", () => {
+    const next = applyOpenAIProviderConfig({});
+    expect(next.agents?.defaults?.models?.[OPENAI_DEFAULT_MODEL]?.agentRuntime).toEqual({
+      id: "pi",
+    });
+  });
+
+  it("preserves an existing runtime for the default model", () => {
+    const next = applyOpenAIProviderConfig({
+      agents: {
+        defaults: {
+          models: {
+            [OPENAI_DEFAULT_MODEL]: { agentRuntime: { id: "codex" } },
+          },
+        },
+      },
+    });
+    expect(next.agents?.defaults?.models?.[OPENAI_DEFAULT_MODEL]?.agentRuntime).toEqual({
+      id: "codex",
+    });
+  });
+
   it("preserves existing alias for the default model", () => {
     const next = applyOpenAIProviderConfig({
       agents: {

--- a/extensions/openai/default-models.ts
+++ b/extensions/openai/default-models.ts
@@ -20,6 +20,7 @@ export function applyOpenAIProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
   const models = { ...next.agents?.defaults?.models };
   models[OPENAI_DEFAULT_MODEL] = {
     ...models[OPENAI_DEFAULT_MODEL],
+    agentRuntime: models[OPENAI_DEFAULT_MODEL]?.agentRuntime ?? { id: "pi" },
     alias: models[OPENAI_DEFAULT_MODEL]?.alias ?? "GPT",
   };
 


### PR DESCRIPTION
## Summary

- Pin the OpenAI API-key onboarding default model (`openai/gpt-5.5`) to the PI runtime.
- Preserve any existing explicit runtime override for that model.
- Add regression coverage and a changelog entry for #79358.

## Root Cause

Fresh OpenAI API-key setup saved credentials into the `openai:default` auth profile, but the official `openai/*` model path can be routed through the implicit Codex harness when no model-scoped runtime is set. That harness path does not consume the saved `openai:default` profile, so requests could go out without the expected Authorization header even though onboarding had written an API-key profile.

## User Impact

Fresh API-key installs now use the saved OpenAI profile for the default `openai/gpt-5.5` model instead of falling into the implicit Codex harness path.

Fixes #79358. Thanks @pubnub-mrruby.

## Verification

- `pnpm test extensions/openai/default-models.test.ts`
- Live temp profile-store smoke with `OPENAI_API_KEY` loaded from `~/.profile` and not printed: `pnpm test:live src/gateway/gateway-models.profiles.live.test.ts -t "runs meaningful prompts across models with available keys"` with `OPENCLAW_LIVE_REQUIRE_PROFILE_KEYS=1` and `OPENCLAW_LIVE_GATEWAY_MODELS=openai/gpt-5.5`; prompt, tool-read, and OpenAI tool-only regression completed.
- `pnpm exec oxfmt --check --threads=1 extensions/openai/default-models.ts extensions/openai/default-models.test.ts CHANGELOG.md`
- `git diff --check`
- `OPENCLAW_TESTBOX=0 pnpm check:changed`