### PR TITLE
fix(google): resolve gemini-3-flash-preview in forward-compat model resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+- fix(google): resolve `gemini-3-flash-preview` in forward-compat model resolver (#79750)
+
 ## 2026.5.8
 
 ### Changes

--- a/extensions/google/provider-models.test.ts
+++ b/extensions/google/provider-models.test.ts
@@ -204,6 +204,29 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
     });
   });
 
+  it("resolves gemini-3-flash-preview from google templates (canonical normalized form)", () => {
+    const model = resolveGoogleGeminiForwardCompatModel({
+      providerId: "google",
+      ctx: createContext({
+        provider: "google",
+        modelId: "gemini-3-flash-preview",
+        models: [
+          createTemplateModel("google", "gemini-3-flash-preview", {
+            reasoning: false,
+          }),
+        ],
+      }),
+    });
+
+    expect(model).toMatchObject({
+      provider: "google",
+      id: "gemini-3-flash-preview",
+      api: "google-generative-ai",
+      reasoning: false,
+      input: ["text", "image"],
+    });
+  });
+
   it("resolves Gemini latest aliases from current Google templates", () => {
     const models = [
       createTemplateModel("google", "gemini-3-pro-preview", { reasoning: true }),

--- a/extensions/google/provider-models.ts
+++ b/extensions/google/provider-models.ts
@@ -12,7 +12,9 @@ const GEMINI_2_5_FLASH_LITE_PREFIX = "gemini-2.5-flash-lite";
 const GEMINI_2_5_FLASH_PREFIX = "gemini-2.5-flash";
 const GEMINI_3_1_PRO_PREFIX = "gemini-3.1-pro";
 const GEMINI_3_1_FLASH_LITE_PREFIX = "gemini-3.1-flash-lite";
+const GEMINI_3_FLASH_LITE_PREFIX = "gemini-3-flash-lite";
 const GEMINI_3_1_FLASH_PREFIX = "gemini-3.1-flash";
+const GEMINI_3_FLASH_PREFIX = "gemini-3-flash";
 const GEMINI_PRO_LATEST_ID = "gemini-pro-latest";
 const GEMINI_FLASH_LATEST_ID = "gemini-flash-latest";
 const GEMINI_FLASH_LITE_LATEST_ID = "gemini-flash-lite-latest";
@@ -161,6 +163,7 @@ export function resolveGoogleGeminiForwardCompatModel(params: {
     }
   } else if (
     lower.startsWith(GEMINI_3_1_FLASH_LITE_PREFIX) ||
+    lower.startsWith(GEMINI_3_FLASH_LITE_PREFIX) ||
     lower === GEMINI_FLASH_LITE_LATEST_ID
   ) {
     family = {
@@ -168,7 +171,11 @@ export function resolveGoogleGeminiForwardCompatModel(params: {
       cliTemplateIds: GEMINI_3_1_FLASH_LITE_TEMPLATE_IDS,
       antigravityTemplateIds: GEMINI_3_FLASH_ANTIGRAVITY_TEMPLATE_IDS,
     };
-  } else if (lower.startsWith(GEMINI_3_1_FLASH_PREFIX) || lower === GEMINI_FLASH_LATEST_ID) {
+  } else if (
+    lower.startsWith(GEMINI_3_1_FLASH_PREFIX) ||
+    lower.startsWith(GEMINI_3_FLASH_PREFIX) ||
+    lower === GEMINI_FLASH_LATEST_ID
+  ) {
     family = {
       googleTemplateIds: GEMINI_3_1_FLASH_TEMPLATE_IDS,
       cliTemplateIds: GEMINI_3_1_FLASH_TEMPLATE_IDS,


### PR DESCRIPTION
## Problem

`gemini-3-flash-preview` (the canonical model ID after normalization) fails the prefix check in `resolveGoogleGeminiForwardCompatModel`. The resolver only checks for `gemini-3.1-flash` prefix, but `normalizeGooglePreviewModelId` maps `gemini-3.1-flash` → `gemini-3-flash-preview`, so by the time the forward-compat resolver runs, the model ID starts with `gemini-3-flash`, not `gemini-3.1-flash`.

This causes:
1. `resolveGoogleGeminiForwardCompatModel` returns `undefined`
2. Falls through to configured fallback which creates a text-only model (`input: ["text"]`)
3. Media understanding check `model.input?.includes("image")` fails
4. Error: "Model does not support images"

## Fix

Add `gemini-3-flash` and `gemini-3-flash-lite` prefix matching to the forward-compat resolver alongside the existing `gemini-3.1-flash` and `gemini-3.1-flash-lite` prefixes. The lite prefix check comes before the non-lite check in the if-else chain, preventing accidental cross-matching.

## Changes

- `extensions/google/provider-models.ts`: Add `GEMINI_3_FLASH_PREFIX` and `GEMINI_3_FLASH_LITE_PREFIX` constants; include them in the respective family prefix checks
- `extensions/google/provider-models.test.ts`: Add test for resolving `gemini-3-flash-preview` (the canonical normalized form) with `input: ["text", "image"]`
- `CHANGELOG.md`: Add entry

## Real behavior proof

Local test run output confirming `gemini-3-flash-preview` now resolves correctly with image input:

```
$ npx vitest run extensions/google/provider-models.test.ts --reporter=verbose

 ✓ extension-providers  > resolveGoogleGeminiForwardCompatModel > resolves gemini-3-flash-preview from google templates (canonical normalized form) 0ms
 ...
 Tests  20 passed (20)
```

The new test verifies that `resolveGoogleGeminiForwardCompatModel` with `modelId: "gemini-3-flash-preview"` returns a model with `input: ["text", "image"]` — previously this returned `undefined`, causing media understanding to reject the model.

**Root cause trace** (from source reading):
1. `normalizeGooglePreviewModelId("gemini-3.1-flash")` → `"gemini-3-flash-preview"` (src/plugin-sdk/provider-model-id-normalize.ts:17)
2. `resolveModelWithRegistry` normalizes the model ID before passing to the dynamic resolver (src/agents/pi-embedded-runner/model.ts:945)
3. In `resolveGoogleGeminiForwardCompatModel`, `"gemini-3-flash-preview".startsWith("gemini-3.1-flash")` → `false` — the model falls through all prefix checks
4. `resolveConfiguredFallbackModel` creates a model with default `input: ["text"]` (src/agents/pi-embedded-runner/model.inline-provider.ts:100)
5. `explicitImageModelVisionStatus` → `"unsupported"` → media understanding skipped

Closes #79750