### PR TITLE
Add /context map treemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Context: add `/context map` to send a treemap image of the current session context contributors. (#79867)
 - Plugin SDK: deprecate public subpaths that existed for at least one month and have no bundled extension production imports, keep legacy barrel/test/zod subpath package exports for backwards compatibility, and track both sets in the SDK surface report.
 - Plugin SDK: deprecate public subpaths currently used by only one or two bundled plugin owners, keeping them importable while steering new plugin code to focused shared SDK seams or plugin-owned APIs.
 - Plugin SDK: remove the owner-specific `provider-auth-login` public subpath after moving Chutes, GitHub Copilot, and OpenAI Codex auth flows back to provider-owned modules.

--- a/docs/concepts/context.md
+++ b/docs/concepts/context.md
@@ -22,6 +22,7 @@ Context is _not the same thing_ as "memory": memory can be stored on disk and re
 - `/status` → quick "how full is my window?" view + session settings.
 - `/context list` → what's injected + rough sizes (per file + totals).
 - `/context detail` → deeper breakdown: per-file, per-tool schema sizes, per-skill entry sizes, and system prompt size.
+- `/context map` → WinDirStat-style treemap image of the current session's tracked context contributors.
 - `/usage tokens` → append per-reply usage footer to normal replies.
 - `/compact` → summarize older history into a compact entry to free window space.
 
@@ -73,6 +74,17 @@ Top tools (schema size):
 - exec: 6,240 chars (~1,560 tok)
 … (+N more tools)
 ```
+
+### `/context map`
+
+Sends an image generated from the same report as `/context list` and `/context detail`. Rectangle area is proportional to tracked prompt characters:
+
+- injected workspace files
+- base system prompt text
+- skill prompt entries
+- tool JSON schemas
+
+The caption shows whether the map came from the latest run-built report or from an on-demand estimate.
 
 ## What counts toward the context window
 

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -156,7 +156,7 @@ Current source-of-truth:
     - `/diagnostics [note]` is the owner-only support-report flow for Gateway bugs and Codex harness runs. It asks for explicit exec approval every time before running `openclaw gateway diagnostics export --json`; do not approve diagnostics with an allow-all rule. After approval, it sends a pasteable report with the local bundle path, manifest summary, privacy notes, and relevant session ids. In group chats, the approval prompt and report go to the owner privately. When the active session uses the OpenAI Codex harness, the same approval also sends relevant Codex feedback to OpenAI servers and the completed reply lists the OpenClaw session ids, Codex thread ids, and `codex resume <thread-id>` commands. See [Diagnostics Export](/gateway/diagnostics).
     - `/crestodian <request>` runs the Crestodian setup and repair helper from an owner DM.
     - `/tasks` lists active/recent background tasks for the current session.
-    - `/context [list|detail|json]` explains how context is assembled.
+    - `/context [list|detail|map|json]` explains how context is assembled. `map` sends a treemap image of the current session context.
     - `/whoami` shows your sender id. Alias: `/id`.
     - `/usage off|tokens|full|cost` controls the per-response usage footer or prints a local cost summary.
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -7,6 +7,7 @@ import {
   embeddedAgentLog,
   nativeHookRelayTesting,
   onAgentEvent,
+  queueAgentHarnessMessage,
   resetAgentEventsForTest,
   type AgentEventPayload,
   type EmbeddedRunAttemptParams,
@@ -17,12 +18,11 @@ import {
 } from "openclaw/plugin-sdk/hook-runtime";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { queueEmbeddedPiMessageWithOutcome } from "../../../../src/agents/pi-embedded-runner/runs.js";
 
 function queueActiveRunMessageForTest(
-  ...args: Parameters<typeof queueEmbeddedPiMessageWithOutcome>
+  ...args: Parameters<typeof queueAgentHarnessMessage>
 ): boolean {
-  return queueEmbeddedPiMessageWithOutcome(...args).queued;
+  return queueAgentHarnessMessage(...args);
 }
 import { CODEX_GPT5_BEHAVIOR_CONTRACT } from "../../prompt-overlay.js";
 import {

--- a/src/auto-reply/reply/commands-context-report.test.ts
+++ b/src/auto-reply/reply/commands-context-report.test.ts
@@ -1,3 +1,4 @@
+import { readFile, unlink } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
 import { buildContextReply } from "./commands-context-report.js";
@@ -154,5 +155,31 @@ describe("buildContextReply", () => {
     expect(result.text).toContain("Actual context usage (cached): 900 tok");
     expect(result.text).toContain("Session tokens (cached): 900 total / ctx=8,192");
     expect(result.text).not.toContain("Actual context usage (cached): 111 tok");
+  });
+
+  it("renders context map as sensitive local PNG media", async () => {
+    const result = await buildContextReply(
+      makeParams("/context map", false, {
+        contextTokens: 8_192,
+        totalTokens: 900,
+      }),
+    );
+    if (!result.mediaUrl) {
+      throw new Error("missing context map media path");
+    }
+    try {
+      const png = await readFile(result.mediaUrl);
+      expect(result.text).toContain("Context treemap");
+      expect(result.text).toContain("Source: run");
+      expect(result.text).toContain("Actual cached context: 900 tok");
+      expect(result.trustedLocalMedia).toBe(true);
+      expect(result.sensitiveMedia).toBe(true);
+      expect(png.subarray(0, 8)).toEqual(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
+      expect(png.subarray(12, 16).toString("ascii")).toBe("IHDR");
+      expect(png.readUInt32BE(16)).toBe(1280);
+      expect(png.readUInt32BE(20)).toBe(860);
+    } finally {
+      await unlink(result.mediaUrl);
+    }
   });
 });

--- a/src/auto-reply/reply/commands-context-report.ts
+++ b/src/auto-reply/reply/commands-context-report.ts
@@ -12,6 +12,7 @@ import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { estimateTokensFromChars } from "../../utils/cjk-chars.js";
 import type { ReplyPayload } from "../types.js";
 import type { HandleCommandsParams } from "./commands-types.js";
+import { renderContextTreemapPng } from "./context-treemap.js";
 
 function formatInt(n: number): string {
   return new Intl.NumberFormat("en-US").format(n);
@@ -91,6 +92,7 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
         "Try:",
         "- /context list   (short breakdown)",
         "- /context detail (per-file + per-tool + per-skill + system prompt size)",
+        "- /context map    (WinDirStat-style treemap image)",
         "- /context json   (same, machine-readable)",
         "",
         "Inline shortcut = a command token inside a normal message (e.g. “hey /status”). It runs immediately (allowlisted senders only) and is stripped before the model sees the remaining text.",
@@ -112,11 +114,27 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
     return { text: JSON.stringify({ report, session }, null, 2) };
   }
 
+  if (sub === "map") {
+    const treemap = await renderContextTreemapPng({
+      report,
+      session: {
+        cachedContextTokens: cachedContextUsageTokens ?? null,
+        contextWindowTokens: session.contextTokens,
+      },
+    });
+    return {
+      text: treemap.caption,
+      mediaUrl: treemap.path,
+      trustedLocalMedia: true,
+      sensitiveMedia: true,
+    };
+  }
+
   if (sub !== "list" && sub !== "show" && sub !== "detail" && sub !== "deep") {
     return {
       text: [
         "Unknown /context mode.",
-        "Use: /context, /context list, /context detail, or /context json",
+        "Use: /context, /context list, /context detail, /context map, or /context json",
       ].join("\n"),
     };
   }

--- a/src/auto-reply/reply/context-treemap.ts
+++ b/src/auto-reply/reply/context-treemap.ts
@@ -1,0 +1,501 @@
+import crypto from "node:crypto";
+import { writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import zlib from "node:zlib";
+import type { SessionSystemPromptReport } from "../../config/sessions/types.js";
+import { estimateTokensFromChars } from "../../utils/cjk-chars.js";
+
+type Rect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+type Rgba = {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+};
+
+type TreemapLeaf = {
+  name: string;
+  value: number;
+};
+
+type TreemapGroup = {
+  name: string;
+  value: number;
+  color: Rgba;
+  leaves: TreemapLeaf[];
+};
+
+type PositionedItem<T> = {
+  item: T;
+  rect: Rect;
+};
+
+type ContextTreemapSessionStats = {
+  cachedContextTokens: number | null;
+  contextWindowTokens: number | null;
+};
+
+const WIDTH = 1280;
+const HEIGHT = 860;
+const HEADER_HEIGHT = 88;
+const FOOTER_HEIGHT = 54;
+const LEGEND_WIDTH = 274;
+const PADDING = 22;
+const TREEMAP_GAP = 4;
+
+const FONT: Record<string, string[]> = {
+  " ": ["00000", "00000", "00000", "00000", "00000", "00000", "00000"],
+  "-": ["00000", "00000", "00000", "11111", "00000", "00000", "00000"],
+  ".": ["00000", "00000", "00000", "00000", "00000", "01100", "01100"],
+  "/": ["00001", "00010", "00010", "00100", "01000", "01000", "10000"],
+  ":": ["00000", "01100", "01100", "00000", "01100", "01100", "00000"],
+  _: ["00000", "00000", "00000", "00000", "00000", "00000", "11111"],
+  "0": ["01110", "10001", "10011", "10101", "11001", "10001", "01110"],
+  "1": ["00100", "01100", "00100", "00100", "00100", "00100", "01110"],
+  "2": ["01110", "10001", "00001", "00010", "00100", "01000", "11111"],
+  "3": ["11110", "00001", "00001", "01110", "00001", "00001", "11110"],
+  "4": ["00010", "00110", "01010", "10010", "11111", "00010", "00010"],
+  "5": ["11111", "10000", "10000", "11110", "00001", "00001", "11110"],
+  "6": ["00110", "01000", "10000", "11110", "10001", "10001", "01110"],
+  "7": ["11111", "00001", "00010", "00100", "01000", "01000", "01000"],
+  "8": ["01110", "10001", "10001", "01110", "10001", "10001", "01110"],
+  "9": ["01110", "10001", "10001", "01111", "00001", "00010", "01100"],
+  A: ["01110", "10001", "10001", "11111", "10001", "10001", "10001"],
+  B: ["11110", "10001", "10001", "11110", "10001", "10001", "11110"],
+  C: ["01111", "10000", "10000", "10000", "10000", "10000", "01111"],
+  D: ["11110", "10001", "10001", "10001", "10001", "10001", "11110"],
+  E: ["11111", "10000", "10000", "11110", "10000", "10000", "11111"],
+  F: ["11111", "10000", "10000", "11110", "10000", "10000", "10000"],
+  G: ["01111", "10000", "10000", "10111", "10001", "10001", "01110"],
+  H: ["10001", "10001", "10001", "11111", "10001", "10001", "10001"],
+  I: ["01110", "00100", "00100", "00100", "00100", "00100", "01110"],
+  J: ["00001", "00001", "00001", "00001", "10001", "10001", "01110"],
+  K: ["10001", "10010", "10100", "11000", "10100", "10010", "10001"],
+  L: ["10000", "10000", "10000", "10000", "10000", "10000", "11111"],
+  M: ["10001", "11011", "10101", "10101", "10001", "10001", "10001"],
+  N: ["10001", "11001", "10101", "10011", "10001", "10001", "10001"],
+  O: ["01110", "10001", "10001", "10001", "10001", "10001", "01110"],
+  P: ["11110", "10001", "10001", "11110", "10000", "10000", "10000"],
+  Q: ["01110", "10001", "10001", "10001", "10101", "10010", "01101"],
+  R: ["11110", "10001", "10001", "11110", "10100", "10010", "10001"],
+  S: ["01111", "10000", "10000", "01110", "00001", "00001", "11110"],
+  T: ["11111", "00100", "00100", "00100", "00100", "00100", "00100"],
+  U: ["10001", "10001", "10001", "10001", "10001", "10001", "01110"],
+  V: ["10001", "10001", "10001", "10001", "10001", "01010", "00100"],
+  W: ["10001", "10001", "10001", "10101", "10101", "10101", "01010"],
+  X: ["10001", "10001", "01010", "00100", "01010", "10001", "10001"],
+  Y: ["10001", "10001", "01010", "00100", "00100", "00100", "00100"],
+  Z: ["11111", "00001", "00010", "00100", "01000", "10000", "11111"],
+};
+
+function clampByte(value: number): number {
+  return Math.max(0, Math.min(255, Math.round(value)));
+}
+
+function rgba(r: number, g: number, b: number, a = 255): Rgba {
+  return { r, g, b, a };
+}
+
+function mixColor(a: Rgba, b: Rgba, amount: number): Rgba {
+  const t = Math.max(0, Math.min(1, amount));
+  return rgba(
+    a.r + (b.r - a.r) * t,
+    a.g + (b.g - a.g) * t,
+    a.b + (b.b - a.b) * t,
+    a.a + (b.a - a.a) * t,
+  );
+}
+
+function formatInt(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function formatSize(value: number): string {
+  return `${formatInt(value)} CH / ~${formatInt(estimateTokensFromChars(value))} TOK`;
+}
+
+function totalValue(items: Array<{ value: number }>): number {
+  return items.reduce((sum, item) => sum + item.value, 0);
+}
+
+function sanitizeLabel(value: string): string {
+  return value
+    .replace(/[^a-zA-Z0-9/_.:-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toUpperCase();
+}
+
+function truncateLabel(value: string, maxChars: number): string {
+  if (maxChars <= 0) {
+    return "";
+  }
+  if (value.length <= maxChars) {
+    return value;
+  }
+  if (maxChars <= 2) {
+    return value.slice(0, maxChars);
+  }
+  return value.slice(0, maxChars - 1);
+}
+
+function layoutBinary<T extends { value: number }>(rawItems: T[], rect: Rect): PositionedItem<T>[] {
+  const items = rawItems.filter((item) => item.value > 0).toSorted((a, b) => b.value - a.value);
+  if (items.length === 0 || rect.width <= 0 || rect.height <= 0) {
+    return [];
+  }
+  if (items.length === 1) {
+    return [{ item: items[0], rect }];
+  }
+  const total = totalValue(items);
+  let splitIndex = 1;
+  let splitSum = items[0]?.value ?? 0;
+  for (let i = 1; i < items.length - 1; i += 1) {
+    const next = splitSum + items[i].value;
+    if (Math.abs(total / 2 - next) > Math.abs(total / 2 - splitSum)) {
+      break;
+    }
+    splitSum = next;
+    splitIndex = i + 1;
+  }
+  const first = items.slice(0, splitIndex);
+  const second = items.slice(splitIndex);
+  const ratio = splitSum / total;
+  if (rect.width >= rect.height) {
+    const firstWidth = rect.width * ratio;
+    return [
+      ...layoutBinary(first, { ...rect, width: firstWidth }),
+      ...layoutBinary(second, {
+        x: rect.x + firstWidth,
+        y: rect.y,
+        width: rect.width - firstWidth,
+        height: rect.height,
+      }),
+    ];
+  }
+  const firstHeight = rect.height * ratio;
+  return [
+    ...layoutBinary(first, { ...rect, height: firstHeight }),
+    ...layoutBinary(second, {
+      x: rect.x,
+      y: rect.y + firstHeight,
+      width: rect.width,
+      height: rect.height - firstHeight,
+    }),
+  ];
+}
+
+class PngCanvas {
+  readonly data = Buffer.alloc(WIDTH * HEIGHT * 4);
+
+  fill(color: Rgba): void {
+    for (let i = 0; i < this.data.length; i += 4) {
+      this.data[i] = color.r;
+      this.data[i + 1] = color.g;
+      this.data[i + 2] = color.b;
+      this.data[i + 3] = color.a;
+    }
+  }
+
+  rect(rect: Rect, color: Rgba): void {
+    const x0 = Math.max(0, Math.floor(rect.x));
+    const y0 = Math.max(0, Math.floor(rect.y));
+    const x1 = Math.min(WIDTH, Math.ceil(rect.x + rect.width));
+    const y1 = Math.min(HEIGHT, Math.ceil(rect.y + rect.height));
+    for (let y = y0; y < y1; y += 1) {
+      for (let x = x0; x < x1; x += 1) {
+        const offset = (y * WIDTH + x) * 4;
+        this.data[offset] = color.r;
+        this.data[offset + 1] = color.g;
+        this.data[offset + 2] = color.b;
+        this.data[offset + 3] = color.a;
+      }
+    }
+  }
+
+  stroke(rect: Rect, color: Rgba, width: number): void {
+    this.rect({ x: rect.x, y: rect.y, width: rect.width, height: width }, color);
+    this.rect(
+      { x: rect.x, y: rect.y + rect.height - width, width: rect.width, height: width },
+      color,
+    );
+    this.rect({ x: rect.x, y: rect.y, width, height: rect.height }, color);
+    this.rect({ x: rect.x + rect.width - width, y: rect.y, width, height: rect.height }, color);
+  }
+
+  text(x: number, y: number, text: string, color: Rgba, scale: number): void {
+    let cursorX = Math.floor(x);
+    const cursorY = Math.floor(y);
+    for (const rawChar of text) {
+      const char = rawChar.toUpperCase();
+      const glyph = FONT[char] ?? FONT[" "];
+      for (let row = 0; row < glyph.length; row += 1) {
+        const line = glyph[row];
+        for (let col = 0; col < line.length; col += 1) {
+          if (line[col] !== "1") {
+            continue;
+          }
+          this.rect(
+            {
+              x: cursorX + col * scale,
+              y: cursorY + row * scale,
+              width: scale,
+              height: scale,
+            },
+            color,
+          );
+        }
+      }
+      cursorX += 6 * scale;
+    }
+  }
+}
+
+function inset(rect: Rect, padding: number): Rect {
+  return {
+    x: rect.x + padding,
+    y: rect.y + padding,
+    width: Math.max(0, rect.width - padding * 2),
+    height: Math.max(0, rect.height - padding * 2),
+  };
+}
+
+function drawLabel(
+  canvas: PngCanvas,
+  rect: Rect,
+  lines: string[],
+  color: Rgba,
+  scale: number,
+): void {
+  const charWidth = 6 * scale;
+  const lineHeight = 9 * scale;
+  const maxChars = Math.floor((rect.width - 12) / charWidth);
+  const maxLines = Math.floor((rect.height - 12) / lineHeight);
+  if (maxChars < 4 || maxLines < 1) {
+    return;
+  }
+  const clipped = lines
+    .slice(0, maxLines)
+    .map((line) => truncateLabel(sanitizeLabel(line), maxChars));
+  clipped.forEach((line, index) => {
+    canvas.text(rect.x + 7, rect.y + 7 + index * lineHeight, line, color, scale);
+  });
+}
+
+function crc32(buffer: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of buffer) {
+    crc ^= byte;
+    for (let i = 0; i < 8; i += 1) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const typeBuffer = Buffer.from(type, "ascii");
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length, 0);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(Buffer.concat([typeBuffer, data])), 0);
+  return Buffer.concat([length, typeBuffer, data, crc]);
+}
+
+function encodePng(data: Buffer): Buffer {
+  const signature = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(WIDTH, 0);
+  ihdr.writeUInt32BE(HEIGHT, 4);
+  ihdr[8] = 8;
+  ihdr[9] = 6;
+  const stride = WIDTH * 4;
+  const raw = Buffer.alloc((stride + 1) * HEIGHT);
+  for (let y = 0; y < HEIGHT; y += 1) {
+    const rowStart = y * (stride + 1);
+    raw[rowStart] = 0;
+    data.copy(raw, rowStart + 1, y * stride, (y + 1) * stride);
+  }
+  return Buffer.concat([
+    signature,
+    pngChunk("IHDR", ihdr),
+    pngChunk("IDAT", zlib.deflateSync(raw)),
+    pngChunk("IEND", Buffer.alloc(0)),
+  ]);
+}
+
+function treemapGroup(params: { name: string; color: Rgba; leaves: TreemapLeaf[] }): TreemapGroup {
+  return { ...params, value: totalValue(params.leaves) };
+}
+
+function buildGroups(report: SessionSystemPromptReport): TreemapGroup[] {
+  const injectedTotal = report.injectedWorkspaceFiles.reduce(
+    (sum, file) => sum + file.injectedChars,
+    0,
+  );
+  const projectFrameChars = Math.max(0, report.systemPrompt.projectContextChars - injectedTotal);
+  const skillTotal = report.skills.entries.reduce((sum, skill) => sum + skill.blockChars, 0);
+  const systemBaseChars = Math.max(0, report.systemPrompt.nonProjectContextChars - skillTotal);
+  const tools = report.tools.entries
+    .map((tool) => ({ name: tool.name, value: tool.schemaChars ?? 0 }))
+    .filter((tool) => tool.value > 0);
+  const groups = [
+    treemapGroup({
+      name: "Workspace files",
+      color: rgba(58, 145, 91),
+      leaves: [
+        ...report.injectedWorkspaceFiles.map((file) => ({
+          name: file.name,
+          value: file.injectedChars,
+        })),
+        { name: "Project context frame", value: projectFrameChars },
+      ],
+    }),
+    treemapGroup({
+      name: "System prompt",
+      color: rgba(222, 138, 46),
+      leaves: [{ name: "Base instructions", value: systemBaseChars }],
+    }),
+    treemapGroup({
+      name: "Tool schemas",
+      color: rgba(59, 118, 184),
+      leaves: tools,
+    }),
+    treemapGroup({
+      name: "Skills",
+      color: rgba(132, 91, 173),
+      leaves: report.skills.entries.map((skill) => ({
+        name: skill.name,
+        value: skill.blockChars,
+      })),
+    }),
+  ];
+  return groups.filter((group) => group.value > 0);
+}
+
+function drawTreemap(canvas: PngCanvas, groups: TreemapGroup[], rect: Rect): void {
+  const groupRects = layoutBinary(groups, rect);
+  groupRects.forEach(({ item: group, rect: groupRect }, groupIndex) => {
+    const groupFill = mixColor(group.color, rgba(18, 22, 27), 0.16);
+    canvas.rect(groupRect, groupFill);
+    canvas.stroke(groupRect, rgba(14, 18, 22), 3);
+    drawLabel(
+      canvas,
+      { x: groupRect.x + 4, y: groupRect.y + 4, width: groupRect.width - 8, height: 38 },
+      [group.name, formatSize(group.value)],
+      rgba(248, 250, 252),
+      groupRect.width > 260 && groupRect.height > 120 ? 2 : 1,
+    );
+    const childRect = inset(
+      {
+        x: groupRect.x + TREEMAP_GAP,
+        y: groupRect.y + (groupRect.height > 92 ? 44 : TREEMAP_GAP),
+        width: groupRect.width - TREEMAP_GAP * 2,
+        height: groupRect.height - (groupRect.height > 92 ? 48 : TREEMAP_GAP * 2),
+      },
+      0,
+    );
+    const leaves = group.leaves.filter((leaf) => leaf.value > 0);
+    const leafRects = layoutBinary(leaves, childRect);
+    leafRects.forEach(({ item: leaf, rect: leafRect }, leafIndex) => {
+      const shade = (leafIndex % 7) / 10 + (groupIndex % 2) * 0.08;
+      const fill = mixColor(group.color, rgba(255, 255, 255), shade);
+      const inner = inset(leafRect, 1.5);
+      canvas.rect(inner, fill);
+      canvas.stroke(inner, rgba(8, 12, 16), 1);
+      if (inner.width * inner.height > 5200) {
+        const textColor =
+          fill.r * 0.299 + fill.g * 0.587 + fill.b * 0.114 > 150
+            ? rgba(16, 23, 31)
+            : rgba(248, 250, 252);
+        drawLabel(canvas, inner, [leaf.name, formatSize(leaf.value)], textColor, 1);
+      }
+    });
+  });
+}
+
+function drawLegend(canvas: PngCanvas, groups: TreemapGroup[], rect: Rect, total: number): void {
+  canvas.rect(rect, rgba(245, 247, 250));
+  canvas.stroke(rect, rgba(213, 220, 228), 1);
+  canvas.text(rect.x + 18, rect.y + 18, "LEGEND", rgba(30, 41, 59), 2);
+  let y = rect.y + 58;
+  groups.forEach((group) => {
+    canvas.rect({ x: rect.x + 18, y, width: 18, height: 18 }, group.color);
+    canvas.stroke({ x: rect.x + 18, y, width: 18, height: 18 }, rgba(15, 23, 42), 1);
+    const pct = total > 0 ? `${Math.round((group.value / total) * 100)} PCT` : "0 PCT";
+    drawLabel(
+      canvas,
+      { x: rect.x + 46, y: y - 1, width: rect.width - 62, height: 38 },
+      [group.name, pct],
+      rgba(30, 41, 59),
+      1,
+    );
+    y += 54;
+  });
+}
+
+export async function renderContextTreemapPng(params: {
+  report: SessionSystemPromptReport;
+  session: ContextTreemapSessionStats;
+}): Promise<{ path: string; trackedChars: number; caption: string }> {
+  const groups = buildGroups(params.report);
+  const trackedChars = totalValue(groups);
+  const canvas = new PngCanvas();
+  canvas.fill(rgba(238, 241, 245));
+  canvas.rect({ x: 0, y: 0, width: WIDTH, height: HEADER_HEIGHT }, rgba(20, 26, 34));
+  canvas.text(PADDING, 24, "CONTEXT TREEMAP", rgba(248, 250, 252), 3);
+  const sourceLine = `${params.report.source.toUpperCase()} / ${params.report.provider ?? "provider"} / ${params.report.model ?? "model"}`;
+  canvas.text(PADDING, 58, sanitizeLabel(sourceLine), rgba(176, 196, 222), 1);
+  const treemapRect = {
+    x: PADDING,
+    y: HEADER_HEIGHT + PADDING,
+    width: WIDTH - LEGEND_WIDTH - PADDING * 3,
+    height: HEIGHT - HEADER_HEIGHT - FOOTER_HEIGHT - PADDING * 2,
+  };
+  drawTreemap(canvas, groups, treemapRect);
+  drawLegend(
+    canvas,
+    groups,
+    {
+      x: WIDTH - LEGEND_WIDTH - PADDING,
+      y: HEADER_HEIGHT + PADDING,
+      width: LEGEND_WIDTH,
+      height: treemapRect.height,
+    },
+    trackedChars,
+  );
+  const footerY = HEIGHT - FOOTER_HEIGHT + 18;
+  const actual =
+    params.session.cachedContextTokens == null
+      ? "ACTUAL CTX UNKNOWN"
+      : `ACTUAL CTX ${formatInt(params.session.cachedContextTokens)} TOK`;
+  const window =
+    params.session.contextWindowTokens == null || params.session.contextWindowTokens <= 0
+      ? "WINDOW UNKNOWN"
+      : `WINDOW ${formatInt(params.session.contextWindowTokens)} TOK`;
+  canvas.text(
+    PADDING,
+    footerY,
+    `${formatSize(trackedChars)} / ${actual} / ${window}`,
+    rgba(51, 65, 85),
+    1,
+  );
+  const outPath = path.join(os.tmpdir(), `openclaw-context-map-${crypto.randomUUID()}.png`);
+  await writeFile(outPath, encodePng(canvas.data));
+  const caption = [
+    "Context treemap",
+    `Source: ${params.report.source}`,
+    `Tracked: ${formatInt(trackedChars)} chars (~${formatInt(estimateTokensFromChars(trackedChars))} tok)`,
+    params.session.cachedContextTokens == null
+      ? "Actual cached context: unavailable"
+      : `Actual cached context: ${formatInt(params.session.cachedContextTokens)} tok`,
+  ].join("\n");
+  return { path: outPath, trackedChars, caption };
+}


### PR DESCRIPTION
## Summary
- add /context map for a WinDirStat-style context treemap image
- render tracked context contributors from the same /context run report used by list/detail
- document the new command

## Real behavior proof
- Behavior addressed: /context map should send a readable treemap image for the current Telegram session context.
- Real environment tested: local OpenClaw gateway from this branch, real Telegram driver/SUT bots in the shared E2E group, repo mock-openai provider, temp OpenClaw config/state.
- Exact steps or command run after this patch: ran a live node Telegram E2E script from the worktree: start mock-openai, start pnpm openclaw gateway, send warmup message, then send /context@foremanclawbot map.
- Evidence after fix: copied live output from the real Telegram run:
```json
{
  "ok": true,
  "mockRequests": 1,
  "normal": { "sentMessageId": 5910, "replyMessageId": 5911, "text": "OPENCLAW_E2E_OK" },
  "map": {
    "sentMessageId": 5912,
    "replyMessageId": 5913,
    "text": "Context treemap\nSource: run\nTracked: 64,458 chars (~16,115 tok)\nActual cached context: 11 tok",
    "hasPhoto": true,
    "hasDocument": false
  }
}
```
- Observed result after fix: Telegram received the /context map reply as a photo, the caption reported Source: run, and the outbound media file was PNG image data, 1280 x 860, 8-bit/color RGBA.
- What was not tested: No known gaps.

## Verification
- pnpm tsgo:core
- pnpm check:changed
