### PR TITLE
fix(imessage): reject attachments on reply instead of silently dropping them

### DIFF
--- a/extensions/imessage/src/actions.test.ts
+++ b/extensions/imessage/src/actions.test.ts
@@ -278,6 +278,36 @@ describe("imessage message actions", () => {
     );
   });
 
+  it("rejects reply with attachment params instead of silently dropping the media", async () => {
+    // The reply action routes through `imsg send-rich --reply-to`, which has
+    // no `--file` flag. Before this guard, supplying media on a reply was
+    // silently dropped: send-rich shipped just the text, the call returned
+    // ok:true, and the agent had no signal that the attachment was lost.
+    probeMock.getCachedIMessagePrivateApiStatus.mockReturnValue({
+      available: true,
+      v2Ready: true,
+      selectors: {},
+    });
+    runtimeMock.resolveChatGuidForTarget.mockResolvedValue("iMessage;+;resolved-ident");
+
+    for (const attachmentField of ["media", "mediaUrl", "filePath", "buffer"]) {
+      runtimeMock.sendRichMessage.mockClear();
+      await expect(
+        imessageMessageActions.handleAction?.({
+          action: "reply",
+          cfg: cfg(),
+          params: {
+            chatIdentifier: "team-thread",
+            messageId: "message-guid",
+            text: "🦞 here it is",
+            [attachmentField]: "/tmp/anything.png",
+          },
+        } as never),
+      ).rejects.toThrow(/iMessage reply does not support attachments/);
+      expect(runtimeMock.sendRichMessage).not.toHaveBeenCalled();
+    }
+  });
+
   describe("phone-number target end-to-end (regressions caught the hard way)", () => {
     it("synthesizes iMessage;-;<phone> chat_identifier from a handle target and sends through to sendReaction", async () => {
       // Scenario from prod: agent calls react with `target:"+12069106512"` and a

--- a/extensions/imessage/src/actions.test.ts
+++ b/extensions/imessage/src/actions.test.ts
@@ -290,7 +290,17 @@ describe("imessage message actions", () => {
     });
     runtimeMock.resolveChatGuidForTarget.mockResolvedValue("iMessage;+;resolved-ident");
 
-    for (const attachmentField of ["media", "mediaUrl", "filePath", "buffer"]) {
+    const stringValue = "/tmp/anything.png";
+    const cases: Array<{ field: string; value: unknown }> = [
+      { field: "media", value: stringValue },
+      { field: "mediaUrl", value: stringValue },
+      { field: "mediaUrls", value: [stringValue, "/tmp/extra.png"] },
+      { field: "filePath", value: stringValue },
+      { field: "fileUrl", value: stringValue },
+      { field: "path", value: stringValue },
+      { field: "buffer", value: stringValue },
+    ];
+    for (const { field, value } of cases) {
       runtimeMock.sendRichMessage.mockClear();
       await expect(
         imessageMessageActions.handleAction?.({
@@ -300,7 +310,7 @@ describe("imessage message actions", () => {
             chatIdentifier: "team-thread",
             messageId: "message-guid",
             text: "🦞 here it is",
-            [attachmentField]: "/tmp/anything.png",
+            [field]: value,
           },
         } as never),
       ).rejects.toThrow(/iMessage reply does not support attachments/);

--- a/extensions/imessage/src/actions.ts
+++ b/extensions/imessage/src/actions.ts
@@ -468,6 +468,23 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
       if (!text) {
         throw new Error("iMessage reply requires text or message.");
       }
+      // The reply action routes through `imsg send-rich --reply-to`, which
+      // does not accept attachments — the only path that handles a file is
+      // `imsg send --file`, used by sendAttachment/upload-file. Silently
+      // dropping the caller's media looked like success and let agents ship
+      // a "here's your image" reply with no attachment attached.
+      const hasMediaParam =
+        readStringParam(params, "media") != null ||
+        readStringParam(params, "mediaUrl") != null ||
+        readStringParam(params, "filePath") != null ||
+        readStringParam(params, "buffer") != null;
+      if (hasMediaParam) {
+        throw new Error(
+          "iMessage reply does not support attachments. Use action 'upload-file' " +
+            "(with filePath/filename) or action 'send' (with media) to deliver the file, " +
+            "then use 'reply' for any text reply.",
+        );
+      }
       const partIndex = readNumberParam(params, "partIndex", { integer: true });
       const resolvedChatGuid = await chatGuid();
       const result = await runtime.sendRichMessage({

--- a/extensions/imessage/src/actions.ts
+++ b/extensions/imessage/src/actions.ts
@@ -240,6 +240,43 @@ function decodeBase64Buffer(params: Record<string, unknown>, action: string): Ui
   return Uint8Array.from(Buffer.from(base64Buffer, "base64"));
 }
 
+// Param names that any caller would reasonably treat as "attach this file
+// to the message". Covers everything the shared message-tool send schema
+// declares (`media`, `buffer`, `path`, `filePath`) plus the plural/url
+// variants that agents and channel adapters tend to reach for, so the reply
+// guard refuses identically regardless of which alias the caller picked.
+const REPLY_ATTACHMENT_PARAM_NAMES: readonly string[] = [
+  "media",
+  "mediaUrl",
+  "mediaUrls",
+  "filePath",
+  "fileUrl",
+  "path",
+  "buffer",
+] as const;
+
+// Truthy attachment-param check that tolerates string, array, and object
+// shapes — agents commonly pass `media: "/tmp/x.png"` as a string but also
+// `mediaUrls: ["/tmp/x.png"]` as an array, and we want both to trip the
+// reply guard rather than silently falling through.
+function hasNonEmptyAttachmentValue(params: Record<string, unknown>, name: string): boolean {
+  const value = params[name];
+  if (value == null) {
+    return false;
+  }
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  if (Array.isArray(value)) {
+    return value.some(
+      (entry) =>
+        (typeof entry === "string" && entry.trim().length > 0) ||
+        (entry != null && typeof entry === "object"),
+    );
+  }
+  return typeof value === "object";
+}
+
 // Whitelist of expressive-send effect IDs the bridge accepts. Restricting
 // to a fixed set lets us return a clear error for typos ("invisible_ink"
 // vs "invisibleink") instead of silently forwarding gibberish to the
@@ -472,13 +509,13 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
       // does not accept attachments — the only path that handles a file is
       // `imsg send --file`, used by sendAttachment/upload-file. Silently
       // dropping the caller's media looked like success and let agents ship
-      // a "here's your image" reply with no attachment attached.
-      const hasMediaParam =
-        readStringParam(params, "media") != null ||
-        readStringParam(params, "mediaUrl") != null ||
-        readStringParam(params, "filePath") != null ||
-        readStringParam(params, "buffer") != null;
-      if (hasMediaParam) {
+      // a "here's your image" reply with no attachment attached. Cover every
+      // attachment-bearing alias the message-tool send schema exposes plus
+      // common plural/url variants agents reach for.
+      const attachmentParam = REPLY_ATTACHMENT_PARAM_NAMES.find((name) =>
+        hasNonEmptyAttachmentValue(params, name),
+      );
+      if (attachmentParam) {
         throw new Error(
           "iMessage reply does not support attachments. Use action 'upload-file' " +
             "(with filePath/filename) or action 'send' (with media) to deliver the file, " +


### PR DESCRIPTION
## Summary

`extensions/imessage/src/actions.ts` accepted `reply` calls that carried `media` / `mediaUrl` / `filePath` / `buffer`, ignored every one of them, and returned `{ ok: true, messageId, repliedTo }`.

The reply action routes through `imsg send-rich --reply-to`, which only handles text — `imsg send --file` is the only CLI path that takes an attachment, and it has no `--reply-to` flag. So the dropped-attachment behavior couldn't have worked even in principle, and the success-shaped result hid it from agents that asked for a "reply with this image" in one tool call.

This change rejects any attachment-bearing param on `reply` with an explicit error pointing the caller at `upload-file` / `send`. The `reply` action stays text-only and continues to use `sendRichMessage` for replyTo threading. Upstream `imsg` issue tracking the missing combined primitive: https://github.com/openclaw/imsg/issues/113.

## Real behavior proof

**Behavior addressed:** Production agent on macOS calls `message` with `{ action: "reply", channel: "imessage", target: "+1...", messageId: "...", message: "🦞 Here it is.", media: "/.../ig_*.png" }`. Pre-fix the bridge ships only the text via `imsg send-rich --reply-to`, the call returns `{ ok: true, messageId, repliedTo }`, and the attachment is silently dropped — the user sees a threaded text bubble with no image and the agent has no signal anything went wrong.

**Real environment tested:** Live OpenClaw gateway on macOS 26.4.0 (Tahoe) M1 — `openclaw 2026.5.6 (71a2042)`, `imsg 0.8.0`, IMCore v2 bridge, SIP disabled. iMessage channel is the native `imessage` extension. Same machine that hits the bug daily via the Lobster agent's iMessage DM session (`agent:lobster:imessage:direct:+1...`), driven by gpt-5.5 / openai-codex. Patched dist chunk applied to the running gateway via `pnpm build` + `openclaw gateway restart`, then exercised with a real iMessage from the owner's phone.

**Exact steps or command run after this patch:**
1. Apply this PR's diff to `extensions/imessage/src/actions.ts`, rebuild the iMessage dist chunk, restart the live gateway: `openclaw gateway restart` picks up the patched `dist/channel-CtTHIcfN.js`.
2. From the owner's phone, send the same flavor of prompt that triggered the original silent-drop incident on this host: _"Generate an image of a cute lobster drawing a painting and send it to me"_.
3. Tail the agent's trajectory file and watch the resulting tool calls:

```
tail -F ~/.openclaw/agents/lobster/sessions/<sessionId>.trajectory.jsonl \
  | grep -E '"type":"(tool\.call|tool\.result)"' \
  | jq -c '{ts, type, tool: .data.name, action: (.data.arguments.action // null), success: (.data.success // null), result: ((.data.contentItems // []) | map(.text) | first // null)}'
```

**After-fix evidence:** Both excerpts copied verbatim (with phone numbers / image GUIDs trimmed) from the live trajectory file `~/.openclaw/agents/lobster/sessions/fab01f44-cfd5-4bf6-a2f7-3e466828cda4.trajectory.jsonl` on the production host.

Before the fix — same DM thread, runId `3e3e1c25-...`, 2026-05-09 13:13 UTC. `reply + media` returns `ok:true` and the attachment is silently dropped:

```
{"ts":"2026-05-09T13:13:55.466Z","type":"tool.call","tool":"message","action":"reply","media":"/.../ig_*.png"}
{"ts":"2026-05-09T13:13:55.486Z","type":"tool.result","tool":"message","success":null,
 "result":"iMessage reply requires text or message."}
{"ts":"2026-05-09T13:13:59.310Z","type":"tool.call","tool":"message","action":"reply","media":"/.../ig_*.png",
 "message":"🦞 Here it is."}
{"ts":"2026-05-09T13:13:59.548Z","type":"tool.result","tool":"message","success":true,
 "result":"{\n  \"ok\": true,\n  \"messageId\": \"DDA2BC6C-...\",\n  \"repliedTo\": \"2A19CA4F-...\"\n}"}
```

The agent then explicitly told the user (verbatim from the same trajectory):
> "🦞 The first time, I only generated the image file locally and failed to follow up with an iMessage attachment send. That was my mistake. After that, the inline reply-media path also didn't render for you, so I switched to upload-file, which is the path that actually sent it."

After the fix — same DM thread, runId `791ef276-...`, 2026-05-09 13:38 UTC, after `openclaw gateway restart` loaded the patched chunk. The agent picks the supported `upload-file` action directly, the imsg bridge actually delivers the file, and the user confirmed receipt:

```
{"ts":"2026-05-09T13:38:08.872Z","type":"tool.call","tool":"message","action":"upload-file",
 "filename":"cute-lobster-painting.png"}
{"ts":"2026-05-09T13:38:09.689Z","type":"tool.result","tool":"message","success":true,
 "result":"{\n  \"ok\": true,\n  \"messageId\": \"ok\"\n}"}
```

Owner confirmation in the same DM thread immediately after this tool result: _"ok fixed"_.

**Observed result after fix:** Live agent on the patched gateway delivers the attachment on the first attempt via `upload-file`; no `reply + media` silent-drop reproduces in the live session. The `reply` handler now refuses any media-bearing param with the explicit error `iMessage reply does not support attachments. Use action 'upload-file' (with filePath/filename) or action 'send' (with media) to deliver the file, then use 'reply' for any text reply.`, surfacing the constraint to any future agent that picks the wrong action.

**What was not tested:** In the live post-fix run the gpt-5.5 agent picked `upload-file` directly (its session-history mirror still contained the prior apology, so it skipped the bug-prone path). The throw itself therefore did not fire in this particular live trajectory — the new regression test in `extensions/imessage/src/actions.test.ts` is what covers the throw path (`pnpm test extensions/imessage/src/actions.test.ts` → 24/24 pass). Re-running this scenario in a brand-new session (no prior failure context) is the remaining live-coverage gap; happy to drive that separately if a reviewer wants the throw exercised end-to-end in trace.

## Best-fix justification

- `imsg send-rich` cannot send attachments and `imsg send` cannot reply-thread, so a single "reply with attachment" can't be a single CLI call. Silently doing the partial thing was the trap. Tracking the upstream `imsg` gap at https://github.com/openclaw/imsg/issues/113.
- Implicitly chaining two CLI calls inside `reply` (text + attachment) would change action semantics across channels and split the result/return contract; making the agent decide between `upload-file`/`send` for the file and a separate `reply` for any text keeps each action's surface honest.
- Compile-time schema rejection would also work, but the channel-action schema is shared across channels (BlueBubbles' `reply` does support attachments via its REST API). Keeping the per-channel runtime check leaves the cross-channel surface uniform.

No changelog entry yet — leaving as draft pending review of the rejection-vs-chain tradeoff above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)