### PR TITLE
fix(sandbox): include container workspace path in path-escape errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Sandbox: include the in-container workspace mount path in "Path escapes sandbox root" errors so LLM agents can pivot to the correct path without retry loops. Thanks @axonrelaybot.
 - Plugins/ACPX: accept an optional `args` array in `agents.<name>` config so paths and flag values containing spaces stay intact when spawning ACP agent processes. Thanks @TheArchitectit and @BunsDev.
 - Agents: inject the current provider/model identity into system prompts, including configured prompt overrides and CLI hook prompt replacements, so agents can answer model-identity questions from the actual runtime selection.
 - Plugins/CLI: add the optional bundled `oc-path` plugin, providing `openclaw path` for surgical `oc://` access to markdown, JSONC, and JSONL workspace files.

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -297,7 +297,9 @@ class OpenShellFsBridge implements SandboxFsBridge {
       };
     }
 
-    throw new Error(`Path escapes sandbox root (${workspaceRoot}): ${params.filePath}`);
+    throw new Error(
+      `Path escapes sandbox root (${workspaceRoot}): ${params.filePath}. Use a path under ${workspaceContainerRoot}/ instead.`,
+    );
   }
 }
 

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -69,7 +69,9 @@ export function resolveSandboxPath(params: { filePath: string; cwd: string; root
     return { resolved, relative: "" };
   }
   if (relative.startsWith("..") || path.isAbsolute(relative) || isWindowsDrivePath(relative)) {
-    throw new Error(`Path escapes sandbox root (${shortPath(rootResolved)}): ${params.filePath}`);
+    throw new Error(
+      `Path escapes sandbox root (${shortPath(rootResolved)}): ${params.filePath}. Use a path under ${SANDBOX_CONTAINER_WORKDIR}/ instead.`,
+    );
   }
   return { resolved, relative };
 }

--- a/src/agents/sandbox/fs-paths.ts
+++ b/src/agents/sandbox/fs-paths.ts
@@ -157,7 +157,9 @@ export function resolveSandboxFsPathWithMounts(params: {
     cwd: params.cwd,
     root: params.defaultWorkspaceRoot,
   });
-  throw new Error(`Path escapes sandbox root (${params.defaultWorkspaceRoot}): ${input}`);
+  throw new Error(
+    `Path escapes sandbox root (${params.defaultWorkspaceRoot}): ${input}. Use a path under ${params.defaultContainerRoot}/ instead.`,
+  );
 }
 
 function compareMountsByContainerPath(a: SandboxFsMount, b: SandboxFsMount): number {


### PR DESCRIPTION
## Summary

- Append the in-container workspace mount target (e.g. `/workspace/`) to the "Path escapes sandbox root" error message in `sandbox-paths.ts`, `fs-paths.ts`, and the openshell `fs-bridge.ts`.
- When an LLM agent provides a host-side path outside the sandbox root, it currently receives only the host root path in the error — with no hint about the in-container path to use instead. This causes 3–5 retry loops before the agent guesses the correct path. With the container mapping in the error, the agent can pivot immediately.

## Real behavior proof

**Behavior addressed:** LLM agents that provide host-side paths outside the sandbox root receive only the host root in the error, causing repeated retry loops. The error should include the in-container workspace mount path so the agent can reroute.

**Real environment tested:** Ubuntu 22.04, Node.js v22.22.0, OpenClaw repo at commit 0dde964 (branch fix/79712-sandbox-path-error-hint), tsx runtime for TS import.

**Exact steps or command run after the patch:**
1. Checked out the fix branch and ran `pnpm install`
2. Wrote a test script importing `resolveSandboxPath` from `src/agents/sandbox-paths.ts`
3. Called it with an out-of-sandbox path: `resolveSandboxPath({ filePath: "/tmp/healthcheck-alert/config.json", cwd: "/tmp", root: "/home/fakeuser/.openclaw/workspace-coder" })`
4. Ran: `node --import tsx test-sandbox-error.mjs`

**Evidence after fix:**
Terminal output from the live `node` invocation confirming the patched error message includes the container path hint:

```
$ node --import tsx test-sandbox-error.mjs

=== Before fix (old message) ===
Path escapes sandbox root (/home/fakeuser/.openclaw/workspace-coder): /tmp/healthcheck-alert/config.json

=== After fix (actual message) ===
Path escapes sandbox root (/home/fakeuser/.openclaw/workspace-coder): /tmp/healthcheck-alert/config.json. Use a path under /workspace/ instead.

=== Verification ===
Contains container path hint: true
Full error: Path escapes sandbox root (/home/fakeuser/.openclaw/workspace-coder): /tmp/healthcheck-alert/config.json. Use a path under /workspace/ instead.
```

**Observed result:** The error message now appends `. Use a path under /workspace/ instead.` — an LLM agent seeing this error once can immediately reroute to `/workspace/healthcheck-alert/config.json`. The three throw sites in `sandbox-paths.ts`, `fs-paths.ts`, and `openshell/fs-bridge.ts` all include the container workspace path constant available at the throw point. Existing unit tests use regex `/Path escapes sandbox root/` which continues to match the extended message (16 + 12 + 59 tests passed).

**What was not tested:** Live sandbox session with a real Docker container and agent tool calls (no sandbox runtime available in this environment). The change is error-message-only; no control flow or permissions are altered.

Closes #79712
