### PR TITLE
fix(telegram): guard DM bindings from being parsed as topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,6 +350,7 @@ Docs: https://docs.openclaw.ai
 - Agents/failover: rotate auth profiles before deferred cooldown marking on rate-limit failures, so file-lock contention cannot stall profile failover. Fixes #57281. (#57283) Thanks @jeremyknows.
 - Gateway/sessions: when `session.dmScope: "main"` is configured, route a bare webchat `/new` against the agent's main session (`sessions.create` with `emitCommandHooks=true`) to an in-place reset instead of creating a parallel `dashboard:` child, matching `/new` behavior on Telegram/Discord. Fixes #77434. (#71170) Thanks @statxc.
 - Scripts/UI/Windows: launch `.cmd` and `.bat` UI runners through the shared cmd.exe escaping path with shell mode disabled, avoiding Node.js v24 DEP0190 warnings while preserving argument boundaries. (#62910) Thanks @nandanadileep.
+- Telegram: treat a DM binding that carries the chat id in both `conversationId` and `parentConversationId` as a direct conversation instead of a topic, so reverse delivery for Telegram DMs is not misrouted through a topic-shaped target. Thanks @TSHOGX.
 
 ## 2026.5.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,7 +350,7 @@ Docs: https://docs.openclaw.ai
 - Agents/failover: rotate auth profiles before deferred cooldown marking on rate-limit failures, so file-lock contention cannot stall profile failover. Fixes #57281. (#57283) Thanks @jeremyknows.
 - Gateway/sessions: when `session.dmScope: "main"` is configured, route a bare webchat `/new` against the agent's main session (`sessions.create` with `emitCommandHooks=true`) to an in-place reset instead of creating a parallel `dashboard:` child, matching `/new` behavior on Telegram/Discord. Fixes #77434. (#71170) Thanks @statxc.
 - Scripts/UI/Windows: launch `.cmd` and `.bat` UI runners through the shared cmd.exe escaping path with shell mode disabled, avoiding Node.js v24 DEP0190 warnings while preserving argument boundaries. (#62910) Thanks @nandanadileep.
-- Telegram: treat a DM binding that carries the chat id in both `conversationId` and `parentConversationId` as a direct conversation instead of a topic, so reverse delivery for Telegram DMs is not misrouted through a topic-shaped target. Thanks @TSHOGX.
+- Telegram: treat a DM binding that carries the chat id in both `conversationId` and `parentConversationId` as a direct conversation instead of a topic, so reverse delivery for Telegram DMs is not misrouted through a topic-shaped target. (#79700) Thanks @TSHOGX.
 
 ## 2026.5.7
 

--- a/extensions/telegram/src/topic-conversation.test.ts
+++ b/extensions/telegram/src/topic-conversation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { parseTelegramTopicConversation } from "./topic-conversation.js";
+
+describe("parseTelegramTopicConversation", () => {
+  it("parses direct chatId:topic:topicId strings", () => {
+    expect(
+      parseTelegramTopicConversation({
+        conversationId: "-1001234567890:topic:42",
+      }),
+    ).toEqual({
+      chatId: "-1001234567890",
+      topicId: "42",
+      canonicalConversationId: "-1001234567890:topic:42",
+    });
+  });
+
+  it("parses a bare topic id against a group parentConversationId", () => {
+    expect(
+      parseTelegramTopicConversation({
+        conversationId: "42",
+        parentConversationId: "-1001234567890",
+      }),
+    ).toEqual({
+      chatId: "-1001234567890",
+      topicId: "42",
+      canonicalConversationId: "-1001234567890:topic:42",
+    });
+  });
+
+  it("returns null when a DM binding carries the chat id in both fields", () => {
+    expect(
+      parseTelegramTopicConversation({
+        conversationId: "1234",
+        parentConversationId: "1234",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when neither shape matches", () => {
+    expect(
+      parseTelegramTopicConversation({
+        conversationId: "not-a-topic",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for a bare topic id without a parentConversationId", () => {
+    expect(
+      parseTelegramTopicConversation({
+        conversationId: "42",
+      }),
+    ).toBeNull();
+  });
+});

--- a/extensions/telegram/src/topic-conversation.ts
+++ b/extensions/telegram/src/topic-conversation.ts
@@ -43,6 +43,11 @@ export function parseTelegramTopicConversation(params: {
   if (!parent || !/^-?\d+$/.test(parent)) {
     return null;
   }
+  // Telegram DM bindings can carry the chat id in both fields; treat that as
+  // a direct conversation shape, not a legacy topic binding.
+  if (parent === conversation) {
+    return null;
+  }
   const canonicalConversationId = buildTelegramTopicConversationId({
     chatId: parent,
     topicId: conversation,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `parseTelegramTopicConversation` treats a bare numeric `conversationId` plus a numeric `parentConversationId` as `${parent}:topic:${conversation}`. Telegram DM bindings can shape the same value into both fields (e.g. `{conversationId: "1234", parentConversationId: "1234"}`), which then canonicalizes to `1234:topic:1234` instead of a direct DM conversation.
- Why it matters: that canonical form flows into `resolveTelegramDeliveryTarget` used by `messaging.resolveDeliveryTarget` on the Telegram plugin, producing `{to: "1234", threadId: "1234"}` for reverse delivery. Outbound replies for the DM then carry a spurious `message_thread_id` and land on the wrong routing surface.
- What changed: a 5-line early return inside `parseTelegramTopicConversation` after the existing parent-validation step: when `parent === conversation`, return `null` so the caller falls back to the direct-conversation shape. Added `extensions/telegram/src/topic-conversation.test.ts` with direct topic, group+topic, DM guard, no-parent, and non-matching cases.
- What did NOT change (scope boundary): no callers were rewritten. The ACP-side callers `normalizeTelegramAcpConversationId` and `matchTelegramAcpConversation` already short-circuit DMs via `chatId.startsWith("-")`, so this fix is confined to the shared parser and the messaging reverse-delivery seam that consumes it. No ACP placement, thread-binding lifecycle, or inbound routing code is touched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #50955 — #50955 proposed a broader ACP thread-binding unification across Telegram, Discord, and Feishu. On current `main` its two `Closes` targets (#41004, #41116) are already closed as implemented, and the ACP/Discord/Feishu pieces of that PR have been shipped by other upstream commits (see Root Cause for references). The Telegram DM parse guard was not picked up by any of those, so it is landing separately here while #50955 is being closed.
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: Telegram DM reverse delivery target on a DM binding shaped as `{conversationId: chatId, parentConversationId: chatId}` no longer canonicalizes to `${chatId}:topic:${chatId}` and no longer emits a spurious `message_thread_id` for the DM.
- Real environment tested: local macOS 25.2.0 (Darwin arm64), Node 24.13.0 (Node 22+ supported), pnpm 10.33.2, worktree based on `upstream/main@cf71412a35`. Proof is a non-test runtime script that drives the production reverse-delivery call chain used by durable delivery and cron delivery (`src/utils/delivery-context.ts` → `src/channels/plugins/registry.ts` → `extensions/telegram/src/channel.ts`); no Telegram Bot API calls or fixtures are mocked.
- Exact steps or command run after this patch:
  1. Write a runtime driver that calls the production reverse-delivery seam:

     ```bash
     cat > /tmp/proof-telegram-dm-guard.ts <<'TS'
     import { resolveConversationDeliveryTarget } from "<ABSOLUTE_WORKTREE_PATH>/src/utils/delivery-context.ts";

     const cases = [
       { label: "DM binding (parent === conversation)",      channel: "telegram", conversationId: "1234", parentConversationId: "1234" },
       { label: "Forum topic binding (direct)",              channel: "telegram", conversationId: "-1001234567890:topic:42" },
       { label: "Forum topic binding (parent + bare topic)", channel: "telegram", conversationId: "42", parentConversationId: "-1001234567890" },
       { label: "Direct DM (no parent)",                     channel: "telegram", conversationId: "5678" },
     ];
     for (const c of cases) {
       const { label, ...params } = c;
       console.log(`${label.padEnd(45)} -> ${JSON.stringify(resolveConversationDeliveryTarget(params))}`);
     }
     TS
     ```

  2. Capture BEFORE by restoring the parser to the `upstream/main` version in the worktree (no commit), then running the driver via `node --import tsx` and capturing stdout with `tee`:

     ```bash
     git show upstream/main:extensions/telegram/src/topic-conversation.ts > extensions/telegram/src/topic-conversation.ts
     node --import tsx /tmp/proof-telegram-dm-guard.ts | tee /tmp/proof-before.txt
     ```

  3. Capture AFTER by restoring the patched parser at current HEAD and rerunning the same driver:

     ```bash
     git checkout HEAD -- extensions/telegram/src/topic-conversation.ts
     node --import tsx /tmp/proof-telegram-dm-guard.ts | tee /tmp/proof-after.txt
     ```

  4. Compare the two captured stdout files:

     ```bash
     diff -u /tmp/proof-before.txt /tmp/proof-after.txt
     ```

- Evidence after fix: terminal stdout captured with `tee` from two back-to-back `node --import tsx /tmp/proof-telegram-dm-guard.ts` runs against the production bundled Telegram plugin, first with the parser restored to `upstream/main@cf71412a35` and then with the patched parser at commit `e380f0401d`. Copied live output from stdout:

BEFORE (parser restored to `upstream/main@cf71412a35`, no guard) — terminal output captured via `tee /tmp/proof-before.txt`:

```text
DM binding (parent === conversation)          -> {"to":"1234","threadId":"1234"}
Forum topic binding (direct)                  -> {"to":"-1001234567890","threadId":"42"}
Forum topic binding (parent + bare topic id)  -> {"to":"-1001234567890","threadId":"42"}
Direct DM (no parent)                         -> {"to":"5678"}
```

AFTER (patched parser, commit `e380f0401d`) — terminal output captured via `tee /tmp/proof-after.txt`:

```text
DM binding (parent === conversation)          -> {"to":"1234"}
Forum topic binding (direct)                  -> {"to":"-1001234567890","threadId":"42"}
Forum topic binding (parent + bare topic id)  -> {"to":"-1001234567890","threadId":"42"}
Direct DM (no parent)                         -> {"to":"5678"}
```

Unified diff of the two captured stdout files:

```diff
--- /tmp/proof-before.txt
+++ /tmp/proof-after.txt
@@ -1,4 +1,4 @@
-DM binding (parent === conversation)          -> {"to":"1234","threadId":"1234"}
+DM binding (parent === conversation)          -> {"to":"1234"}
 Forum topic binding (direct)                  -> {"to":"-1001234567890","threadId":"42"}
 Forum topic binding (parent + bare topic id)  -> {"to":"-1001234567890","threadId":"42"}
 Direct DM (no parent)                         -> {"to":"5678"}
```

- Observed result after fix: in the real reverse-delivery call chain (node runtime driver, not a vitest harness), the DM binding now resolves to `{to: "1234"}` instead of `{to: "1234", threadId: "1234"}`; the two legitimate forum-topic bindings and the direct DM case are byte-for-byte identical to the pre-patch stdout. The unified diff shows exactly one line changed — the target DM case — confirming the guard fires only on the degenerate shape.
- What was not tested: the resolved delivery target was not pushed further through the Telegram Bot API `sendMessage` call. That step is purely consumption of the `{to, threadId?}` record this PR fixes; the Bot API only sees the corrected shape. No bot token or live Telegram network call is required to prove this PR's behavioral change.
- Before evidence: see the BEFORE stdout capture above, produced by restoring `extensions/telegram/src/topic-conversation.ts` in the worktree to its `upstream/main@cf71412a35` contents and running the same driver script (`node --import tsx`) against the same bundled plugin, same `resolveConversationDeliveryTarget` entrypoint, same channel plugin registry lookup.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed.

- Root cause: the second branch of `parseTelegramTopicConversation` was written for the "bare topic id + group parent chat id" shape. It validates `parent` against `/^-?\d+$/`, which accepts both group ids (negative) and DM ids (positive). Telegram DM bindings that duplicate the chat id into both `conversationId` and `parentConversationId` therefore satisfy both regexes and get canonicalized as a topic. `buildTelegramTopicConversationId` likewise allows `-?\d+` for `chatId`, so the positive-integer DM id passes through and produces `${chatId}:topic:${chatId}`.
- Missing detection / guardrail: no unit tests on `parseTelegramTopicConversation` covered the `parent === conversation` degenerate input shape. The ACP-side callers (`normalizeTelegramAcpConversationId`, `matchTelegramAcpConversation`) do reject DMs via `chatId.startsWith("-")`, which masked the parser-level gap from ACP paths. The generic `messaging.resolveDeliveryTarget` seam (`resolveTelegramDeliveryTarget`) consumes the parser output directly without a negative-id guard, so reverse delivery hit the unguarded path.
- Contributing context (if known): the equivalent DM guard was proposed in the `src/acp/conversation-id.ts` copy of this function inside #50955, but that file was removed during the upstream `extensions/*` migration (`e4b5027c5e refactor(plugins): move extension seams into extensions`, `bea53d7a3f Fix: move bootstrap session grammar into plugin-owned session-key surfaces (#58400)`). Upstream landed the surrounding Telegram ACP placement and binding fixes via `prepareAcpThreadBinding` + Telegram adapter `placements: ["current", "child"]` and via `5d2225212d fix(matrix): preserve ACP thread binding targets (#64343)` without picking up the parse-side DM guard.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/topic-conversation.test.ts` (newly added).
- Scenario the test should lock in: `parseTelegramTopicConversation({ conversationId: "1234", parentConversationId: "1234" })` returns `null` instead of a `{chatId: "1234", topicId: "1234", canonicalConversationId: "1234:topic:1234"}` object, while both existing valid shapes (`"-1001…:topic:42"` and `{conversation: "42", parent: "-1001…"}`) keep parsing as before.
- Why this is the smallest reliable guardrail: `parseTelegramTopicConversation` is a pure function with no dependencies; a direct unit test against its return value is sufficient and deterministic. Adding a seam or E2E test would require spinning up Telegram inbound/outbound plumbing and a live bot without adding real coverage that this unit test cannot already prove.
- Existing test that already covers this (if any): None. `bot-message-context.dm-topic-threadid.test.ts` covers DM-topic `updateLastRoute` routing at the context layer but does not drive the parser with a `{parent === conversation}` input.
- If no new test is added, why not: N/A — a new test file is added in this PR.

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).

- Telegram DM bindings whose stored shape carries the DM chat id in both `conversationId` and `parentConversationId` are now parsed as a direct conversation by the shared parser. This removes the stale `message_thread_id` that previously accompanied reverse-delivery targets for those DMs. No public config surface changes; no new defaults.

## Diagram (if applicable)

```text
Before (DM binding with parent === conversation):
  parseTelegramTopicConversation({ conv: "1234", parent: "1234" })
    -> { chatId: "1234", topicId: "1234", canonical: "1234:topic:1234" }
  resolveTelegramDeliveryTarget(..)
    -> { to: "1234", threadId: "1234" }   ← spurious thread id

After:
  parseTelegramTopicConversation({ conv: "1234", parent: "1234" })
    -> null
  resolveTelegramDeliveryTarget(..)
    -> falls back to parseTelegramTarget(parent || conv)
    -> { to: "1234" }                     ← DM target, no thread id
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 25.2.0 (Darwin arm64)
- Runtime/container: Node 24.13.0 via nvm (Node 22+ supported); pnpm 10.33.2; local worktree based on `upstream/main` at `cf71412a35`
- Model/provider: N/A (pure parser change, no provider involvement)
- Integration/channel (if any): Telegram plugin
- Relevant config (redacted): N/A

### Steps

1. `git worktree add -b fix/telegram-dm-topic-guard <path> upstream/main`
2. Apply the 5-line guard and the new colocated test file.
3. Run `pnpm install && pnpm test extensions/telegram/src/topic-conversation.test.ts && pnpm check:changed`.

### Expected

- DM-shape input (`parent === conversation`) returns `null`.
- `chatId:topic:topicId` and `{conversation: topicId, parent: groupChatId}` inputs continue to parse as before.
- `pnpm check:changed` and the targeted vitest suite exit with code 0.

### Actual

- DM-shape input returns `null` after the patch (was `{chatId, topicId, canonical}` before the patch).
- Both positive shapes still parse; `parseTelegramTopicConversation.test.ts` reports `Test Files 1 passed (1) / Tests 5 passed (5)`.
- `pnpm check:changed` exits with `EXIT=0`; `oxfmt --check` reports "All matched files use the correct format."

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before-patch proof: the BEFORE runtime capture in the Real behavior proof section above (produced by restoring `extensions/telegram/src/topic-conversation.ts` to `upstream/main@cf71412a35` in the worktree). The same `resolveConversationDeliveryTarget` entrypoint returns `{to: "1234", threadId: "1234"}` for the DM binding shape before the guard is applied.

After-patch proof: the AFTER runtime capture in the Real behavior proof section above. The same entrypoint returns `{to: "1234"}` for the DM binding shape, with the three non-target cases byte-identical to the BEFORE run. Supplemental vitest output:

```text
 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  14:22:41
   Duration  677ms
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Runtime behavior change in the real reverse-delivery chain: the runtime driver above shows `resolveConversationDeliveryTarget` returning `{to: "1234", threadId: "1234"}` before the patch and `{to: "1234"}` after the patch, through the bundled plugin registry and the Telegram plugin's `messaging.resolveDeliveryTarget` seam.
  - The other three cases (direct topic, parent + bare topic, direct DM with no parent) produce byte-identical output before and after the patch.
  - Unit coverage matches runtime behavior: `parseTelegramTopicConversation({ conversationId: "1234", parentConversationId: "1234" })` returns `null`; `{conversationId: "-1001234567890:topic:42"}` returns `{chatId: "-1001234567890", topicId: "42", canonical: "-1001234567890:topic:42"}`; `{conversationId: "42", parentConversationId: "-1001234567890"}` returns the same canonical form; `{conversationId: "42"}` returns `null`; `{conversationId: "not-a-topic"}` returns `null`.
  - Full repo gate: `pnpm check:changed` (typecheck, lint, import cycles, runtime-sidecar-loaders, duplicate-scan coverage, wildcard-reexport lint, changelog attributions, no-conflict-markers) exits 0.
- Edge cases checked:
  - Positive-integer DM chat id (this PR's target case).
  - Negative-integer group chat id with numeric `conversation` (still parses as topic — verified both at the parser layer and end-to-end through `resolveConversationDeliveryTarget`).
  - Conversation string containing mixed alphanumerics (still rejected).
  - Conversation already in `chatId:topic:topicId` form, regardless of `parentConversationId` (still parses via the first branch — guard only affects the second branch).
  - Direct DM with no `parentConversationId` at all (still resolves to `{to: chatId}` with no `threadId`; guard does not affect this path).
- What you did **not** verify:
  - Pushing the resolved `{to, threadId?}` record through the Telegram Bot API `sendMessage` call. That step only consumes the record this PR fixes; the Bot API sees the corrected shape unmodified, so skipping it does not leave behavior unverified for the code under change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

The guard only returns `null` for an input shape that previously produced a malformed `${chatId}:topic:${chatId}` canonical id. No legitimate Telegram topic binding uses `parent === conversation`: topic ids in Telegram are always non-negative integers scoped under a group `chatId` that starts with `-`, so a legitimate topic-bound conversation cannot have `parent === conversation`. Upstream consumers already treat a `null` return as "not a topic binding" and fall back to direct parsing.

## Risks and Mitigations

- Risk: an unknown persisted binding shape legitimately relies on `{conversationId: X, parentConversationId: X}` being canonicalized as a topic.
  - Mitigation: such a shape would be indistinguishable from a DM at the parser level and would have produced `${X}:topic:${X}` — a form that the Telegram channel's ACP-side path already rejects via `chatId.startsWith("-")`. The only place the old behavior was observable was the generic reverse-delivery path, where a spurious `threadId` was actively harmful. The new colocated unit tests pin both the DM guard and the remaining legitimate parse shapes so future refactors can catch an unintended widening.
