### PR TITLE
fix(sandbox): include container path hint in sandbox-root escape error (#79712)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/sandbox: include the container workspace path hint in sandbox-root escape errors while preserving shortened host workspace roots. Fixes #79712. Thanks @haumanto and @hclsys.
 - QQBot: route gateway WebSocket connections through the ambient proxy agent so deployments with `https_proxy`, `HTTPS_PROXY`, or `HTTP_PROXY` can reach the QQ gateway. (#72961) Thanks @xialonglee.
 - Agents/subagents: treat `sessions_spawn` `model: "default"` as the default-model fallback and ignore ACP-only stream targets for native sub-agent spawns. Fixes #72078. (#72101) Thanks @xialonglee.
 - Agents/failover: stop retrying assistant-prefill format rejections across auth profiles or model fallbacks, surfacing the deterministic provider error instead of requeueing the lane. Fixes #79688. (#79728) Thanks @hclsys.

--- a/src/agents/sandbox/fs-paths.test.ts
+++ b/src/agents/sandbox/fs-paths.test.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -125,6 +126,35 @@ describe("resolveSandboxFsPathWithMounts", () => {
     ).toThrow(
       /Path escapes sandbox root \(.*container root \/sandbox-root\): \/tmp\/healthcheck-alert\/config\.json\. Use a path under \/sandbox-root\/ instead\./,
     );
+  });
+
+  it("includes container workspace hint without exposing a full home workspace root", () => {
+    const workspaceDir = path.join(os.homedir(), "workspace-coder");
+    const sandbox = createSandbox({
+      workspaceDir,
+      agentWorkspaceDir: workspaceDir,
+    });
+    const mounts = buildSandboxFsMounts(sandbox);
+    let thrown: unknown;
+    try {
+      resolveSandboxFsPathWithMounts({
+        filePath: "/tmp/outside",
+        cwd: sandbox.workspaceDir,
+        defaultWorkspaceRoot: sandbox.workspaceDir,
+        defaultContainerRoot: sandbox.containerWorkdir,
+        mounts,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    const message = (thrown as Error).message;
+    expect(message).toContain(
+      "Path escapes sandbox root (~/workspace-coder; container root /workspace): /tmp/outside",
+    );
+    expect(message).toContain("Use a path under /workspace/ instead.");
+    expect(message).not.toContain(os.homedir());
   });
 
   it("prefers custom bind mounts over default workspace mount at /workspace", () => {

--- a/src/agents/sandbox/fs-paths.ts
+++ b/src/agents/sandbox/fs-paths.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import path from "node:path";
 import { isPathInside } from "../../infra/path-guards.js";
 import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
@@ -174,7 +175,16 @@ function formatSandboxRootEscapeMessage(params: {
   defaultContainerRoot: string;
 }): string {
   const containerRoot = normalizeContainerPath(params.defaultContainerRoot);
-  return `Path escapes sandbox root (${params.defaultWorkspaceRoot}; container root ${containerRoot}): ${params.input}. Use a path under ${containerRoot}/ instead.`;
+  const workspaceRoot = shortenHomePath(path.resolve(params.defaultWorkspaceRoot));
+  return `Path escapes sandbox root (${workspaceRoot}; container root ${containerRoot}): ${params.input}. Use a path under ${containerRoot}/ instead.`;
+}
+
+function shortenHomePath(value: string): string {
+  const home = os.homedir();
+  if (value === home || value.startsWith(`${home}${path.sep}`)) {
+    return `~${value.slice(home.length)}`;
+  }
+  return value;
 }
 
 function compareMountsByContainerPath(a: SandboxFsMount, b: SandboxFsMount): number {


### PR DESCRIPTION
## Root cause

When a sandbox fs-bridge path escapes the sandbox root, the error message needs to show the container-side workspace mapping without leaking the full host home path. Otherwise model-driven callers may retry the same invalid host path instead of switching to the container workspace.

## Fix

Preserve the bind-aware sandbox fs resolver's container-root hint while shortening home-scoped host workspace roots to `~/...` in the escape message.

Example after the fix:

```
Path escapes sandbox root (~/workspace-coder; container root /workspace): /tmp/outside. Use a path under /workspace/ instead.
```

## Real behavior proof

- Behavior or issue addressed: sandbox fs bridge outside-root errors now include the container workspace hint and keep home-scoped host workspace roots shortened.
- Real environment tested: local OpenClaw source checkout on macOS with the rebased PR branch, using the actual `resolveSandboxFsPathWithMounts` resolver path used by the sandbox fs bridge.
- Exact steps or command run after this patch: `pnpm exec tsx -e 'import os from "node:os"; import path from "node:path"; import { buildSandboxFsMounts, resolveSandboxFsPathWithMounts } from "./src/agents/sandbox/fs-paths.ts"; import { createSandboxTestContext } from "./src/agents/sandbox/test-fixtures.ts"; const workspaceDir = path.join(os.homedir(), "workspace-coder"); const sandbox = createSandboxTestContext({ overrides: { workspaceDir, agentWorkspaceDir: workspaceDir } }); const mounts = buildSandboxFsMounts(sandbox); try { resolveSandboxFsPathWithMounts({ filePath: "/tmp/outside", cwd: sandbox.workspaceDir, defaultWorkspaceRoot: sandbox.workspaceDir, defaultContainerRoot: sandbox.containerWorkdir, mounts }); } catch (error) { console.log((error as Error).message); }'`
- Evidence after fix: console output from the command:

```console
Path escapes sandbox root (~/workspace-coder; container root /workspace): /tmp/outside. Use a path under /workspace/ instead.
```

- Observed result after fix: the rejected `/tmp/outside` path reports `/workspace/` as the container path to use and does not include the full host home directory.
- What was not tested: no full Docker container write was run here; the changed behavior is the pure bind-aware resolver error path, covered by the focused regression test `pnpm test src/agents/sandbox/fs-paths.test.ts` with 9 passing tests.

Closes #79712
