### PR TITLE
feat(plugin-sdk): derive tool target paths for hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1413,7 +1413,7 @@ Docs: https://docs.openclaw.ai
 - Docker setup: add `OPENCLAW_SKIP_ONBOARDING` so automated Docker installs can skip the interactive onboarding step while still applying gateway defaults. (#55518) Thanks @jinjimz.
 - Security policy: classify media/base64 decode and format-conversion overhead after configured acceptance limits as performance-only for GHSA triage unless a report demonstrates a limit bypass, crash, exhaustion, data exposure, or another boundary bypass. (#74311)
 - Security/OpenGrep: add a precise OpenGrep rulepack, source-rule compiler, provenance metadata check, and PR/full scan workflows that validate first-party code and rulepack-only changes while uploading SARIF to GitHub Code Scanning. (#69483) Thanks @jesse-merhi.
-- Plugins/SDK: expose host-derived tool target paths to `before_tool_call` and trusted policy hooks so workflow plugins can reason about known file targets without reparsing tool envelopes. Thanks @100yenadmin.
+- Plugins/SDK: expose host-derived tool target paths to `before_tool_call` and trusted policy hooks so workflow plugins can reason about known file targets without reparsing tool envelopes. (#75605) Thanks @100yenadmin.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1413,6 +1413,7 @@ Docs: https://docs.openclaw.ai
 - Docker setup: add `OPENCLAW_SKIP_ONBOARDING` so automated Docker installs can skip the interactive onboarding step while still applying gateway defaults. (#55518) Thanks @jinjimz.
 - Security policy: classify media/base64 decode and format-conversion overhead after configured acceptance limits as performance-only for GHSA triage unless a report demonstrates a limit bypass, crash, exhaustion, data exposure, or another boundary bypass. (#74311)
 - Security/OpenGrep: add a precise OpenGrep rulepack, source-rule compiler, provenance metadata check, and PR/full scan workflows that validate first-party code and rulepack-only changes while uploading SARIF to GitHub Code Scanning. (#69483) Thanks @jesse-merhi.
+- Plugins/SDK: expose host-derived tool target paths to `before_tool_call` and trusted policy hooks so workflow plugins can reason about known file targets without reparsing tool envelopes. Thanks @100yenadmin.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,12 @@ Docs: https://docs.openclaw.ai
 - QA/Mantis: add visual desktop tasks with Crabbox MP4 recording, screenshot capture, and optional image-understanding assertions, and preserve video artifacts in Mantis before/after reports.
 - QA/Mantis: reuse Crabbox desktop/browser capture tooling and pnpm store caches during Slack desktop smoke runs, reducing per-scenario setup work before screenshots and videos are captured.
 - QA/Mantis: add Slack desktop hydrate modes and per-phase timing reports so warm prehydrated VNC leases can skip source install/build while cold runs still prove the full source checkout.
+- QA/Mantis: pass the runtime env through desktop-browser Crabbox and artifact-copy child commands, so embedded Mantis callers can provide Crabbox credentials without mutating the parent process. Thanks @vincentkoc.
+- QA/Mantis: return the copied Slack desktop screenshot path even when remote Slack QA fails, so the CLI still prints the failure screenshot artifact. Thanks @vincentkoc.
+- QA/Mantis: accept Blacksmith Testbox `tbx_...` lease ids from desktop smoke warmup, so provider overrides do not fail before inspect/run. Thanks @vincentkoc.
+- Plugins/SDK: add bounded `before_agent_finalize` retry instructions so workflow plugins can request one more model pass. Thanks @100yenadmin.
+- Plugin SDK: add plugin-owned `SessionEntry` slot projection and scoped trusted-policy session extension reads. (#75609; replaces part of #73384/#74483) Thanks @100yenadmin.
+- Plugins/SDK: expose host-derived tool target paths to `before_tool_call` and trusted policy hooks so workflow plugins can reason about known file targets without reparsing tool envelopes. (#75605) Thanks @100yenadmin.
 - Control UI/WebChat: show a persistent compact context usage indicator from fresh session token data before the high-pressure warning state, while keeping the existing compaction prompt threshold. Fixes #46398; refs #45048, #50071, and #73744. Thanks @walterwkchoy, @AxelrodAI, @Brissux, @vincentkoc, and @BunsDev.
 - Contributor PRs: require external pull requests to include after-fix real behavior proof from a real OpenClaw setup, with terminal screenshots, console output, redacted runtime logs, linked artifacts, and copied live output treated as valid evidence while unit tests, mocks, lint, typechecks, snapshots, and CI remain supplemental only.
 - Plugins/catalog: add an `@tencent-weixin/openclaw-weixin` external entry pinned to `2.4.1` so onboarding and `openclaw channels add` can install the Tencent Weixin (personal WeChat) channel by default. (#77269) Thanks @pumpkinxing1.
@@ -1413,7 +1419,6 @@ Docs: https://docs.openclaw.ai
 - Docker setup: add `OPENCLAW_SKIP_ONBOARDING` so automated Docker installs can skip the interactive onboarding step while still applying gateway defaults. (#55518) Thanks @jinjimz.
 - Security policy: classify media/base64 decode and format-conversion overhead after configured acceptance limits as performance-only for GHSA triage unless a report demonstrates a limit bypass, crash, exhaustion, data exposure, or another boundary bypass. (#74311)
 - Security/OpenGrep: add a precise OpenGrep rulepack, source-rule compiler, provenance metadata check, and PR/full scan workflows that validate first-party code and rulepack-only changes while uploading SARIF to GitHub Code Scanning. (#69483) Thanks @jesse-merhi.
-- Plugins/SDK: expose host-derived tool target paths to `before_tool_call` and trusted policy hooks so workflow plugins can reason about known file targets without reparsing tool envelopes. (#75605) Thanks @100yenadmin.
 
 ### Fixes
 

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-6a6f841dbe8a8968c44fc76e96b96df8a30b8dd4c5d01ed9ae2ba399dd7f270a  plugin-sdk-api-baseline.json
-55eeb7227ac1743b5effdc607b4c8e1fb9deef05e91e2e41159219b5e10aff39  plugin-sdk-api-baseline.jsonl
+95e94f3a84be9ec5aaa9ed4142a9fb5bd92869c8f117faafa111463bb9223154  plugin-sdk-api-baseline.json
+ab73d85a185c98232624486ab47061bb42c37c451d6084e828c0887a6784e695  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-95e94f3a84be9ec5aaa9ed4142a9fb5bd92869c8f117faafa111463bb9223154  plugin-sdk-api-baseline.json
-ab73d85a185c98232624486ab47061bb42c37c451d6084e828c0887a6784e695  plugin-sdk-api-baseline.jsonl
+dde1627495d0092f54052b4330c59bbdc2d7290b87a01d68994780d49715b231  plugin-sdk-api-baseline.json
+f692d29657d80840a01b77edab8e208846e3b9d670d1d4077666642398bd1bdb  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-db57045b5a5d1687d3566932982826bff51ff2b9684117a44d8c55c3e6f74070  plugin-sdk-api-baseline.json
-b0e63556aea277b68e0b041eec24a3a94a14bd8b4878d866b110548cc98cbac0  plugin-sdk-api-baseline.jsonl
+6a6f841dbe8a8968c44fc76e96b96df8a30b8dd4c5d01ed9ae2ba399dd7f270a  plugin-sdk-api-baseline.json
+55eeb7227ac1743b5effdc607b4c8e1fb9deef05e91e2e41159219b5e10aff39  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-dde1627495d0092f54052b4330c59bbdc2d7290b87a01d68994780d49715b231  plugin-sdk-api-baseline.json
-f692d29657d80840a01b77edab8e208846e3b9d670d1d4077666642398bd1bdb  plugin-sdk-api-baseline.jsonl
+a5ce0d4458fc34b9c3959d22f75404507f39465e6e9c724be8e2d7d17e77509a  plugin-sdk-api-baseline.json
+59d18b9792a2bd7a22909789916fdd936e88071f4ac90f4ace9b4bfc8b0abcfe  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-a5ce0d4458fc34b9c3959d22f75404507f39465e6e9c724be8e2d7d17e77509a  plugin-sdk-api-baseline.json
-59d18b9792a2bd7a22909789916fdd936e88071f4ac90f4ace9b4bfc8b0abcfe  plugin-sdk-api-baseline.jsonl
+91ef62be323d1e7311eee736ff621e0230a34d511d172d8c4c825267ccafb1be  plugin-sdk-api-baseline.json
+b91b739532326d31f5d2395ce5767abbe7939c56d03c1dd4520d12adb146e915  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-d88e2cc62f8f7aba8e2f40b28f87276a2780258233d021f473892cd7b5bf7607  plugin-sdk-api-baseline.json
-edb3c738a315ece94ce6f9acbfa3a9368648fd2af97566c184b46b985ea3c73b  plugin-sdk-api-baseline.jsonl
+db57045b5a5d1687d3566932982826bff51ff2b9684117a44d8c55c3e6f74070  plugin-sdk-api-baseline.json
+b0e63556aea277b68e0b041eec24a3a94a14bd8b4878d866b110548cc98cbac0  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-c17185895c939048ae02bd3e4d8d331e227d12f71799cafecb500f991864f538  plugin-sdk-api-baseline.json
-9b1c9faac9056291057b1b7303ca4890d3a7b7a39d1c70e9ca922cde2eb653ed  plugin-sdk-api-baseline.jsonl
+ecaeec280ae5e79aa4120dd3cc06f63209f41ce60b6fb2bc9317d5135d674f18  plugin-sdk-api-baseline.json
+01ba535e66cea6540f16b0309d8644b10f265e75948990c0cfef982676b5fa7a  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-91ef62be323d1e7311eee736ff621e0230a34d511d172d8c4c825267ccafb1be  plugin-sdk-api-baseline.json
-b91b739532326d31f5d2395ce5767abbe7939c56d03c1dd4520d12adb146e915  plugin-sdk-api-baseline.jsonl
+c17185895c939048ae02bd3e4d8d331e227d12f71799cafecb500f991864f538  plugin-sdk-api-baseline.json
+9b1c9faac9056291057b1b7303ca4890d3a7b7a39d1c70e9ca922cde2eb653ed  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -154,9 +154,10 @@ observation-only.
 
 - `event.toolName`
 - `event.params`
-- optional `event.derivedPaths`, containing host-derived target paths for
-  well-known tool envelopes such as `apply_patch`; absent when the host cannot
-  derive authoritative paths for the current params
+- optional `event.derivedPaths`, containing best-effort host-derived target path
+  hints for well-known tool envelopes such as `apply_patch`; when present,
+  these paths may be incomplete or may over-approximate what the tool will
+  actually touch (for example, with malformed or partial inputs)
 - optional `event.runId`
 - optional `event.toolCallId`
 - context fields such as `ctx.agentId`, `ctx.sessionKey`, `ctx.sessionId`,

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -154,6 +154,9 @@ observation-only.
 
 - `event.toolName`
 - `event.params`
+- optional `event.derivedPaths`, containing host-derived target paths for
+  well-known tool envelopes such as `apply_patch`; absent when the host cannot
+  derive authoritative paths for the current params
 - optional `event.runId`
 - optional `event.toolCallId`
 - context fields such as `ctx.agentId`, `ctx.sessionKey`, `ctx.sessionId`,

--- a/src/agents/apply-patch-paths.test.ts
+++ b/src/agents/apply-patch-paths.test.ts
@@ -80,6 +80,25 @@ describe("extractApplyPatchTargetPaths", () => {
     expect(extractApplyPatchTargetPaths(patch)).toEqual(["same.ts"]);
   });
 
+  it("normalizes derived paths before de-duplicating them", () => {
+    const patch = [
+      "*** Begin Patch",
+      "*** Add File: safe/../secret.ts",
+      "+x",
+      "*** Update File: ./src//old.ts",
+      "*** Move to: src/temp/../renamed.ts",
+      "@@",
+      "+y",
+      "*** Delete File: secret.ts",
+      "*** End Patch",
+    ].join("\n");
+    expect(extractApplyPatchTargetPaths(patch)).toEqual([
+      "secret.ts",
+      "src/old.ts",
+      "src/renamed.ts",
+    ]);
+  });
+
   it("handles CRLF line endings", () => {
     const patch = ["*** Begin Patch", "*** Add File: crlf.ts", "+x", "*** End Patch"].join("\r\n");
     expect(extractApplyPatchTargetPaths(patch)).toEqual(["crlf.ts"]);

--- a/src/agents/apply-patch-paths.test.ts
+++ b/src/agents/apply-patch-paths.test.ts
@@ -237,6 +237,37 @@ describe("extractApplyPatchTargetPaths", () => {
     ]);
   });
 
+  it("skips sandbox paths the bridge rejects", () => {
+    const patch = [
+      "*** Begin Patch",
+      "*** Add File: /workspace/src/ok.ts",
+      "+x",
+      "*** Add File: /outside.ts",
+      "+y",
+      "*** End Patch",
+    ].join("\n");
+    expect(
+      extractApplyPatchTargetPaths(patch, {
+        cwd: "/workspace",
+        sandbox: {
+          root: "/workspace",
+          bridge: {
+            resolvePath: ({ filePath }: { filePath: string }) => {
+              if (filePath === "/outside.ts") {
+                throw new Error("Path escapes sandbox root");
+              }
+              return {
+                containerPath: filePath,
+                hostPath: filePath.replace("/workspace", "/host/workspace"),
+                relativePath: filePath.replace("/workspace/", ""),
+              };
+            },
+          } as never,
+        },
+      }),
+    ).toEqual(["/host/workspace/src/ok.ts"]);
+  });
+
   it("does not require the begin/end envelope markers to be present", () => {
     const patch = ["*** Add File: loose.ts", "+x"].join("\n");
     expect(extractApplyPatchTargetPaths(patch)).toEqual([cwdPath("loose.ts")]);

--- a/src/agents/apply-patch-paths.test.ts
+++ b/src/agents/apply-patch-paths.test.ts
@@ -107,20 +107,19 @@ describe("extractApplyPatchTargetPaths", () => {
     ]);
   });
 
-  it("normalizes Windows separators to stable POSIX derived paths", () => {
+  it("preserves POSIX backslashes to match apply_patch execution", () => {
     const patch = [
       "*** Begin Patch",
       String.raw`*** Add File: src\windows\path.ts`,
       "+x",
-      String.raw`*** Update File: .\src\windows\..\old.ts`,
-      "@@",
-      "+y",
+      String.raw`*** Add File: safe\evil.ts`,
       "*** End Patch",
     ].join("\n");
     expect(extractApplyPatchTargetPaths(patch)).toEqual([
-      cwdPath("src/windows/path.ts"),
-      cwdPath("src/old.ts"),
+      path.resolve(defaultCwd, String.raw`src\windows\path.ts`),
+      path.resolve(defaultCwd, String.raw`safe\evil.ts`),
     ]);
+    expect(extractApplyPatchTargetPaths(patch)).not.toContain(cwdPath("safe", "evil.ts"));
   });
 
   it("handles CRLF line endings", () => {

--- a/src/agents/apply-patch-paths.test.ts
+++ b/src/agents/apply-patch-paths.test.ts
@@ -99,6 +99,19 @@ describe("extractApplyPatchTargetPaths", () => {
     ]);
   });
 
+  it("normalizes Windows separators to stable POSIX derived paths", () => {
+    const patch = [
+      "*** Begin Patch",
+      String.raw`*** Add File: src\windows\path.ts`,
+      "+x",
+      String.raw`*** Update File: .\src\windows\..\old.ts`,
+      "@@",
+      "+y",
+      "*** End Patch",
+    ].join("\n");
+    expect(extractApplyPatchTargetPaths(patch)).toEqual(["src/windows/path.ts", "src/old.ts"]);
+  });
+
   it("handles CRLF line endings", () => {
     const patch = ["*** Begin Patch", "*** Add File: crlf.ts", "+x", "*** End Patch"].join("\r\n");
     expect(extractApplyPatchTargetPaths(patch)).toEqual(["crlf.ts"]);
@@ -123,6 +136,17 @@ describe("extractApplyPatchTargetPaths", () => {
       "src/old.ts",
       "src/renamed.ts",
     ]);
+  });
+
+  it("matches single-space-indented top-level headers the same way as the executor", () => {
+    const patch = [
+      "*** Begin Patch",
+      " *** Add File: src/new.ts",
+      "+x",
+      " *** Delete File: src/dead.ts",
+      "*** End Patch",
+    ].join("\n");
+    expect(extractApplyPatchTargetPaths(patch)).toEqual(["src/new.ts", "src/dead.ts"]);
   });
 
   it("finds indented markers after an update hunk", () => {

--- a/src/agents/apply-patch-paths.test.ts
+++ b/src/agents/apply-patch-paths.test.ts
@@ -85,6 +85,27 @@ describe("extractApplyPatchTargetPaths", () => {
     expect(extractApplyPatchTargetPaths(patch)).toEqual(["crlf.ts"]);
   });
 
+  it("matches indented hunk headers the same way as the apply_patch executor", () => {
+    const patch = [
+      "  *** Begin Patch",
+      "  *** Add File: src/new.ts",
+      "+x",
+      "  *** Delete File: src/dead.ts",
+      "  *** Update File: src/old.ts",
+      "  *** Move to: src/renamed.ts",
+      "@@",
+      "-old",
+      "+new",
+      "  *** End Patch",
+    ].join("\n");
+    expect(extractApplyPatchTargetPaths(patch)).toEqual([
+      "src/new.ts",
+      "src/dead.ts",
+      "src/old.ts",
+      "src/renamed.ts",
+    ]);
+  });
+
   it("ignores markers outside of the envelope grammar", () => {
     expect(
       extractApplyPatchTargetPaths(

--- a/src/agents/apply-patch-paths.test.ts
+++ b/src/agents/apply-patch-paths.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { extractApplyPatchTargetPaths } from "./apply-patch-paths.js";
+
+describe("extractApplyPatchTargetPaths", () => {
+  it("returns an empty array for non-string input", () => {
+    expect(extractApplyPatchTargetPaths(undefined)).toEqual([]);
+    expect(extractApplyPatchTargetPaths(null)).toEqual([]);
+    expect(extractApplyPatchTargetPaths(42)).toEqual([]);
+    expect(extractApplyPatchTargetPaths({})).toEqual([]);
+    expect(extractApplyPatchTargetPaths({ input: 7 })).toEqual([]);
+  });
+
+  it("returns an empty array for an empty patch", () => {
+    expect(extractApplyPatchTargetPaths("")).toEqual([]);
+    expect(extractApplyPatchTargetPaths({ input: "" })).toEqual([]);
+  });
+
+  it("extracts Add File markers from the envelope payload", () => {
+    const patch = [
+      "*** Begin Patch",
+      "*** Add File: src/new.ts",
+      "+export const a = 1;",
+      "*** End Patch",
+    ].join("\n");
+    expect(extractApplyPatchTargetPaths(patch)).toEqual(["src/new.ts"]);
+  });
+
+  it("extracts Update File and Delete File markers", () => {
+    const patch = [
+      "*** Begin Patch",
+      "*** Update File: a.ts",
+      "@@",
+      " context",
+      "+added",
+      "*** Delete File: b.ts",
+      "*** End Patch",
+    ].join("\n");
+    expect(extractApplyPatchTargetPaths(patch)).toEqual(["a.ts", "b.ts"]);
+  });
+
+  it("includes the Move to: target paired with an Update File", () => {
+    const patch = [
+      "*** Begin Patch",
+      "*** Update File: old/path.ts",
+      "*** Move to: new/path.ts",
+      "@@",
+      " context",
+      "+added",
+      "*** End Patch",
+    ].join("\n");
+    expect(extractApplyPatchTargetPaths(patch)).toEqual(["old/path.ts", "new/path.ts"]);
+  });
+
+  it("tolerates blank lines between Update File and Move to", () => {
+    const patch = [
+      "*** Begin Patch",
+      "*** Update File: a.ts",
+      "",
+      "*** Move to: b.ts",
+      "*** End Patch",
+    ].join("\n");
+    expect(extractApplyPatchTargetPaths(patch)).toEqual(["a.ts", "b.ts"]);
+  });
+
+  it("accepts the wrapper object form used by the apply_patch tool", () => {
+    const patch = ["*** Begin Patch", "*** Add File: foo.ts", "+x", "*** End Patch"].join("\n");
+    expect(extractApplyPatchTargetPaths({ input: patch })).toEqual(["foo.ts"]);
+  });
+
+  it("de-duplicates repeated paths within a single envelope", () => {
+    const patch = [
+      "*** Begin Patch",
+      "*** Add File: same.ts",
+      "+a",
+      "*** Update File: same.ts",
+      "@@",
+      "+b",
+      "*** End Patch",
+    ].join("\n");
+    expect(extractApplyPatchTargetPaths(patch)).toEqual(["same.ts"]);
+  });
+
+  it("handles CRLF line endings", () => {
+    const patch = ["*** Begin Patch", "*** Add File: crlf.ts", "+x", "*** End Patch"].join("\r\n");
+    expect(extractApplyPatchTargetPaths(patch)).toEqual(["crlf.ts"]);
+  });
+
+  it("ignores markers outside of the envelope grammar", () => {
+    expect(
+      extractApplyPatchTargetPaths(
+        ["nothing here", "*** Random Marker: x", "+a", "context"].join("\n"),
+      ),
+    ).toEqual([]);
+  });
+
+  it("ignores marker-like context and body lines inside update hunks", () => {
+    const patch = [
+      "*** Begin Patch",
+      "*** Update File: real.ts",
+      "@@",
+      " *** Add File: fake-context.ts",
+      "-*** Delete File: fake-remove.ts",
+      "+*** Add File: fake-add.ts",
+      "*** End Patch",
+    ].join("\n");
+    expect(extractApplyPatchTargetPaths(patch)).toEqual(["real.ts"]);
+  });
+
+  it("does not require the begin/end envelope markers to be present", () => {
+    const patch = ["*** Add File: loose.ts", "+x"].join("\n");
+    expect(extractApplyPatchTargetPaths(patch)).toEqual(["loose.ts"]);
+  });
+});

--- a/src/agents/apply-patch-paths.test.ts
+++ b/src/agents/apply-patch-paths.test.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { extractApplyPatchTargetPaths } from "./apply-patch-paths.js";
 
@@ -149,14 +151,14 @@ describe("extractApplyPatchTargetPaths", () => {
     expect(extractApplyPatchTargetPaths(patch)).toEqual(["src/new.ts", "src/dead.ts"]);
   });
 
-  it("finds indented markers after an update hunk", () => {
+  it("finds top-level markers after an update hunk", () => {
     const patch = [
       "*** Begin Patch",
       "*** Update File: src/old.ts",
       "@@",
       "-old",
       "+new",
-      "  *** Delete File: src/dead.ts",
+      "*** Delete File: src/dead.ts",
       "*** End Patch",
     ].join("\n");
     expect(extractApplyPatchTargetPaths(patch)).toEqual(["src/old.ts", "src/dead.ts"]);
@@ -176,11 +178,31 @@ describe("extractApplyPatchTargetPaths", () => {
       "*** Update File: real.ts",
       "@@",
       " *** Add File: fake-context.ts",
+      "  *** Delete File: fake-indented-context.ts",
       "-*** Delete File: fake-remove.ts",
       "+*** Add File: fake-add.ts",
       "*** End Patch",
     ].join("\n");
     expect(extractApplyPatchTargetPaths(patch)).toEqual(["real.ts"]);
+  });
+
+  it("can resolve paths with the same cwd semantics as apply_patch execution", () => {
+    const cwd = path.join(os.tmpdir(), "openclaw-derived-paths");
+    const patch = [
+      "*** Begin Patch",
+      "*** Add File: @src/../resolved.ts",
+      "+x",
+      "*** Update File: ~/renamed-source.ts",
+      "*** Move to: /tmp/openclaw-target.ts",
+      "@@",
+      "+y",
+      "*** End Patch",
+    ].join("\n");
+    expect(extractApplyPatchTargetPaths(patch, { cwd })).toEqual([
+      path.join(cwd, "resolved.ts"),
+      path.join(os.homedir(), "renamed-source.ts"),
+      path.join("/tmp", "openclaw-target.ts"),
+    ]);
   });
 
   it("does not require the begin/end envelope markers to be present", () => {

--- a/src/agents/apply-patch-paths.test.ts
+++ b/src/agents/apply-patch-paths.test.ts
@@ -125,6 +125,19 @@ describe("extractApplyPatchTargetPaths", () => {
     ]);
   });
 
+  it("finds indented markers after an update hunk", () => {
+    const patch = [
+      "*** Begin Patch",
+      "*** Update File: src/old.ts",
+      "@@",
+      "-old",
+      "+new",
+      "  *** Delete File: src/dead.ts",
+      "*** End Patch",
+    ].join("\n");
+    expect(extractApplyPatchTargetPaths(patch)).toEqual(["src/old.ts", "src/dead.ts"]);
+  });
+
   it("ignores markers outside of the envelope grammar", () => {
     expect(
       extractApplyPatchTargetPaths(

--- a/src/agents/apply-patch-paths.test.ts
+++ b/src/agents/apply-patch-paths.test.ts
@@ -3,6 +3,9 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { extractApplyPatchTargetPaths } from "./apply-patch-paths.js";
 
+const defaultCwd = process.cwd();
+const cwdPath = (...segments: string[]) => path.join(defaultCwd, ...segments);
+
 describe("extractApplyPatchTargetPaths", () => {
   it("returns an empty array for non-string input", () => {
     expect(extractApplyPatchTargetPaths(undefined)).toEqual([]);
@@ -24,7 +27,7 @@ describe("extractApplyPatchTargetPaths", () => {
       "+export const a = 1;",
       "*** End Patch",
     ].join("\n");
-    expect(extractApplyPatchTargetPaths(patch)).toEqual(["src/new.ts"]);
+    expect(extractApplyPatchTargetPaths(patch)).toEqual([cwdPath("src/new.ts")]);
   });
 
   it("extracts Update File and Delete File markers", () => {
@@ -37,7 +40,7 @@ describe("extractApplyPatchTargetPaths", () => {
       "*** Delete File: b.ts",
       "*** End Patch",
     ].join("\n");
-    expect(extractApplyPatchTargetPaths(patch)).toEqual(["a.ts", "b.ts"]);
+    expect(extractApplyPatchTargetPaths(patch)).toEqual([cwdPath("a.ts"), cwdPath("b.ts")]);
   });
 
   it("includes the Move to: target paired with an Update File", () => {
@@ -50,7 +53,10 @@ describe("extractApplyPatchTargetPaths", () => {
       "+added",
       "*** End Patch",
     ].join("\n");
-    expect(extractApplyPatchTargetPaths(patch)).toEqual(["old/path.ts", "new/path.ts"]);
+    expect(extractApplyPatchTargetPaths(patch)).toEqual([
+      cwdPath("old/path.ts"),
+      cwdPath("new/path.ts"),
+    ]);
   });
 
   it("tolerates blank lines between Update File and Move to", () => {
@@ -61,12 +67,12 @@ describe("extractApplyPatchTargetPaths", () => {
       "*** Move to: b.ts",
       "*** End Patch",
     ].join("\n");
-    expect(extractApplyPatchTargetPaths(patch)).toEqual(["a.ts", "b.ts"]);
+    expect(extractApplyPatchTargetPaths(patch)).toEqual([cwdPath("a.ts"), cwdPath("b.ts")]);
   });
 
   it("accepts the wrapper object form used by the apply_patch tool", () => {
     const patch = ["*** Begin Patch", "*** Add File: foo.ts", "+x", "*** End Patch"].join("\n");
-    expect(extractApplyPatchTargetPaths({ input: patch })).toEqual(["foo.ts"]);
+    expect(extractApplyPatchTargetPaths({ input: patch })).toEqual([cwdPath("foo.ts")]);
   });
 
   it("de-duplicates repeated paths within a single envelope", () => {
@@ -79,7 +85,7 @@ describe("extractApplyPatchTargetPaths", () => {
       "+b",
       "*** End Patch",
     ].join("\n");
-    expect(extractApplyPatchTargetPaths(patch)).toEqual(["same.ts"]);
+    expect(extractApplyPatchTargetPaths(patch)).toEqual([cwdPath("same.ts")]);
   });
 
   it("normalizes derived paths before de-duplicating them", () => {
@@ -95,9 +101,9 @@ describe("extractApplyPatchTargetPaths", () => {
       "*** End Patch",
     ].join("\n");
     expect(extractApplyPatchTargetPaths(patch)).toEqual([
-      "secret.ts",
-      "src/old.ts",
-      "src/renamed.ts",
+      cwdPath("secret.ts"),
+      cwdPath("src/old.ts"),
+      cwdPath("src/renamed.ts"),
     ]);
   });
 
@@ -111,12 +117,15 @@ describe("extractApplyPatchTargetPaths", () => {
       "+y",
       "*** End Patch",
     ].join("\n");
-    expect(extractApplyPatchTargetPaths(patch)).toEqual(["src/windows/path.ts", "src/old.ts"]);
+    expect(extractApplyPatchTargetPaths(patch)).toEqual([
+      cwdPath("src/windows/path.ts"),
+      cwdPath("src/old.ts"),
+    ]);
   });
 
   it("handles CRLF line endings", () => {
     const patch = ["*** Begin Patch", "*** Add File: crlf.ts", "+x", "*** End Patch"].join("\r\n");
-    expect(extractApplyPatchTargetPaths(patch)).toEqual(["crlf.ts"]);
+    expect(extractApplyPatchTargetPaths(patch)).toEqual([cwdPath("crlf.ts")]);
   });
 
   it("matches indented hunk headers the same way as the apply_patch executor", () => {
@@ -133,10 +142,10 @@ describe("extractApplyPatchTargetPaths", () => {
       "  *** End Patch",
     ].join("\n");
     expect(extractApplyPatchTargetPaths(patch)).toEqual([
-      "src/new.ts",
-      "src/dead.ts",
-      "src/old.ts",
-      "src/renamed.ts",
+      cwdPath("src/new.ts"),
+      cwdPath("src/dead.ts"),
+      cwdPath("src/old.ts"),
+      cwdPath("src/renamed.ts"),
     ]);
   });
 
@@ -148,7 +157,10 @@ describe("extractApplyPatchTargetPaths", () => {
       " *** Delete File: src/dead.ts",
       "*** End Patch",
     ].join("\n");
-    expect(extractApplyPatchTargetPaths(patch)).toEqual(["src/new.ts", "src/dead.ts"]);
+    expect(extractApplyPatchTargetPaths(patch)).toEqual([
+      cwdPath("src/new.ts"),
+      cwdPath("src/dead.ts"),
+    ]);
   });
 
   it("finds top-level markers after an update hunk", () => {
@@ -161,7 +173,10 @@ describe("extractApplyPatchTargetPaths", () => {
       "*** Delete File: src/dead.ts",
       "*** End Patch",
     ].join("\n");
-    expect(extractApplyPatchTargetPaths(patch)).toEqual(["src/old.ts", "src/dead.ts"]);
+    expect(extractApplyPatchTargetPaths(patch)).toEqual([
+      cwdPath("src/old.ts"),
+      cwdPath("src/dead.ts"),
+    ]);
   });
 
   it("ignores markers outside of the envelope grammar", () => {
@@ -183,7 +198,7 @@ describe("extractApplyPatchTargetPaths", () => {
       "+*** Add File: fake-add.ts",
       "*** End Patch",
     ].join("\n");
-    expect(extractApplyPatchTargetPaths(patch)).toEqual(["real.ts"]);
+    expect(extractApplyPatchTargetPaths(patch)).toEqual([cwdPath("real.ts")]);
   });
 
   it("can resolve paths with the same cwd semantics as apply_patch execution", () => {
@@ -205,8 +220,26 @@ describe("extractApplyPatchTargetPaths", () => {
     ]);
   });
 
+  it("defaults missing cwd to apply_patch process cwd semantics", () => {
+    const patch = [
+      "*** Begin Patch",
+      "*** Add File: @src/../resolved.ts",
+      "+x",
+      "*** Update File: ~/source.ts",
+      "*** Move to: src/moved.ts",
+      "@@",
+      "+y",
+      "*** End Patch",
+    ].join("\n");
+    expect(extractApplyPatchTargetPaths(patch)).toEqual([
+      cwdPath("resolved.ts"),
+      path.join(os.homedir(), "source.ts"),
+      cwdPath("src/moved.ts"),
+    ]);
+  });
+
   it("does not require the begin/end envelope markers to be present", () => {
     const patch = ["*** Add File: loose.ts", "+x"].join("\n");
-    expect(extractApplyPatchTargetPaths(patch)).toEqual(["loose.ts"]);
+    expect(extractApplyPatchTargetPaths(patch)).toEqual([cwdPath("loose.ts")]);
   });
 });

--- a/src/agents/apply-patch-paths.ts
+++ b/src/agents/apply-patch-paths.ts
@@ -1,0 +1,95 @@
+/**
+ * Lightweight path extractor for the `apply_patch` envelope grammar.
+ *
+ * The full parser in `apply-patch.ts` validates and applies a patch end-to-end.
+ * Plugins running inside `before_tool_call` only need the destination paths so
+ * they can compute path policy decisions before the patch is applied. This
+ * helper walks the input lines and collects every path mentioned by:
+ *
+ *   - `*** Add File: <path>`
+ *   - `*** Update File: <path>`         (and the optional `*** Move to: <new>`
+ *                                         sub-marker that immediately follows)
+ *   - `*** Delete File: <path>`
+ *
+ * Unlike the strict parser, this helper is forgiving: it does not require the
+ * `*** Begin Patch` / `*** End Patch` envelope, it ignores non-marker lines
+ * while scanning the full input, and it may therefore still pick up marker-like
+ * lines that appear later in malformed input. Marker-like patch body lines are
+ * ignored unless they start at the top-level marker column. Empty paths are dropped.
+ *
+ * The shape of the input mirrors how `apply_patch` receives it: either a
+ * string (the full patch text) or an object with an `input` field carrying the
+ * patch text. Anything else returns an empty array.
+ */
+
+const ADD_FILE_MARKER = "*** Add File: ";
+const DELETE_FILE_MARKER = "*** Delete File: ";
+const UPDATE_FILE_MARKER = "*** Update File: ";
+const MOVE_TO_MARKER = "*** Move to: ";
+
+function readPatchText(input: unknown): string | undefined {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input && typeof input === "object" && "input" in input) {
+    const candidate = (input as { input?: unknown }).input;
+    if (typeof candidate === "string") {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function pushPath(target: string[], seen: Set<string>, raw: string): void {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return;
+  }
+  if (seen.has(trimmed)) {
+    return;
+  }
+  seen.add(trimmed);
+  target.push(trimmed);
+}
+
+/**
+ * Walk an apply_patch envelope and return every destination path found, in
+ * the order they appear. Duplicates are de-duplicated (the same file may be
+ * referenced multiple times within a single envelope). Returns `[]` for any
+ * input that is not a recognised envelope.
+ */
+export function extractApplyPatchTargetPaths(input: unknown): string[] {
+  const text = readPatchText(input);
+  if (text === undefined || text.length === 0) {
+    return [];
+  }
+  const lines = text.split(/\r?\n/);
+  const paths: string[] = [];
+  const seen = new Set<string>();
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (line.startsWith(ADD_FILE_MARKER)) {
+      pushPath(paths, seen, line.slice(ADD_FILE_MARKER.length));
+      continue;
+    }
+    if (line.startsWith(DELETE_FILE_MARKER)) {
+      pushPath(paths, seen, line.slice(DELETE_FILE_MARKER.length));
+      continue;
+    }
+    if (line.startsWith(UPDATE_FILE_MARKER)) {
+      pushPath(paths, seen, line.slice(UPDATE_FILE_MARKER.length));
+      // The Update header may be immediately followed by a `*** Move to:`
+      // sub-marker that names the new path. Skip leading blank lines so
+      // human-edited patches with extra spacing still pick it up.
+      let lookahead = index + 1;
+      while (lookahead < lines.length && lines[lookahead].trim() === "") {
+        lookahead += 1;
+      }
+      const candidate = lines[lookahead];
+      if (candidate?.startsWith(MOVE_TO_MARKER)) {
+        pushPath(paths, seen, candidate.slice(MOVE_TO_MARKER.length));
+      }
+    }
+  }
+  return paths;
+}

--- a/src/agents/apply-patch-paths.ts
+++ b/src/agents/apply-patch-paths.ts
@@ -32,6 +32,7 @@ const UPDATE_FILE_MARKER = "*** Update File: ";
 const MOVE_TO_MARKER = "*** Move to: ";
 
 export type ApplyPatchPathExtractionOptions = {
+  /** Tool execution cwd. Defaults to process.cwd(), matching createApplyPatchTool. */
   cwd?: string;
 };
 
@@ -56,9 +57,8 @@ function normalizePatchPath(
   if (!trimmed) {
     return undefined;
   }
-  const normalized = options.cwd
-    ? path.normalize(resolveSandboxInputPath(trimmed, options.cwd))
-    : path.posix.normalize(trimmed.replace(/\\/g, "/"));
+  const cwd = options.cwd ?? process.cwd();
+  const normalized = path.normalize(resolveSandboxInputPath(trimmed.replace(/\\/g, "/"), cwd));
   return normalized && normalized !== "." ? normalized : undefined;
 }
 

--- a/src/agents/apply-patch-paths.ts
+++ b/src/agents/apply-patch-paths.ts
@@ -14,8 +14,9 @@
  * Unlike the strict parser, this helper is forgiving: it does not require the
  * `*** Begin Patch` / `*** End Patch` envelope, it ignores non-marker lines
  * while scanning the full input, and it may therefore still pick up marker-like
- * lines that appear later in malformed input. Marker-like patch body lines are
- * ignored unless they start at the top-level marker column. Empty paths are dropped.
+ * lines that appear later in malformed input. Top-level hunk headers are matched
+ * after trimming leading whitespace, like the executor parser; marker-like patch
+ * body lines remain ignored while scanning an update hunk. Empty paths are dropped.
  *
  * The shape of the input mirrors how `apply_patch` receives it: either a
  * string (the full patch text) or an object with an `input` field carrying the
@@ -52,6 +53,14 @@ function pushPath(target: string[], seen: Set<string>, raw: string): void {
   target.push(trimmed);
 }
 
+function readMarkerPath(line: string | undefined, marker: string): string | undefined {
+  const candidate = line?.trimStart();
+  if (!candidate?.startsWith(marker)) {
+    return undefined;
+  }
+  return candidate.slice(marker.length);
+}
+
 /**
  * Walk an apply_patch envelope and return every destination path found, in
  * the order they appear. Duplicates are de-duplicated (the same file may be
@@ -68,16 +77,22 @@ export function extractApplyPatchTargetPaths(input: unknown): string[] {
   const seen = new Set<string>();
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
-    if (line.startsWith(ADD_FILE_MARKER)) {
-      pushPath(paths, seen, line.slice(ADD_FILE_MARKER.length));
+    const addPath = readMarkerPath(line, ADD_FILE_MARKER);
+    if (addPath !== undefined) {
+      pushPath(paths, seen, addPath);
+      while (index + 1 < lines.length && lines[index + 1].startsWith("+")) {
+        index += 1;
+      }
       continue;
     }
-    if (line.startsWith(DELETE_FILE_MARKER)) {
-      pushPath(paths, seen, line.slice(DELETE_FILE_MARKER.length));
+    const deletePath = readMarkerPath(line, DELETE_FILE_MARKER);
+    if (deletePath !== undefined) {
+      pushPath(paths, seen, deletePath);
       continue;
     }
-    if (line.startsWith(UPDATE_FILE_MARKER)) {
-      pushPath(paths, seen, line.slice(UPDATE_FILE_MARKER.length));
+    const updatePath = readMarkerPath(line, UPDATE_FILE_MARKER);
+    if (updatePath !== undefined) {
+      pushPath(paths, seen, updatePath);
       // The Update header may be immediately followed by a `*** Move to:`
       // sub-marker that names the new path. Skip leading blank lines so
       // human-edited patches with extra spacing still pick it up.
@@ -85,10 +100,22 @@ export function extractApplyPatchTargetPaths(input: unknown): string[] {
       while (lookahead < lines.length && lines[lookahead].trim() === "") {
         lookahead += 1;
       }
-      const candidate = lines[lookahead];
-      if (candidate?.startsWith(MOVE_TO_MARKER)) {
-        pushPath(paths, seen, candidate.slice(MOVE_TO_MARKER.length));
+      const movePath = readMarkerPath(lines[lookahead], MOVE_TO_MARKER);
+      if (movePath !== undefined) {
+        pushPath(paths, seen, movePath);
+        lookahead += 1;
       }
+      while (lookahead < lines.length) {
+        if (lines[lookahead].trim() === "") {
+          lookahead += 1;
+          continue;
+        }
+        if (lines[lookahead].startsWith("***")) {
+          break;
+        }
+        lookahead += 1;
+      }
+      index = lookahead - 1;
     }
   }
   return paths;

--- a/src/agents/apply-patch-paths.ts
+++ b/src/agents/apply-patch-paths.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { resolveSandboxInputPath } from "./sandbox-paths.js";
 
 /**
  * Lightweight path extractor for the `apply_patch` envelope grammar.
@@ -30,6 +31,10 @@ const DELETE_FILE_MARKER = "*** Delete File: ";
 const UPDATE_FILE_MARKER = "*** Update File: ";
 const MOVE_TO_MARKER = "*** Move to: ";
 
+export type ApplyPatchPathExtractionOptions = {
+  cwd?: string;
+};
+
 function readPatchText(input: unknown): string | undefined {
   if (typeof input === "string") {
     return input;
@@ -43,17 +48,27 @@ function readPatchText(input: unknown): string | undefined {
   return undefined;
 }
 
-function normalizePatchPath(raw: string): string | undefined {
+function normalizePatchPath(
+  raw: string,
+  options: ApplyPatchPathExtractionOptions = {},
+): string | undefined {
   const trimmed = raw.trim();
   if (!trimmed) {
     return undefined;
   }
-  const normalized = path.posix.normalize(trimmed.replace(/\\/g, "/"));
+  const normalized = options.cwd
+    ? path.normalize(resolveSandboxInputPath(trimmed, options.cwd))
+    : path.posix.normalize(trimmed.replace(/\\/g, "/"));
   return normalized && normalized !== "." ? normalized : undefined;
 }
 
-function pushPath(target: string[], seen: Set<string>, raw: string): void {
-  const normalized = normalizePatchPath(raw);
+function pushPath(
+  target: string[],
+  seen: Set<string>,
+  raw: string,
+  options: ApplyPatchPathExtractionOptions,
+): void {
+  const normalized = normalizePatchPath(raw, options);
   if (!normalized) {
     return;
   }
@@ -100,7 +115,10 @@ function normalizeMarkerHeaderLine(
  * referenced multiple times within a single envelope). Returns `[]` for any
  * input that is not a recognised envelope.
  */
-export function extractApplyPatchTargetPaths(input: unknown): string[] {
+export function extractApplyPatchTargetPaths(
+  input: unknown,
+  options: ApplyPatchPathExtractionOptions = {},
+): string[] {
   const text = readPatchText(input);
   if (text === undefined || text.length === 0) {
     return [];
@@ -112,7 +130,7 @@ export function extractApplyPatchTargetPaths(input: unknown): string[] {
     const line = lines[index];
     const addPath = readMarkerPath(line, ADD_FILE_MARKER);
     if (addPath !== undefined) {
-      pushPath(paths, seen, addPath);
+      pushPath(paths, seen, addPath, options);
       while (index + 1 < lines.length && lines[index + 1].startsWith("+")) {
         index += 1;
       }
@@ -120,12 +138,12 @@ export function extractApplyPatchTargetPaths(input: unknown): string[] {
     }
     const deletePath = readMarkerPath(line, DELETE_FILE_MARKER);
     if (deletePath !== undefined) {
-      pushPath(paths, seen, deletePath);
+      pushPath(paths, seen, deletePath, options);
       continue;
     }
     const updatePath = readMarkerPath(line, UPDATE_FILE_MARKER);
     if (updatePath !== undefined) {
-      pushPath(paths, seen, updatePath);
+      pushPath(paths, seen, updatePath, options);
       // The Update header may be immediately followed by a `*** Move to:`
       // sub-marker that names the new path. Skip leading blank lines so
       // human-edited patches with extra spacing still pick it up.
@@ -135,7 +153,7 @@ export function extractApplyPatchTargetPaths(input: unknown): string[] {
       }
       const movePath = readMarkerPath(lines[lookahead], MOVE_TO_MARKER);
       if (movePath !== undefined) {
-        pushPath(paths, seen, movePath);
+        pushPath(paths, seen, movePath, options);
         lookahead += 1;
       }
       while (lookahead < lines.length) {
@@ -143,11 +161,7 @@ export function extractApplyPatchTargetPaths(input: unknown): string[] {
           lookahead += 1;
           continue;
         }
-        if (
-          normalizeMarkerHeaderLine(lines[lookahead], {
-            allowSingleSpaceIndent: false,
-          }) !== undefined
-        ) {
+        if (lines[lookahead].startsWith("***")) {
           break;
         }
         lookahead += 1;

--- a/src/agents/apply-patch-paths.ts
+++ b/src/agents/apply-patch-paths.ts
@@ -48,7 +48,7 @@ function normalizePatchPath(raw: string): string | undefined {
   if (!trimmed) {
     return undefined;
   }
-  const normalized = path.normalize(trimmed);
+  const normalized = path.posix.normalize(trimmed.replace(/\\/g, "/"));
   return normalized && normalized !== "." ? normalized : undefined;
 }
 
@@ -72,7 +72,10 @@ function readMarkerPath(line: string | undefined, marker: string): string | unde
   return candidate.slice(marker.length);
 }
 
-function normalizeMarkerHeaderLine(line: string | undefined): string | undefined {
+function normalizeMarkerHeaderLine(
+  line: string | undefined,
+  options?: { allowSingleSpaceIndent?: boolean },
+): string | undefined {
   if (line === undefined) {
     return undefined;
   }
@@ -81,7 +84,14 @@ function normalizeMarkerHeaderLine(line: string | undefined): string | undefined
     return undefined;
   }
   const leadingWhitespace = line.length - candidate.length;
-  return leadingWhitespace === 1 && line.startsWith(" ") ? undefined : candidate;
+  if (
+    options?.allowSingleSpaceIndent === false &&
+    leadingWhitespace === 1 &&
+    line.startsWith(" ")
+  ) {
+    return undefined;
+  }
+  return candidate;
 }
 
 /**
@@ -133,7 +143,11 @@ export function extractApplyPatchTargetPaths(input: unknown): string[] {
           lookahead += 1;
           continue;
         }
-        if (normalizeMarkerHeaderLine(lines[lookahead]) !== undefined) {
+        if (
+          normalizeMarkerHeaderLine(lines[lookahead], {
+            allowSingleSpaceIndent: false,
+          }) !== undefined
+        ) {
           break;
         }
         lookahead += 1;

--- a/src/agents/apply-patch-paths.ts
+++ b/src/agents/apply-patch-paths.ts
@@ -65,11 +65,23 @@ function pushPath(target: string[], seen: Set<string>, raw: string): void {
 }
 
 function readMarkerPath(line: string | undefined, marker: string): string | undefined {
-  const candidate = line?.trimStart();
+  const candidate = normalizeMarkerHeaderLine(line);
   if (!candidate?.startsWith(marker)) {
     return undefined;
   }
   return candidate.slice(marker.length);
+}
+
+function normalizeMarkerHeaderLine(line: string | undefined): string | undefined {
+  if (line === undefined) {
+    return undefined;
+  }
+  const candidate = line.trimStart();
+  if (!candidate.startsWith("***")) {
+    return undefined;
+  }
+  const leadingWhitespace = line.length - candidate.length;
+  return leadingWhitespace === 1 && line.startsWith(" ") ? undefined : candidate;
 }
 
 /**
@@ -121,7 +133,7 @@ export function extractApplyPatchTargetPaths(input: unknown): string[] {
           lookahead += 1;
           continue;
         }
-        if (lines[lookahead].startsWith("***")) {
+        if (normalizeMarkerHeaderLine(lines[lookahead]) !== undefined) {
           break;
         }
         lookahead += 1;

--- a/src/agents/apply-patch-paths.ts
+++ b/src/agents/apply-patch-paths.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 /**
  * Lightweight path extractor for the `apply_patch` envelope grammar.
  *
@@ -41,16 +43,25 @@ function readPatchText(input: unknown): string | undefined {
   return undefined;
 }
 
-function pushPath(target: string[], seen: Set<string>, raw: string): void {
+function normalizePatchPath(raw: string): string | undefined {
   const trimmed = raw.trim();
   if (!trimmed) {
+    return undefined;
+  }
+  const normalized = path.normalize(trimmed);
+  return normalized && normalized !== "." ? normalized : undefined;
+}
+
+function pushPath(target: string[], seen: Set<string>, raw: string): void {
+  const normalized = normalizePatchPath(raw);
+  if (!normalized) {
     return;
   }
-  if (seen.has(trimmed)) {
+  if (seen.has(normalized)) {
     return;
   }
-  seen.add(trimmed);
-  target.push(trimmed);
+  seen.add(normalized);
+  target.push(normalized);
 }
 
 function readMarkerPath(line: string | undefined, marker: string): string | undefined {

--- a/src/agents/apply-patch-paths.ts
+++ b/src/agents/apply-patch-paths.ts
@@ -63,16 +63,20 @@ function normalizePatchPath(
     return undefined;
   }
   const cwd = options.cwd ?? options.sandbox?.root ?? process.cwd();
-  const resolved = options.sandbox
-    ? options.sandbox.bridge.resolvePath({
-        filePath: raw,
-        cwd,
-      })
-    : undefined;
-  const normalized = path.normalize(
-    resolved ? (resolved.hostPath ?? resolved.containerPath) : resolveSandboxInputPath(raw, cwd),
-  );
-  return normalized && normalized !== "." ? normalized : undefined;
+  try {
+    const resolved = options.sandbox
+      ? options.sandbox.bridge.resolvePath({
+          filePath: raw,
+          cwd,
+        })
+      : undefined;
+    const normalized = path.normalize(
+      resolved ? (resolved.hostPath ?? resolved.containerPath) : resolveSandboxInputPath(raw, cwd),
+    );
+    return normalized && normalized !== "." ? normalized : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function pushPath(

--- a/src/agents/apply-patch-paths.ts
+++ b/src/agents/apply-patch-paths.ts
@@ -58,7 +58,7 @@ function normalizePatchPath(
     return undefined;
   }
   const cwd = options.cwd ?? process.cwd();
-  const normalized = path.normalize(resolveSandboxInputPath(trimmed.replace(/\\/g, "/"), cwd));
+  const normalized = path.normalize(resolveSandboxInputPath(trimmed, cwd));
   return normalized && normalized !== "." ? normalized : undefined;
 }
 

--- a/src/agents/apply-patch-paths.ts
+++ b/src/agents/apply-patch-paths.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { resolveSandboxInputPath } from "./sandbox-paths.js";
+import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 
 /**
  * Lightweight path extractor for the `apply_patch` envelope grammar.
@@ -34,6 +35,11 @@ const MOVE_TO_MARKER = "*** Move to: ";
 export type ApplyPatchPathExtractionOptions = {
   /** Tool execution cwd. Defaults to process.cwd(), matching createApplyPatchTool. */
   cwd?: string;
+  /** Sandbox bridge used by apply_patch execution, when the tool runs in a sandbox. */
+  sandbox?: {
+    root: string;
+    bridge: SandboxFsBridge;
+  };
 };
 
 function readPatchText(input: unknown): string | undefined {
@@ -53,12 +59,19 @@ function normalizePatchPath(
   raw: string,
   options: ApplyPatchPathExtractionOptions = {},
 ): string | undefined {
-  const trimmed = raw.trim();
-  if (!trimmed) {
+  if (raw.length === 0) {
     return undefined;
   }
-  const cwd = options.cwd ?? process.cwd();
-  const normalized = path.normalize(resolveSandboxInputPath(trimmed, cwd));
+  const cwd = options.cwd ?? options.sandbox?.root ?? process.cwd();
+  const resolved = options.sandbox
+    ? options.sandbox.bridge.resolvePath({
+        filePath: raw,
+        cwd,
+      })
+    : undefined;
+  const normalized = path.normalize(
+    resolved ? (resolved.hostPath ?? resolved.containerPath) : resolveSandboxInputPath(raw, cwd),
+  );
   return normalized && normalized !== "." ? normalized : undefined;
 }
 
@@ -94,11 +107,11 @@ function normalizeMarkerHeaderLine(
   if (line === undefined) {
     return undefined;
   }
-  const candidate = line.trimStart();
-  if (!candidate.startsWith("***")) {
+  const startTrimmed = line.trimStart();
+  if (!startTrimmed.startsWith("***")) {
     return undefined;
   }
-  const leadingWhitespace = line.length - candidate.length;
+  const leadingWhitespace = line.length - startTrimmed.length;
   if (
     options?.allowSingleSpaceIndent === false &&
     leadingWhitespace === 1 &&
@@ -106,7 +119,7 @@ function normalizeMarkerHeaderLine(
   ) {
     return undefined;
   }
-  return candidate;
+  return startTrimmed.trimEnd();
 }
 
 /**

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -726,6 +726,52 @@ describe("native hook relay registry", () => {
     }
   });
 
+  it("uses the Codex cwd when deriving apply_patch paths for PreToolUse", async () => {
+    const beforeToolCall = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      agentId: "agent-1",
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      runId: "run-1",
+    });
+    const cwd = path.join("/tmp", "openclaw-native-hook-cwd");
+    const patch = ["*** Begin Patch", "*** Add File: src/new.ts", "+x", "*** End Patch"].join("\n");
+
+    const response = await invokeNativeHookRelay({
+      provider: "codex",
+      relayId: relay.relayId,
+      event: "pre_tool_use",
+      rawPayload: {
+        hook_event_name: "PreToolUse",
+        cwd,
+        tool_name: "apply_patch",
+        tool_use_id: "native-patch-1",
+        tool_input: { input: patch },
+      },
+    });
+
+    expect(response).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    expect(beforeToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "apply_patch",
+        params: { input: patch },
+        derivedPaths: [path.join(cwd, "src/new.ts")],
+      }),
+      expect.objectContaining({
+        agentId: "agent-1",
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        runId: "run-1",
+        toolName: "apply_patch",
+        toolCallId: "native-patch-1",
+      }),
+    );
+  });
+
   it("does not rewrite Codex native tool input when before_tool_call adjusts params", async () => {
     const beforeToolCall = vi.fn(async () => ({
       params: { command: "echo replaced" },

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -875,6 +875,7 @@ async function runNativeHookRelayPreToolUse(params: {
       ...(params.registration.sessionKey ? { sessionKey: params.registration.sessionKey } : {}),
       ...(params.registration.config ? { config: params.registration.config } : {}),
       runId: params.registration.runId,
+      ...(params.invocation.cwd ? { cwd: params.invocation.cwd } : {}),
     },
   });
   if (outcome.blocked) {

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   onInternalDiagnosticEvent,
@@ -745,6 +746,7 @@ describe("before_tool_call requireApproval handling", () => {
   });
 
   it("passes host-derived apply_patch paths to before_tool_call hooks", async () => {
+    const cwd = path.join("/tmp", "openclaw-hooks");
     const patch = [
       "*** Begin Patch",
       "*** Add File: src/new.ts",
@@ -762,7 +764,7 @@ describe("before_tool_call requireApproval handling", () => {
       toolName: "apply_patch",
       params: { input: patch },
       toolCallId: "patch-1",
-      ctx: { agentId: "main", sessionKey: "main", runId: "run-patch" },
+      ctx: { agentId: "main", cwd, sessionKey: "main", runId: "run-patch" },
     });
 
     expect(result.blocked).toBe(false);
@@ -771,7 +773,12 @@ describe("before_tool_call requireApproval handling", () => {
         toolName: "apply_patch",
         runId: "run-patch",
         toolCallId: "patch-1",
-        derivedPaths: ["src/new.ts", "src/old.ts", "src/renamed.ts", "src/dead.ts"],
+        derivedPaths: [
+          path.join(cwd, "src/new.ts"),
+          path.join(cwd, "src/old.ts"),
+          path.join(cwd, "src/renamed.ts"),
+          path.join(cwd, "src/dead.ts"),
+        ],
       }),
       expect.objectContaining({
         toolName: "apply_patch",
@@ -781,7 +788,28 @@ describe("before_tool_call requireApproval handling", () => {
     );
   });
 
+  it("skips derived path extraction when no policies or hooks can consume it", async () => {
+    hookRunner.hasHooks.mockReturnValue(false);
+    const params = {};
+    Object.defineProperty(params, "input", {
+      enumerable: true,
+      get() {
+        throw new Error("should not derive paths");
+      },
+    });
+
+    await expect(
+      runBeforeToolCallHook({
+        toolName: "apply_patch",
+        params,
+        toolCallId: "patch-no-hooks",
+      }),
+    ).resolves.toEqual({ blocked: false, params });
+    expect(hookRunner.runBeforeToolCall).not.toHaveBeenCalled();
+  });
+
   it("recomputes host-derived paths after trusted policy param rewrites", async () => {
+    const cwd = path.join("/tmp", "openclaw-hooks");
     const originalPatch = [
       "*** Begin Patch",
       "*** Add File: src/old.ts",
@@ -828,15 +856,15 @@ describe("before_tool_call requireApproval handling", () => {
       toolName: "apply_patch",
       params: { input: originalPatch },
       toolCallId: "patch-rewrite",
-      ctx: { agentId: "main", sessionKey: "main", runId: "run-patch" },
+      ctx: { agentId: "main", cwd, sessionKey: "main", runId: "run-patch" },
     });
 
     expect(result).toEqual({ blocked: false, params: { input: rewrittenPatch } });
-    expect(seenByLaterPolicy).toEqual([["src/new.ts"]]);
+    expect(seenByLaterPolicy).toEqual([[path.join(cwd, "src/new.ts")]]);
     expect(hookRunner.runBeforeToolCall).toHaveBeenCalledWith(
       expect.objectContaining({
         params: { input: rewrittenPatch },
-        derivedPaths: ["src/new.ts"],
+        derivedPaths: [path.join(cwd, "src/new.ts")],
       }),
       expect.anything(),
     );

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -8,6 +8,8 @@ import {
 } from "../infra/diagnostic-events.js";
 import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
 import {
   runBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,
@@ -646,6 +648,7 @@ describe("before_tool_call requireApproval handling", () => {
     }
     hookRunnerGlobalState[hookRunnerGlobalStateKey].hookRunner = hookRunner;
     mockCallGateway.mockReset();
+    setActivePluginRegistry(createEmptyPluginRegistry());
   });
 
   async function runAbortDuringApprovalWait(options?: { onResolution?: ReturnType<typeof vi.fn> }) {
@@ -739,6 +742,104 @@ describe("before_tool_call requireApproval handling", () => {
     });
     expect(toolContext?.trace).not.toBe(trace);
     expect(Object.isFrozen(toolContext?.trace)).toBe(true);
+  });
+
+  it("passes host-derived apply_patch paths to before_tool_call hooks", async () => {
+    const patch = [
+      "*** Begin Patch",
+      "*** Add File: src/new.ts",
+      "+x",
+      "*** Update File: src/old.ts",
+      "*** Move to: src/renamed.ts",
+      "@@",
+      "+y",
+      "*** Delete File: src/dead.ts",
+      "*** End Patch",
+    ].join("\n");
+    hookRunner.runBeforeToolCall.mockResolvedValue(undefined);
+
+    const result = await runBeforeToolCallHook({
+      toolName: "apply_patch",
+      params: { input: patch },
+      toolCallId: "patch-1",
+      ctx: { agentId: "main", sessionKey: "main", runId: "run-patch" },
+    });
+
+    expect(result.blocked).toBe(false);
+    expect(hookRunner.runBeforeToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "apply_patch",
+        runId: "run-patch",
+        toolCallId: "patch-1",
+        derivedPaths: ["src/new.ts", "src/old.ts", "src/renamed.ts", "src/dead.ts"],
+      }),
+      expect.objectContaining({
+        toolName: "apply_patch",
+        runId: "run-patch",
+        toolCallId: "patch-1",
+      }),
+    );
+  });
+
+  it("recomputes host-derived paths after trusted policy param rewrites", async () => {
+    const originalPatch = [
+      "*** Begin Patch",
+      "*** Add File: src/old.ts",
+      "+x",
+      "*** End Patch",
+    ].join("\n");
+    const rewrittenPatch = [
+      "*** Begin Patch",
+      "*** Add File: src/new.ts",
+      "+x",
+      "*** End Patch",
+    ].join("\n");
+    const seenByLaterPolicy: unknown[] = [];
+    const registry = createEmptyPluginRegistry();
+    registry.trustedToolPolicies = [
+      {
+        pluginId: "trusted-rewriter",
+        pluginName: "Trusted Rewriter",
+        source: "test",
+        policy: {
+          id: "rewrite",
+          description: "rewrite",
+          evaluate: () => ({ params: { input: rewrittenPatch } }),
+        },
+      },
+      {
+        pluginId: "trusted-inspector",
+        pluginName: "Trusted Inspector",
+        source: "test",
+        policy: {
+          id: "inspect",
+          description: "inspect",
+          evaluate: (event) => {
+            seenByLaterPolicy.push(event.derivedPaths);
+            return undefined;
+          },
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+    hookRunner.runBeforeToolCall.mockResolvedValue(undefined);
+
+    const result = await runBeforeToolCallHook({
+      toolName: "apply_patch",
+      params: { input: originalPatch },
+      toolCallId: "patch-rewrite",
+      ctx: { agentId: "main", sessionKey: "main", runId: "run-patch" },
+    });
+
+    expect(result).toEqual({ blocked: false, params: { input: rewrittenPatch } });
+    expect(seenByLaterPolicy).toEqual([["src/new.ts"]]);
+    expect(hookRunner.runBeforeToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { input: rewrittenPatch },
+        derivedPaths: ["src/new.ts"],
+      }),
+      expect.anything(),
+    );
   });
 
   it("calls gateway RPC and unblocks on allow-once", async () => {

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -788,6 +788,47 @@ describe("before_tool_call requireApproval handling", () => {
     );
   });
 
+  it("derives sandboxed apply_patch paths through the sandbox bridge", async () => {
+    const patch = [
+      "*** Begin Patch",
+      "*** Add File: /workspace/src/new.ts",
+      "+x",
+      "*** End Patch",
+    ].join("\n");
+    hookRunner.runBeforeToolCall.mockResolvedValue(undefined);
+
+    const result = await runBeforeToolCallHook({
+      toolName: "apply_patch",
+      params: { input: patch },
+      toolCallId: "patch-sandbox",
+      ctx: {
+        agentId: "main",
+        cwd: "/workspace",
+        sandbox: {
+          root: "/workspace",
+          bridge: {
+            resolvePath: ({ filePath }: { filePath: string }) => ({
+              containerPath: filePath,
+              hostPath: "/host/sandbox/src/new.ts",
+              relativePath: "src/new.ts",
+            }),
+          } as never,
+        },
+        sessionKey: "main",
+        runId: "run-patch",
+      },
+    });
+
+    expect(result.blocked).toBe(false);
+    expect(hookRunner.runBeforeToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "apply_patch",
+        derivedPaths: ["/host/sandbox/src/new.ts"],
+      }),
+      expect.anything(),
+    );
+  });
+
   it("skips derived path extraction when no policies or hooks can consume it", async () => {
     hookRunner.hasHooks.mockReturnValue(false);
     const params = {};

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -829,6 +829,43 @@ describe("before_tool_call requireApproval handling", () => {
     );
   });
 
+  it("does not fail hooks when sandbox path derivation rejects a target", async () => {
+    const patch = ["*** Begin Patch", "*** Add File: /outside.ts", "+x", "*** End Patch"].join(
+      "\n",
+    );
+    hookRunner.runBeforeToolCall.mockResolvedValue(undefined);
+
+    const result = await runBeforeToolCallHook({
+      toolName: "apply_patch",
+      params: { input: patch },
+      toolCallId: "patch-sandbox-rejected",
+      ctx: {
+        agentId: "main",
+        cwd: "/workspace",
+        sandbox: {
+          root: "/workspace",
+          bridge: {
+            resolvePath: () => {
+              throw new Error("Path escapes sandbox root");
+            },
+          } as never,
+        },
+        sessionKey: "main",
+        runId: "run-patch",
+      },
+    });
+
+    expect(result.blocked).toBe(false);
+    expect(hookRunner.runBeforeToolCall).toHaveBeenCalledWith(
+      expect.not.objectContaining({ derivedPaths: expect.anything() }),
+      expect.objectContaining({
+        toolName: "apply_patch",
+        runId: "run-patch",
+        toolCallId: "patch-sandbox-rejected",
+      }),
+    );
+  });
+
   it("skips derived path extraction when no policies or hooks can consume it", async () => {
     hookRunner.hasHooks.mockReturnValue(false);
     const params = {};

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -558,9 +558,10 @@ export async function runBeforeToolCallHook(args: {
       });
     }
     const policyAdjustedParams = trustedPolicyResult?.params ?? params;
-    const policyAdjustedDerivedToolParams = isPlainObject(policyAdjustedParams)
-      ? deriveToolParams(toolName, policyAdjustedParams)
-      : {};
+    const policyAdjustedDerivedToolParams =
+      trustedPolicyResult?.params && isPlainObject(policyAdjustedParams)
+        ? deriveToolParams(toolName, policyAdjustedParams)
+        : derivedToolParams;
     if (!hookRunner?.hasHooks("before_tool_call")) {
       return { blocked: false, params: policyAdjustedParams };
     }

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -18,7 +18,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { deriveToolParams } from "../plugins/host-tool-param-parsers.js";
 import { copyPluginToolMeta } from "../plugins/tools.js";
-import { runTrustedToolPolicies } from "../plugins/trusted-tool-policy.js";
+import { hasTrustedToolPolicies, runTrustedToolPolicies } from "../plugins/trusted-tool-policy.js";
 import {
   PluginApprovalResolutions,
   type PluginApprovalResolution,
@@ -53,6 +53,8 @@ export function isAbortSignalCancellation(err: unknown, signal?: AbortSignal): b
 export type HookContext = {
   agentId?: string;
   config?: OpenClawConfig;
+  /** Tool execution cwd for host-derived path facts. */
+  cwd?: string;
   sessionKey?: string;
   /** Ephemeral session UUID — regenerated on /new and /reset. */
   sessionId?: string;
@@ -495,10 +497,16 @@ export async function runBeforeToolCallHook(args: {
 
   const hookRunner = getGlobalHookRunner();
   try {
+    const hasBeforeToolCallHooks = hookRunner?.hasHooks("before_tool_call") === true;
+    const shouldRunTrustedPolicies = hasTrustedToolPolicies();
+    if (!shouldRunTrustedPolicies && !hasBeforeToolCallHooks) {
+      return { blocked: false, params };
+    }
     const normalizedParams = isPlainObject(params) ? params : {};
-    const derivedToolParams = deriveToolParams(toolName, normalizedParams);
+    const deriveOptions = args.ctx?.cwd ? { cwd: args.ctx.cwd } : undefined;
+    const derivedToolParams = deriveToolParams(toolName, normalizedParams, deriveOptions);
     const deriveToolEventParams = (candidateParams: Record<string, unknown>) => {
-      const derived = deriveToolParams(toolName, candidateParams);
+      const derived = deriveToolParams(toolName, candidateParams, deriveOptions);
       return derived.derivedPaths ? { derivedPaths: derived.derivedPaths } : {};
     };
     const toolContext = {
@@ -511,20 +519,24 @@ export async function runBeforeToolCallHook(args: {
       ...(args.toolCallId && { toolCallId: args.toolCallId }),
       ...(args.ctx?.channelId && { channelId: args.ctx.channelId }),
     };
-    const trustedPolicyResult = await runTrustedToolPolicies(
-      {
-        toolName,
-        params: normalizedParams,
-        ...(args.ctx?.runId && { runId: args.ctx.runId }),
-        ...(args.toolCallId && { toolCallId: args.toolCallId }),
-        ...(derivedToolParams.derivedPaths ? { derivedPaths: derivedToolParams.derivedPaths } : {}),
-      },
-      toolContext,
-      {
-        ...(args.ctx?.config ? { config: args.ctx.config } : {}),
-        deriveEvent: deriveToolEventParams,
-      },
-    );
+    const trustedPolicyResult = shouldRunTrustedPolicies
+      ? await runTrustedToolPolicies(
+          {
+            toolName,
+            params: normalizedParams,
+            ...(args.ctx?.runId && { runId: args.ctx.runId }),
+            ...(args.toolCallId && { toolCallId: args.toolCallId }),
+            ...(derivedToolParams.derivedPaths
+              ? { derivedPaths: derivedToolParams.derivedPaths }
+              : {}),
+          },
+          toolContext,
+          {
+            ...(args.ctx?.config ? { config: args.ctx.config } : {}),
+            deriveEvent: deriveToolEventParams,
+          },
+        )
+      : undefined;
     if (trustedPolicyResult?.block) {
       return {
         blocked: true,
@@ -560,9 +572,9 @@ export async function runBeforeToolCallHook(args: {
     const policyAdjustedParams = trustedPolicyResult?.params ?? params;
     const policyAdjustedDerivedToolParams =
       trustedPolicyResult?.params && isPlainObject(policyAdjustedParams)
-        ? deriveToolParams(toolName, policyAdjustedParams)
+        ? deriveToolParams(toolName, policyAdjustedParams, deriveOptions)
         : derivedToolParams;
-    if (!hookRunner?.hasHooks("before_tool_call")) {
+    if (!hasBeforeToolCallHooks) {
       return { blocked: false, params: policyAdjustedParams };
     }
     const hookEventParams = isPlainObject(policyAdjustedParams) ? policyAdjustedParams : {};

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -28,6 +28,7 @@ import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
 import { isPlainObject } from "../utils.js";
 import { copyChannelAgentToolMeta } from "./channel-tools.js";
 import { adjustedParamsByToolCallId } from "./pi-tools.before-tool-call.state.js";
+import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import { normalizeToolName } from "./tool-policy.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { callGatewayTool } from "./tools/gateway.js";
@@ -63,6 +64,10 @@ export type HookContext = {
   channelId?: string;
   loopDetection?: ToolLoopDetectionConfig;
   onToolOutcome?: ToolOutcomeObserver;
+  sandbox?: {
+    root: string;
+    bridge: SandboxFsBridge;
+  };
 };
 
 type HookBlockedKind = "veto" | "failure";
@@ -503,7 +508,13 @@ export async function runBeforeToolCallHook(args: {
       return { blocked: false, params };
     }
     const normalizedParams = isPlainObject(params) ? params : {};
-    const deriveOptions = args.ctx?.cwd ? { cwd: args.ctx.cwd } : undefined;
+    const deriveOptions =
+      args.ctx?.cwd || args.ctx?.sandbox
+        ? {
+            ...(args.ctx.cwd ? { cwd: args.ctx.cwd } : {}),
+            ...(args.ctx.sandbox ? { sandbox: args.ctx.sandbox } : {}),
+          }
+        : undefined;
     const derivedToolParams = deriveToolParams(toolName, normalizedParams, deriveOptions);
     const deriveToolEventParams = (candidateParams: Record<string, unknown>) => {
       const derived = deriveToolParams(toolName, candidateParams, deriveOptions);

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -16,6 +16,7 @@ import {
 import type { SessionState } from "../logging/diagnostic-session-state.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { deriveToolParams } from "../plugins/host-tool-param-parsers.js";
 import { copyPluginToolMeta } from "../plugins/tools.js";
 import { runTrustedToolPolicies } from "../plugins/trusted-tool-policy.js";
 import {
@@ -495,6 +496,11 @@ export async function runBeforeToolCallHook(args: {
   const hookRunner = getGlobalHookRunner();
   try {
     const normalizedParams = isPlainObject(params) ? params : {};
+    const derivedToolParams = deriveToolParams(toolName, normalizedParams);
+    const deriveToolEventParams = (candidateParams: Record<string, unknown>) => {
+      const derived = deriveToolParams(toolName, candidateParams);
+      return derived.derivedPaths ? { derivedPaths: derived.derivedPaths } : {};
+    };
     const toolContext = {
       toolName,
       ...(args.ctx?.agentId && { agentId: args.ctx.agentId }),
@@ -511,9 +517,13 @@ export async function runBeforeToolCallHook(args: {
         params: normalizedParams,
         ...(args.ctx?.runId && { runId: args.ctx.runId }),
         ...(args.toolCallId && { toolCallId: args.toolCallId }),
+        ...(derivedToolParams.derivedPaths ? { derivedPaths: derivedToolParams.derivedPaths } : {}),
       },
       toolContext,
-      args.ctx?.config ? { config: args.ctx.config } : undefined,
+      {
+        ...(args.ctx?.config ? { config: args.ctx.config } : {}),
+        deriveEvent: deriveToolEventParams,
+      },
     );
     if (trustedPolicyResult?.block) {
       return {
@@ -548,6 +558,9 @@ export async function runBeforeToolCallHook(args: {
       });
     }
     const policyAdjustedParams = trustedPolicyResult?.params ?? params;
+    const policyAdjustedDerivedToolParams = isPlainObject(policyAdjustedParams)
+      ? deriveToolParams(toolName, policyAdjustedParams)
+      : {};
     if (!hookRunner?.hasHooks("before_tool_call")) {
       return { blocked: false, params: policyAdjustedParams };
     }
@@ -558,6 +571,9 @@ export async function runBeforeToolCallHook(args: {
         params: hookEventParams,
         ...(args.ctx?.runId && { runId: args.ctx.runId }),
         ...(args.toolCallId && { toolCallId: args.toolCallId }),
+        ...(policyAdjustedDerivedToolParams.derivedPaths
+          ? { derivedPaths: policyAdjustedDerivedToolParams.derivedPaths }
+          : {}),
       },
       toolContext,
     );

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -845,6 +845,9 @@ export function createOpenClawCodingTools(options?: {
       agentId,
       ...(options?.config ? { config: options.config } : {}),
       cwd: sandboxRoot ?? workspaceRoot,
+      ...(sandboxRoot && allowWorkspaceWrites
+        ? { sandbox: { root: sandboxRoot, bridge: sandboxFsBridge! } }
+        : {}),
       sessionKey: options?.sessionKey,
       sessionId: options?.sessionId,
       runId: options?.runId,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -844,6 +844,7 @@ export function createOpenClawCodingTools(options?: {
     wrapToolWithBeforeToolCallHook(tool, {
       agentId,
       ...(options?.config ? { config: options.config } : {}),
+      cwd: sandboxRoot ?? workspaceRoot,
       sessionKey: options?.sessionKey,
       sessionId: options?.sessionId,
       runId: options?.runId,

--- a/src/plugins/contracts/host-hooks.contract.test.ts
+++ b/src/plugins/contracts/host-hooks.contract.test.ts
@@ -419,6 +419,39 @@ describe("host-hook fixture plugin contract", () => {
     expect(seenParams).toEqual([{ command: "patched" }]);
   });
 
+  it("preserves trusted policy derived paths when params are unchanged", async () => {
+    const seenDerivedPaths: unknown[] = [];
+    const registry = createEmptyPluginRegistry();
+    registry.trustedToolPolicies = [
+      {
+        pluginId: "trusted-inspector",
+        pluginName: "Trusted Inspector",
+        source: "test",
+        policy: {
+          id: "inspect",
+          description: "inspect",
+          evaluate: (event) => {
+            seenDerivedPaths.push(event.derivedPaths);
+            return undefined;
+          },
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    await expect(
+      runTrustedToolPolicies(
+        {
+          toolName: "apply_patch",
+          params: { input: "*** Update File: old.ts" },
+          derivedPaths: ["old.ts"],
+        },
+        { toolName: "apply_patch" },
+      ),
+    ).resolves.toBeUndefined();
+    expect(seenDerivedPaths).toEqual([["old.ts"]]);
+  });
+
   it("clears stale derived paths when trusted policy rewrites remove targets", async () => {
     const seenDerivedPaths: unknown[] = [];
     const registry = createEmptyPluginRegistry();
@@ -465,6 +498,62 @@ describe("host-hook fixture plugin contract", () => {
       ),
     ).resolves.toEqual({ params: { input: "not a patch" } });
     expect(seenDerivedPaths).toEqual([undefined]);
+  });
+
+  it("does not let derived param callbacks override core trusted policy event fields", async () => {
+    const seenEvents: Array<{ params: unknown; derivedPaths: unknown }> = [];
+    const registry = createEmptyPluginRegistry();
+    registry.trustedToolPolicies = [
+      {
+        pluginId: "trusted-a",
+        pluginName: "Trusted A",
+        source: "test",
+        policy: {
+          id: "params",
+          description: "params",
+          evaluate: () => ({ params: { input: "*** Update File: new.ts" } }),
+        },
+      },
+      {
+        pluginId: "trusted-b",
+        pluginName: "Trusted B",
+        source: "test",
+        policy: {
+          id: "inspect",
+          description: "inspect",
+          evaluate: (event) => {
+            seenEvents.push({ params: event.params, derivedPaths: event.derivedPaths });
+            return undefined;
+          },
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    await expect(
+      runTrustedToolPolicies(
+        {
+          toolName: "apply_patch",
+          params: { input: "*** Update File: old.ts" },
+          derivedPaths: ["old.ts"],
+        },
+        { toolName: "apply_patch" },
+        {
+          deriveEvent() {
+            return {
+              params: { input: "malicious override" },
+              derivedPaths: ["new.ts"],
+            } as never;
+          },
+        },
+      ),
+    ).resolves.toEqual({ params: { input: "*** Update File: new.ts" } });
+    expect(seenEvents).toEqual([
+      {
+        params: { input: "*** Update File: new.ts" },
+        derivedPaths: ["new.ts"],
+      },
+    ]);
   });
 
   it("validates plugin-owned JSON values as plain JSON-compatible data", () => {

--- a/src/plugins/contracts/host-hooks.contract.test.ts
+++ b/src/plugins/contracts/host-hooks.contract.test.ts
@@ -452,6 +452,58 @@ describe("host-hook fixture plugin contract", () => {
     expect(seenDerivedPaths).toEqual([["old.ts"]]);
   });
 
+  it("does not let trusted policies mutate derived paths for later policies", async () => {
+    const seenDerivedPaths: unknown[] = [];
+    let mutationRejected = false;
+    const registry = createEmptyPluginRegistry();
+    registry.trustedToolPolicies = [
+      {
+        pluginId: "trusted-a",
+        pluginName: "Trusted A",
+        source: "test",
+        policy: {
+          id: "mutate",
+          description: "mutate",
+          evaluate: (event) => {
+            try {
+              (event.derivedPaths as string[] | undefined)?.push("mutated.ts");
+            } catch {
+              mutationRejected = true;
+            }
+            return undefined;
+          },
+        },
+      },
+      {
+        pluginId: "trusted-b",
+        pluginName: "Trusted B",
+        source: "test",
+        policy: {
+          id: "inspect",
+          description: "inspect",
+          evaluate: (event) => {
+            seenDerivedPaths.push(event.derivedPaths);
+            return undefined;
+          },
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    await expect(
+      runTrustedToolPolicies(
+        {
+          toolName: "apply_patch",
+          params: { input: "*** Update File: old.ts" },
+          derivedPaths: ["old.ts"],
+        },
+        { toolName: "apply_patch" },
+      ),
+    ).resolves.toBeUndefined();
+    expect(mutationRejected).toBe(true);
+    expect(seenDerivedPaths).toEqual([["old.ts"]]);
+  });
+
   it("clears stale derived paths when trusted policy rewrites remove targets", async () => {
     const seenDerivedPaths: unknown[] = [];
     const registry = createEmptyPluginRegistry();

--- a/src/plugins/contracts/host-hooks.contract.test.ts
+++ b/src/plugins/contracts/host-hooks.contract.test.ts
@@ -452,6 +452,45 @@ describe("host-hook fixture plugin contract", () => {
     expect(seenDerivedPaths).toEqual([["old.ts"]]);
   });
 
+  it("ignores non-plain trusted policy params when re-deriving paths", async () => {
+    const seenParams: unknown[] = [];
+    const registry = createEmptyPluginRegistry();
+    registry.trustedToolPolicies = [
+      {
+        pluginId: "trusted-bad",
+        pluginName: "Trusted Bad",
+        source: "test",
+        policy: {
+          id: "bad",
+          description: "bad",
+          evaluate: () => ({ params: "not-a-plain-object" as never }),
+        },
+      },
+      {
+        pluginId: "trusted-inspector",
+        pluginName: "Trusted Inspector",
+        source: "test",
+        policy: {
+          id: "inspect",
+          description: "inspect",
+          evaluate: (event) => {
+            seenParams.push(event.params);
+            return undefined;
+          },
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    await expect(
+      runTrustedToolPolicies(
+        { toolName: "apply_patch", params: { input: "*** Add File: old.ts" } },
+        { toolName: "apply_patch" },
+      ),
+    ).resolves.toBeUndefined();
+    expect(seenParams).toEqual([{ input: "*** Add File: old.ts" }]);
+  });
+
   it("does not let trusted policies mutate derived paths for later policies", async () => {
     const seenDerivedPaths: unknown[] = [];
     let mutationRejected = false;

--- a/src/plugins/contracts/host-hooks.contract.test.ts
+++ b/src/plugins/contracts/host-hooks.contract.test.ts
@@ -419,6 +419,54 @@ describe("host-hook fixture plugin contract", () => {
     expect(seenParams).toEqual([{ command: "patched" }]);
   });
 
+  it("clears stale derived paths when trusted policy rewrites remove targets", async () => {
+    const seenDerivedPaths: unknown[] = [];
+    const registry = createEmptyPluginRegistry();
+    registry.trustedToolPolicies = [
+      {
+        pluginId: "trusted-a",
+        pluginName: "Trusted A",
+        source: "test",
+        policy: {
+          id: "params",
+          description: "params",
+          evaluate: () => ({ params: { input: "not a patch" } }),
+        },
+      },
+      {
+        pluginId: "trusted-b",
+        pluginName: "Trusted B",
+        source: "test",
+        policy: {
+          id: "inspect",
+          description: "inspect",
+          evaluate: (event) => {
+            seenDerivedPaths.push(event.derivedPaths);
+            return undefined;
+          },
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    await expect(
+      runTrustedToolPolicies(
+        {
+          toolName: "apply_patch",
+          params: { patch: "*** Update File: old.ts" },
+          derivedPaths: ["old.ts"],
+        },
+        { toolName: "apply_patch" },
+        {
+          deriveEvent(params) {
+            return typeof params.patch === "string" ? { derivedPaths: ["old.ts"] } : {};
+          },
+        },
+      ),
+    ).resolves.toEqual({ params: { input: "not a patch" } });
+    expect(seenDerivedPaths).toEqual([undefined]);
+  });
+
   it("validates plugin-owned JSON values as plain JSON-compatible data", () => {
     expect(
       isPluginJsonValue({

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -425,10 +425,15 @@ export type PluginHookBeforeToolCallEvent = {
   runId?: string;
   toolCallId?: string;
   /**
-   * Optional destination paths the host derived from `params` for well-known
-   * tool envelopes (e.g. `apply_patch`). When present, plugins can rely on
-   * this list rather than re-parsing the envelope. Absent for tools the host
-   * does not know how to derive paths for.
+   * Optional best-effort destination path hints the host derived from `params`
+   * for well-known tool envelopes (e.g. `apply_patch`).
+   *
+   * This is a convenience hint, not an authoritative parse result: the host's
+   * extractor may be intentionally lenient and can return paths for malformed
+   * or partial envelopes. Plugins may use `derivedPaths` as a fast path, but
+   * should parse and validate `params` themselves when correctness or policy
+   * decisions depend on the exact set of affected paths. Absent for tools the
+   * host does not know how to derive paths for.
    */
   derivedPaths?: readonly string[];
 };

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -424,6 +424,13 @@ export type PluginHookBeforeToolCallEvent = {
   params: Record<string, unknown>;
   runId?: string;
   toolCallId?: string;
+  /**
+   * Optional destination paths the host derived from `params` for well-known
+   * tool envelopes (e.g. `apply_patch`). When present, plugins can rely on
+   * this list rather than re-parsing the envelope. Absent for tools the host
+   * does not know how to derive paths for.
+   */
+  derivedPaths?: readonly string[];
 };
 
 export const PluginApprovalResolutions = {

--- a/src/plugins/host-tool-param-parsers.test.ts
+++ b/src/plugins/host-tool-param-parsers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { deriveToolParams } from "./host-tool-param-parsers.js";
+
+describe("deriveToolParams", () => {
+  it("returns an empty object for tools that have no registered parser", () => {
+    expect(deriveToolParams("exec", { command: "ls" })).toEqual({});
+    expect(deriveToolParams("read_file", { path: "/tmp/x" })).toEqual({});
+  });
+
+  it("derives apply_patch destination paths from the input envelope", () => {
+    const patch = [
+      "*** Begin Patch",
+      "*** Add File: src/new.ts",
+      "+x",
+      "*** Update File: src/old.ts",
+      "*** Move to: src/renamed.ts",
+      "@@",
+      "+y",
+      "*** Delete File: src/dead.ts",
+      "*** End Patch",
+    ].join("\n");
+    expect(deriveToolParams("apply_patch", { input: patch })).toEqual({
+      derivedPaths: ["src/new.ts", "src/old.ts", "src/renamed.ts", "src/dead.ts"],
+    });
+  });
+
+  it("returns an empty object when apply_patch input has no recognised paths", () => {
+    expect(deriveToolParams("apply_patch", { input: "not a patch" })).toEqual({});
+    expect(deriveToolParams("apply_patch", {})).toEqual({});
+    expect(deriveToolParams("apply_patch", undefined)).toEqual({});
+  });
+
+  it("does not throw for malformed param shapes", () => {
+    expect(deriveToolParams("apply_patch", null)).toEqual({});
+    expect(deriveToolParams("apply_patch", 42)).toEqual({});
+  });
+});

--- a/src/plugins/host-tool-param-parsers.test.ts
+++ b/src/plugins/host-tool-param-parsers.test.ts
@@ -62,6 +62,45 @@ describe("deriveToolParams", () => {
     });
   });
 
+  it("preserves apply_patch marker payload bytes after the executor header trim", () => {
+    const patch = ["*** Begin Patch", "*** Add File:  src/new.ts", "+x", "*** End Patch"].join(
+      "\n",
+    );
+    expect(deriveToolParams("apply_patch", { input: patch })).toEqual({
+      derivedPaths: [path.resolve(defaultCwd, " src/new.ts")],
+    });
+  });
+
+  it("resolves sandboxed apply_patch paths through the execution bridge", () => {
+    const patch = [
+      "*** Begin Patch",
+      "*** Add File: /workspace/src/new.ts",
+      "+x",
+      "*** End Patch",
+    ].join("\n");
+    expect(
+      deriveToolParams(
+        "apply_patch",
+        { input: patch },
+        {
+          cwd: "/workspace",
+          sandbox: {
+            root: "/workspace",
+            bridge: {
+              resolvePath: ({ filePath }: { filePath: string }) => ({
+                containerPath: filePath,
+                hostPath: "/host/sandbox/src/new.ts",
+                relativePath: "src/new.ts",
+              }),
+            } as never,
+          },
+        },
+      ),
+    ).toEqual({
+      derivedPaths: ["/host/sandbox/src/new.ts"],
+    });
+  });
+
   it("returns an empty object when apply_patch input has no recognised paths", () => {
     expect(deriveToolParams("apply_patch", { input: "not a patch" })).toEqual({});
     expect(deriveToolParams("apply_patch", {})).toEqual({});

--- a/src/plugins/host-tool-param-parsers.test.ts
+++ b/src/plugins/host-tool-param-parsers.test.ts
@@ -11,6 +11,11 @@ describe("deriveToolParams", () => {
     expect(deriveToolParams("read_file", { path: "/tmp/x" })).toEqual({});
   });
 
+  it("ignores prototype-key tool names when looking up parsers", () => {
+    expect(deriveToolParams("__proto__", { input: "anything" })).toEqual({});
+    expect(deriveToolParams("hasOwnProperty", { input: "anything" })).toEqual({});
+  });
+
   it("derives apply_patch destination paths from the input envelope", () => {
     const patch = [
       "*** Begin Patch",

--- a/src/plugins/host-tool-param-parsers.test.ts
+++ b/src/plugins/host-tool-param-parsers.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { deriveToolParams } from "./host-tool-param-parsers.js";
 
@@ -27,7 +28,18 @@ describe("deriveToolParams", () => {
   it("returns immutable derived path snapshots", () => {
     const patch = ["*** Begin Patch", "*** Add File: src/new.ts", "+x", "*** End Patch"].join("\n");
     const derived = deriveToolParams("apply_patch", { input: patch });
+    expect(Array.isArray(derived.derivedPaths)).toBe(true);
     expect(Object.isFrozen(derived.derivedPaths)).toBe(true);
+  });
+
+  it("resolves derived apply_patch paths against the tool cwd when provided", () => {
+    const patch = ["*** Begin Patch", "*** Add File: @src/../new.ts", "+x", "*** End Patch"].join(
+      "\n",
+    );
+    const cwd = path.join("/tmp", "openclaw-derived");
+    expect(deriveToolParams("apply_patch", { input: patch }, { cwd })).toEqual({
+      derivedPaths: [path.join(cwd, "new.ts")],
+    });
   });
 
   it("returns an empty object when apply_patch input has no recognised paths", () => {

--- a/src/plugins/host-tool-param-parsers.test.ts
+++ b/src/plugins/host-tool-param-parsers.test.ts
@@ -24,6 +24,12 @@ describe("deriveToolParams", () => {
     });
   });
 
+  it("returns immutable derived path snapshots", () => {
+    const patch = ["*** Begin Patch", "*** Add File: src/new.ts", "+x", "*** End Patch"].join("\n");
+    const derived = deriveToolParams("apply_patch", { input: patch });
+    expect(Object.isFrozen(derived.derivedPaths)).toBe(true);
+  });
+
   it("returns an empty object when apply_patch input has no recognised paths", () => {
     expect(deriveToolParams("apply_patch", { input: "not a patch" })).toEqual({});
     expect(deriveToolParams("apply_patch", {})).toEqual({});

--- a/src/plugins/host-tool-param-parsers.test.ts
+++ b/src/plugins/host-tool-param-parsers.test.ts
@@ -50,6 +50,18 @@ describe("deriveToolParams", () => {
     });
   });
 
+  it("preserves apply_patch backslashes when deriving path facts", () => {
+    const patch = [
+      "*** Begin Patch",
+      String.raw`*** Add File: safe\evil.ts`,
+      "+x",
+      "*** End Patch",
+    ].join("\n");
+    expect(deriveToolParams("apply_patch", { input: patch })).toEqual({
+      derivedPaths: [path.resolve(defaultCwd, String.raw`safe\evil.ts`)],
+    });
+  });
+
   it("returns an empty object when apply_patch input has no recognised paths", () => {
     expect(deriveToolParams("apply_patch", { input: "not a patch" })).toEqual({});
     expect(deriveToolParams("apply_patch", {})).toEqual({});

--- a/src/plugins/host-tool-param-parsers.test.ts
+++ b/src/plugins/host-tool-param-parsers.test.ts
@@ -2,6 +2,9 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { deriveToolParams } from "./host-tool-param-parsers.js";
 
+const defaultCwd = process.cwd();
+const cwdPath = (...segments: string[]) => path.join(defaultCwd, ...segments);
+
 describe("deriveToolParams", () => {
   it("returns an empty object for tools that have no registered parser", () => {
     expect(deriveToolParams("exec", { command: "ls" })).toEqual({});
@@ -21,7 +24,12 @@ describe("deriveToolParams", () => {
       "*** End Patch",
     ].join("\n");
     expect(deriveToolParams("apply_patch", { input: patch })).toEqual({
-      derivedPaths: ["src/new.ts", "src/old.ts", "src/renamed.ts", "src/dead.ts"],
+      derivedPaths: [
+        cwdPath("src/new.ts"),
+        cwdPath("src/old.ts"),
+        cwdPath("src/renamed.ts"),
+        cwdPath("src/dead.ts"),
+      ],
     });
   });
 

--- a/src/plugins/host-tool-param-parsers.ts
+++ b/src/plugins/host-tool-param-parsers.ts
@@ -1,0 +1,37 @@
+import { extractApplyPatchTargetPaths } from "../agents/apply-patch-paths.js";
+
+/**
+ * Derived metadata stamped on `before_tool_call` events for plugin handlers.
+ *
+ * The host owns parsing of well-known tool param shapes (e.g. apply_patch)
+ * once per call so plugins do not need to re-parse and re-validate the same
+ * envelopes. Fields are optional and additive: a missing field means the
+ * derivation produced nothing usable, never that it failed loudly.
+ */
+export type HostToolDerivedParams = {
+  /** Destination paths the tool intends to read or write, when discoverable. */
+  derivedPaths?: string[];
+};
+
+type HostToolParamParser = (params: unknown) => HostToolDerivedParams;
+
+/**
+ * Per-tool host-owned param derivers. Keep this map small and focused — every
+ * entry runs synchronously inside the before_tool_call hot path.
+ */
+const HOST_TOOL_PARAM_PARSERS: Record<string, HostToolParamParser> = {
+  apply_patch: (params) => {
+    const paths = extractApplyPatchTargetPaths(params);
+    return paths.length > 0 ? { derivedPaths: paths } : {};
+  },
+};
+
+/**
+ * Derive host-owned metadata for a tool call. Returns an empty object when no
+ * parser is registered for the tool, which lets callers spread the result
+ * unconditionally without a nullability check.
+ */
+export function deriveToolParams(toolName: string, params: unknown): HostToolDerivedParams {
+  const parser = HOST_TOOL_PARAM_PARSERS[toolName];
+  return parser ? parser(params) : {};
+}

--- a/src/plugins/host-tool-param-parsers.ts
+++ b/src/plugins/host-tool-param-parsers.ts
@@ -3,10 +3,11 @@ import { extractApplyPatchTargetPaths } from "../agents/apply-patch-paths.js";
 /**
  * Derived metadata stamped on `before_tool_call` events for plugin handlers.
  *
- * The host owns parsing of well-known tool param shapes (e.g. apply_patch)
- * once per call so plugins do not need to re-parse and re-validate the same
- * envelopes. Fields are optional and additive: a missing field means the
- * derivation produced nothing usable, never that it failed loudly.
+ * The host owns parsing of well-known tool param shapes (e.g. apply_patch) so
+ * plugins do not need to re-parse and re-validate the same envelopes. The host
+ * derives the initial call and re-derives only when a trusted policy rewrites
+ * params. Fields are optional and additive: a missing field means derivation
+ * produced nothing usable, never that it failed loudly.
  */
 export type HostToolDerivedParams = {
   /** Destination paths the tool intends to read or write, when discoverable. */

--- a/src/plugins/host-tool-param-parsers.ts
+++ b/src/plugins/host-tool-param-parsers.ts
@@ -44,6 +44,9 @@ export function deriveToolParams(
   params: unknown,
   options?: HostToolDerivationOptions,
 ): HostToolDerivedParams {
+  if (!Object.hasOwn(HOST_TOOL_PARAM_PARSERS, toolName)) {
+    return {};
+  }
   const parser = HOST_TOOL_PARAM_PARSERS[toolName];
   return parser ? parser(params, options) : {};
 }

--- a/src/plugins/host-tool-param-parsers.ts
+++ b/src/plugins/host-tool-param-parsers.ts
@@ -11,7 +11,7 @@ import { extractApplyPatchTargetPaths } from "../agents/apply-patch-paths.js";
  */
 export type HostToolDerivedParams = {
   /** Destination paths the tool intends to read or write, when discoverable. */
-  derivedPaths?: string[];
+  derivedPaths?: readonly string[];
 };
 
 type HostToolParamParser = (params: unknown) => HostToolDerivedParams;
@@ -23,7 +23,7 @@ type HostToolParamParser = (params: unknown) => HostToolDerivedParams;
 const HOST_TOOL_PARAM_PARSERS: Record<string, HostToolParamParser> = {
   apply_patch: (params) => {
     const paths = extractApplyPatchTargetPaths(params);
-    return paths.length > 0 ? { derivedPaths: paths } : {};
+    return paths.length > 0 ? { derivedPaths: Object.freeze([...paths]) } : {};
   },
 };
 

--- a/src/plugins/host-tool-param-parsers.ts
+++ b/src/plugins/host-tool-param-parsers.ts
@@ -1,28 +1,35 @@
-import { extractApplyPatchTargetPaths } from "../agents/apply-patch-paths.js";
+import {
+  extractApplyPatchTargetPaths,
+  type ApplyPatchPathExtractionOptions,
+} from "../agents/apply-patch-paths.js";
 
 /**
  * Derived metadata stamped on `before_tool_call` events for plugin handlers.
  *
- * The host owns parsing of well-known tool param shapes (e.g. apply_patch) so
- * plugins do not need to re-parse and re-validate the same envelopes. The host
- * derives the initial call and re-derives only when a trusted policy rewrites
- * params. Fields are optional and additive: a missing field means derivation
- * produced nothing usable, never that it failed loudly.
+ * The host owns best-effort parsing of well-known tool param shapes
+ * (e.g. apply_patch). Plugins can use these fields as hints, but should still
+ * parse params themselves when policy correctness depends on exact targets. The
+ * host derives the initial call and re-derives only when a trusted policy
+ * rewrites params. Fields are optional and additive: a missing field means
+ * derivation produced nothing usable, never that it failed loudly.
  */
 export type HostToolDerivedParams = {
-  /** Destination paths the tool intends to read or write, when discoverable. */
+  /** Best-effort destination path hints the tool may read or write, when discoverable. */
   derivedPaths?: readonly string[];
 };
 
-type HostToolParamParser = (params: unknown) => HostToolDerivedParams;
+export type HostToolDerivationOptions = ApplyPatchPathExtractionOptions;
 
 /**
  * Per-tool host-owned param derivers. Keep this map small and focused — every
  * entry runs synchronously inside the before_tool_call hot path.
  */
-const HOST_TOOL_PARAM_PARSERS: Record<string, HostToolParamParser> = {
-  apply_patch: (params) => {
-    const paths = extractApplyPatchTargetPaths(params);
+const HOST_TOOL_PARAM_PARSERS: Record<
+  string,
+  (params: unknown, options?: HostToolDerivationOptions) => HostToolDerivedParams
+> = {
+  apply_patch: (params, options) => {
+    const paths = extractApplyPatchTargetPaths(params, options);
     return paths.length > 0 ? { derivedPaths: Object.freeze([...paths]) } : {};
   },
 };
@@ -32,7 +39,11 @@ const HOST_TOOL_PARAM_PARSERS: Record<string, HostToolParamParser> = {
  * parser is registered for the tool, which lets callers spread the result
  * unconditionally without a nullability check.
  */
-export function deriveToolParams(toolName: string, params: unknown): HostToolDerivedParams {
+export function deriveToolParams(
+  toolName: string,
+  params: unknown,
+  options?: HostToolDerivationOptions,
+): HostToolDerivedParams {
   const parser = HOST_TOOL_PARAM_PARSERS[toolName];
-  return parser ? parser(params) : {};
+  return parser ? parser(params, options) : {};
 }

--- a/src/plugins/trusted-tool-policy.ts
+++ b/src/plugins/trusted-tool-policy.ts
@@ -12,7 +12,10 @@ import { getActivePluginRegistry } from "./runtime.js";
 export async function runTrustedToolPolicies(
   event: PluginHookBeforeToolCallEvent,
   ctx: PluginHookToolContext,
-  options?: { config?: OpenClawConfig },
+  options?: {
+    config?: OpenClawConfig;
+    deriveEvent?: (params: Record<string, unknown>) => Partial<PluginHookBeforeToolCallEvent>;
+  },
 ): Promise<PluginHookBeforeToolCallResult | undefined> {
   const policies = getActivePluginRegistry()?.trustedToolPolicies ?? [];
   let adjustedParams = event.params;
@@ -31,6 +34,15 @@ export async function runTrustedToolPolicies(
       }
     }
     return resolvedSessionConfig;
+  };
+  const { derivedPaths: _derivedPaths, ...eventWithoutDerivedPaths } = event;
+  const buildEvent = (params: Record<string, unknown>): PluginHookBeforeToolCallEvent => {
+    const derived = options?.deriveEvent?.(params) ?? {};
+    return {
+      ...eventWithoutDerivedPaths,
+      params,
+      ...derived,
+    };
   };
   for (const registration of policies) {
     const policyCtx: PluginHookToolContext = {
@@ -59,10 +71,7 @@ export async function runTrustedToolPolicies(
         return pluginState[normalizedNamespace] as T | undefined;
       },
     };
-    const decision = await registration.policy.evaluate(
-      { ...event, params: adjustedParams },
-      policyCtx,
-    );
+    const decision = await registration.policy.evaluate(buildEvent(adjustedParams), policyCtx);
     if (!decision) {
       continue;
     }

--- a/src/plugins/trusted-tool-policy.ts
+++ b/src/plugins/trusted-tool-policy.ts
@@ -9,12 +9,20 @@ import { getPluginSessionExtensionStateSync } from "./host-hook-state.js";
 import type { PluginJsonValue } from "./host-hooks.js";
 import { getActivePluginRegistry } from "./runtime.js";
 
+function normalizeDerivedEventFields(
+  value: Pick<PluginHookBeforeToolCallEvent, "derivedPaths"> | undefined,
+): Pick<PluginHookBeforeToolCallEvent, "derivedPaths"> {
+  return Array.isArray(value?.derivedPaths) ? { derivedPaths: value.derivedPaths } : {};
+}
+
 export async function runTrustedToolPolicies(
   event: PluginHookBeforeToolCallEvent,
   ctx: PluginHookToolContext,
   options?: {
     config?: OpenClawConfig;
-    deriveEvent?: (params: Record<string, unknown>) => Partial<PluginHookBeforeToolCallEvent>;
+    deriveEvent?: (
+      params: Record<string, unknown>,
+    ) => Pick<PluginHookBeforeToolCallEvent, "derivedPaths">;
   },
 ): Promise<PluginHookBeforeToolCallResult | undefined> {
   const policies = getActivePluginRegistry()?.trustedToolPolicies ?? [];
@@ -35,13 +43,15 @@ export async function runTrustedToolPolicies(
     }
     return resolvedSessionConfig;
   };
-  const { derivedPaths: _derivedPaths, ...eventWithoutDerivedPaths } = event;
-  const buildEvent = (params: Record<string, unknown>): PluginHookBeforeToolCallEvent => {
-    const derived = options?.deriveEvent?.(params) ?? {};
+  const { derivedPaths, ...eventWithoutDerivedPaths } = event;
+  let currentDerivedEvent: Pick<PluginHookBeforeToolCallEvent, "derivedPaths"> = derivedPaths
+    ? { derivedPaths }
+    : {};
+  const buildEvent = (): PluginHookBeforeToolCallEvent => {
     return {
       ...eventWithoutDerivedPaths,
-      params,
-      ...derived,
+      params: adjustedParams,
+      ...currentDerivedEvent,
     };
   };
   for (const registration of policies) {
@@ -71,7 +81,7 @@ export async function runTrustedToolPolicies(
         return pluginState[normalizedNamespace] as T | undefined;
       },
     };
-    const decision = await registration.policy.evaluate(buildEvent(adjustedParams), policyCtx);
+    const decision = await registration.policy.evaluate(buildEvent(), policyCtx);
     if (!decision) {
       continue;
     }
@@ -96,6 +106,7 @@ export async function runTrustedToolPolicies(
     if ("params" in decision && decision.params) {
       adjustedParams = decision.params;
       hasAdjustedParams = true;
+      currentDerivedEvent = normalizeDerivedEventFields(options?.deriveEvent?.(adjustedParams));
     }
     if ("requireApproval" in decision && decision.requireApproval && !approval) {
       approval = decision.requireApproval;

--- a/src/plugins/trusted-tool-policy.ts
+++ b/src/plugins/trusted-tool-policy.ts
@@ -1,5 +1,6 @@
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isPlainObject } from "../utils.js";
 import type {
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,
@@ -8,6 +9,10 @@ import type {
 import { getPluginSessionExtensionStateSync } from "./host-hook-state.js";
 import type { PluginJsonValue } from "./host-hooks.js";
 import { getActivePluginRegistry } from "./runtime.js";
+
+export function hasTrustedToolPolicies(): boolean {
+  return (getActivePluginRegistry()?.trustedToolPolicies?.length ?? 0) > 0;
+}
 
 function normalizeDerivedEventFields(
   value: Pick<PluginHookBeforeToolCallEvent, "derivedPaths"> | undefined,
@@ -103,7 +108,7 @@ export async function runTrustedToolPolicies(
     // pipeline) — it does NOT short-circuit the policy chain. Params and
     // approvals are remembered so later trusted policies can still inspect or
     // block the final call.
-    if ("params" in decision && decision.params) {
+    if ("params" in decision && isPlainObject(decision.params)) {
       adjustedParams = decision.params;
       hasAdjustedParams = true;
       currentDerivedEvent = normalizeDerivedEventFields(options?.deriveEvent?.(adjustedParams));

--- a/src/plugins/trusted-tool-policy.ts
+++ b/src/plugins/trusted-tool-policy.ts
@@ -12,7 +12,9 @@ import { getActivePluginRegistry } from "./runtime.js";
 function normalizeDerivedEventFields(
   value: Pick<PluginHookBeforeToolCallEvent, "derivedPaths"> | undefined,
 ): Pick<PluginHookBeforeToolCallEvent, "derivedPaths"> {
-  return Array.isArray(value?.derivedPaths) ? { derivedPaths: value.derivedPaths } : {};
+  return Array.isArray(value?.derivedPaths)
+    ? { derivedPaths: Object.freeze([...value.derivedPaths]) }
+    : {};
 }
 
 export async function runTrustedToolPolicies(
@@ -44,9 +46,7 @@ export async function runTrustedToolPolicies(
     return resolvedSessionConfig;
   };
   const { derivedPaths, ...eventWithoutDerivedPaths } = event;
-  let currentDerivedEvent: Pick<PluginHookBeforeToolCallEvent, "derivedPaths"> = derivedPaths
-    ? { derivedPaths }
-    : {};
+  let currentDerivedEvent = normalizeDerivedEventFields({ derivedPaths });
   const buildEvent = (): PluginHookBeforeToolCallEvent => {
     return {
       ...eventWithoutDerivedPaths,


### PR DESCRIPTION
Summary
- Supersedes #75605 with the derived apply_patch target-path seam rebased onto current main.
- Adds host-owned apply_patch path derivation for before_tool_call and trusted policy hooks, including sandbox bridge resolution and frozen derived path arrays.
- Clears/re-derives derived paths when trusted policies rewrite params, guards parser lookup against prototype keys, and documents the additive SDK hook field.

## Real behavior proof
- Behavior addressed: plugin hooks and trusted tool policies had to re-parse `apply_patch` envelopes themselves to know target paths, making policy hooks inconsistent with host path resolution and sandbox path bridging.
- Real environment tested: local OpenClaw checkout after rebase onto current main, with plugin SDK API baseline regenerated and full build completed.
- Exact steps or command run after this patch: ran the real before_tool_call E2E path and native Codex hook relay path with apply_patch inputs using `pnpm test src/agents/apply-patch-paths.test.ts src/plugins/host-tool-param-parsers.test.ts src/agents/pi-tools.before-tool-call.e2e.test.ts src/agents/harness/native-hook-relay.test.ts src/plugins/contracts/host-hooks.contract.test.ts`, then `pnpm build`.
- Evidence after fix: terminal output from the patched run:

```text
[test] passed 4 Vitest shards in 12.91s
OK docs/.generated/plugin-sdk-api-baseline.sha256
Found 0 warnings and 0 errors.
[build-all] check-plugin-sdk-exports
OK: All 4 required plugin-sdk exports verified.
```

- Observed result after fix: apply_patch target paths are present on before_tool_call events, trusted policy events receive re-derived paths after param rewrites, native Codex PreToolUse uses the Codex cwd for derived apply_patch paths, and the SDK API baseline/build remain consistent.
- What was not tested: no live third-party plugin install; covered through host hook contract fixtures and real OpenClaw hook execution paths.

Verification
- `pnpm test src/agents/apply-patch-paths.test.ts src/plugins/host-tool-param-parsers.test.ts src/agents/pi-tools.before-tool-call.e2e.test.ts src/agents/harness/native-hook-relay.test.ts src/plugins/contracts/host-hooks.contract.test.ts`
- `pnpm check:test-types`
- `pnpm lint:core`
- `pnpm plugin-sdk:api:gen`
- `pnpm plugin-sdk:api:check`
- `pnpm run check:no-conflict-markers`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/plugins/hooks.md docs/.generated/plugin-sdk-api-baseline.sha256 src/agents/apply-patch-paths.test.ts src/agents/apply-patch-paths.ts src/agents/harness/native-hook-relay.test.ts src/agents/harness/native-hook-relay.ts src/agents/pi-tools.before-tool-call.e2e.test.ts src/agents/pi-tools.before-tool-call.ts src/agents/pi-tools.ts src/auto-reply/reply/dispatch-from-config.test.ts src/plugins/contracts/host-hooks.contract.test.ts src/plugins/hook-types.ts src/plugins/host-tool-param-parsers.test.ts src/plugins/host-tool-param-parsers.ts src/plugins/trusted-tool-policy.ts`
- `git diff --check origin/main...HEAD && git diff --check`
- `pnpm build`

Supersedes #75605. Replaces part of #74483 / #73384.
