### PR TITLE
filter: Skip WhatsApp system messages (join/leave/admin notifications)

### DIFF
--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -495,6 +495,16 @@ export async function attachWebInboxToSocket(
       return null;
     }
 
+    // Filter out WhatsApp system/protocol messages (join/leave notifications, admin changes, etc.)
+    // messageStubType is non-zero/non-null for system events like GROUP_PARTICIPANT_ADD/REMOVE
+    if (msg.messageStubType != null && msg.messageStubType !== 0) {
+      logWhatsAppVerbose(
+        options.verbose,
+        `Skipping system message with messageStubType ${msg.messageStubType} for ${remoteJid}`,
+      );
+      return null;
+    }
+
     const group = isGroupJid(remoteJid);
     // Drop echoes of messages the gateway itself sent (tracked by sendTrackedMessage).
     // Applies to both groups and DMs/self-chat — without this, self-chat mode


### PR DESCRIPTION
## Problem

WhatsApp group system messages (member joined, member left, admin changes, etc.) are currently processed and included in agent context. These messages clutter the conversation and make it harder for agents to understand the actual human discussion.

Relates to #79733

## Solution

Added  check in  to filter out system/protocol messages before they reach the agent.

WhatsApp uses  (non-zero/non-null) to mark system events like:
- `GROUP_PARTICIPANT_ADD` (member joined)
- `GROUP_PARTICIPANT_REMOVE` (member left)  
- `GROUP_CHANGE_SUBJECT`/`ICON`/`DESCRIPTION`
- `GROUP_CREATE`/`DELETE`/`ANNOUNCE`
- Admin promotions/demotions

## Changes

**File:** `extensions/whatsapp/src/inbound/monitor.ts`

Added filter at line 497-506 in `normalizeInboundMessage`:
```typescript
// Filter out WhatsApp system/protocol messages  
if (msg.messageStubType != null && msg.messageStubType !== 0) {
  logWhatsAppVerbose(
    options.verbose,
    `Skipping system message with messageStubType ${msg.messageStubType} for ${remoteJid}`,
  );
  return null;
}
```

## Impact

✅ Cleaner agent context in group chats  
✅ Better conversation understanding  
✅ Reduced token usage  
✅ No impact on actual user messages, media, or reactions  

## Testing

- [x] Code compiles
- [ ] Manual test: verify join/leave messages no longer appear in agent context
- [ ] Verify normal messages still work
- [ ] Verify quoted messages still work