### PR TITLE
fix(slack): wake interactive reply sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - Feishu: auto-thread `message(action="send")` replies inside the topic when the active session is group_topic or group_topic_sender, and propagate `replyInThread` through text, card, and media outbound adapters so topic-scoped sessions no longer post at the group root. Fixes #74903. (#77151) Thanks @ai-hpc.
 - WhatsApp: pass routing context into voice-note transcript echo preflight so echoed transcripts can deliver to the originating chat. Fixes #79778. (#79788) Thanks @hclsys.
 - Cron/failover: classify structured OpenAI-compatible `server_error` payloads as `server_error`, expose that reason in cron state, and let one-shot cron retry policy honor `retryOn: ["server_error"]` without requiring raw `5xx` text. (#45594) Thanks @clovericbot.
+- Slack: wake the resolved thread session after interactive reply button/select clicks and carry Slack delivery context through the queued interaction event, so clicks continue the visible conversation. Fixes #79676 and #61502. (#79836) Thanks @velvet-shark, @tianxiaochannel-oss88, and @Saicheg.
 
 ## 2026.5.9
 
@@ -174,7 +175,6 @@ Docs: https://docs.openclaw.ai
 
 - Memory: close temp SQLite handles before failed atomic reindex cleanup and retry Windows EBUSY/EPERM/EACCES temp file removals, so `memory index --force` does not abort or leave temp sidecars on locked filesystems. Fixes #79708. Thanks @LobsterFarmerAmp and @hclsys.
 - Agents/CLI: add an explicit `reseedFromRawTranscriptWhenUncompacted` backend opt-in so safe invalidated CLI sessions can reseed from a bounded raw OpenClaw transcript tail before compaction while auth-boundary resets remain no-raw. Fixes #79713. (#79764) Thanks @hclsys.
-- Slack: wake the resolved thread session after interactive reply button/select clicks and carry Slack delivery context through the queued interaction event, so clicks continue the visible conversation. Fixes #79676 and #61502. Thanks @tianxiaochannel-oss88 and @Saicheg.
 - Agents/CLI: handle resumed CLI JSONL output and bound supervisor output buffering so resumed runs stay readable without letting noisy child output grow unbounded.
 - Codex app-server: honor per-call `timeoutMs`, configured `image_generate` timeouts, and media image-understanding timeouts for dynamic tool calls, capped at 600000 ms, so slow image generation and image analysis no longer fail at the 30s bridge default. Fixes #79810. Thanks @omarshahine.
 - Agents/sandbox: include the container workspace path hint in sandbox-root escape errors while preserving shortened host workspace roots. Fixes #79712. Thanks @haumanto and @hclsys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@ Docs: https://docs.openclaw.ai
 
 - Memory: close temp SQLite handles before failed atomic reindex cleanup and retry Windows EBUSY/EPERM/EACCES temp file removals, so `memory index --force` does not abort or leave temp sidecars on locked filesystems. Fixes #79708. Thanks @LobsterFarmerAmp and @hclsys.
 - Agents/CLI: add an explicit `reseedFromRawTranscriptWhenUncompacted` backend opt-in so safe invalidated CLI sessions can reseed from a bounded raw OpenClaw transcript tail before compaction while auth-boundary resets remain no-raw. Fixes #79713. (#79764) Thanks @hclsys.
+- Slack: wake the resolved thread session after interactive reply button/select clicks and carry Slack delivery context through the queued interaction event, so clicks continue the visible conversation. Fixes #79676 and #61502. Thanks @tianxiaochannel-oss88 and @Saicheg.
 - Agents/CLI: handle resumed CLI JSONL output and bound supervisor output buffering so resumed runs stay readable without letting noisy child output grow unbounded.
 - Codex app-server: honor per-call `timeoutMs`, configured `image_generate` timeouts, and media image-understanding timeouts for dynamic tool calls, capped at 600000 ms, so slow image generation and image analysis no longer fail at the 30s bridge default. Fixes #79810. Thanks @omarshahine.
 - Agents/sandbox: include the container workspace path hint in sandbox-root escape errors while preserving shortened host workspace roots. Fixes #79712. Thanks @haumanto and @hclsys.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-1aa92e012261d21474fde2aea8b1724bea369b5bc730e9fb943ff82de73f38de  plugin-sdk-api-baseline.json
-f076fb0cc1d09b5d50502741428e88a52725d73db950745801ae4fe782d709e2  plugin-sdk-api-baseline.jsonl
+fce2653618d6a41bd46fd4503b66f8ad912b9abee111cda24661ea1629c293b2  plugin-sdk-api-baseline.json
+5d73209fe60e9ab89296242d1921d43d6b385d113155c17d31bf0bf174ad964c  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -427,7 +427,7 @@ releases.
     | Need | Import |
     | --- | --- |
     | System event queue helpers | `openclaw/plugin-sdk/system-event-runtime` |
-    | Heartbeat event and visibility helpers | `openclaw/plugin-sdk/heartbeat-runtime` |
+    | Heartbeat wake, event, and visibility helpers | `openclaw/plugin-sdk/heartbeat-runtime` |
     | Pending delivery queue drain | `openclaw/plugin-sdk/delivery-queue-runtime` |
     | Channel activity telemetry | `openclaw/plugin-sdk/channel-activity-runtime` |
     | In-memory dedupe caches | `openclaw/plugin-sdk/dedupe-runtime` |
@@ -545,7 +545,7 @@ releases.
   | `plugin-sdk/ssrf-policy` | SSRF policy helpers | Host allowlist and private-network policy helpers |
   | `plugin-sdk/ssrf-runtime` | SSRF runtime helpers | Pinned-dispatcher, guarded fetch, SSRF policy helpers |
   | `plugin-sdk/system-event-runtime` | System event helpers | `enqueueSystemEvent`, `peekSystemEventEntries` |
-  | `plugin-sdk/heartbeat-runtime` | Heartbeat helpers | Heartbeat event and visibility helpers |
+  | `plugin-sdk/heartbeat-runtime` | Heartbeat helpers | Heartbeat wake, event, and visibility helpers |
   | `plugin-sdk/delivery-queue-runtime` | Delivery queue helpers | `drainPendingDeliveries` |
   | `plugin-sdk/channel-activity-runtime` | Channel activity helpers | `recordChannelActivity` |
   | `plugin-sdk/dedupe-runtime` | Dedupe helpers | In-memory dedupe caches |

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -238,7 +238,7 @@ For the plugin authoring guide, see [Plugin SDK overview](/plugins/sdk-overview)
     | `plugin-sdk/dedupe-runtime` | In-memory dedupe cache helpers |
     | `plugin-sdk/delivery-queue-runtime` | Outbound pending-delivery drain helper |
     | `plugin-sdk/file-access-runtime` | Safe local-file and media-source path helpers |
-    | `plugin-sdk/heartbeat-runtime` | Heartbeat event and visibility helpers |
+    | `plugin-sdk/heartbeat-runtime` | Heartbeat wake, event, and visibility helpers |
     | `plugin-sdk/number-runtime` | Numeric coercion helper |
     | `plugin-sdk/secure-random-runtime` | Secure token/UUID helpers |
     | `plugin-sdk/system-event-runtime` | System event queue helpers |

--- a/extensions/slack/src/monitor/context.test.ts
+++ b/extensions/slack/src/monitor/context.test.ts
@@ -83,3 +83,18 @@ describe("createSlackMonitorContext shouldDropMismatchedSlackEvent", () => {
     ).toBe(false);
   });
 });
+
+describe("createSlackMonitorContext resolveSlackSystemEventSessionKey", () => {
+  it("routes threaded interaction events to the Slack thread session", () => {
+    const ctx = createTestContext();
+
+    expect(
+      ctx.resolveSlackSystemEventSessionKey({
+        channelId: "C_THREAD",
+        channelType: "channel",
+        senderId: "U_CLICKER",
+        threadTs: "1712345678.123456",
+      }),
+    ).toBe("agent:main:slack:channel:c_thread:thread:1712345678.123456");
+  });
+});

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -7,10 +7,12 @@ import type {
 } from "openclaw/plugin-sdk/config-types";
 import type { SessionScope } from "openclaw/plugin-sdk/config-types";
 import type { DmPolicy, GroupPolicy } from "openclaw/plugin-sdk/config-types";
+import { resolveRuntimeConversationBindingRoute } from "openclaw/plugin-sdk/conversation-runtime";
 import { createDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
+import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -78,6 +80,7 @@ export type SlackMonitorContext = {
     channelId?: string | null;
     channelType?: string | null;
     senderId?: string | null;
+    threadTs?: string | null;
   }) => string;
   isChannelAllowed: (params: {
     channelId?: string;
@@ -178,6 +181,7 @@ export function createSlackMonitorContext(params: {
     channelId?: string | null;
     channelType?: string | null;
     senderId?: string | null;
+    threadTs?: string | null;
   }) => {
     const channelId = normalizeOptionalString(p.channelId) ?? "";
     if (!channelId) {
@@ -207,18 +211,58 @@ export function createSlackMonitorContext(params: {
           teamId: params.teamId,
           peer: { kind: peerKind, id: peerId },
         });
-        return route.sessionKey;
+        const threadTs = normalizeOptionalString(p.threadTs);
+        const baseConversationId = isDirectMessage ? `user:${senderId}` : channelId;
+        const threadBindingRoute = threadTs
+          ? resolveRuntimeConversationBindingRoute({
+              route,
+              conversation: {
+                channel: "slack",
+                accountId: params.accountId,
+                conversationId: threadTs,
+                parentConversationId: baseConversationId,
+              },
+            })
+          : null;
+        const runtimeRoute =
+          threadBindingRoute?.boundSessionKey || threadBindingRoute?.bindingRecord
+            ? threadBindingRoute
+            : resolveRuntimeConversationBindingRoute({
+                route,
+                conversation: {
+                  channel: "slack",
+                  accountId: params.accountId,
+                  conversationId: baseConversationId,
+                },
+              });
+        if (runtimeRoute.boundSessionKey) {
+          return runtimeRoute.route.sessionKey;
+        }
+        return resolveThreadSessionKeys({
+          baseSessionKey: runtimeRoute.route.sessionKey,
+          threadId: threadTs,
+          parentSessionKey:
+            threadTs && params.threadInheritParent ? runtimeRoute.route.sessionKey : undefined,
+        }).sessionKey;
       }
     } catch {
       // Fall through to legacy key derivation.
     }
 
-    return resolveSessionKey(
+    const legacySessionKey = resolveSessionKey(
       params.sessionScope,
       { From: from, ChatType: chatType, Provider: "slack" },
       params.mainKey,
       resolveDefaultAgentId(params.cfg),
     );
+    return resolveThreadSessionKeys({
+      baseSessionKey: legacySessionKey,
+      threadId: normalizeOptionalString(p.threadTs),
+      parentSessionKey:
+        normalizeOptionalString(p.threadTs) && params.threadInheritParent
+          ? legacySessionKey
+          : undefined,
+    }).sessionKey;
   };
 
   const resolveChannelName = async (channelId: string) => {

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -6,6 +6,7 @@ import {
   resolveCommandAuthorization,
   resolveCommandAuthorizedFromAuthorizers,
 } from "openclaw/plugin-sdk/command-auth-native";
+import { requestHeartbeat } from "openclaw/plugin-sdk/heartbeat-runtime";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import {
@@ -778,6 +779,7 @@ function enqueueSlackBlockActionEvent(params: {
     channelId: params.parsed.channelId,
     channelType: params.auth.channelType,
     senderId: params.parsed.userId,
+    threadTs: params.parsed.threadTs,
   });
   const contextParts = [
     "slack:interaction",
@@ -785,10 +787,31 @@ function enqueueSlackBlockActionEvent(params: {
     params.parsed.messageTs,
     params.parsed.actionId,
   ].filter(Boolean);
-  enqueueSystemEvent(params.formatSystemEvent(eventPayload), {
+  const queued = enqueueSystemEvent(params.formatSystemEvent(eventPayload), {
     sessionKey,
     contextKey: contextParts.join(":"),
+    deliveryContext: {
+      channel: "slack",
+      to:
+        params.auth.channelType === "im"
+          ? `user:${params.parsed.userId}`
+          : params.parsed.channelId
+            ? `channel:${params.parsed.channelId}`
+            : undefined,
+      accountId: params.ctx.accountId,
+      threadId: params.parsed.threadTs,
+    },
+    trusted: false,
   });
+  if (queued) {
+    requestHeartbeat({
+      source: "hook",
+      intent: "immediate",
+      reason: "hook:slack-interaction",
+      sessionKey,
+      heartbeat: { target: "last" },
+    });
+  }
 }
 
 function buildSlackConfirmationBlocks(params: {

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const enqueueSystemEventMock = vi.hoisted(() => vi.fn());
+const requestHeartbeatMock = vi.hoisted(() => vi.fn());
 type DispatchPluginInteractiveHandlerResult = {
   matched: boolean;
   handled: boolean;
@@ -26,6 +27,14 @@ vi.mock("openclaw/plugin-sdk/system-event-runtime", async (importOriginal) => {
   return {
     ...actual,
     enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/heartbeat-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/heartbeat-runtime")>();
+  return {
+    ...actual,
+    requestHeartbeat: (...args: unknown[]) => requestHeartbeatMock(...args),
   };
 });
 
@@ -307,7 +316,9 @@ describe("registerSlackInteractionEvents", () => {
   });
 
   beforeEach(() => {
-    enqueueSystemEventMock.mockClear();
+    enqueueSystemEventMock.mockReset();
+    enqueueSystemEventMock.mockReturnValue(true);
+    requestHeartbeatMock.mockClear();
     dispatchPluginInteractiveHandlerMock.mockClear();
     resolvePluginConversationBindingApprovalMock.mockClear();
     resolvePluginConversationBindingApprovalMock.mockResolvedValue({ status: "expired" });
@@ -394,6 +405,7 @@ describe("registerSlackInteractionEvents", () => {
       channelId: "C1",
       channelType: "channel",
       senderId: "U123",
+      threadTs: "100.100",
     });
     expect(trackEvent).toHaveBeenCalledTimes(1);
     expect(app.client.chat.update).toHaveBeenCalledTimes(1);
@@ -642,7 +654,7 @@ describe("registerSlackInteractionEvents", () => {
   });
 
   it("treats Slack reply buttons as plain interaction events instead of plugin dispatch", async () => {
-    const { ctx, app, getHandler } = createContext();
+    const { ctx, app, getHandler, resolveSessionKey } = createContext();
     registerSlackInteractionEvents({ ctx: ctx as never });
 
     const handler = getHandler();
@@ -679,8 +691,31 @@ describe("registerSlackInteractionEvents", () => {
     expect(dispatchPluginInteractiveHandlerMock).not.toHaveBeenCalled();
     expect(enqueueSystemEventMock).toHaveBeenCalledWith(
       expect.stringContaining('"actionId":"openclaw:reply_button"'),
-      expect.any(Object),
+      expect.objectContaining({
+        contextKey: "slack:interaction:C1:100.200:openclaw:reply_button",
+        deliveryContext: {
+          accountId: "default",
+          channel: "slack",
+          threadId: "100.100",
+          to: "channel:C1",
+        },
+        sessionKey: "agent:ops:slack:channel:C1",
+        trusted: false,
+      }),
     );
+    expect(resolveSessionKey).toHaveBeenCalledWith({
+      channelId: "C1",
+      channelType: "channel",
+      senderId: "U123",
+      threadTs: "100.100",
+    });
+    expect(requestHeartbeatMock).toHaveBeenCalledWith({
+      source: "hook",
+      intent: "immediate",
+      reason: "hook:slack-interaction",
+      sessionKey: "agent:ops:slack:channel:C1",
+      heartbeat: { target: "last" },
+    });
     expect(app.client.chat.update).toHaveBeenCalledTimes(1);
   });
 
@@ -1459,6 +1494,7 @@ describe("registerSlackInteractionEvents", () => {
       channelId: "C222",
       channelType: "channel",
       senderId: "U111",
+      threadTs: "222.111",
     });
     expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
     const [eventText] = enqueueSystemEventMock.mock.calls[0] as [string];

--- a/scripts/pr-lib/push.sh
+++ b/scripts/pr-lib/push.sh
@@ -124,8 +124,12 @@ GRAPHQL
     }}')
   rm -f "$additions_file" "$deletions_file"
 
+  local payload
+  payload=$(jq -n --arg query "$query" --argjson variables "$variables" \
+    '{query: $query, variables: $variables}')
+
   local result
-  result=$(gh api graphql -f query="$query" --input - <<< "$variables" 2>&1) || {
+  result=$(gh api graphql --input - <<< "$payload" 2>&1) || {
     echo "GraphQL push failed: $result" >&2
     return 1
   }

--- a/scripts/pr-lib/push.sh
+++ b/scripts/pr-lib/push.sh
@@ -124,9 +124,14 @@ GRAPHQL
     }}')
   rm -f "$additions_file" "$deletions_file"
 
+  local variables_file
+  variables_file=$(mktemp)
+  printf '%s\n' "$variables" >"$variables_file"
+
   local payload
-  payload=$(jq -n --arg query "$query" --argjson variables "$variables" \
-    '{query: $query, variables: $variables}')
+  payload=$(jq -n --arg query "$query" --slurpfile variables "$variables_file" \
+    '{query: $query, variables: $variables[0]}')
+  rm -f "$variables_file"
 
   local result
   result=$(gh api graphql --input - <<< "$payload" 2>&1) || {

--- a/scripts/pr-lib/push.sh
+++ b/scripts/pr-lib/push.sh
@@ -102,20 +102,27 @@ mutation($input: CreateCommitOnBranchInput!) {
 GRAPHQL
 )
 
+  local additions_file deletions_file
+  additions_file=$(mktemp)
+  deletions_file=$(mktemp)
+  printf '%s\n' "$additions" >"$additions_file"
+  printf '%s\n' "$deletions" >"$deletions_file"
+
   local variables
   variables=$(jq -n \
     --arg nwo "$repo_nwo" \
     --arg branch "$branch" \
     --arg oid "$expected_oid" \
     --arg headline "$commit_headline" \
-    --argjson additions "$additions" \
-    --argjson deletions "$deletions" \
+    --slurpfile additions "$additions_file" \
+    --slurpfile deletions "$deletions_file" \
     '{input: {
       branch: { repositoryNameWithOwner: $nwo, branchName: $branch },
       message: { headline: $headline },
-      fileChanges: { additions: $additions, deletions: $deletions },
+      fileChanges: { additions: $additions[0], deletions: $deletions[0] },
       expectedHeadOid: $oid
     }}')
+  rm -f "$additions_file" "$deletions_file"
 
   local result
   result=$(gh api graphql -f query="$query" --input - <<< "$variables" 2>&1) || {

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -382,14 +382,17 @@ describe("buildInboundUserContextPrefix", () => {
   });
 
   it("includes formatted timestamp in conversation info when provided", () => {
-    const text = buildInboundUserContextPrefix({
-      ChatType: "group",
-      MessageSid: "msg-with-ts",
-      Timestamp: Date.UTC(2026, 1, 15, 13, 35),
-    } as TemplateContext);
+    const text = buildInboundUserContextPrefix(
+      {
+        ChatType: "group",
+        MessageSid: "msg-with-ts",
+        Timestamp: Date.UTC(2026, 1, 15, 13, 35),
+      } as TemplateContext,
+      { timezone: "utc" },
+    );
 
     const conversationInfo = parseConversationInfoPayload(text);
-    expect(conversationInfo["timestamp"]).toMatch(/^Sun 2026-02-15 13:35 (?:GMT|UTC)$/);
+    expect(conversationInfo["timestamp"]).toBe("Sun 2026-02-15T13:35Z");
   });
 
   it("honors envelope user timezone for conversation timestamps", () => {

--- a/src/plugin-sdk/heartbeat-runtime.ts
+++ b/src/plugin-sdk/heartbeat-runtime.ts
@@ -2,3 +2,4 @@
 
 export * from "../infra/heartbeat-events.js";
 export * from "../infra/heartbeat-visibility.js";
+export { requestHeartbeat } from "../infra/heartbeat-wake.js";

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -204,7 +204,7 @@ describe("version resolution", () => {
     expect(resolveUsableRuntimeVersion(" 2026.3.2 ")).toBe("2026.3.2");
   });
 
-  it("prefers runtime VERSION over service/package markers and ignores blank env values", () => {
+  it("prefers runtime VERSION over service/package markers and ignores unusable env values", () => {
     expect(
       resolveRuntimeServiceVersion({
         OPENCLAW_VERSION: "   ",
@@ -230,6 +230,14 @@ describe("version resolution", () => {
         },
         "fallback",
       ),
+    ).toBe(VERSION);
+
+    expect(
+      resolveRuntimeServiceVersion({
+        OPENCLAW_VERSION: "undefined",
+        OPENCLAW_SERVICE_VERSION: "null",
+        npm_package_version: "1.0.0-package",
+      }),
     ).toBe(VERSION);
   });
 });

--- a/src/version.ts
+++ b/src/version.ts
@@ -48,7 +48,7 @@ function readVersionFromJsonCandidates(
 function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
   for (const value of values) {
     const trimmed = normalizeOptionalString(value);
-    if (trimmed) {
+    if (trimmed && trimmed.toLowerCase() !== "undefined" && trimmed.toLowerCase() !== "null") {
       return trimmed;
     }
   }


### PR DESCRIPTION
## Summary

- Problem: Slack interactive reply buttons/selects were delivered to OpenClaw and logged, but the queued interaction did not reliably wake the active Slack session.
- Why it matters: users could click a visible Slack choice and see no continuation, especially for threaded Slack conversations and approval-style flows.
- What changed: Slack block actions now resolve with `threadTs`, enqueue untrusted interaction events with Slack delivery context, and request an immediate heartbeat for the resolved session when the event queues.
- What did NOT change (scope boundary): exec/plugin approval handling and plugin interactive dispatch keep their existing early-return paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #79676
- Related #61502
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Slack `[[slack_buttons]]` / `[[slack_select]]` interactions should continue the visible Slack conversation instead of only logging the interaction.
- Real environment tested: local macOS checkout with Slack env credentials unavailable.
- Exact steps or command run after this patch: targeted Slack interaction tests and monitor tests listed below.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied local test output in Verification.
- Observed result after fix: reply-button interaction coverage now asserts thread-aware session resolution, Slack delivery context, untrusted system-event enqueue, and immediate heartbeat wake.
- What was not tested: live Slack click-through, because `SLACK_BOT_TOKEN`, `OPENCLAW_SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `OPENCLAW_SLACK_APP_TOKEN`, `SLACK_SIGNING_SECRET`, and `OPENCLAW_SLACK_SIGNING_SECRET` were not present in `~/.profile`.
- Before evidence (optional but encouraged): issue reports show Slack logged `slack:interaction action=openclaw:reply_button...` without a visible continuation.

## Root Cause (if applicable)

- Root cause: Slack block actions were queued as system events after resolving the base Slack session without carrying thread routing into the resolver and without requesting a wake for the resolved session.
- Missing detection / guardrail: existing tests asserted enqueue and message update but did not assert `threadTs`, delivery context, or heartbeat wake behavior.
- Contributing context (if known): #61502 identified the same thread-session routing gap for threaded Slack button flows.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/slack/src/monitor/events/interactions.test.ts`, `extensions/slack/src/monitor/context.test.ts`
- Scenario the test should lock in: a Slack reply-button click with `container.thread_ts` queues to the resolved session with delivery context and requests a heartbeat wake.
- Why this is the smallest reliable guardrail: it exercises the Slack-owned interaction ingestion path without requiring live Slack infrastructure.
- Existing test that already covers this (if any): none; existing coverage stopped at enqueue/update assertions.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Slack interactive reply button/select clicks now wake the resolved Slack session so the current conversation can continue visibly.

## Diagram (if applicable)

```text
Before:
Slack click -> system event queued -> no immediate session wake

After:
Slack click -> thread-aware session resolution -> system event + delivery context -> immediate heartbeat wake
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Slack
- Relevant config (redacted): interactive replies path; live Slack tokens unavailable locally

### Steps

1. Send a Slack reply directive such as `[[slack_buttons: Approve:approve, Reject:reject]]`.
2. Click an option in a Slack thread.
3. The interaction handler queues the structured event and wakes the resolved Slack session.

### Expected

- The click routes to the current Slack session/thread and continues the turn.

### Actual

- Fixed by this PR; automated coverage now asserts the wake and routing behavior.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
pnpm test extensions/slack/src/monitor/events/interactions.test.ts extensions/slack/src/monitor/context.test.ts
Test Files  2 passed (2)
Tests  39 passed (39)

pnpm test extensions/slack/src/monitor/monitor.test.ts
Test Files  1 passed (1)
Tests  24 passed (24)

pnpm plugin-sdk:api:check
OK docs/.generated/plugin-sdk-api-baseline.sha256

pnpm docs:check-mdx
Docs MDX check passed (627 files)

git diff --check HEAD~1..HEAD
passed
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Slack reply-button interaction enqueue/wake behavior, Slack thread session-key resolution, Slack monitor adjacent tests, Plugin SDK API baseline, docs MDX validity, whitespace check.
- Edge cases checked: interactions only request wake when `enqueueSystemEvent` returns queued; plugin/approval paths still return before the generic reply event path.
- What you did **not** verify: live Slack click-through and broad `pnpm check:changed`; Crabbox/Blacksmith Testbox CLI was not installed in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: waking on duplicate consecutive interaction events could create extra turns.
  - Mitigation: the heartbeat request only runs when `enqueueSystemEvent` reports that a new event was queued.
