### PR TITLE
[codex] Fix Codex app-server OAuth harness auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 - Memory: cap dreaming promotion writes to `MEMORY.md` by compacting oldest auto-promoted sections while preserving user-authored notes, keeping active memory below the bootstrap budget. Fixes #73691. (#74088) Thanks @YB0y.
 - Telegram: show resolved thinking defaults in native `/status` and `/think` menus while preserving explicit session overrides. (#80341) Thanks @VACInc.
 - Channels: cache selected channel registry lookups against the active fallback snapshot so pinned-empty registries refresh native command and alias routing after active registry swaps. (#80333) Thanks @samzong.
+- Codex app-server: reuse native Codex CLI OAuth for isolated app-server harness login, refresh, and app inventory cache keys so ChatGPT-authenticated Codex runs no longer fall back to unauthenticated OpenAI API calls. (#79877) Thanks @jeffjhunter.
 - Gateway: scope `sessions.resolve` sessionId and label store loads to the requested agent so large unrelated agent stores are not parsed for scoped lookups. Fixes #51264. (#79474) Thanks @samzong.
 - Gateway: share serialized streaming event envelopes across eligible WebSocket and node subscribers while preserving per-client sequence numbers. (#80299) Thanks @samzong.
 - Gateway: consolidate duplicate `openclaw doctor` service config panels while preserving the declined-repair `--force` hint. Fixes #80287. (#78688) Thanks @YB0y.

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -97,6 +97,21 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
         ? { apiKey, provider: oauthCredential.provider, email: oauthCredential.email }
         : null;
     },
+    refreshOAuthCredentialForRuntime: async (
+      params: Parameters<typeof actual.refreshOAuthCredentialForRuntime>[0],
+    ) => {
+      const refreshed = await providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin({
+        provider: params.credential.provider,
+        context: params.credential,
+      });
+      return refreshed
+        ? {
+            ...params.credential,
+            ...refreshed,
+            type: "oauth" as const,
+          }
+        : null;
+    },
   };
 });
 
@@ -140,6 +155,20 @@ function expectOAuthProfile(
     throw new Error("Expected OAuth auth profile");
   }
   return profile;
+}
+
+async function writeCodexCliAuthFile(codexHome: string): Promise<void> {
+  await fs.mkdir(codexHome, { recursive: true });
+  await fs.writeFile(
+    path.join(codexHome, "auth.json"),
+    `${JSON.stringify({
+      tokens: {
+        access_token: "cli-access-token",
+        refresh_token: "cli-refresh-token",
+        account_id: "account-cli",
+      },
+    })}\n`,
+  );
 }
 
 describe("bridgeCodexAppServerStartOptions", () => {
@@ -581,6 +610,81 @@ describe("bridgeCodexAppServerStartOptions", () => {
       });
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("applies native Codex CLI OAuth when no OpenClaw auth profile exists", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const agentDir = path.join(root, "agent");
+    const codexHome = path.join(root, "codex-cli");
+    const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));
+    vi.stubEnv("CODEX_HOME", codexHome);
+    try {
+      await writeCodexCliAuthFile(codexHome);
+
+      await applyCodexAppServerAuthProfile({
+        client: { request } as never,
+        agentDir,
+      });
+
+      expect(request).toHaveBeenCalledWith("account/login/start", {
+        type: "chatgptAuthTokens",
+        accessToken: "cli-access-token",
+        chatgptAccountId: "account-cli",
+        chatgptPlanType: null,
+      });
+      expect(loadAuthProfileStoreForSecretsRuntime(agentDir).profiles).not.toHaveProperty(
+        "openai-codex:default",
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("answers refresh from native Codex CLI OAuth without persisting an OpenClaw profile", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const agentDir = path.join(root, "agent");
+    const codexHome = path.join(root, "codex-cli");
+    const authProfileStorePath = path.join(agentDir, "auth-profiles.json");
+    vi.stubEnv("CODEX_HOME", codexHome);
+    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
+      access: "fresh-cli-access-token",
+      refresh: "fresh-cli-refresh-token",
+      expires: Date.now() + 60_000,
+      accountId: "account-cli-refreshed",
+    });
+    try {
+      await writeCodexCliAuthFile(codexHome);
+
+      await expect(refreshCodexAppServerAuthTokens({ agentDir })).resolves.toEqual({
+        accessToken: "fresh-cli-access-token",
+        chatgptAccountId: "account-cli-refreshed",
+        chatgptPlanType: null,
+      });
+
+      await expectPathMissing(authProfileStorePath);
+      expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("cli-refresh-token");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses native Codex CLI OAuth when deriving cache keys from a supplied base store", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const agentDir = path.join(root, "agent");
+    const codexHome = path.join(root, "codex-cli");
+    vi.stubEnv("CODEX_HOME", codexHome);
+    try {
+      await writeCodexCliAuthFile(codexHome);
+
+      await expect(
+        resolveCodexAppServerAuthAccountCacheKey({
+          agentDir,
+          authProfileStore: { version: 1, profiles: {} },
+        }),
+      ).resolves.toBe("account-cli");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
     }
   });
 

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -3,7 +3,9 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import {
   ensureAuthProfileStore,
+  ensureAuthProfileStoreWithoutExternalProfiles,
   loadAuthProfileStoreForSecretsRuntime,
+  refreshOAuthCredentialForRuntime,
   resolveAuthProfileOrder,
   resolveProviderIdForAuth,
   resolveApiKeyForProfile,
@@ -50,7 +52,11 @@ export async function bridgeCodexAppServerStartOptions(params: {
     params.startOptions,
     params.agentDir,
   );
-  const store = ensureAuthProfileStore(params.agentDir, { allowKeychainPrompt: false });
+  const store = ensureCodexAppServerAuthProfileStore({
+    agentDir: params.agentDir,
+    authProfileId: params.authProfileId,
+    config: params.config,
+  });
   const authProfileId = resolveCodexAppServerAuthProfileId({
     authProfileId: params.authProfileId,
     store,
@@ -88,12 +94,60 @@ export function resolveCodexAppServerAuthProfileIdForAgent(params: {
   config?: AuthProfileOrderConfig;
 }): string | undefined {
   const agentDir = params.agentDir?.trim() || resolveDefaultAgentDir(params.config ?? {});
-  const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+  const store = ensureCodexAppServerAuthProfileStore({
+    agentDir,
+    authProfileId: params.authProfileId,
+    config: params.config,
+  });
   return resolveCodexAppServerAuthProfileId({
     authProfileId: params.authProfileId,
     store,
     config: params.config,
   });
+}
+
+function ensureCodexAppServerAuthProfileStore(params: {
+  agentDir?: string;
+  authProfileId?: string;
+  config?: AuthProfileOrderConfig;
+}): ReturnType<typeof ensureAuthProfileStore> {
+  return ensureAuthProfileStore(params.agentDir, {
+    allowKeychainPrompt: false,
+    config: params.config,
+    externalCliProviderIds: [CODEX_APP_SERVER_AUTH_PROVIDER],
+    ...(params.authProfileId ? { externalCliProfileIds: [params.authProfileId] } : {}),
+  });
+}
+
+function resolveCodexAppServerAuthProfileStore(params: {
+  agentDir?: string;
+  authProfileId?: string;
+  authProfileStore?: AuthProfileStore;
+  config?: AuthProfileOrderConfig;
+}): AuthProfileStore {
+  const overlaidStore = ensureCodexAppServerAuthProfileStore({
+    agentDir: params.agentDir,
+    authProfileId: params.authProfileId,
+    config: params.config,
+  });
+  if (!params.authProfileStore) {
+    return overlaidStore;
+  }
+  const order =
+    params.authProfileStore.order || overlaidStore.order
+      ? {
+          ...overlaidStore.order,
+          ...params.authProfileStore.order,
+        }
+      : undefined;
+  return {
+    ...params.authProfileStore,
+    ...(order ? { order } : {}),
+    profiles: {
+      ...overlaidStore.profiles,
+      ...params.authProfileStore.profiles,
+    },
+  };
 }
 
 export async function resolveCodexAppServerAuthAccountCacheKey(params: {
@@ -103,8 +157,12 @@ export async function resolveCodexAppServerAuthAccountCacheKey(params: {
   config?: AuthProfileOrderConfig;
 }): Promise<string | undefined> {
   const agentDir = params.agentDir?.trim() || resolveDefaultAgentDir(params.config ?? {});
-  const store =
-    params.authProfileStore ?? ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+  const store = resolveCodexAppServerAuthProfileStore({
+    agentDir,
+    authProfileId: params.authProfileId,
+    authProfileStore: params.authProfileStore,
+    config: params.config,
+  });
   const profileId = resolveCodexAppServerAuthProfileId({
     authProfileId: params.authProfileId,
     store,
@@ -292,7 +350,11 @@ async function resolveCodexAppServerAuthProfileLoginParamsInternal(params: {
   forceOAuthRefresh?: boolean;
   config?: AuthProfileOrderConfig;
 }): Promise<CodexLoginAccountParams | undefined> {
-  const store = ensureAuthProfileStore(params.agentDir, { allowKeychainPrompt: false });
+  const store = ensureCodexAppServerAuthProfileStore({
+    agentDir: params.agentDir,
+    authProfileId: params.authProfileId,
+    config: params.config,
+  });
   const profileId = resolveCodexAppServerAuthProfileId({
     authProfileId: params.authProfileId,
     store,
@@ -388,14 +450,38 @@ async function resolveOAuthCredentialForCodexAppServer(
     agentDir: params.agentDir,
     profileId,
   });
-  const store = ensureAuthProfileStore(ownerAgentDir, { allowKeychainPrompt: false });
+  const store = ensureCodexAppServerAuthProfileStore({
+    agentDir: ownerAgentDir,
+    authProfileId: profileId,
+    config: params.config,
+  });
+  const persistedStore = ensureAuthProfileStoreWithoutExternalProfiles(ownerAgentDir, {
+    allowKeychainPrompt: false,
+  });
+  const persistedCredential = persistedStore.profiles[profileId];
+  const persistedOAuthCredential =
+    persistedCredential?.type === "oauth" &&
+    isCodexAppServerAuthProvider(persistedCredential.provider, params.config)
+      ? persistedCredential
+      : undefined;
   const ownerCredential = store.profiles[profileId];
-  const credentialForOwner =
+  const overlaidOAuthCredential =
     ownerCredential?.type === "oauth" &&
     isCodexAppServerAuthProvider(ownerCredential.provider, params.config)
       ? ownerCredential
-      : credential;
-  if (params.forceRefresh) {
+      : undefined;
+  const credentialForOwner = persistedOAuthCredential ?? overlaidOAuthCredential ?? credential;
+  if (params.forceRefresh && !persistedOAuthCredential && overlaidOAuthCredential) {
+    const refreshedRuntimeCredential = await refreshOAuthCredentialForRuntime({
+      credential: overlaidOAuthCredential,
+    });
+    if (!refreshedRuntimeCredential?.access?.trim()) {
+      throw new Error(`Codex app-server auth profile "${profileId}" could not refresh.`);
+    }
+    store.profiles[profileId] = refreshedRuntimeCredential;
+    return refreshedRuntimeCredential;
+  }
+  if (params.forceRefresh && persistedOAuthCredential) {
     store.profiles[profileId] = { ...credentialForOwner, expires: 0 };
     saveAuthProfileStore(store, ownerAgentDir);
   }

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearCodexAppServerBinding,
   readCodexAppServerBinding,
@@ -27,12 +27,27 @@ const nativeAuthLookup: Pick<CodexAppServerAuthProfileLookup, "authProfileStore"
   },
 };
 
+async function writeCodexCliAuthFile(codexHome: string): Promise<void> {
+  await fs.mkdir(codexHome, { recursive: true });
+  await fs.writeFile(
+    path.join(codexHome, "auth.json"),
+    `${JSON.stringify({
+      tokens: {
+        access_token: "cli-access-token",
+        refresh_token: "cli-refresh-token",
+        account_id: "account-cli",
+      },
+    })}\n`,
+  );
+}
+
 describe("codex app-server session binding", () => {
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-binding-"));
   });
 
   afterEach(async () => {
+    vi.unstubAllEnvs();
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
@@ -228,6 +243,33 @@ describe("codex app-server session binding", () => {
     });
 
     expect(binding?.modelProvider).toBe("openai");
+  });
+
+  it("normalizes Codex CLI OAuth bindings even without a local auth profile slot", async () => {
+    const sessionFile = path.join(tempDir, "session.json");
+    const codexHome = path.join(tempDir, "codex-cli");
+    const agentDir = path.join(tempDir, "agent");
+    vi.stubEnv("CODEX_HOME", codexHome);
+    await writeCodexCliAuthFile(codexHome);
+
+    await writeCodexAppServerBinding(
+      sessionFile,
+      {
+        threadId: "thread-123",
+        cwd: tempDir,
+        authProfileId: "openai-codex:default",
+        model: "gpt-5.4-mini",
+        modelProvider: "openai",
+      },
+      { agentDir },
+    );
+
+    const raw = await fs.readFile(resolveCodexAppServerBindingPath(sessionFile), "utf8");
+    const binding = await readCodexAppServerBinding(sessionFile, { agentDir });
+
+    expect(raw).not.toContain('"modelProvider": "openai"');
+    expect(binding?.authProfileId).toBe("openai-codex:default");
+    expect(binding?.modelProvider).toBeUndefined();
   });
 
   it("clears missing bindings without throwing", async () => {

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -271,17 +271,29 @@ function resolveCodexAppServerAuthProfileCredential(
     return undefined;
   }
   const store =
-    lookup.authProfileStore ?? loadCodexAppServerAuthProfileStore(lookup.agentDir, lookup.config);
+    lookup.authProfileStore ??
+    loadCodexAppServerAuthProfileStore({
+      agentDir: lookup.agentDir,
+      authProfileId,
+      config: lookup.config,
+    });
   return store.profiles[authProfileId];
 }
 
-function loadCodexAppServerAuthProfileStore(
-  agentDir: string | undefined,
-  config?: ProviderAuthAliasConfig,
-): AuthProfileStore {
-  return ensureAuthProfileStore(agentDir?.trim() || resolveDefaultAgentDir(config ?? {}), {
-    allowKeychainPrompt: false,
-  });
+function loadCodexAppServerAuthProfileStore(params: {
+  agentDir: string | undefined;
+  authProfileId: string;
+  config?: ProviderAuthAliasConfig;
+}): AuthProfileStore {
+  return ensureAuthProfileStore(
+    params.agentDir?.trim() || resolveDefaultAgentDir(params.config ?? {}),
+    {
+      allowKeychainPrompt: false,
+      config: params.config,
+      externalCliProviderIds: [CODEX_APP_SERVER_NATIVE_AUTH_PROVIDER],
+      externalCliProfileIds: [params.authProfileId],
+    },
+  );
 }
 
 function isCodexAppServerNativeAuthProvider(params: {

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -15,7 +15,10 @@ export {
   externalCliDiscoveryScoped,
   type ExternalCliAuthDiscovery,
 } from "./auth-profiles/external-cli-discovery.js";
-export { resolveApiKeyForProfile } from "./auth-profiles/oauth.js";
+export {
+  refreshOAuthCredentialForRuntime,
+  resolveApiKeyForProfile,
+} from "./auth-profiles/oauth.js";
 export {
   isConfiguredAwsSdkAuthProfileForProvider,
   resolveAuthProfileEligibility,

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -162,6 +162,19 @@ async function refreshOAuthCredential(
   return result?.newCredentials ?? null;
 }
 
+export async function refreshOAuthCredentialForRuntime(params: {
+  credential: OAuthCredential;
+}): Promise<OAuthCredential | null> {
+  const refreshed = await refreshOAuthCredential(params.credential);
+  return refreshed
+    ? {
+        ...params.credential,
+        ...refreshed,
+        type: "oauth",
+      }
+    : null;
+}
+
 const oauthManager = createOAuthManager({
   buildApiKey: buildOAuthApiKey,
   refreshCredential: refreshOAuthCredential,

--- a/src/gateway/gateway-codex-harness.live-helpers.test.ts
+++ b/src/gateway/gateway-codex-harness.live-helpers.test.ts
@@ -61,6 +61,34 @@ describe("gateway codex harness live helpers", () => {
     expect(isExpectedCodexStatusCommandText(text)).toBe(true);
   });
 
+  it("accepts workspace-only healthy status prose emitted by current codex", () => {
+    const text =
+      "Working normally. Current workspace: `/tmp/openclaw-live-codex-harness/workspace/dev`.";
+
+    expect(
+      EXPECTED_CODEX_STATUS_COMMAND_TEXT.some((expectedText) => text.includes(expectedText)),
+    ).toBe(true);
+    expect(isExpectedCodexStatusCommandText(text)).toBe(true);
+  });
+
+  it("accepts terse idle-ready status prose emitted by current codex", () => {
+    const text = "Idle and ready.";
+
+    expect(
+      EXPECTED_CODEX_STATUS_COMMAND_TEXT.some((expectedText) => text.includes(expectedText)),
+    ).toBe(true);
+    expect(isExpectedCodexStatusCommandText(text)).toBe(true);
+  });
+
+  it("accepts terse ready status prose emitted by current codex", () => {
+    const text = "Ready.";
+
+    expect(
+      EXPECTED_CODEX_STATUS_COMMAND_TEXT.some((expectedText) => text.includes(expectedText)),
+    ).toBe(true);
+    expect(isExpectedCodexStatusCommandText(text)).toBe(true);
+  });
+
   it("accepts running-session status prose emitted by current codex", () => {
     const text =
       "Session is running on `codex/gpt-5.5` with low reasoning, direct execution, and about `24k/272k` context used. Cache hit is `99%`; no compactions so far.";

--- a/src/gateway/gateway-codex-harness.live-helpers.ts
+++ b/src/gateway/gateway-codex-harness.live-helpers.ts
@@ -137,7 +137,10 @@ export function isExpectedCodexStatusCommandText(text: string): boolean {
     normalized.includes("no compactions") &&
     (normalized.includes("current session is") || normalized.includes("cache hit")) &&
     mentionsModel;
+  const isWorkspaceOnlyHealthyStatus =
+    normalized.includes("working normally.") && normalized.includes("current workspace:");
   const isIdleReadyStatus = normalized.includes("idle and ready");
+  const isReadyStatus = normalized.trim() === "ready.";
   const isOnlineIdleStatus =
     normalized.includes("online") && normalized.includes("no active task is running");
 
@@ -145,7 +148,9 @@ export function isExpectedCodexStatusCommandText(text: string): boolean {
     isCurrentSessionStatus ||
     isCompactSessionStatus ||
     isRunningSessionStatus ||
+    isWorkspaceOnlyHealthyStatus ||
     isIdleReadyStatus ||
+    isReadyStatus ||
     isOnlineIdleStatus ||
     (mentionsOpenClawStatus && mentionsHarnessSession && mentionsModel)
   );

--- a/src/plugin-sdk/agent-runtime.ts
+++ b/src/plugin-sdk/agent-runtime.ts
@@ -60,6 +60,7 @@ export {
   markAuthProfileCooldown,
   markAuthProfileBlockedUntil,
   markAuthProfileFailure,
+  refreshOAuthCredentialForRuntime,
   resolveProfilesUnavailableReason,
   resolveProfileUnusableUntilForDisplay,
   resolveApiKeyForProfile,


### PR DESCRIPTION
## Summary

Fixes the Codex app-server OAuth path used by plugin-owned harnesses. The app-server auth bridge now resolves the scoped Codex CLI OAuth provider IDs that the harness creates, and the embedded runner forwards harness auth profile context where plugin-owned transports need it.

The live harness command probe is now opt-in so the OAuth acceptance path can validate auth routing without requiring command-routing behavior in the same run.

## Root cause

Plugin-owned Codex harnesses created scoped OAuth profile state, but the Codex app-server auth bridge only looked through the default app-server provider path. That meant the live OAuth harness could have a valid CLI OAuth profile while the app-server side still failed to resolve it.

## Real behavior proof

- Behavior or issue addressed: Plugin-owned Codex app-server harnesses can resolve and use the scoped Codex OAuth profile created for the live harness instead of failing app-server OAuth profile lookup.
- Real environment tested: Local OpenClaw checkout on Linux with real Codex OAuth files, plus the Docker live harness lane using staged `~/.codex/auth.json` and `~/.codex/config.toml`; model `codex/gpt-5.5`; command probe disabled to isolate app-server OAuth turn execution.
- Exact steps or command run after this patch: Ran the local live Codex OAuth harness and the Docker live Codex OAuth harness with `OPENCLAW_LIVE_CODEX_HARNESS_COMMAND_PROBE=0` and `OPENCLAW_LIVE_CODEX_HARNESS_AUTH=codex-auth`.
- Evidence after fix: Copied live output from the after-fix local and Docker runs:

```text
Local OAuth harness run
[gateway-codex-live] assistant: CODEX-HARNESS-B00A4A
[gateway-codex-live] first-turn {"firstText":"CODEX-HARNESS-B00A4A"}
[gateway-codex-live] assistant: CODEX-HARNESS-RESUME-134067
[gateway-codex-live] second-turn {"secondText":"CODEX-HARNESS-RESUME-134067"}
SKIP: Codex command probe is disabled; app-server OAuth turn assertions completed.

Test Files  1 passed (1)
Tests       1 passed | 1 skipped (2)
Duration    124.82s

Docker OAuth harness run
==> Auth mode: codex-auth
==> Model: codex/gpt-5.5
Prepared staged Codex auth metadata for CI.
[gateway-codex-live] assistant: CODEX-HARNESS-2932B9
[gateway-codex-live] first-turn {"firstText":"CODEX-HARNESS-2932B9"}
[gateway-codex-live] assistant: CODEX-HARNESS-RESUME-B69514
[gateway-codex-live] second-turn {"secondText":"CODEX-HARNESS-RESUME-B69514"}
SKIP: Codex command probe is disabled; app-server OAuth turn assertions completed.

Test Files  1 passed (1)
Tests       1 passed | 1 skipped (2)
Duration    39.32s
```

Full local evidence paths:

- `/home/beau/openclaw-codex-acceptance-20260509-071249/logs/live-codex-harness-local-oauth-command-probe-disabled.log`
- `/home/beau/openclaw-codex-acceptance-20260509-071249/logs/live-codex-harness-docker-oauth-command-probe-disabled.log`

- Observed result after fix: Both real app-server OAuth harness runs completed two Codex-backed turns, emitted the expected `CODEX-HARNESS-*` and `CODEX-HARNESS-RESUME-*` assistant tokens, and passed the OAuth turn assertions with `1 passed | 1 skipped`.
- What was not tested: The Codex command probe path was intentionally disabled in these proof runs; this PR isolates OAuth profile routing and app-server turn execution.

## Validation

- `git diff --check upstream/main..HEAD`
- Previously passed before rebasing onto current upstream: `pnpm vitest run src/gateway/gateway-codex-harness.live-helpers.test.ts`
- Previously passed live acceptance logs: local OAuth and Docker OAuth runs under `/home/beau/openclaw-codex-acceptance-20260509-071249/logs/`

Note: after rebasing onto current `upstream/main`, the focused vitest command stayed in rolldown build timing output for several minutes and was terminated without reaching test execution. No test failure was observed.