### PR TITLE
fix(health): surface stopped channel runtime errors

### DIFF
--- a/src/commands/health-format.ts
+++ b/src/commands/health-format.ts
@@ -201,6 +201,16 @@ export const formatHealthChannelLines = (
       continue;
     }
 
+    const runtimeError =
+      typeof baseSummary.lastError === "string" && baseSummary.lastError.trim()
+        ? baseSummary.lastError.trim()
+        : null;
+    const running = typeof baseSummary.running === "boolean" ? baseSummary.running : null;
+    if (runtimeError && running === false) {
+      lines.push(`${label}: failed (runtime) - ${runtimeError}`);
+      continue;
+    }
+
     const accountTimings =
       accountMode === "all"
         ? listSummaries

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -132,6 +132,54 @@ describe("healthCommand", () => {
     );
   });
 
+  it("formats stopped runtime errors as failed channel health", () => {
+    const summary: HealthSummary = {
+      ok: true,
+      ts: Date.now(),
+      durationMs: 5,
+      channels: {
+        imessage: {
+          accountId: "default",
+          configured: true,
+          running: false,
+          lastError: "imsg rpc exited: Cannot access Messages database",
+          accounts: {
+            default: {
+              accountId: "default",
+              configured: true,
+              running: false,
+              lastError: "imsg rpc exited: Cannot access Messages database",
+            },
+          },
+        },
+      },
+      channelOrder: ["imessage"],
+      channelLabels: { imessage: "iMessage" },
+      heartbeatSeconds: 60,
+      defaultAgentId: "main",
+      agents: [
+        {
+          agentId: "main",
+          isDefault: true,
+          heartbeat: {
+            enabled: true,
+            every: "1m",
+            everyMs: 60_000,
+            prompt: "hi",
+            target: "last",
+            ackMaxChars: 160,
+          },
+          sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
+        },
+      ],
+      sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
+    };
+
+    expect(formatHealthChannelLines(summary, { accountMode: "all" })).toContain(
+      "iMessage: failed (runtime) - imsg rpc exited: Cannot access Messages database",
+    );
+  });
+
   it("formats per-account probe timings", () => {
     const summary = createHealthSummary({
       channels: {


### PR DESCRIPTION
Addresses tadassce/drz#55.\n\n## Summary\n- show configured-but-stopped channel runtime failures as health failures instead of plain configured\n- add regression coverage for iMessage Full Disk Access / Messages DB runtime errors\n\n## Test plan\n- pnpm test -- src/commands/health.test.ts src/commands/health.snapshot.test.ts src/commands/status.test.ts src/commands/channels.surfaces-signal-runtime-errors-channels-status-output.test.ts\n- pnpm exec oxlint --type-aware -- src/commands/health-format.ts src/commands/health.test.ts