### PR TITLE
fix(google): recover and validate Gemini tool-call thought_signature on replay

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -166,6 +166,30 @@ function requireThinkingConfig(config: Record<string, unknown>): Record<string, 
   return thinkingConfig as Record<string, unknown>;
 }
 
+type GoogleTestContentTurn = Record<string, unknown> & {
+  parts: Array<Record<string, unknown>>;
+};
+
+function isModelTurnWithParts(content: Record<string, unknown>): content is GoogleTestContentTurn {
+  return content.role === "model" && Array.isArray(content.parts);
+}
+
+function getFirstModelTurn(contents: Array<Record<string, unknown>>): GoogleTestContentTurn {
+  const turn = contents.find(isModelTurnWithParts);
+  if (!turn) {
+    throw new Error("Expected at least one Google model turn");
+  }
+  return turn;
+}
+
+function getLastModelTurn(contents: Array<Record<string, unknown>>): GoogleTestContentTurn {
+  const turn = contents.toReversed().find(isModelTurnWithParts);
+  if (!turn) {
+    throw new Error("Expected at least one Google model turn");
+  }
+  return turn;
+}
+
 describe("google transport stream", () => {
   beforeAll(async () => {
     ({
@@ -797,8 +821,7 @@ describe("google transport stream", () => {
 
     // Find the last model-role content; should carry the replayed signature
     // even though the second stored toolCall block had none.
-    const modelTurns = params.contents.filter((c: { role: string }) => c.role === "model");
-    expect(modelTurns[modelTurns.length - 1]).toMatchObject({
+    expect(getLastModelTurn(params.contents)).toMatchObject({
       role: "model",
       parts: [
         {
@@ -855,23 +878,23 @@ describe("google transport stream", () => {
       ],
     } as never);
 
-    // The foreign signature should be omitted from the Gemini outbound payload
-    const modelTurns = params.contents.filter((c: { role: string }) => c.role === "model");
-    expect(modelTurns[0]).toMatchObject({
+    // The foreign signature should not be replayed into the Gemini payload.
+    // Gemini 3 still needs the documented skip fallback for unsigned function
+    // calls that came from another route.
+    const firstModelTurn = getFirstModelTurn(params.contents);
+    expect(firstModelTurn).toMatchObject({
       role: "model",
       parts: [
         {
+          thoughtSignature: "skip_thought_signature_validator",
           functionCall: { name: "lookup", args: { q: "hello" } },
         },
       ],
     });
-    // Confirm thoughtSignature is absent — not replayed from a foreign route
-    expect(
-      (modelTurns[0] as { parts: Array<Record<string, unknown>> }).parts[0].thoughtSignature,
-    ).toBeUndefined();
+    expect(firstModelTurn.parts[0].thoughtSignature).not.toBe("msg_01XFDUDYJgAACcnSM2TTgQsA");
   });
 
-  it("drops non-base64 Gemini tool-call thought signatures like reasoning", () => {
+  it("replaces non-base64 Gemini tool-call thought signatures with the skip fallback", () => {
     const model = buildGeminiModel({
       id: "gemini-3.1-pro-preview",
       name: "Gemini 3.1 Pro Preview",
@@ -900,11 +923,13 @@ describe("google transport stream", () => {
     } as never);
 
     const part = (params.contents[0] as { parts: Array<Record<string, unknown>> }).parts[0];
-    expect(part).toMatchObject({ functionCall: { name: "lookup", args: { q: "hello" } } });
-    expect(part).not.toHaveProperty("thoughtSignature");
+    expect(part).toMatchObject({
+      thoughtSignature: "skip_thought_signature_validator",
+      functionCall: { name: "lookup", args: { q: "hello" } },
+    });
   });
 
-  it("drops skip-validator thought signatures before Gemini replay serialization", () => {
+  it("preserves the skip-validator fallback for unsigned Gemini tool-call replay", () => {
     const model = buildGeminiModel({
       id: "gemini-3.1-pro-preview",
       name: "Gemini 3.1 Pro Preview",
@@ -933,8 +958,10 @@ describe("google transport stream", () => {
     } as never);
 
     const part = (params.contents[0] as { parts: Array<Record<string, unknown>> }).parts[0];
-    expect(part).toMatchObject({ functionCall: { name: "lookup", args: { q: "hello" } } });
-    expect(part).not.toHaveProperty("thoughtSignature");
+    expect(part).toMatchObject({
+      thoughtSignature: "skip_thought_signature_validator",
+      functionCall: { name: "lookup", args: { q: "hello" } },
+    });
   });
 
   it("does not trust cross-provider tool-call thought signatures for non-Gemini-3 models", () => {

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -809,6 +809,68 @@ describe("google transport stream", () => {
     });
   });
 
+  it("does not replay tool-call thought signatures from a different provider route", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    // Prior turn came from an Anthropic route — its signature looks valid base64
+    // but must NOT be replayed into a Gemini request.
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        {
+          role: "assistant",
+          provider: "anthropic",
+          api: "anthropic",
+          model: "claude-sonnet-4",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_foreign",
+              name: "lookup",
+              arguments: { q: "hello" },
+              // Plausible-looking base64 from a non-Gemini provider
+              thoughtSignature: "msg_01XFDUDYJgAACcnSM2TTgQsA",
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          timestamp: 1,
+          content: [
+            {
+              type: "toolResult",
+              toolCallId: "call_foreign",
+              content: [{ type: "text", text: "ok" }],
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "Continue." }],
+        },
+      ],
+    } as never);
+
+    // The foreign signature should be omitted from the Gemini outbound payload
+    const modelTurns = params.contents.filter((c: { role: string }) => c.role === "model");
+    expect(modelTurns[0]).toMatchObject({
+      role: "model",
+      parts: [
+        {
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+    // Confirm thoughtSignature is absent — not replayed from a foreign route
+    expect(
+      (modelTurns[0] as { parts: Array<Record<string, unknown>> }).parts[0].thoughtSignature,
+    ).toBeUndefined();
+  });
+
   it("drops non-base64 Gemini tool-call thought signatures like reasoning", () => {
     const model = buildGeminiModel({
       id: "gemini-3.1-pro-preview",

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -326,6 +326,52 @@ describe("google transport stream", () => {
     expect(result.content[2]).toHaveProperty("thoughtSignature", "call_sig_1");
   });
 
+  it("merges tool-call thought signatures from sibling SSE parts", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: { id: "call_1", name: "lookup", args: { q: "hello" } },
+                  },
+                  { thoughtSignature: "call_sig_merged_1" },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ]),
+    );
+
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel({
+          id: "gemini-3.1-pro-preview",
+          name: "Gemini 3.1 Pro Preview",
+        }),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as never,
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_1",
+        name: "lookup",
+        arguments: { q: "hello" },
+        thoughtSignature: "call_sig_merged_1",
+      },
+    ]);
+  });
+
   it("builds a lean Gemini 3 first-response retry payload", () => {
     const model = buildGeminiModel({
       id: "gemini-3.1-pro-preview",
@@ -694,7 +740,7 @@ describe("google transport stream", () => {
     });
   });
 
-  it("uses Gemini skip-validator thought signatures for cross-provider tool-call replay", () => {
+  it("re-attaches replayed Gemini thought signatures when a later tool call is missing one", () => {
     const model = buildGeminiModel({
       id: "gemini-3.1-pro-preview",
       name: "Gemini 3.1 Pro Preview",
@@ -704,9 +750,9 @@ describe("google transport stream", () => {
       messages: [
         {
           role: "assistant",
-          provider: "anthropic",
-          api: "anthropic-messages",
-          model: "claude-opus-4-7",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
           stopReason: "toolUse",
           timestamp: 0,
           content: [
@@ -715,21 +761,118 @@ describe("google transport stream", () => {
               id: "call_1",
               name: "lookup",
               arguments: { q: "hello" },
+              thoughtSignature: "call_sig_replay_1",
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          timestamp: 1,
+          content: [
+            {
+              type: "toolResult",
+              toolCallId: "call_1",
+              content: [{ type: "text", text: "ok" }],
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 2,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello-again" },
             },
           ],
         },
       ],
     } as never);
 
-    expect(params.contents[0]).toEqual({
+    // Find the last model-role content; should carry the replayed signature
+    // even though the second stored toolCall block had none.
+    const modelTurns = params.contents.filter((c: { role: string }) => c.role === "model");
+    expect(modelTurns[modelTurns.length - 1]).toMatchObject({
       role: "model",
       parts: [
         {
-          thoughtSignature: "skip_thought_signature_validator",
-          functionCall: { name: "lookup", args: { q: "hello" } },
+          thoughtSignature: "call_sig_replay_1",
+          functionCall: { name: "lookup", args: { q: "hello-again" } },
         },
       ],
     });
+  });
+
+  it("drops non-base64 Gemini tool-call thought signatures like reasoning", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello" },
+              thoughtSignature: "reasoning",
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    const part = (params.contents[0] as { parts: Array<Record<string, unknown>> }).parts[0];
+    expect(part).toMatchObject({ functionCall: { name: "lookup", args: { q: "hello" } } });
+    expect(part).not.toHaveProperty("thoughtSignature");
+  });
+
+  it("drops skip-validator thought signatures before Gemini replay serialization", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "lookup",
+              arguments: { q: "hello" },
+              thoughtSignature: "skip_thought_signature_validator",
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    const part = (params.contents[0] as { parts: Array<Record<string, unknown>> }).parts[0];
+    expect(part).toMatchObject({ functionCall: { name: "lookup", args: { q: "hello" } } });
+    expect(part).not.toHaveProperty("thoughtSignature");
   });
 
   it("does not trust cross-provider tool-call thought signatures for non-Gemini-3 models", () => {

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -138,6 +138,8 @@ type GoogleSseChunk = {
 
 let toolCallCounter = 0;
 const GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP = "skip_thought_signature_validator";
+const GEMINI_THOUGHT_SIGNATURE_PATTERN = /^[A-Za-z0-9_+/=-]+$/;
+const GEMINI_THOUGHT_SIGNATURE_MIN_LENGTH = 8;
 
 function normalizeOptionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
@@ -164,6 +166,63 @@ function retainThoughtSignature(existing: string | undefined, incoming: string |
     return incoming;
   }
   return existing;
+}
+
+function isJsonLikeThoughtSignature(value: string): boolean {
+  const trimmed = value.trim();
+  return (
+    trimmed.startsWith("{") ||
+    trimmed.startsWith("[") ||
+    trimmed.includes('":') ||
+    trimmed.includes('","') ||
+    trimmed.includes('"type"')
+  );
+}
+
+function sanitizeGeminiToolCallThoughtSignature(
+  thoughtSignature: string | undefined,
+): string | undefined {
+  if (typeof thoughtSignature !== "string") {
+    return undefined;
+  }
+  const trimmed = thoughtSignature.trim();
+  if (trimmed.length < GEMINI_THOUGHT_SIGNATURE_MIN_LENGTH) {
+    return undefined;
+  }
+  if (isJsonLikeThoughtSignature(trimmed)) {
+    return undefined;
+  }
+  const lowered = normalizeLowercaseStringOrEmpty(trimmed);
+  if (
+    lowered === "reasoning" ||
+    lowered === normalizeLowercaseStringOrEmpty(GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP)
+  ) {
+    return undefined;
+  }
+  if (!GEMINI_THOUGHT_SIGNATURE_PATTERN.test(trimmed)) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function collectToolCallThoughtSignatures(context: Context): Map<string, string> {
+  const sigById = new Map<string, string>();
+  for (const msg of context.messages ?? []) {
+    if (msg.role !== "assistant" || !Array.isArray(msg.content)) {
+      continue;
+    }
+    for (const block of msg.content) {
+      if (block.type !== "toolCall") {
+        continue;
+      }
+      const signature = sanitizeGeminiToolCallThoughtSignature(block.thoughtSignature);
+      if (!signature) {
+        continue;
+      }
+      sigById.set(block.id, signature);
+    }
+  }
+  return sigById;
 }
 
 function mapToolChoice(
@@ -385,6 +444,9 @@ function normalizeGoogleThinkingConfig(
 
 function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
   const contents: Array<Record<string, unknown>> = [];
+  const replayToolCallThoughtSignatures = requiresToolCallThoughtSignature(model.id)
+    ? collectToolCallThoughtSignatures(context)
+    : new Map<string, string>();
   const transformedMessages = transformTransportMessages(
     context.messages,
     model,
@@ -453,11 +515,13 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
           continue;
         }
         if (block.type === "toolCall") {
-          const thoughtSignature =
-            (isSameProviderAndModel ? block.thoughtSignature : undefined) ??
-            (requiresToolCallThoughtSignature(model.id)
-              ? GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP
-              : undefined);
+          const replayedThoughtSignature = replayToolCallThoughtSignatures.get(block.id);
+          const thoughtSignature = sanitizeGeminiToolCallThoughtSignature(
+            retainThoughtSignature(block.thoughtSignature, replayedThoughtSignature) ??
+              (requiresToolCallThoughtSignature(model.id)
+                ? GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP
+                : undefined),
+          );
           parts.push({
             functionCall: {
               name: block.name,
@@ -1098,6 +1162,16 @@ function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
                 typeof part.thoughtSignature === "string" && part.thoughtSignature.length > 0;
               const hasText = typeof part.text === "string";
               if (hasText || (hasThoughtSignature && !part.functionCall)) {
+                if (hasThoughtSignature && !hasText) {
+                  const latestBlock = output.content[output.content.length - 1];
+                  if (latestBlock?.type === "toolCall") {
+                    latestBlock.thoughtSignature = retainThoughtSignature(
+                      latestBlock.thoughtSignature,
+                      part.thoughtSignature,
+                    );
+                    continue;
+                  }
+                }
                 const isThinking = part.thought === true || !hasText;
                 const currentBlock = output.content[currentBlockIndex];
                 if (
@@ -1164,6 +1238,15 @@ function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
                 const isDuplicate = output.content.some(
                   (block) => block.type === "toolCall" && block.id === providedId,
                 );
+                const existingToolCall =
+                  typeof providedId === "string"
+                    ? output.content.find(
+                        (
+                          block,
+                        ): block is Extract<GoogleTransportContentBlock, { type: "toolCall" }> =>
+                          block.type === "toolCall" && block.id === providedId,
+                      )
+                    : undefined;
                 const toolCallId =
                   providedId && !isDuplicate
                     ? providedId
@@ -1173,7 +1256,10 @@ function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
                   id: toolCallId,
                   name: part.functionCall.name || "",
                   arguments: part.functionCall.args ?? {},
-                  thoughtSignature: part.thoughtSignature,
+                  thoughtSignature: retainThoughtSignature(
+                    existingToolCall?.thoughtSignature,
+                    part.thoughtSignature,
+                  ),
                 };
                 output.content.push(toolCall);
                 const blockIndex = output.content.length - 1;

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -205,6 +205,15 @@ function sanitizeGeminiToolCallThoughtSignature(
   return trimmed;
 }
 
+function isSameGoogleTransportRoute(
+  source: { api?: string; provider?: string; model?: string },
+  model: GoogleTransportModel,
+): boolean {
+  return (
+    source.provider === model.provider && source.api === model.api && source.model === model.id
+  );
+}
+
 function collectToolCallThoughtSignatures(
   context: Context,
   model: GoogleTransportModel,
@@ -219,9 +228,7 @@ function collectToolCallThoughtSignatures(
     // sanitizer but are not valid Gemini-issued values and must not be
     // replayed. Gemini requires its own signatures returned exactly as issued.
     const source = msg as { api?: string; provider?: string; model?: string };
-    const isSameRoute =
-      source.provider === model.provider && source.api === model.api && source.model === model.id;
-    if (!isSameRoute) {
+    if (!isSameGoogleTransportRoute(source, model)) {
       continue;
     }
     for (const block of msg.content) {
@@ -497,7 +504,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
     }
 
     if (msg.role === "assistant") {
-      const isSameProviderAndModel = msg.provider === model.provider && msg.model === model.id;
+      const isSameRoute = isSameGoogleTransportRoute(msg, model);
       const parts: Array<Record<string, unknown>> = [];
       for (const block of msg.content) {
         if (block.type === "text") {
@@ -506,7 +513,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
           }
           parts.push({
             text: sanitizeTransportPayloadText(block.text),
-            ...(isSameProviderAndModel && block.textSignature
+            ...(isSameRoute && block.textSignature
               ? { thoughtSignature: block.textSignature }
               : {}),
           });
@@ -516,7 +523,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
           if (!block.thinking.trim()) {
             continue;
           }
-          if (isSameProviderAndModel) {
+          if (isSameRoute) {
             parts.push({
               thought: true,
               text: sanitizeTransportPayloadText(block.thinking),
@@ -533,13 +540,14 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
           // otherwise fall back to a same-route replayed value from context.
           // Never replay signatures from foreign providers — Gemini requires
           // its own signatures returned exactly as issued.
-          const ownSignature = isSameProviderAndModel ? block.thoughtSignature : undefined;
-          const thoughtSignature = sanitizeGeminiToolCallThoughtSignature(
+          const ownSignature = isSameRoute
+            ? sanitizeGeminiToolCallThoughtSignature(block.thoughtSignature)
+            : undefined;
+          const thoughtSignature =
             retainThoughtSignature(ownSignature, replayedThoughtSignature) ??
-              (requiresToolCallThoughtSignature(model.id)
-                ? GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP
-                : undefined),
-          );
+            (requiresToolCallThoughtSignature(model.id)
+              ? GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP
+              : undefined);
           parts.push({
             functionCall: {
               name: block.name,

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -205,10 +205,23 @@ function sanitizeGeminiToolCallThoughtSignature(
   return trimmed;
 }
 
-function collectToolCallThoughtSignatures(context: Context): Map<string, string> {
+function collectToolCallThoughtSignatures(
+  context: Context,
+  model: GoogleTransportModel,
+): Map<string, string> {
   const sigById = new Map<string, string>();
   for (const msg of context.messages ?? []) {
     if (msg.role !== "assistant" || !Array.isArray(msg.content)) {
+      continue;
+    }
+    // Only trust thought signatures from the same Google route. Signatures
+    // from other providers (e.g. Anthropic, OpenAI) may pass the base64
+    // sanitizer but are not valid Gemini-issued values and must not be
+    // replayed. Gemini requires its own signatures returned exactly as issued.
+    const source = msg as { api?: string; provider?: string; model?: string };
+    const isSameRoute =
+      source.provider === model.provider && source.api === model.api && source.model === model.id;
+    if (!isSameRoute) {
       continue;
     }
     for (const block of msg.content) {
@@ -445,7 +458,7 @@ function normalizeGoogleThinkingConfig(
 function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
   const contents: Array<Record<string, unknown>> = [];
   const replayToolCallThoughtSignatures = requiresToolCallThoughtSignature(model.id)
-    ? collectToolCallThoughtSignatures(context)
+    ? collectToolCallThoughtSignatures(context, model)
     : new Map<string, string>();
   const transformedMessages = transformTransportMessages(
     context.messages,
@@ -516,8 +529,13 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
         }
         if (block.type === "toolCall") {
           const replayedThoughtSignature = replayToolCallThoughtSignatures.get(block.id);
+          // Use stored signature only when it came from the same Google route;
+          // otherwise fall back to a same-route replayed value from context.
+          // Never replay signatures from foreign providers — Gemini requires
+          // its own signatures returned exactly as issued.
+          const ownSignature = isSameProviderAndModel ? block.thoughtSignature : undefined;
           const thoughtSignature = sanitizeGeminiToolCallThoughtSignature(
-            retainThoughtSignature(block.thoughtSignature, replayedThoughtSignature) ??
+            retainThoughtSignature(ownSignature, replayedThoughtSignature) ??
               (requiresToolCallThoughtSignature(model.id)
                 ? GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP
                 : undefined),


### PR DESCRIPTION
Fixes #72879.

## Summary

Addresses Gemini `thought_signature` replay failures observed on v2026.5.7 during native Google tool-call replay. The fix is limited to `extensions/google/transport-stream.ts` and regression tests.

The PR now covers four related failure modes:

1. Native Google streaming can deliver a `functionCall` and its `thoughtSignature` across sibling SSE parts; the parser now merges the signature back onto the tool call.
2. Multi-turn Gemini replay can serialize a stored tool call that no longer has its original signature; the serializer now reuses a valid same-route signature from prior assistant history.
3. Foreign/provider-route signatures can look base64-compatible but are not Gemini-issued; replay trust is now exact by `provider + api + model`.
4. Invalid stored values such as `reasoning` are sanitized, while Gemini 3's documented `skip_thought_signature_validator` fallback is preserved for unsigned Gemini function-call replay.

## Fix details

### Parser merge across SSE parts

The native Google parser previously stored `thoughtSignature: part.thoughtSignature` from a single SSE part. Thinking/text parsers already used `retainThoughtSignature(...)` to merge values across sibling parts in the same turn. This PR applies the same merge behavior to tool-call parts and attaches orphan `thoughtSignature`-only parts back to the most recent tool-call block instead of discarding them.

### Native replay injection

Adds a native-Google replay helper that walks prior assistant messages, collects valid signatures by tool-call block id, and re-attaches them at serialization time when the stored block is missing one. Replay is gated to Gemini 3 models and to the same native Google transport route.

### Route-exact trust boundary

Stored signatures are trusted only when the prior message route matches the current Google transport route by `provider`, `api`, and `model`. This prevents Anthropic/OpenAI-compatible signatures or sentinels from being replayed into native Gemini requests.

### Validation guard plus fallback preservation

`sanitizeGeminiToolCallThoughtSignature` filters outbound real signatures that are clearly invalid, including JSON-like values, known bad sentinels such as `reasoning`, and non-base64url values. After sanitizing real signatures, unsigned Gemini 3 tool-call replay still emits `skip_thought_signature_validator` as the fallback.

## Evidence

The linked issue includes a direct Gemini API repro matrix showing that replay without a thought signature fails with the production 400 and replay with the real returned signature succeeds: https://github.com/openclaw/openclaw/issues/72879#issuecomment-4412392166

Network/proxy/DNS were ruled out. The bug is in native Google replay serialization and streamed tool-call parsing.

## Real behavior proof

- **Behavior addressed:** Native Google Gemini tool-call replay must not send foreign/provider-route thought signatures, must preserve valid same-route Gemini signatures, and must keep the Gemini 3 `skip_thought_signature_validator` fallback for unsigned function-call replay.
- **Real environment tested:** Azure Crabbox VM `cbx_ace9a5d36d50` / `swift-krill`, `Standard_D8ads_v6` on-demand in `eastus2`, Linux amd64, Node `v22.22.2`, pnpm `10.33.2`, repo branch `fix/gemini-thought-signature-replay` at `826de52bec9d24469dc245b88b5e00a964c2050f`.
- **Exact steps or command run after this patch:** Synced the PR checkout to the Azure Crabbox VM, installed Node 22 and pnpm 10.33.2, then ran:

```sh
pnpm install --frozen-lockfile
pnpm exec oxfmt --check --threads=1 extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts
pnpm test extensions/google/transport-stream.test.ts
pnpm check:test-types
```

- **Evidence after fix:** Terminal output from the Azure Crabbox run showed the real remote environment and command output:

```text
provisioning provider=azure lease=cbx_ace9a5d36d50 slug=swift-krill class=standard preferred_type=Standard_D8ads_v6 location=eastus2 rg=crabbox-leases-eastus2 keep=false
provisioned lease=cbx_ace9a5d36d50 server=crabbox-swift-krill-2b8202d3 type=Standard_D8ads_v6
running on 20.62.109.43 set -euxo pipefail
+ node --version
v22.22.2
+ pnpm --version
10.33.2
+ env CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 pnpm exec oxfmt --check --threads=1 extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts
Checking formatting...
All matched files use the correct format.
+ env CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 pnpm test extensions/google/transport-stream.test.ts
✓ extension-providers extensions/google/transport-stream.test.ts (39 tests) 3394ms
Test Files 1 passed (1)
Tests 39 passed (39)
+ env CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 pnpm check:test-types
command complete in 1m51.073s total=2m11.191s
run summary sync=19.577s command=1m51.073s total=2m11.191s sync_skipped=false exit=0
{"provider":"azure","leaseId":"cbx_ace9a5d36d50","slug":"swift-krill","exitCode":0}
```

- **Observed result after fix:** The Google transport regression suite passed on the remote Linux VM, including the route-exact replay and fallback-preservation cases; test typecheck and formatter also passed. Azure cleanup completed after validation; only shared VNet/NSG resources remain in the Crabbox resource groups.
- **What was not tested:** No additional live paid Gemini API call was made for this final hygiene commit. The PR still relies on the linked issue's direct Gemini replay repro plus the existing PR body's earlier built-dist live Gemini evidence for the paid API behavior; this final run verifies the OpenClaw transport behavior and regression tests on a real remote Linux setup.
