### PR TITLE
fix(yuanbao) support sourceReplyDeliveryMode: "automatic" for group chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Yuanbao: bump `openclaw-plugin-yuanbao` to 2.13.1 to support `sourceReplyDeliveryMode: "automatic"` for group chat. (#79814) Thanks @loongfay.
 - Memory: keep `memory_search` result `corpus` labels aligned with the hit source, so session transcript hits surface as `sessions` and memory-file hits stay `memory`. Fixes #72885. (#71898, #72886) Thanks @rubencu.
 - Google/Gemini: normalize retired nested Gemini 3 Pro Preview ids while converting manifest catalog rows into emitted provider config, so `google/gemini-3.1-pro-preview` is used for testing instead of `google/gemini-3-pro-preview`.
 - Native apps: advertise the Gateway protocol compatibility range so chat and node sessions can connect to v3 gateways after additive v4 client updates.

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -76,9 +76,9 @@
           }
         },
         "install": {
-          "npmSpec": "openclaw-plugin-yuanbao@2.13.0",
+          "npmSpec": "openclaw-plugin-yuanbao@2.13.1",
           "defaultChoice": "npm",
-          "expectedIntegrity": "sha512-mx6b2gO8oqZxECG9NLLQofScaIZXjmQXqJxevagVx8IKXLGeLrpTWlvnW1P2NP5dqaSMrkvBsgJqtW+rVM7h4w=="
+          "expectedIntegrity": "sha512-lH2I9/nsmrg7l0YJJSQhOSpWMEFBAa6FwKbZcRLDFHDT2+mOZkHa44XE+8KYN4VmorlUdAxHzpZQmVr7C98IuA=="
         }
       }
     },

--- a/src/channels/plugins/catalog.test.ts
+++ b/src/channels/plugins/catalog.test.ts
@@ -24,7 +24,7 @@ describe("channel plugin catalog", () => {
         pluginId: "openclaw-plugin-yuanbao",
         trustedSourceLinkedOfficialInstall: true,
         install: expect.objectContaining({
-          npmSpec: "openclaw-plugin-yuanbao@2.13.0",
+          npmSpec: "openclaw-plugin-yuanbao@2.13.1",
         }),
       }),
     );

--- a/src/channels/plugins/contracts/channel-catalog.contract.test.ts
+++ b/src/channels/plugins/contracts/channel-catalog.contract.test.ts
@@ -45,6 +45,6 @@ describeChannelCatalogEntryContract({
 
 describeChannelCatalogEntryContract({
   channelId: "yuanbao",
-  npmSpec: "openclaw-plugin-yuanbao@2.13.0",
+  npmSpec: "openclaw-plugin-yuanbao@2.13.1",
   alias: "yb",
 });

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -28,7 +28,7 @@ describe("official external plugin catalog", () => {
     );
     expect(resolveOfficialExternalPluginId(yuanbaoByChannel)).toBe("openclaw-plugin-yuanbao");
     expect(resolveOfficialExternalPluginInstall(yuanbaoByChannel)?.npmSpec).toBe(
-      "openclaw-plugin-yuanbao@2.13.0",
+      "openclaw-plugin-yuanbao@2.13.1",
     );
   });
 

--- a/test/official-channel-catalog.test.ts
+++ b/test/official-channel-catalog.test.ts
@@ -169,10 +169,10 @@ describe("buildOfficialChannelCatalog", () => {
         aliases: ["yuanbao", "yb", "tencent-yuanbao", "元宝"],
       },
       install: {
-        npmSpec: "openclaw-plugin-yuanbao@2.13.0",
+        npmSpec: "openclaw-plugin-yuanbao@2.13.1",
         defaultChoice: "npm",
         expectedIntegrity:
-          "sha512-mx6b2gO8oqZxECG9NLLQofScaIZXjmQXqJxevagVx8IKXLGeLrpTWlvnW1P2NP5dqaSMrkvBsgJqtW+rVM7h4w==",
+          "sha512-lH2I9/nsmrg7l0YJJSQhOSpWMEFBAa6FwKbZcRLDFHDT2+mOZkHa44XE+8KYN4VmorlUdAxHzpZQmVr7C98IuA==",
       },
     });
     expect(


### PR DESCRIPTION
Set sourceReplyDeliveryMode to automatic to support group chat reply deliver.


## Summary

Update `openclaw-plugin-yuanbao` from `2.13.0` to `2.13.1` in the official external channel catalog and align all related tests.

## Changes

- **`scripts/lib/official-external-channel-catalog.json`**: Bumped `npmSpec` to `openclaw-plugin-yuanbao@2.13.1` and updated `expectedIntegrity` to match the new npm registry hash.
- **`test/official-channel-catalog.test.ts`**: Updated `npmSpec` and `expectedIntegrity` assertions.
- **`src/channels/plugins/contracts/channel-catalog.contract.test.ts`**: Updated `npmSpec` in contract test.
- **`src/plugins/official-external-plugin-catalog.test.ts`**: Updated `npmSpec` assertion.
- **`src/channels/plugins/catalog.test.ts`**: Updated `npmSpec` in catalog test.

---

## Real behavior proof

**Behavior or issue addressed**: Update `openclaw-plugin-yuanbao` catalog entry from `2.13.0` to `2.13.1` with correct integrity hash, ensuring plugin installation passes integrity verification.

**Real environment tested**: macOS, OpenClaw 2026.5.6 (commit 95fb080), Node.js, local dev setup with `pnpm openclaw`.

**Exact steps or command run after this patch**:
1. `npm view openclaw-plugin-yuanbao@2.13.1 dist.integrity` — confirmed registry hash matches catalog value


```bash
npm view openclaw-plugin-yuanbao@2.13.1 dist.integrity

sha512-lH2I9/nsmrg7l0YJJSQhOSpWMEFBAa6FwKbZcRLDFHDT2+mOZkHa44XE+8KYN4VmorlUdAxHzpZQmVr7C98IuA==
```

2. `pnpm openclaw plugins install openclaw-plugin-yuanbao` — installed plugin with integrity chec

```bash
pnpm openclaw plugins install openclaw-plugin-yuanbao  

> openclaw@2026.5.6 openclaw /Users/loongfay/tencent/personal/openclaw
> node scripts/run-node.mjs plugins install openclaw-plugin-yuanbao


🦞 OpenClaw 2026.5.6 (95fb080) — I've survived more breaking changes than your last three relationships.

Installing openclaw-plugin-yuanbao@2.13.1 into /Users/loongfay/.openclaw/npm…
Linked peerDependency "openclaw" -> /Users/loongfay/tencent/personal/openclaw
Linked peerDependency "openclaw" -> /Users/loongfay/tencent/personal/openclaw
Config overwrite: /Users/loongfay/.openclaw/openclaw.json
Installed plugin: openclaw-plugin-yuanbao
Restart the gateway to load plugins.
```

3. `pnpm openclaw onboard` — verified yuanbao channel appears and onboards successfully

**Evidence after fix**:

<img width="924" height="393" alt="Clipboard_Screenshot_1778333180" src="https://github.com/user-attachments/assets/d28600cf-60ee-4676-996c-25b96b77d04d" />


```bash
$ pnpm openclaw plugins install openclaw-plugin-yuanbao
Installing openclaw-plugin-yuanbao@2.13.1 into /Users/loongfay/.openclaw/npm…
Installed plugin: openclaw-plugin-yuanbao
```

**Observed result after fix**: Plugin installs successfully with integrity verified. Onboard flow shows yuanbao channel available and functional.

**What was not tested**: None


---