### PR TITLE
fix(btw): apply provider wrapStreamFn so /btw against Copilot adds IDE headers

### DIFF
--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -19,6 +19,7 @@ const resolveSessionAgentIdsMock = vi.fn();
 const resolveAgentWorkspaceDirMock = vi.fn();
 const listAgentEntriesMock = vi.fn();
 const prepareProviderRuntimeAuthMock = vi.fn();
+const wrapProviderStreamFnMock = vi.fn();
 const registerProviderStreamForModelMock = vi.fn();
 const diagDebugMock = vi.fn();
 
@@ -76,6 +77,7 @@ vi.mock("./agent-scope.js", () => ({
 
 vi.mock("../plugins/provider-runtime.js", () => ({
   prepareProviderRuntimeAuth: (...args: unknown[]) => prepareProviderRuntimeAuthMock(...args),
+  wrapProviderStreamFn: (...args: unknown[]) => wrapProviderStreamFnMock(...args),
 }));
 
 vi.mock("./provider-stream.js", () => ({
@@ -302,6 +304,10 @@ describe("runBtwSideQuestion", () => {
     resolveAgentWorkspaceDirMock.mockReset();
     listAgentEntriesMock.mockReset();
     prepareProviderRuntimeAuthMock.mockReset();
+    wrapProviderStreamFnMock.mockReset();
+    // Default to no-op wrapping; tests that care about the wrapped fn can
+    // override the mock individually.
+    wrapProviderStreamFnMock.mockReturnValue(undefined);
     registerProviderStreamForModelMock.mockReset();
     diagDebugMock.mockReset();
 
@@ -526,6 +532,45 @@ describe("runBtwSideQuestion", () => {
 
     expect(result).toEqual({ text: "Fallback answer." });
     expect(streamSimpleMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies the provider plugin's wrapStreamFn so /btw against Copilot adds Editor-Version headers", async () => {
+    // Regression: before this fix, /btw called the base provider stream fn
+    // (or streamSimple) without invoking wrapProviderStreamFn, so github-
+    // copilot models bypassed buildCopilotIdeHeaders and the Copilot API
+    // returned 400 "missing Editor-Version header for IDE auth".
+    resolveModelWithRegistryMock.mockReturnValue({
+      provider: "github-copilot",
+      id: "claude-opus-4.7-1m-internal",
+      api: "anthropic-messages",
+      baseUrl: "https://api.individual.githubcopilot.com",
+    });
+    const baseStreamFn = vi.fn();
+    const wrappedStreamFn = vi
+      .fn()
+      .mockReturnValue(makeAsyncEvents([createDoneEvent("Copilot answer.")]));
+    registerProviderStreamForModelMock.mockReturnValue(baseStreamFn);
+    wrapProviderStreamFnMock.mockReturnValue(wrappedStreamFn);
+
+    const result = await runSideQuestion({
+      provider: "github-copilot",
+      model: "claude-opus-4.7-1m-internal",
+    });
+
+    expect(result).toEqual({ text: "Copilot answer." });
+    expect(wrapProviderStreamFnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "github-copilot",
+        context: expect.objectContaining({
+          provider: "github-copilot",
+          modelId: "claude-opus-4.7-1m-internal",
+          streamFn: baseStreamFn,
+        }),
+      }),
+    );
+    expect(wrappedStreamFn).toHaveBeenCalledTimes(1);
+    expect(baseStreamFn).not.toHaveBeenCalled();
+    expect(streamSimpleMock).not.toHaveBeenCalled();
   });
 
   it("strips injected empty tools arrays from BTW payloads before sending", async () => {

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -12,7 +12,7 @@ import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import type { ReasoningLevel, ThinkLevel } from "../auto-reply/thinking.js";
 import type { SessionEntry as StoredSessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { prepareProviderRuntimeAuth } from "../plugins/provider-runtime.js";
+import { prepareProviderRuntimeAuth, wrapProviderStreamFn } from "../plugins/provider-runtime.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "./agent-scope.js";
 import { resolveSessionAuthProfileOverride } from "./auth-profiles/session-override.js";
@@ -397,13 +397,35 @@ export async function runBtwSideQuestion(
   // `/api/chat` or `/v1/chat/completions` paths based on api mode) construct
   // URLs correctly. Without this, streamSimple hits the provider's baseUrl
   // directly and 404s on endpoints like Ollama Cloud (#68336).
-  const providerStreamFn = registerProviderStreamForModel({
+  const providerStreamBase = registerProviderStreamForModel({
     model: runtimeModel,
     cfg: params.cfg,
     agentDir: params.agentDir,
     workspaceDir,
     env: process.env,
   });
+  // Apply the provider plugin's wrapStreamFn (e.g. github-copilot's IDE
+  // header injection). Without this, /btw against Copilot models fails with
+  // "400 bad request: missing Editor-Version header for IDE auth" because the
+  // base stream fn is the raw transport-aware fn that doesn't add the
+  // Editor-Version / Editor-Plugin-Version / User-Agent headers Copilot
+  // requires for /chat/completions.
+  const providerStreamWrapped = wrapProviderStreamFn({
+    provider: model.provider,
+    config: params.cfg,
+    workspaceDir,
+    env: process.env,
+    context: {
+      config: params.cfg,
+      agentDir: params.agentDir,
+      workspaceDir,
+      provider: model.provider,
+      modelId: model.id,
+      model: runtimeModel,
+      streamFn: providerStreamBase,
+    },
+  });
+  const providerStreamFn = providerStreamWrapped ?? providerStreamBase;
 
   const chunker =
     params.opts?.onBlockReply && params.blockReplyChunking


### PR DESCRIPTION
## Problem

`/btw` side-questions against any github-copilot model fail with:

```
400 bad request: missing Editor-Version header for IDE auth
```

Reproducible on `2026.5.7` with `claude-opus-4.7-1m-internal` and any other Copilot model. The bot is otherwise healthy - regular agent turns work fine, only `/btw` is affected.

## Root cause

`/btw` builds its own minimal stream pipeline via `registerProviderStreamForModel` (in `src/agents/provider-stream.ts`), which only resolves the provider plugin's `createStreamFn` hook. It does **not** invoke `wrapProviderStreamFn`.

The github-copilot plugin only registers `wrapStreamFn`, not `createStreamFn`:

```ts
// extensions/github-copilot/index.ts
{
  ...
  wrapStreamFn: wrapCopilotProviderStream,  // injects buildCopilotDynamicHeaders
}
```

`wrapCopilotProviderStream` (in `extensions/github-copilot/stream.ts`) is what calls `buildCopilotDynamicHeaders` → `buildCopilotIdeHeaders`, which adds the required `Editor-Version`, `Editor-Plugin-Version`, and `User-Agent` headers for `/chat/completions` IDE auth.

Result: `/btw` falls through to `createTransportAwareStreamFnForModel` and bypasses the IDE header layer entirely. The regular embedded runner path goes through `extra-params.ts:817` where `wrapProviderStreamFn` IS invoked, which is why normal agent turns work.

## Fix

After resolving the base provider stream in `btw.ts`, run it through `wrapProviderStreamFn` to apply the github-copilot wrapper (and any other provider wrappers like Anthropic ephemeral cache markers). Falls back to the unwrapped base stream when no plugin wrapper is registered, so non-Copilot providers (Ollama, etc.) keep their existing behavior.

## Test plan

- New regression test in `src/agents/btw.test.ts`: "applies the provider plugin's wrapStreamFn so /btw against Copilot adds Editor-Version headers"
- Verifies that `wrapProviderStreamFn` is called with the github-copilot context, that the wrapped stream fn is the one actually invoked, and that the base stream is NOT called directly.
- All 26 tests pass (was 25, +1).

```
$ pnpm test -- src/agents/btw.test.ts
✓ agents src/agents/btw.test.ts (26 tests) 46ms
Test Files  1 passed (1)
     Tests  26 passed (26)
```

## Real environment validation

Built locally on top of `v2026.5.7` and deployed to my live install. After the fix `/btw` against `claude-opus-4.7-1m-internal` returns answers normally. Before the fix the same setup returned the 400 every time.

