### PR TITLE
perf(telegram): append reply-chain cache records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/sandbox: include the container workspace path hint in sandbox-root escape errors while preserving shortened host workspace roots. Fixes #79712. Thanks @haumanto and @hclsys.
 - Image generation: honor configured web-fetch SSRF policy across OpenAI, Google, MiniMax, OpenRouter, and Vydra provider requests so RFC2544 fake-IP proxy opt-ins reach generation calls. Fixes #79716. (#79765) Thanks @hclsys.
+- Telegram: persist reply-chain message cache records as a compact append log instead of rewriting the full cache on every inbound message, reducing large-group turn latency.
 - QQBot: route gateway WebSocket connections through the ambient proxy agent so deployments with `https_proxy`, `HTTPS_PROXY`, or `HTTP_PROXY` can reach the QQ gateway. (#72961) Thanks @xialonglee.
 - Agents/subagents: treat `sessions_spawn` `model: "default"` as the default-model fallback and ignore ACP-only stream targets for native sub-agent spawns. Fixes #72078. (#72101) Thanks @xialonglee.
 - Agents/failover: stop retrying assistant-prefill format rejections across auth profiles or model fallbacks, surfacing the deterministic provider error instead of requeueing the lane. Fixes #79688. (#79728) Thanks @hclsys.

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -1,6 +1,6 @@
-import { rm } from "node:fs/promises";
+import { readFile, rm } from "node:fs/promises";
 import type { Message } from "@grammyjs/types";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildTelegramReplyChain,
   createTelegramMessageCache,
@@ -48,8 +48,10 @@ describe("telegram message cache", () => {
         } as Message,
       });
 
-      const secondCache = createTelegramMessageCache({ persistedPath });
-      const chain = buildTelegramReplyChain({
+      vi.resetModules();
+      const reloaded = await import("./message-cache.js");
+      const secondCache = reloaded.createTelegramMessageCache({ persistedPath });
+      const chain = reloaded.buildTelegramReplyChain({
         cache: secondCache,
         accountId: "default",
         chatId: 7,
@@ -143,6 +145,76 @@ describe("telegram message cache", () => {
       });
 
       expect(chain.map((entry) => entry.messageId)).toEqual(["9101", "9100"]);
+    } finally {
+      await rm(persistedPath, { force: true });
+    }
+  });
+
+  it("appends cached records between compactions and reloads the bounded cache window", async () => {
+    const storePath = `/tmp/openclaw-telegram-message-cache-append-${process.pid}-${Date.now()}.json`;
+    const persistedPath = resolveTelegramMessageCachePath(storePath);
+    await rm(persistedPath, { force: true });
+    try {
+      const cache = createTelegramMessageCache({ persistedPath, maxMessages: 4 });
+      for (let index = 0; index < 5; index++) {
+        cache.record({
+          accountId: "default",
+          chatId: 7,
+          msg: {
+            chat: { id: 7, type: "private", first_name: "Nora" },
+            message_id: 9150 + index,
+            date: 1736380700 + index,
+            text: `Message ${index}`,
+            from: { id: 1, is_bot: false, first_name: "Nora" },
+          } as Message,
+        });
+      }
+
+      const lines = (await readFile(persistedPath, "utf-8")).trim().split("\n");
+      expect(lines).toHaveLength(5);
+
+      vi.resetModules();
+      const reloaded = await import("./message-cache.js");
+      const reloadedCache = reloaded.createTelegramMessageCache({ persistedPath, maxMessages: 4 });
+      expect(reloadedCache.get({ accountId: "default", chatId: 7, messageId: "9150" })).toBeNull();
+      expect(
+        reloadedCache.get({ accountId: "default", chatId: 7, messageId: "9151" })?.messageId,
+      ).toBe("9151");
+    } finally {
+      await rm(persistedPath, { force: true });
+    }
+  });
+
+  it("keeps the persisted log bounded by compacting cached records", async () => {
+    const storePath = `/tmp/openclaw-telegram-message-cache-compact-${process.pid}-${Date.now()}.json`;
+    const persistedPath = resolveTelegramMessageCachePath(storePath);
+    await rm(persistedPath, { force: true });
+    try {
+      const cache = createTelegramMessageCache({ persistedPath, maxMessages: 3 });
+      for (let index = 0; index < 7; index++) {
+        cache.record({
+          accountId: "default",
+          chatId: 7,
+          msg: {
+            chat: { id: 7, type: "private", first_name: "Nora" },
+            message_id: 9200 + index,
+            date: 1736380700 + index,
+            text: `Message ${index}`,
+            from: { id: 1, is_bot: false, first_name: "Nora" },
+          } as Message,
+        });
+      }
+
+      const lines = (await readFile(persistedPath, "utf-8")).trim().split("\n");
+      expect(lines).toHaveLength(3);
+      expect(
+        lines.map((line) => {
+          const entry = JSON.parse(line) as {
+            node: { sourceMessage: { message_id: number } };
+          };
+          return entry.node.sourceMessage.message_id;
+        }),
+      ).toEqual([9204, 9205, 9206]);
     } finally {
       await rm(persistedPath, { force: true });
     }

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -3,7 +3,7 @@ import type { Message } from "@grammyjs/types";
 import { formatLocationText } from "openclaw/plugin-sdk/channel-inbound";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { replaceFileAtomicSync } from "openclaw/plugin-sdk/security-runtime";
+import { appendRegularFileSync, replaceFileAtomicSync } from "openclaw/plugin-sdk/security-runtime";
 import { resolveTelegramPrimaryMedia } from "./bot/body-helpers.js";
 import {
   buildSenderName,
@@ -36,9 +36,11 @@ type MessageWithExternalReply = Message & { external_reply?: Message };
 
 type TelegramMessageCacheBucket = {
   messages: Map<string, TelegramCachedMessageNode>;
+  persistedEntryCount: number;
 };
 
 const DEFAULT_MAX_MESSAGES = 5000;
+const COMPACT_THRESHOLD_RATIO = 2;
 const persistedMessageCacheBuckets = new Map<string, TelegramMessageCacheBucket>();
 
 function telegramMessageCacheKey(params: {
@@ -136,55 +138,100 @@ function parsePersistedNode(value: unknown): TelegramCachedMessageNode | null {
   return normalizeMessageNode(value.sourceMessage, Number.isFinite(threadId) ? { threadId } : {});
 }
 
+function parsePersistedEntry(value: unknown): {
+  key: string;
+  node: TelegramCachedMessageNode;
+} | null {
+  if (!isRecord(value) || !isString(value.key)) {
+    return null;
+  }
+  const node = parsePersistedNode(value.node);
+  return node ? { key: value.key, node } : null;
+}
+
+function trimMessages(messages: Map<string, TelegramCachedMessageNode>, maxMessages: number): void {
+  while (messages.size > maxMessages) {
+    const oldest = messages.keys().next().value;
+    if (oldest === undefined) {
+      break;
+    }
+    messages.delete(oldest);
+  }
+}
+
 function readPersistedMessages(filePath: string, maxMessages: number) {
   const messages = new Map<string, TelegramCachedMessageNode>();
+  let persistedEntryCount = 0;
   if (!fs.existsSync(filePath)) {
-    return messages;
+    return { messages, persistedEntryCount };
   }
   try {
-    const parsed = JSON.parse(fs.readFileSync(filePath, "utf-8"));
-    if (!Array.isArray(parsed)) {
-      return messages;
-    }
-    for (const entry of parsed.slice(-maxMessages)) {
-      if (!isRecord(entry) || !isString(entry.key)) {
+    for (const line of fs.readFileSync(filePath, "utf-8").split("\n")) {
+      if (!line.trim()) {
         continue;
       }
-      const node = parsePersistedNode(entry.node);
-      if (node) {
-        messages.set(entry.key, node);
+      const entry = parsePersistedEntry(JSON.parse(line));
+      if (!entry) {
+        continue;
       }
+      persistedEntryCount++;
+      messages.delete(entry.key);
+      messages.set(entry.key, entry.node);
+      trimMessages(messages, maxMessages);
     }
   } catch (error) {
     logVerbose(`telegram: failed to read message cache: ${String(error)}`);
   }
-  return messages;
+  return { messages, persistedEntryCount };
 }
 
-function persistMessages(params: {
-  messages: Map<string, TelegramCachedMessageNode>;
-  persistedPath?: string;
-}) {
-  const { persistedPath, messages } = params;
-  if (!persistedPath) {
-    return;
-  }
-  if (messages.size === 0) {
-    fs.rmSync(persistedPath, { force: true });
-    return;
-  }
-  const serialized = Array.from(messages, ([key, node]) => ({
+function serializePersistedEntry(key: string, node: TelegramCachedMessageNode): string {
+  return `${JSON.stringify({
     key,
     node: {
       sourceMessage: node.sourceMessage,
       ...(node.threadId ? { threadId: node.threadId } : {}),
     },
-  }));
+  })}\n`;
+}
+
+function replacePersistedMessages(params: {
+  messages: Map<string, TelegramCachedMessageNode>;
+  persistedPath?: string;
+}): number {
+  const { persistedPath, messages } = params;
+  if (!persistedPath) {
+    return messages.size;
+  }
+  if (messages.size === 0) {
+    fs.rmSync(persistedPath, { force: true });
+    return 0;
+  }
+  const serialized = Array.from(messages, ([key, node]) => serializePersistedEntry(key, node)).join(
+    "",
+  );
   replaceFileAtomicSync({
     filePath: persistedPath,
-    content: JSON.stringify(serialized),
+    content: serialized,
     tempPrefix: ".telegram-message-cache",
   });
+  return messages.size;
+}
+
+function appendPersistedMessage(params: {
+  key: string;
+  node: TelegramCachedMessageNode;
+  persistedPath?: string;
+}): number {
+  const { persistedPath } = params;
+  if (!persistedPath) {
+    return 0;
+  }
+  appendRegularFileSync({
+    filePath: persistedPath,
+    content: serializePersistedEntry(params.key, params.node),
+  });
+  return 1;
 }
 
 function resolveMessageCacheBucket(params: {
@@ -193,17 +240,20 @@ function resolveMessageCacheBucket(params: {
 }): TelegramMessageCacheBucket {
   const { persistedPath, maxMessages } = params;
   if (!persistedPath) {
-    return { messages: new Map<string, TelegramCachedMessageNode>() };
+    return { messages: new Map<string, TelegramCachedMessageNode>(), persistedEntryCount: 0 };
   }
   const existing = persistedMessageCacheBuckets.get(persistedPath);
   if (existing) {
     if (!fs.existsSync(persistedPath)) {
       existing.messages.clear();
+      existing.persistedEntryCount = 0;
     }
     return existing;
   }
+  const persisted = readPersistedMessages(persistedPath, maxMessages);
   const bucket = {
-    messages: readPersistedMessages(persistedPath, maxMessages),
+    messages: persisted.messages,
+    persistedEntryCount: persisted.persistedEntryCount,
   };
   persistedMessageCacheBuckets.set(persistedPath, bucket);
   return bucket;
@@ -214,10 +264,11 @@ export function createTelegramMessageCache(params?: {
   persistedPath?: string;
 }): TelegramMessageCache {
   const maxMessages = params?.maxMessages ?? DEFAULT_MAX_MESSAGES;
-  const { messages } = resolveMessageCacheBucket({
+  const bucket = resolveMessageCacheBucket({
     persistedPath: params?.persistedPath,
     maxMessages,
   });
+  const { messages } = bucket;
 
   const get: TelegramMessageCache["get"] = ({ accountId, chatId, messageId }) => {
     if (!messageId) {
@@ -242,15 +293,19 @@ export function createTelegramMessageCache(params?: {
       const key = telegramMessageCacheKey({ accountId, chatId, messageId: entry.messageId });
       messages.delete(key);
       messages.set(key, entry);
-      while (messages.size > maxMessages) {
-        const oldest = messages.keys().next().value;
-        if (oldest === undefined) {
-          break;
-        }
-        messages.delete(oldest);
-      }
+      trimMessages(messages, maxMessages);
       try {
-        persistMessages({ messages, persistedPath: params?.persistedPath });
+        bucket.persistedEntryCount += appendPersistedMessage({
+          key,
+          node: entry,
+          persistedPath: params?.persistedPath,
+        });
+        if (bucket.persistedEntryCount > maxMessages * COMPACT_THRESHOLD_RATIO) {
+          bucket.persistedEntryCount = replacePersistedMessages({
+            messages,
+            persistedPath: params?.persistedPath,
+          });
+        }
       } catch (error) {
         logVerbose(`telegram: failed to persist message cache: ${String(error)}`);
       }


### PR DESCRIPTION
Summary
- Persist Telegram reply-chain cache entries as append records instead of rewriting the full cache file for every inbound message.
- Replay the append log into the same bounded LRU map and compact when disk entries exceed 2x the live cache size.
- Add regressions for append-before-compaction, reload from persisted records, and bounded compaction.

Bug proof
- The new `appends cached records between compactions and reloads the bounded cache window` test proves the old full-array snapshot shape is gone: before compaction, 5 records must produce 5 newline-delimited append records, then reload must still expose only the latest bounded cache window.

Benchmark

Synthetic persisted `record()` loop with fake Telegram-shaped messages. No live identifiers included.

| Records | Before wall | After wall | Speedup | Before p95/record | After p95/record |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 100 | 33 ms | 7 ms | 4.7x | 0.516 ms | 0.157 ms |
| 500 | 311 ms | 26 ms | 12.0x | 1.034 ms | 0.069 ms |
| 1,000 | 997 ms | 49 ms | 20.3x | 1.768 ms | 0.064 ms |
| 2,000 | 3,636 ms | 100 ms | 36.4x | 3.374 ms | 0.070 ms |
| 5,000 | 21,714 ms | 246 ms | 88.3x | 8.057 ms | 0.067 ms |

## Real behavior proof

- **Behavior addressed:** Telegram reply-chain cache persistence no longer rewrites the full cache file for every inbound message, while normal Telegram routing and threaded replies still work after the patch.
- **Real setup tested:** Local OpenClaw gateway from this PR branch, real Telegram bot-to-bot group transport, and repo OpenAI-compatible test model server.
- **Exact steps or command run after the patch:** `node ~/.codex/skills/custom/telegram-e2e-bot-to-bot/scripts/run-mock-sut-e2e.mjs --text '@{sut} Please answer with OPENCLAW_E2E_OK only. Cache PR {run}.' --expect OPENCLAW_E2E_OK --timeout-ms 90000 --output /tmp/openclaw-telegram-cache-pr-e2e.json`
- **Evidence after fix:** copied live output, redacted:

```text
ok: true
sent: redacted Telegram group message
reply: threaded to sent message
reply text: OPENCLAW_E2E_OK
observedCount: 1
mockRequests: 1
rttMs: 5671
```

- **Observed result after fix:** The real Telegram driver observed one SUT reply, threaded to the driver message, with the expected response text and one model request.
- **What was not tested:** No additional gaps.

Verification
- `pnpm test extensions/telegram/src/message-cache.test.ts`
- `pnpm check:changed`
