### PR TITLE
fix(memory): retry transient EBUSY errors when removing temp index files

### DIFF
--- a/extensions/memory-core/src/memory/manager-atomic-reindex.ts
+++ b/extensions/memory-core/src/memory/manager-atomic-reindex.ts
@@ -20,12 +20,14 @@ const defaultFileOps: MemoryIndexFileOps = {
   wait: sleep,
 };
 
-const transientRenameErrorCodes = new Set(["EBUSY", "EPERM", "EACCES"]);
+const transientFileErrorCodes = new Set(["EBUSY", "EPERM", "EACCES"]);
 const defaultMaxRenameAttempts = 6;
 const defaultRenameRetryDelayMs = 25;
+const defaultMaxRemoveAttempts = 6;
+const defaultRemoveRetryDelayMs = 25;
 
-function isTransientRenameError(err: unknown): boolean {
-  return transientRenameErrorCodes.has((err as NodeJS.ErrnoException).code ?? "");
+function isTransientFileError(err: unknown): boolean {
+  return transientFileErrorCodes.has((err as NodeJS.ErrnoException).code ?? "");
 }
 
 async function renameWithRetry(
@@ -41,7 +43,7 @@ async function renameWithRetry(
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
         return;
       }
-      if (!isTransientRenameError(err) || attempt === options.maxRenameAttempts) {
+      if (!isTransientFileError(err) || attempt === options.maxRenameAttempts) {
         throw err;
       }
       await options.fileOps.wait(options.renameRetryDelayMs * attempt);
@@ -68,12 +70,40 @@ export async function moveMemoryIndexFiles(
   }
 }
 
-async function removeMemoryIndexFiles(
+async function removeWithRetry(
+  filePath: string,
+  fileOps: MemoryIndexFileOps,
+  maxAttempts: number,
+  retryDelayMs: number,
+): Promise<void> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await fileOps.rm(filePath, { force: true });
+      return;
+    } catch (err) {
+      if (!isTransientFileError(err) || attempt === maxAttempts) {
+        throw err;
+      }
+      await fileOps.wait(retryDelayMs * attempt);
+    }
+  }
+}
+
+export async function removeMemoryIndexFiles(
   basePath: string,
   fileOps: MemoryIndexFileOps = defaultFileOps,
 ): Promise<void> {
   const suffixes = ["", "-wal", "-shm"];
-  await Promise.all(suffixes.map((suffix) => fileOps.rm(`${basePath}${suffix}`, { force: true })));
+  await Promise.all(
+    suffixes.map((suffix) =>
+      removeWithRetry(
+        `${basePath}${suffix}`,
+        fileOps,
+        defaultMaxRemoveAttempts,
+        defaultRemoveRetryDelayMs,
+      ),
+    ),
+  );
 }
 
 async function swapMemoryIndexFiles(targetPath: string, tempPath: string): Promise<void> {

--- a/extensions/memory-core/src/memory/manager.atomic-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.atomic-reindex.test.ts
@@ -3,7 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { moveMemoryIndexFiles, runMemoryAtomicReindex } from "./manager-atomic-reindex.js";
+import {
+  moveMemoryIndexFiles,
+  removeMemoryIndexFiles,
+  runMemoryAtomicReindex,
+} from "./manager-atomic-reindex.js";
 
 async function expectPathMissing(targetPath: string): Promise<void> {
   await expect(fs.access(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
@@ -113,6 +117,46 @@ describe("memory manager atomic reindex", () => {
     });
 
     expect(rename).toHaveBeenCalledTimes(3);
+    expect(wait).not.toHaveBeenCalled();
+  });
+
+  it("retries transient remove failures during temp file cleanup", async () => {
+    const rm = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("busy"), { code: "EBUSY" }))
+      .mockResolvedValue(undefined);
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await removeMemoryIndexFiles("index.sqlite.tmp", { rename: fs.rename, rm, wait });
+
+    // 3 suffixes, first suffix fails once then succeeds = 4 calls total
+    expect(rm).toHaveBeenCalledTimes(4);
+    expect(wait).toHaveBeenCalledTimes(1);
+    expect(wait).toHaveBeenCalledWith(25);
+  });
+
+  it("throws after exhausting remove retry attempts", async () => {
+    const rm = vi.fn().mockRejectedValue(Object.assign(new Error("busy"), { code: "EBUSY" }));
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      removeMemoryIndexFiles("index.sqlite.tmp", { rename: fs.rename, rm, wait }),
+    ).rejects.toMatchObject({ code: "EBUSY" });
+
+    expect(rm).toHaveBeenCalled();
+    expect(wait).toHaveBeenCalled();
+  });
+
+  it("does not retry non-transient remove failures", async () => {
+    const rm = vi.fn().mockRejectedValue(Object.assign(new Error("no space"), { code: "ENOSPC" }));
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      removeMemoryIndexFiles("index.sqlite.tmp", { rename: fs.rename, rm, wait }),
+    ).rejects.toMatchObject({ code: "ENOSPC" });
+
+    // Each suffix attempted once (parallel), no retries
+    expect(rm).toHaveBeenCalledTimes(3);
     expect(wait).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

On Windows, `openclaw memory index --force` fails with `EBUSY` when cleaning up temporary SQLite database files (`.sqlite.tmp-<uuid>`, `-wal`, `-shm`). The OS may not release file handles immediately after `db.close()`, so `fs.rm` fails on the still-locked WAL/SHM sidecar files.

## Changes

- Add `removeWithRetry()` with exponential backoff for transient file errors (`EBUSY`, `EPERM`, `EACCES`), matching the existing `renameWithRetry()` pattern in the same module
- Rename `isTransientRenameError` → `isTransientFileError` and `transientRenameErrorCodes` → `transientFileErrorCodes` since the helper is now shared by both rename and remove paths
- Export `removeMemoryIndexFiles` for testability
- Add 3 tests: retry succeeds, retry exhausted, non-transient error not retried

## Root Cause

`removeMemoryIndexFiles()` called `fs.rm({ force: true })` without retry. The `force` flag only suppresses `ENOENT` — it does not handle `EBUSY`. On Windows, SQLite WAL/SHM file handles are released asynchronously after `DatabaseSync.close()`, so the immediate `fs.rm` call races against handle release.

The fix follows the same retry-with-backoff pattern already used by `renameWithRetry()` in the same file (6 attempts, 25ms × attempt backoff).

Fixes #79708

## Real behavior proof

**Behavior or issue addressed**: `EBUSY: resource busy or locked, unlink` during `openclaw memory index --force` on Windows when cleaning up temp SQLite WAL/SHM files after atomic reindex

**Real environment tested**: Linux (vitest), code path is platform-agnostic — the retry logic works identically on Windows where EBUSY is triggered by delayed handle release

**Exact steps or command run after this patch**: `pnpm vitest run extensions/memory-core/src/memory/manager.atomic-reindex.test.ts`

**Evidence after fix**: 9/9 tests pass (6 existing + 3 new), including tests that verify EBUSY retry succeeds after transient failures and throws after exhausting retries

**Observed result after fix**: `removeMemoryIndexFiles` now retries up to 6 times with linear backoff on EBUSY/EPERM/EACCES, matching the existing `renameWithRetry` behavior for file moves

**What was not tested**: Cannot reproduce Windows EBUSY in CI (Linux-only); the retry logic is validated via mocked `fs.rm` that simulates transient failures