### PR TITLE
Add Telegram auth transition E2E

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -288,6 +288,7 @@ Scenarios (`extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime
 - `telegram-tools-compact-command`
 - `telegram-whoami-command`
 - `telegram-status-command`
+- `telegram-repeated-command-authorization`
 - `telegram-other-bot-command-gating`
 - `telegram-context-command`
 - `telegram-current-session-status-tool`

--- a/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts
@@ -331,6 +331,7 @@ describe("telegram live qa runtime", () => {
       "telegram-tools-compact-command",
       "telegram-whoami-command",
       "telegram-status-command",
+      "telegram-repeated-command-authorization",
       "telegram-other-bot-command-gating",
       "telegram-context-command",
       "telegram-current-session-status-tool",
@@ -347,6 +348,7 @@ describe("telegram live qa runtime", () => {
       "telegram-tools-compact-command",
       "telegram-whoami-command",
       "telegram-status-command",
+      "telegram-repeated-command-authorization",
       "telegram-other-bot-command-gating",
       "telegram-context-command",
       "telegram-current-session-status-tool",
@@ -359,16 +361,26 @@ describe("telegram live qa runtime", () => {
     ]);
     expect(
       scenarios.find((scenario) => scenario.id === "telegram-status-command")?.buildRun("sut_bot")
-        .input,
+        .steps[0].input,
     ).toBe("/status@sut_bot");
     expect(
       scenarios.find((scenario) => scenario.id === "telegram-status-command")?.buildRun("sut_bot")
-        .expectedTextIncludes,
+        .steps[0].expectedTextIncludes,
     ).toEqual(["OpenClaw", "Model:", "Session:", "Activation:"]);
     expect(
       scenarios
+        .find((scenario) => scenario.id === "telegram-repeated-command-authorization")
+        ?.buildRun("sut_bot").steps,
+    ).toMatchObject([
+      { driverGroupAuthorization: "deny", input: "/status@sut_bot", expectReply: false },
+      { driverGroupAuthorization: "allow", input: "/status@sut_bot", expectReply: true },
+      { input: "/help@sut_bot", expectReply: true },
+      { input: "/commands@sut_bot", expectReply: true },
+    ]);
+    expect(
+      scenarios
         .find((scenario) => scenario.id === "telegram-other-bot-command-gating")
-        ?.buildRun("sut_bot"),
+        ?.buildRun("sut_bot").steps[0],
     ).toMatchObject({
       expectReply: false,
       input: "/status@OpenClawQaOtherBot",
@@ -376,7 +388,7 @@ describe("telegram live qa runtime", () => {
     expect(
       scenarios
         .find((scenario) => scenario.id === "telegram-current-session-status-tool")
-        ?.buildRun("sut_bot"),
+        ?.buildRun("sut_bot").steps[0],
     ).toMatchObject({
       expectedTextIncludes: ["QA-TELEGRAM-CURRENT-SESSION-OK", ":telegram:group:"],
       replyToLatestSutMessage: true,
@@ -384,12 +396,12 @@ describe("telegram live qa runtime", () => {
     expect(
       scenarios
         .find((scenario) => scenario.id === "telegram-mentioned-message-reply")
-        ?.buildRun("sut_bot").replyToLatestSutMessage,
+        ?.buildRun("sut_bot").steps[0].replyToLatestSutMessage,
     ).toBe(true);
     expect(
       scenarios
         .find((scenario) => scenario.id === "telegram-reply-chain-exact-marker")
-        ?.buildRun("sut_bot"),
+        ?.buildRun("sut_bot").steps[0],
     ).toMatchObject({
       expectedJoinedSutTextIncludes: ["QA-TELEGRAM-REPLY-CHAIN-OK"],
       expectedSutMessageCount: 1,
@@ -398,7 +410,7 @@ describe("telegram live qa runtime", () => {
     expect(
       scenarios
         .find((scenario) => scenario.id === "telegram-stream-final-single-message")
-        ?.buildRun("sut_bot"),
+        ?.buildRun("sut_bot").steps[0],
     ).toMatchObject({
       expectedJoinedSutTextIncludes: ["QA-TELEGRAM-STREAM-SINGLE-OK"],
       expectedSutMessageCount: 1,
@@ -407,7 +419,7 @@ describe("telegram live qa runtime", () => {
     expect(
       scenarios
         .find((scenario) => scenario.id === "telegram-long-final-reuses-preview")
-        ?.buildRun("sut_bot"),
+        ?.buildRun("sut_bot").steps[0],
     ).toMatchObject({
       expectedJoinedSutTextIncludes: ["TELEGRAM-LONG-FINAL-BEGIN", "TELEGRAM-LONG-FINAL-END"],
       expectedSutMessageCount: 2,
@@ -416,7 +428,7 @@ describe("telegram live qa runtime", () => {
     expect(
       scenarios
         .find((scenario) => scenario.id === "telegram-long-final-three-chunks")
-        ?.buildRun("sut_bot"),
+        ?.buildRun("sut_bot").steps[0],
     ).toMatchObject({
       expectedJoinedSutTextIncludes: [
         "TELEGRAM-LONG-FINAL-3CHUNK-BEGIN",
@@ -436,6 +448,7 @@ describe("telegram live qa runtime", () => {
       "telegram-tools-compact-command",
       "telegram-whoami-command",
       "telegram-status-command",
+      "telegram-repeated-command-authorization",
       "telegram-other-bot-command-gating",
       "telegram-context-command",
       "telegram-mentioned-message-reply",
@@ -451,6 +464,7 @@ describe("telegram live qa runtime", () => {
         "telegram-tools-compact-command",
         "telegram-whoami-command",
         "telegram-status-command",
+        "telegram-repeated-command-authorization",
         "telegram-other-bot-command-gating",
         "telegram-context-command",
         "telegram-mentioned-message-reply",

--- a/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts
@@ -48,6 +48,7 @@ type TelegramQaScenarioId =
   | "telegram-tools-compact-command"
   | "telegram-whoami-command"
   | "telegram-status-command"
+  | "telegram-repeated-command-authorization"
   | "telegram-other-bot-command-gating"
   | "telegram-context-command"
   | "telegram-current-session-status-tool"
@@ -58,8 +59,9 @@ type TelegramQaScenarioId =
   | "telegram-mentioned-message-reply"
   | "telegram-mention-gating";
 
-type TelegramQaScenarioRun = {
+type TelegramQaScenarioStep = {
   allowAnySutReply?: boolean;
+  driverGroupAuthorization?: "allow" | "deny";
   expectReply: boolean;
   input: string;
   expectedTextIncludes?: string[];
@@ -68,6 +70,11 @@ type TelegramQaScenarioRun = {
   matchText?: string;
   replyToLatestSutMessage?: boolean;
   settleMs?: number;
+  timeoutMs?: number;
+};
+
+type TelegramQaScenarioRun = {
+  steps: TelegramQaScenarioStep[];
 };
 
 type TelegramQaScenarioDefinition = LiveTransportScenarioDefinition<TelegramQaScenarioId> & {
@@ -233,6 +240,10 @@ type TelegramSendMessageResult = {
   };
 };
 
+function telegramQaStepRun(step: TelegramQaScenarioStep): TelegramQaScenarioRun {
+  return { steps: [step] };
+}
+
 const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
   {
     id: "telegram-help-command",
@@ -240,44 +251,48 @@ const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
     title: "Telegram help command reply",
     rationale: "Canary-grade native command reply path.",
     timeoutMs: 45_000,
-    buildRun: (sutUsername) => ({
-      expectReply: true,
-      input: `/help@${sutUsername}`,
-      expectedTextIncludes: ["/new", "/commands for full list"],
-    }),
+    buildRun: (sutUsername) =>
+      telegramQaStepRun({
+        expectReply: true,
+        input: `/help@${sutUsername}`,
+        expectedTextIncludes: ["/new", "/commands for full list"],
+      }),
   },
   {
     id: "telegram-commands-command",
     title: "Telegram commands list reply",
     rationale: "Native command catalog must render in Telegram group replies.",
     timeoutMs: 45_000,
-    buildRun: (sutUsername) => ({
-      expectReply: true,
-      input: `/commands@${sutUsername}`,
-      expectedTextIncludes: ["Commands (1/", "/session", "/verbose"],
-    }),
+    buildRun: (sutUsername) =>
+      telegramQaStepRun({
+        expectReply: true,
+        input: `/commands@${sutUsername}`,
+        expectedTextIncludes: ["Commands (1/", "/session", "/verbose"],
+      }),
   },
   {
     id: "telegram-tools-compact-command",
     title: "Telegram tools compact reply",
     rationale: "Tool catalog rendering catches command dispatch plus model-tool inventory drift.",
     timeoutMs: 45_000,
-    buildRun: (sutUsername) => ({
-      expectReply: true,
-      input: `/tools@${sutUsername} compact`,
-      expectedTextIncludes: ["exec", "Use /tools verbose for descriptions."],
-    }),
+    buildRun: (sutUsername) =>
+      telegramQaStepRun({
+        expectReply: true,
+        input: `/tools@${sutUsername} compact`,
+        expectedTextIncludes: ["exec", "Use /tools verbose for descriptions."],
+      }),
   },
   {
     id: "telegram-whoami-command",
     title: "Telegram whoami reply",
     rationale: "Identity command proves Telegram channel context is attached to native commands.",
     timeoutMs: 45_000,
-    buildRun: (sutUsername) => ({
-      expectReply: true,
-      input: `/whoami@${sutUsername}`,
-      expectedTextIncludes: ["🧭 Identity", "Channel: telegram"],
-    }),
+    buildRun: (sutUsername) =>
+      telegramQaStepRun({
+        expectReply: true,
+        input: `/whoami@${sutUsername}`,
+        expectedTextIncludes: ["🧭 Identity", "Channel: telegram"],
+      }),
   },
   {
     id: "telegram-status-command",
@@ -285,32 +300,69 @@ const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
     rationale: "Recent Telegram group regressions broke /status while normal chat still worked.",
     regressionRefs: ["openclaw/openclaw#74698"],
     timeoutMs: 45_000,
-    buildRun: (sutUsername) => ({
-      expectReply: true,
-      input: `/status@${sutUsername}`,
-      expectedTextIncludes: ["OpenClaw", "Model:", "Session:", "Activation:"],
-    }),
+    buildRun: (sutUsername) =>
+      telegramQaStepRun({
+        expectReply: true,
+        input: `/status@${sutUsername}`,
+        expectedTextIncludes: ["OpenClaw", "Model:", "Session:", "Activation:"],
+      }),
+  },
+  {
+    id: "telegram-repeated-command-authorization",
+    title: "Telegram repeated command authorization",
+    rationale:
+      "Allowlisted bot-to-bot operators should not hit a fresh auth gate for each native slash command.",
+    timeoutMs: 45_000,
+    buildRun: (sutUsername) => {
+      const steps = [
+        {
+          driverGroupAuthorization: "deny",
+          expectReply: false,
+          input: `/status@${sutUsername}`,
+          timeoutMs: 8_000,
+        },
+        {
+          driverGroupAuthorization: "allow",
+          expectReply: true,
+          input: `/status@${sutUsername}`,
+          expectedTextIncludes: ["OpenClaw", "Session:"],
+        },
+        {
+          expectReply: true,
+          input: `/help@${sutUsername}`,
+          expectedTextIncludes: ["/new", "/commands for full list"],
+        },
+        {
+          expectReply: true,
+          input: `/commands@${sutUsername}`,
+          expectedTextIncludes: ["Commands (1/", "/session", "/verbose"],
+        },
+      ] satisfies TelegramQaScenarioStep[];
+      return { steps };
+    },
   },
   {
     id: "telegram-other-bot-command-gating",
     title: "Telegram command addressed to another bot is ignored",
     rationale: "Bot-to-bot groups must not let commands addressed to another bot wake the SUT.",
     timeoutMs: 8_000,
-    buildRun: () => ({
-      expectReply: false,
-      input: "/status@OpenClawQaOtherBot",
-    }),
+    buildRun: () =>
+      telegramQaStepRun({
+        expectReply: false,
+        input: "/status@OpenClawQaOtherBot",
+      }),
   },
   {
     id: "telegram-context-command",
     title: "Telegram context reply",
     rationale: "Context command exercises native command routing into Telegram-specific help text.",
     timeoutMs: 45_000,
-    buildRun: (sutUsername) => ({
-      expectReply: true,
-      input: `/context@${sutUsername}`,
-      expectedTextIncludes: ["/context list", "Inline shortcut"],
-    }),
+    buildRun: (sutUsername) =>
+      telegramQaStepRun({
+        expectReply: true,
+        input: `/context@${sutUsername}`,
+        expectedTextIncludes: ["/context list", "Inline shortcut"],
+      }),
   },
   {
     id: "telegram-current-session-status-tool",
@@ -319,23 +371,25 @@ const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
     rationale:
       "Opt-in threaded probe for current Telegram group session resolution through model tools.",
     timeoutMs: 60_000,
-    buildRun: (sutUsername) => ({
-      expectReply: true,
-      input: `@${sutUsername} Telegram current session_status QA check. Call session_status with sessionKey set to current, then reply with the exact QA marker and resolved session key.`,
-      expectedTextIncludes: ["QA-TELEGRAM-CURRENT-SESSION-OK", ":telegram:group:"],
-      replyToLatestSutMessage: true,
-    }),
+    buildRun: (sutUsername) =>
+      telegramQaStepRun({
+        expectReply: true,
+        input: `@${sutUsername} Telegram current session_status QA check. Call session_status with sessionKey set to current, then reply with the exact QA marker and resolved session key.`,
+        expectedTextIncludes: ["QA-TELEGRAM-CURRENT-SESSION-OK", ":telegram:group:"],
+        replyToLatestSutMessage: true,
+      }),
   },
   {
     id: "telegram-mentioned-message-reply",
     title: "Telegram mentioned message gets a reply",
     rationale: "Bot-to-bot group mention routing must produce a threaded SUT reply.",
     timeoutMs: 45_000,
-    buildRun: (sutUsername) => ({
-      expectReply: true,
-      input: `@${sutUsername} Telegram QA mention routing check. Reply with a short acknowledgement.`,
-      replyToLatestSutMessage: true,
-    }),
+    buildRun: (sutUsername) =>
+      telegramQaStepRun({
+        expectReply: true,
+        input: `@${sutUsername} Telegram QA mention routing check. Reply with a short acknowledgement.`,
+        replyToLatestSutMessage: true,
+      }),
   },
   {
     id: "telegram-reply-chain-exact-marker",
@@ -343,15 +397,16 @@ const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
     defaultProviderModes: ["mock-openai"],
     rationale: "Mock-backed reply-chain check proves quoted bot-to-bot follow-ups keep threading.",
     timeoutMs: 45_000,
-    buildRun: (sutUsername) => ({
-      expectReply: true,
-      input: `@${sutUsername} Telegram reply-chain marker QA. Reply exactly: QA-TELEGRAM-REPLY-CHAIN-OK`,
-      expectedTextIncludes: ["QA-TELEGRAM-REPLY-CHAIN-OK"],
-      expectedJoinedSutTextIncludes: ["QA-TELEGRAM-REPLY-CHAIN-OK"],
-      expectedSutMessageCount: 1,
-      replyToLatestSutMessage: true,
-      settleMs: 4_000,
-    }),
+    buildRun: (sutUsername) =>
+      telegramQaStepRun({
+        expectReply: true,
+        input: `@${sutUsername} Telegram reply-chain marker QA. Reply exactly: QA-TELEGRAM-REPLY-CHAIN-OK`,
+        expectedTextIncludes: ["QA-TELEGRAM-REPLY-CHAIN-OK"],
+        expectedJoinedSutTextIncludes: ["QA-TELEGRAM-REPLY-CHAIN-OK"],
+        expectedSutMessageCount: 1,
+        replyToLatestSutMessage: true,
+        settleMs: 4_000,
+      }),
   },
   {
     id: "telegram-stream-final-single-message",
@@ -360,16 +415,17 @@ const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
     rationale: "Regression guard for duplicate final replies from Telegram streaming paths.",
     regressionRefs: ["openclaw/openclaw#39905"],
     timeoutMs: 45_000,
-    buildRun: (sutUsername) => ({
-      allowAnySutReply: true,
-      expectReply: true,
-      input: `@${sutUsername} Quiet streaming QA check. Reply exactly: QA-TELEGRAM-STREAM-SINGLE-OK`,
-      expectedTextIncludes: ["QA-TELEGRAM-STREAM-SINGLE-OK"],
-      expectedJoinedSutTextIncludes: ["QA-TELEGRAM-STREAM-SINGLE-OK"],
-      expectedSutMessageCount: 1,
-      replyToLatestSutMessage: true,
-      settleMs: 4_000,
-    }),
+    buildRun: (sutUsername) =>
+      telegramQaStepRun({
+        allowAnySutReply: true,
+        expectReply: true,
+        input: `@${sutUsername} Quiet streaming QA check. Reply exactly: QA-TELEGRAM-STREAM-SINGLE-OK`,
+        expectedTextIncludes: ["QA-TELEGRAM-STREAM-SINGLE-OK"],
+        expectedJoinedSutTextIncludes: ["QA-TELEGRAM-STREAM-SINGLE-OK"],
+        expectedSutMessageCount: 1,
+        replyToLatestSutMessage: true,
+        settleMs: 4_000,
+      }),
   },
   {
     id: "telegram-long-final-reuses-preview",
@@ -378,16 +434,17 @@ const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
     rationale: "Regression guard for long streamed finals leaving stale preview messages behind.",
     regressionRefs: ["openclaw/openclaw#39905"],
     timeoutMs: 60_000,
-    buildRun: (sutUsername) => ({
-      allowAnySutReply: true,
-      expectReply: true,
-      input: `@${sutUsername} Telegram long final QA check. Use the scripted long final response.`,
-      expectedTextIncludes: ["TELEGRAM-LONG-FINAL-BEGIN"],
-      expectedJoinedSutTextIncludes: ["TELEGRAM-LONG-FINAL-BEGIN", "TELEGRAM-LONG-FINAL-END"],
-      expectedSutMessageCount: 2,
-      replyToLatestSutMessage: true,
-      settleMs: 4_000,
-    }),
+    buildRun: (sutUsername) =>
+      telegramQaStepRun({
+        allowAnySutReply: true,
+        expectReply: true,
+        input: `@${sutUsername} Telegram long final QA check. Use the scripted long final response.`,
+        expectedTextIncludes: ["TELEGRAM-LONG-FINAL-BEGIN"],
+        expectedJoinedSutTextIncludes: ["TELEGRAM-LONG-FINAL-BEGIN", "TELEGRAM-LONG-FINAL-END"],
+        expectedSutMessageCount: 2,
+        replyToLatestSutMessage: true,
+        settleMs: 4_000,
+      }),
   },
   {
     id: "telegram-long-final-three-chunks",
@@ -396,19 +453,20 @@ const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
     rationale: "Opt-in stress probe for Telegram long final chunk accounting.",
     regressionRefs: ["openclaw/openclaw#39905"],
     timeoutMs: 60_000,
-    buildRun: (sutUsername) => ({
-      allowAnySutReply: true,
-      expectReply: true,
-      input: `@${sutUsername} Telegram long final three chunk QA check. Use the scripted three chunk final response.`,
-      expectedTextIncludes: ["TELEGRAM-LONG-FINAL-3CHUNK-BEGIN"],
-      expectedJoinedSutTextIncludes: [
-        "TELEGRAM-LONG-FINAL-3CHUNK-BEGIN",
-        "TELEGRAM-LONG-FINAL-3CHUNK-END",
-      ],
-      expectedSutMessageCount: 3,
-      replyToLatestSutMessage: true,
-      settleMs: 4_000,
-    }),
+    buildRun: (sutUsername) =>
+      telegramQaStepRun({
+        allowAnySutReply: true,
+        expectReply: true,
+        input: `@${sutUsername} Telegram long final three chunk QA check. Use the scripted three chunk final response.`,
+        expectedTextIncludes: ["TELEGRAM-LONG-FINAL-3CHUNK-BEGIN"],
+        expectedJoinedSutTextIncludes: [
+          "TELEGRAM-LONG-FINAL-3CHUNK-BEGIN",
+          "TELEGRAM-LONG-FINAL-3CHUNK-END",
+        ],
+        expectedSutMessageCount: 3,
+        replyToLatestSutMessage: true,
+        settleMs: 4_000,
+      }),
   },
   {
     id: "telegram-mention-gating",
@@ -418,11 +476,11 @@ const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
     timeoutMs: 8_000,
     buildRun: () => {
       const token = `TELEGRAM_QA_NOMENTION_${randomUUID().slice(0, 8).toUpperCase()}`;
-      return {
+      return telegramQaStepRun({
         expectReply: false,
         input: `reply with only this exact marker: ${token}`,
         matchText: token,
-      };
+      });
     },
   },
 ];
@@ -461,6 +519,18 @@ function resolveEnvValue(env: NodeJS.ProcessEnv, key: (typeof TELEGRAM_QA_ENV_KE
 function isTruthyOptIn(value: string | undefined) {
   const normalized = value?.trim().toLowerCase();
   return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readConfigRecord(root: Record<string, unknown>, key: string): Record<string, unknown> {
+  const value = root[key];
+  if (!isRecord(value)) {
+    throw new Error(`Telegram QA config missing object at ${key}`);
+  }
+  return value;
 }
 
 function parseTelegramQaProgressBooleanEnv(value: string | undefined): boolean | undefined {
@@ -986,6 +1056,33 @@ async function waitForTelegramChannelRunning(
   throw new Error(`telegram account "${accountId}" did not become ready`);
 }
 
+async function setTelegramQaDriverGroupAuthorization(params: {
+  driverBotId: number;
+  gateway: Awaited<ReturnType<typeof startQaGatewayChild>>;
+  groupId: string;
+  sutAccountId: string;
+  authorized: boolean;
+}) {
+  await params.gateway.restartAfterStateMutation(async ({ configPath }) => {
+    const parsed: unknown = JSON.parse(await fs.readFile(configPath, "utf8"));
+    if (!isRecord(parsed)) {
+      throw new Error("Telegram QA config root must be an object");
+    }
+    const channels = readConfigRecord(parsed, "channels");
+    const telegram = readConfigRecord(channels, "telegram");
+    const accounts = readConfigRecord(telegram, "accounts");
+    const account = readConfigRecord(accounts, params.sutAccountId);
+    const groups = readConfigRecord(account, "groups");
+    const group = readConfigRecord(groups, params.groupId);
+    group.allowFrom = params.authorized ? [String(params.driverBotId)] : [];
+    await fs.writeFile(configPath, `${JSON.stringify(parsed, null, 2)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+  });
+  await waitForTelegramChannelRunning(params.gateway, params.sutAccountId);
+}
+
 function renderTelegramQaMarkdown(params: {
   cleanupIssues: string[];
   credentialSource: "convex" | "env";
@@ -1154,6 +1251,80 @@ function assertTelegramScenarioReply(params: {
         `reply message ${params.message.messageId} missing expected text: ${expected}`,
       );
     }
+  }
+}
+
+function resolveTelegramQaScenarioSteps(run: TelegramQaScenarioRun): TelegramQaScenarioStep[] {
+  if (run.steps.length === 0) {
+    throw new Error("Telegram QA scenario must include at least one step");
+  }
+  return run.steps;
+}
+
+async function runTelegramQaScenarioStep(params: {
+  driverOffset: number;
+  driverToken: string;
+  groupId: string;
+  latestSutMessageId?: number;
+  observedMessages: TelegramObservedMessage[];
+  scenario: TelegramQaScenarioDefinition;
+  step: TelegramQaScenarioStep;
+  sutBotId: number;
+}) {
+  const stepTimeoutMs = params.step.expectReply
+    ? resolveTelegramQaScenarioTimeoutMs(params.step.timeoutMs ?? params.scenario.timeoutMs)
+    : (params.step.timeoutMs ?? params.scenario.timeoutMs);
+  const requestStartedAtMs = Date.now();
+  const sent = await sendGroupMessage(
+    params.driverToken,
+    params.groupId,
+    params.step.input,
+    params.step.replyToLatestSutMessage
+      ? { replyToMessageId: params.latestSutMessageId }
+      : undefined,
+  );
+  try {
+    const matched = await waitForObservedMessage({
+      token: params.driverToken,
+      initialOffset: params.driverOffset,
+      timeoutMs: stepTimeoutMs,
+      observedMessages: params.observedMessages,
+      observationScenarioId: params.scenario.id,
+      observationScenarioTitle: params.scenario.title,
+      expectedTextIncludes: params.step.expectReply ? params.step.expectedTextIncludes : undefined,
+      predicate: (message) =>
+        matchesTelegramScenarioReply({
+          allowAnySutReply: params.step.allowAnySutReply,
+          groupId: params.groupId,
+          matchText: params.step.matchText,
+          message,
+          sentMessageId: sent.message_id,
+          sutBotId: params.sutBotId,
+        }),
+    });
+    if (!params.step.expectReply) {
+      throw new Error(`unexpected reply message ${matched.message.messageId} matched`);
+    }
+    return {
+      matched,
+      requestStartedAt: new Date(requestStartedAtMs).toISOString(),
+      requestStartedAtMs,
+      sentMessageId: sent.message_id,
+    };
+  } catch (error) {
+    if (
+      !params.step.expectReply &&
+      formatErrorMessage(error) ===
+        `timed out after ${stepTimeoutMs}ms waiting for Telegram message`
+    ) {
+      return {
+        matched: undefined,
+        requestStartedAt: new Date(requestStartedAtMs).toISOString(),
+        requestStartedAtMs,
+        sentMessageId: sent.message_id,
+      };
+    }
+    throw error;
   }
 }
 
@@ -1578,119 +1749,116 @@ export async function runTelegramQaLive(params: {
           );
           assertLeaseHealthy();
           const scenarioRun = scenario.buildRun(sutUsername);
-          const scenarioTimeoutMs = scenarioRun.expectReply
-            ? resolveTelegramQaScenarioTimeoutMs(scenario.timeoutMs)
-            : scenario.timeoutMs;
           try {
-            const requestStartedAtMs = Date.now();
-            const sent = await sendGroupMessage(
-              runtimeEnv.driverToken,
-              runtimeEnv.groupId,
-              scenarioRun.input,
-              scenarioRun.replyToLatestSutMessage
-                ? { replyToMessageId: latestSutMessageId }
-                : undefined,
-            );
-            const requestStartedAt = new Date(requestStartedAtMs).toISOString();
-            const matched = await waitForObservedMessage({
-              token: runtimeEnv.driverToken,
-              initialOffset: driverOffset,
-              timeoutMs: scenarioTimeoutMs,
-              observedMessages,
-              observationScenarioId: scenario.id,
-              observationScenarioTitle: scenario.title,
-              expectedTextIncludes: scenarioRun.expectReply
-                ? scenarioRun.expectedTextIncludes
-                : undefined,
-              predicate: (message) =>
-                matchesTelegramScenarioReply({
-                  allowAnySutReply: scenarioRun.allowAnySutReply,
+            const scenarioSteps = resolveTelegramQaScenarioSteps(scenarioRun);
+            let firstRequestStartedAt: string | undefined;
+            let lastRequestStartedAtMs = 0;
+            let lastMatched: Awaited<ReturnType<typeof waitForObservedMessage>> | undefined;
+            let lastSentMessageId: number | undefined;
+            for (const step of scenarioSteps) {
+              if (step.driverGroupAuthorization) {
+                await setTelegramQaDriverGroupAuthorization({
+                  driverBotId: driverIdentity.id,
+                  gateway: gatewayHarness.gateway,
                   groupId: runtimeEnv.groupId,
-                  matchText: scenarioRun.matchText,
-                  message,
-                  sentMessageId: sent.message_id,
-                  sutBotId: sutIdentity.id,
-                }),
-            });
-            driverOffset = matched.nextOffset;
-            if (scenarioRun.settleMs !== undefined) {
-              driverOffset = await collectObservedMessages({
-                token: runtimeEnv.driverToken,
-                initialOffset: driverOffset,
-                settleMs: scenarioRun.settleMs,
+                  sutAccountId,
+                  authorized: step.driverGroupAuthorization === "allow",
+                });
+                driverOffset = await flushTelegramUpdates(runtimeEnv.driverToken);
+              }
+              const stepResult = await runTelegramQaScenarioStep({
+                driverOffset,
+                driverToken: runtimeEnv.driverToken,
+                groupId: runtimeEnv.groupId,
+                latestSutMessageId,
                 observedMessages,
-                observationScenarioId: scenario.id,
-                observationScenarioTitle: scenario.title,
-                predicate: (message) =>
-                  matchesTelegramScenarioReply({
-                    allowAnySutReply: scenarioRun.allowAnySutReply,
-                    groupId: runtimeEnv.groupId,
-                    matchText: scenarioRun.matchText,
-                    message,
-                    sentMessageId: sent.message_id,
-                    sutBotId: sutIdentity.id,
-                  }),
+                scenario,
+                step,
+                sutBotId: sutIdentity.id,
               });
+              firstRequestStartedAt ??= stepResult.requestStartedAt;
+              lastRequestStartedAtMs = stepResult.requestStartedAtMs;
+              lastSentMessageId = stepResult.sentMessageId;
+              const matched = stepResult.matched;
+              if (!matched) {
+                continue;
+              }
+              driverOffset = matched.nextOffset;
+              if (step.settleMs !== undefined) {
+                driverOffset = await collectObservedMessages({
+                  token: runtimeEnv.driverToken,
+                  initialOffset: driverOffset,
+                  settleMs: step.settleMs,
+                  observedMessages,
+                  observationScenarioId: scenario.id,
+                  observationScenarioTitle: scenario.title,
+                  predicate: (message) =>
+                    matchesTelegramScenarioReply({
+                      allowAnySutReply: step.allowAnySutReply,
+                      groupId: runtimeEnv.groupId,
+                      matchText: step.matchText,
+                      message,
+                      sentMessageId: stepResult.sentMessageId,
+                      sutBotId: sutIdentity.id,
+                    }),
+                });
+              }
+              assertTelegramScenarioReply({
+                expectedTextIncludes: step.expectedTextIncludes,
+                message: matched.message,
+              });
+              assertTelegramScenarioMessageSet({
+                expectedJoinedSutTextIncludes: step.expectedJoinedSutTextIncludes,
+                expectedSutMessageCount: step.expectedSutMessageCount,
+                groupId: runtimeEnv.groupId,
+                observedMessages,
+                scenarioId: scenario.id,
+                sutBotId: sutIdentity.id,
+              });
+              latestSutMessageId = matched.message.messageId;
+              lastMatched = matched;
             }
-            if (!scenarioRun.expectReply) {
-              throw new Error(`unexpected reply message ${matched.message.messageId} matched`);
+            if (!lastMatched || !firstRequestStartedAt || lastSentMessageId === undefined) {
+              const result = {
+                id: scenario.id,
+                title: scenario.title,
+                status: "pass",
+                details: "no reply",
+              } satisfies TelegramQaScenarioResult;
+              scenarioResults.push(result);
+              writeTelegramQaProgress(
+                progressEnabled,
+                `scenario pass ${scenarioIndexLabel}: ${scenarioIdForLog}`,
+              );
+              continue;
             }
-            assertTelegramScenarioReply({
-              expectedTextIncludes: scenarioRun.expectedTextIncludes,
-              message: matched.message,
-            });
-            assertTelegramScenarioMessageSet({
-              expectedJoinedSutTextIncludes: scenarioRun.expectedJoinedSutTextIncludes,
-              expectedSutMessageCount: scenarioRun.expectedSutMessageCount,
-              groupId: runtimeEnv.groupId,
-              observedMessages,
-              scenarioId: scenario.id,
-              sutBotId: sutIdentity.id,
-            });
-            const rttMs = matched.observedAtMs - requestStartedAtMs;
+            const lastStep = scenarioSteps.at(-1);
+            const rttMs = lastMatched.observedAtMs - lastRequestStartedAtMs;
             const suffix =
-              scenarioRun.expectedSutMessageCount === undefined
-                ? ""
-                : `; observed ${scenarioRun.expectedSutMessageCount} SUT message(s)`;
+              scenarioSteps.length === 1
+                ? lastStep?.expectedSutMessageCount === undefined
+                  ? ""
+                  : `; observed ${lastStep.expectedSutMessageCount} SUT message(s)`
+                : `; ${scenarioSteps.filter((step) => step.expectReply).length} command replies matched`;
             const result = {
               id: scenario.id,
               title: scenario.title,
               status: "pass",
               details: redactPublicMetadata
                 ? `reply matched in ${rttMs}ms${suffix}`
-                : `reply message ${matched.message.messageId} matched in ${rttMs}ms${suffix}`,
+                : `reply message ${lastMatched.message.messageId} matched in ${rttMs}ms${suffix}`,
               rttMs,
-              requestStartedAt,
-              responseObservedAt: new Date(matched.observedAtMs).toISOString(),
-              sentMessageId: redactPublicMetadata ? undefined : sent.message_id,
-              responseMessageId: redactPublicMetadata ? undefined : matched.message.messageId,
+              requestStartedAt: firstRequestStartedAt,
+              responseObservedAt: new Date(lastMatched.observedAtMs).toISOString(),
+              sentMessageId: redactPublicMetadata ? undefined : lastSentMessageId,
+              responseMessageId: redactPublicMetadata ? undefined : lastMatched.message.messageId,
             } satisfies TelegramQaScenarioResult;
             scenarioResults.push(result);
-            latestSutMessageId = matched.message.messageId;
             writeTelegramQaProgress(
               progressEnabled,
               `scenario pass ${scenarioIndexLabel}: ${scenarioIdForLog}`,
             );
           } catch (error) {
-            if (!scenarioRun.expectReply) {
-              const details = formatErrorMessage(error);
-              if (
-                details === `timed out after ${scenarioTimeoutMs}ms waiting for Telegram message`
-              ) {
-                const result = {
-                  id: scenario.id,
-                  title: scenario.title,
-                  status: "pass",
-                  details: "no reply",
-                } satisfies TelegramQaScenarioResult;
-                scenarioResults.push(result);
-                writeTelegramQaProgress(
-                  progressEnabled,
-                  `scenario pass ${scenarioIndexLabel}: ${scenarioIdForLog}`,
-                );
-                continue;
-              }
-            }
             const result = {
               id: scenario.id,
               title: scenario.title,


### PR DESCRIPTION
Summary
- Adds a live Telegram QA scenario that first deny-lists the driver bot, proves /status@SUT gets no SUT reply, then allow-lists the driver and verifies /status, /help, and /commands all reply.
- Normalizes Telegram QA scenario runs as ordered steps so single-command and multi-step scenarios use the same runner path.
- Lists the scenario in the QA E2E docs.

Verification
- pnpm test extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts
- pnpm exec oxfmt --check --threads=1 extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts
- OPENCLAW_QA_CREDENTIAL_SOURCE=env OPENCLAW_QA_SUITE_PROGRESS=1 pnpm openclaw qa telegram --provider-mode mock-openai --scenario telegram-repeated-command-authorization
  - passed: telegram-canary + telegram-repeated-command-authorization
  - scenario details: reply message 5755 matched in 1267ms; 3 command replies matched
- git diff --check origin/main...HEAD

Note
- pnpm check:changed -- docs/concepts/qa-e2e-automation.md extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts currently reaches extension typecheck, then fails on unrelated oc-path jsonc-parser errors.
