### PR TITLE
fix(webchat): always suppress HEARTBEAT_OK from chat stream regardless of showOk (#79735)

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1668,6 +1668,40 @@ describe("agent event handler", () => {
     );
   });
 
+  it("suppresses heartbeat HEARTBEAT_OK from webchat even when showOk is true (#79735)", () => {
+    vi.mocked(getRuntimeConfig).mockReturnValue({
+      agents: { defaults: { heartbeat: {} } },
+      channels: { defaults: { heartbeat: { showOk: true } } },
+    });
+
+    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness({ now: 4_000 });
+    chatRunState.registry.add("run-heartbeat-showok", {
+      sessionKey: "session-heartbeat-showok",
+      clientRunId: "client-heartbeat-showok",
+    });
+    registerAgentRunContext("run-heartbeat-showok", {
+      sessionKey: "session-heartbeat-showok",
+      isHeartbeat: true,
+      verboseLevel: "off",
+    });
+
+    handler({
+      runId: "run-heartbeat-showok",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "HEARTBEAT_OK" },
+    });
+
+    expect(chatBroadcastCalls(broadcast)).toHaveLength(0);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(0);
+
+    emitLifecycleEnd(handler, "run-heartbeat-showok");
+
+    const finalPayload = expectSingleFinalChatPayload(broadcast) as { message?: unknown };
+    expect(finalPayload.message).toBeUndefined();
+  });
+
   describe("spawnedBy enrichment in chat and agent broadcasts", () => {
     it("includes spawnedBy in chat delta broadcasts for subagent sessions", () => {
       vi.mocked(loadGatewaySessionRow).mockReturnValue({

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -3,7 +3,6 @@ import { normalizeVerboseLevel } from "../auto-reply/thinking.js";
 import { getRuntimeConfig } from "../config/io.js";
 import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-events.js";
 import { detectErrorKind, type ErrorKind } from "../infra/errors.js";
-import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
 import { isAcpSessionKey, isSubagentSessionKey } from "../sessions/session-key-utils.js";
 import { setSafeTimeout } from "../utils/timer-delay.js";
 import {
@@ -67,21 +66,12 @@ function resolveHeartbeatContext(runId: string, sourceRunId?: string) {
 
 /**
  * Check if heartbeat ACK/noise should be hidden from interactive chat surfaces.
+ * webchat is not a deliverable channel — HEARTBEAT_OK is always suppressed from
+ * the streaming UI regardless of showOk (which gates external channel delivery only).
  */
 function shouldHideHeartbeatChatOutput(runId: string, sourceRunId?: string): boolean {
   const runContext = resolveHeartbeatContext(runId, sourceRunId);
-  if (!runContext?.isHeartbeat) {
-    return false;
-  }
-
-  try {
-    const cfg = getRuntimeConfig();
-    const visibility = resolveHeartbeatVisibility({ cfg, channel: "webchat" });
-    return !visibility.showOk;
-  } catch {
-    // Default to suppressing if we can't load config
-    return true;
-  }
+  return Boolean(runContext?.isHeartbeat);
 }
 
 function normalizeHeartbeatChatFinalText(params: {


### PR DESCRIPTION
## Root cause

`shouldHideHeartbeatChatOutput()` in `gateway/server-chat.ts` returned `!visibility.showOk`. When `channels.defaults.heartbeat.showOk: true` is set (to get OK messages on Telegram/WhatsApp), this inverted: `!true = false` → heartbeat chat output NOT hidden → `HEARTBEAT_OK` token visible in webchat streaming.

`showOk` only gates `sendDurableMessageBatch` to external deliverable channels. `webchat` is `INTERNAL_MESSAGE_CHANNEL` — always `channel: none` from `resolveHeartbeatDeliveryTarget`.

## Fix

Simplified `shouldHideHeartbeatChatOutput` to `return Boolean(runContext?.isHeartbeat)`. Removed unused `resolveHeartbeatVisibility` import.

## Real behavior proof

- **Behavior addressed**: `HEARTBEAT_OK` visible in webchat UI when `showOk: true` was set for external channels.
- **Root cause confirmed**: `shouldHideHeartbeatChatOutput` returned `!visibility.showOk = !true = false` → not hidden.
- **After fix**: webchat streaming always suppresses `HEARTBEAT_OK` on heartbeat runs. External delivery (`sendDurableMessageBatch`) unaffected — gated separately by `showOk` in `heartbeat-runner.ts`.
- **Proof test**: `server-chat.agent-events.test.ts` — with `showOk: true` in config, verifies zero chat broadcast calls and `message: undefined` in final payload.

Closes #79735