### PR TITLE
Deduplicate repeated Telegram intake

### DIFF
--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -86,6 +86,32 @@ describe("telegram bot message processor", () => {
     );
   }
 
+  async function processMessageWithText(
+    processMessage: ReturnType<typeof createTelegramMessageProcessor>,
+    params: {
+      chatId?: number;
+      threadId?: number;
+      messageId?: number;
+      date?: number;
+      text?: string;
+    },
+  ) {
+    await processMessage(
+      {
+        message: {
+          chat: { id: params.chatId ?? 123, type: "private", title: "chat" },
+          message_id: params.messageId ?? 456,
+          message_thread_id: params.threadId,
+          date: params.date,
+          text: params.text ?? "hello there",
+        },
+      } as unknown as Parameters<typeof processMessage>[0],
+      [],
+      [],
+      {},
+    );
+  }
+
   function createDispatchFailureHarness(
     context: Record<string, unknown>,
     sendMessage: ReturnType<typeof vi.fn>,
@@ -144,6 +170,67 @@ describe("telegram bot message processor", () => {
     await processSampleMessage(processMessage);
     expect(dispatchTelegramMessage).not.toHaveBeenCalled();
     expect(telegramInboundInfo).not.toHaveBeenCalled();
+  });
+
+  it("drops byte-identical same-chat same-topic messages within 60 seconds", async () => {
+    buildTelegramMessageContext.mockResolvedValue(
+      createMessageContext({
+        ctxPayload: {
+          From: "telegram:123",
+          To: "telegram:123",
+          ChatType: "direct",
+          RawBody: "repeat me",
+        },
+      }),
+    );
+    const processMessage = createTelegramMessageProcessor(baseDeps);
+
+    await processMessageWithText(processMessage, {
+      threadId: 42,
+      messageId: 1,
+      date: 1_000,
+      text: "repeat me",
+    });
+    await processMessageWithText(processMessage, {
+      threadId: 42,
+      messageId: 2,
+      date: 1_050,
+      text: "repeat me",
+    });
+
+    expect(dispatchTelegramMessage).toHaveBeenCalledTimes(1);
+    expect(telegramInboundInfo).toHaveBeenCalledWith(
+      expect.stringContaining("Dropped duplicate inbound message chatId=123 topic=42"),
+    );
+  });
+
+  it("does not dedup the same text across different Telegram topics", async () => {
+    buildTelegramMessageContext.mockResolvedValue(
+      createMessageContext({
+        ctxPayload: {
+          From: "telegram:123",
+          To: "telegram:123",
+          ChatType: "direct",
+          RawBody: "repeat me",
+        },
+      }),
+    );
+    const processMessage = createTelegramMessageProcessor(baseDeps);
+
+    await processMessageWithText(processMessage, {
+      threadId: 42,
+      messageId: 1,
+      date: 1_000,
+      text: "repeat me",
+    });
+    await processMessageWithText(processMessage, {
+      threadId: 99,
+      messageId: 2,
+      date: 1_050,
+      text: "repeat me",
+    });
+
+    expect(dispatchTelegramMessage).toHaveBeenCalledTimes(2);
   });
 
   it("formats Telegram inbound summaries without message content", () => {

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -22,6 +22,12 @@ import type { TelegramContext, TelegramStreamMode } from "./bot/types.js";
 import type { TelegramReplyChainEntry } from "./message-cache.js";
 
 const telegramInboundLog = createSubsystemLogger("gateway/channels/telegram").child("inbound");
+const TELEGRAM_INTAKE_DEDUP_WINDOW_MS = 60_000;
+
+type LastTelegramInboundMessage = {
+  body: string;
+  seenAtMs: number;
+};
 
 export function formatTelegramInboundLogLine(params: {
   from: string;
@@ -72,6 +78,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     telegramDeps,
     opts,
   } = deps;
+  const lastInboundByChatTopic = new Map<string, LastTelegramInboundMessage>();
 
   return async (
     primaryCtx: TelegramContext,
@@ -130,6 +137,21 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
           (options?.ingressBuffer ? ` buffer=${options.ingressBuffer}` : ""),
       );
     }
+    const dedupKey = buildTelegramDedupKey(primaryCtx, context.chatId);
+    const messageTimestampMs = getTelegramMessageTimestampMs(primaryCtx, ingressReceivedAtMs);
+    if (
+      shouldDropDuplicateTelegramInbound({
+        cache: lastInboundByChatTopic,
+        key: dedupKey,
+        body: context.ctxPayload.RawBody,
+        seenAtMs: messageTimestampMs,
+      })
+    ) {
+      telegramInboundLog.info(
+        `Dropped duplicate inbound message chatId=${context.chatId} topic=${formatTelegramDedupTopic(primaryCtx)} windowMs=${TELEGRAM_INTAKE_DEDUP_WINDOW_MS} bodyChars=${context.ctxPayload.RawBody.length}`,
+      );
+      return;
+    }
     void context.sendTyping().catch((err) => {
       logVerbose(`telegram early typing cue failed for chat ${context.chatId}: ${String(err)}`);
     });
@@ -175,3 +197,56 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     }
   };
 };
+
+function getTelegramMessageTimestampMs(
+  ctx: TelegramContext,
+  fallbackReceivedAtMs: number | undefined,
+): number {
+  const timestampSeconds = (ctx.message as { date?: unknown }).date;
+  if (typeof timestampSeconds === "number" && Number.isFinite(timestampSeconds)) {
+    return timestampSeconds * 1000;
+  }
+  return fallbackReceivedAtMs ?? Date.now();
+}
+
+function buildTelegramDedupKey(ctx: TelegramContext, chatId: number | string): string {
+  return `${chatId}\u0000${formatTelegramDedupTopic(ctx)}`;
+}
+
+function formatTelegramDedupTopic(ctx: TelegramContext): string {
+  const messageThreadId = (ctx.message as { message_thread_id?: unknown }).message_thread_id;
+  if (typeof messageThreadId === "number" || typeof messageThreadId === "string") {
+    return String(messageThreadId);
+  }
+  return "general";
+}
+
+function shouldDropDuplicateTelegramInbound(params: {
+  cache: Map<string, LastTelegramInboundMessage>;
+  key: string;
+  body: string;
+  seenAtMs: number;
+}): boolean {
+  if (params.body.length === 0) {
+    params.cache.delete(params.key);
+    return false;
+  }
+
+  const prior = params.cache.get(params.key);
+  if (prior) {
+    const ageMs = params.seenAtMs - prior.seenAtMs;
+    if (
+      ageMs >= 0 &&
+      ageMs <= TELEGRAM_INTAKE_DEDUP_WINDOW_MS &&
+      prior.body === params.body
+    ) {
+      return true;
+    }
+  }
+
+  params.cache.set(params.key, {
+    body: params.body,
+    seenAtMs: params.seenAtMs,
+  });
+  return false;
+}


### PR DESCRIPTION
## Summary
- drop byte-identical Telegram inbound messages from the same chat/topic when they immediately repeat within 60 seconds
- scope dedup by chat and message thread/topic so independent topics are unaffected
- add regression tests for same-topic dedup and cross-topic delivery

## Context
This is a narrow intake guard for loop prevention: if Telegram delivers or a user/client repeats the exact same payload into the same chat/topic within the dedup window, OpenClaw ignores the second copy before it can create another agent turn.

## Tests
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/bot-message.test.ts`

Note: local install required `pnpm install --ignore-scripts` and replacing `@openclaw/fs-safe` from the registry tarball because its git dependency prepack failed in this checkout. The targeted Telegram test suite passed after that local test-environment workaround.
