### PR TITLE
fix(agents): include container path mapping in sandbox path escape errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/sandbox: include the container path mapping in `Path escapes sandbox root` errors so LLM-driven agents can immediately use the correct in-container path instead of retrying the rejected host path. (#79712)
 - Cron/Telegram: key isolated direct-delivery dedupe to each cron execution instead of the reused session id, so recurring Telegram announce runs no longer report delivered while silently skipping later sends. (#69000) Thanks @obviyus.
 - Models/Kimi: default bundled Kimi thinking to off and normalize Anthropic-compatible `thinking` payloads so stale session `/think` state no longer silently re-enables reasoning on Kimi runs. (#68907) Thanks @frankekn.
 - Control UI/cron: keep the runtime-only `last` delivery sentinel from being materialized into persisted cron delivery and failure-alert channel configs when jobs are created or edited. (#68829) Thanks @tianhaocui.

--- a/src/agents/sandbox/fs-paths.ts
+++ b/src/agents/sandbox/fs-paths.ts
@@ -156,7 +156,12 @@ export function resolveSandboxFsPathWithMounts(params: {
     cwd: params.cwd,
     root: params.defaultWorkspaceRoot,
   });
-  throw new Error(`Path escapes sandbox root (${params.defaultWorkspaceRoot}): ${input}`);
+  throw new Error(
+    `Path escapes sandbox root: '${input}' is outside the sandbox. ` +
+      `The sandbox is rooted at ${params.defaultWorkspaceRoot} ` +
+      `(mapped to ${params.defaultContainerRoot} inside the container). ` +
+      `Use a path under ${params.defaultContainerRoot}/ instead.`,
+  );
 }
 
 function compareMountsByContainerPath(a: SandboxFsMount, b: SandboxFsMount): number {


### PR DESCRIPTION
## Summary

Addresses #79712.

When an LLM-driven agent provides a host-side path (e.g. `/tmp/healthcheck-alert/config.json`) that falls outside the sandbox root, the rejection error now surfaces the in-container mount target that OpenClaw already knows about. This gives the agent everything it needs to pivot in a single turn.

### Before
```
Path escapes sandbox root (~/.openclaw/workspace-coder): /tmp/healthcheck-alert/config.json
```

### After
```
Path escapes sandbox root: '/tmp/healthcheck-alert/config.json' is outside the sandbox. The sandbox is rooted at ~/.openclaw/workspace-coder (mapped to /workspace inside the container). Use a path under /workspace/ instead.
```

## Changes

- `src/agents/sandbox/fs-paths.ts`: Improve the error thrown from `resolveSandboxFsPathWithMounts` to include `params.defaultContainerRoot` (already available in scope) alongside the existing `params.defaultWorkspaceRoot`.
- `CHANGELOG.md`: Added entry under Fixes.

## Tests

All existing tests use `/Path escapes sandbox root/i` regex matchers — no test changes required, all still pass against the new message wording. The test at `src/agents/sandbox/fs-paths.test.ts:103` exercises exactly this code path.

## Why just this file?

The adjacent `sandbox-paths.ts` error path (used for non-sandboxed tools) doesn't have access to a container root concept — it only knows the host sandbox root. This PR is intentionally scoped to the Docker/container-aware code path in `fs-paths.ts` where the container mapping is already present.