### PR TITLE
test: sandbox audit-exec-surface under HOME tempdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Cron/failover: classify structured OpenAI-compatible `server_error` payloads as `server_error`, expose that reason in cron state, and let one-shot cron retry policy honor `retryOn: ["server_error"]` without requiring raw `5xx` text. (#45594) Thanks @clovericbot.
 - Slack: wake the resolved thread session after interactive reply button/select clicks and carry Slack delivery context through the queued interaction event, so clicks continue the visible conversation. Fixes #79676 and #61502. (#79836) Thanks @velvet-shark, @tianxiaochannel-oss88, and @Saicheg.
 - WhatsApp/streaming: send only the new suffix when text-end block replies repeat prior preambles across tool-call cycles, preventing cumulative WhatsApp preamble messages. Fixes #78946. (#79120) Thanks @brokemac79 and @papawattu.
+- Tests/security audit: sandbox `audit-exec-surface.test.ts` under a per-case OpenClaw home tempdir, redirecting `OPENCLAW_HOME` (which wins over `HOME`/`USERPROFILE` in `resolveRawHomeDir`) alongside `HOME` and `USERPROFILE`, so its `saveExecApprovals(...)` calls never touch the live `~/.openclaw/exec-approvals.json` on the host running the suite. Sibling exec-approvals tests already used the tempdir pattern; this file did not, so running `pnpm test` against a contributor's local checkout was silently truncating their real approvals to `{ "version": 1, "agents": {} }`. (#79885) Thanks @omarshahine.
 
 ## 2026.5.9
 

--- a/src/security/audit-exec-surface.test.ts
+++ b/src/security/audit-exec-surface.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { saveExecApprovals } from "../infra/exec-approvals.js";
 import { collectExecRuntimeFindings } from "./audit.js";
@@ -27,11 +30,61 @@ function requireFinding(
   return finding;
 }
 
-afterEach(() => {
-  saveExecApprovals({ version: 1, agents: {} });
-});
-
 describe("security audit exec surface findings", () => {
+  // Redirect the OpenClaw home (OPENCLAW_HOME wins over HOME/USERPROFILE in
+  // `resolveRawHomeDir`) to a per-test tempdir so `saveExecApprovals` never
+  // touches the real `~/.openclaw/exec-approvals.json` on the host running
+  // the suite.
+  let previousOpenClawHome: string | undefined;
+  let previousHome: string | undefined;
+  let previousUserProfile: string | undefined;
+  let tempRoot = "";
+  let tempCaseIndex = 0;
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-exec-approvals-"));
+  });
+
+  beforeEach(async () => {
+    previousOpenClawHome = process.env.OPENCLAW_HOME;
+    previousHome = process.env.HOME;
+    previousUserProfile = process.env.USERPROFILE;
+    const tempDir = path.join(tempRoot, `case-${++tempCaseIndex}`);
+    await fs.mkdir(path.join(tempDir, ".openclaw"), { recursive: true });
+    // OPENCLAW_HOME takes precedence over HOME/USERPROFILE in resolveRawHomeDir,
+    // so all three must point at the tempdir to neutralize whichever the host
+    // happens to have set.
+    process.env.OPENCLAW_HOME = tempDir;
+    process.env.HOME = tempDir;
+    // Windows uses USERPROFILE for os.homedir()
+    process.env.USERPROFILE = tempDir;
+  });
+
+  afterEach(() => {
+    saveExecApprovals({ version: 1, agents: {} });
+    if (previousOpenClawHome === undefined) {
+      delete process.env.OPENCLAW_HOME;
+    } else {
+      process.env.OPENCLAW_HOME = previousOpenClawHome;
+    }
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+    if (previousUserProfile === undefined) {
+      delete process.env.USERPROFILE;
+    } else {
+      process.env.USERPROFILE = previousUserProfile;
+    }
+  });
+
+  afterAll(async () => {
+    if (tempRoot) {
+      await fs.rm(tempRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+    }
+  });
+
   it("warns when exec approvals enable autoAllowSkills", () => {
     saveExecApprovals({
       version: 1,


### PR DESCRIPTION
## Summary

`src/security/audit-exec-surface.test.ts` calls `saveExecApprovals({ version: 1, agents: {} })` in its `afterEach` and inside `it()` blocks without redirecting the OpenClaw home env vars. Sibling exec-approvals tests (`src/agents/bash-tools.exec.approval-id.test.ts`, `src/infra/exec-approvals-store.test.ts`) already wrap their cases in `beforeAll(mkdtemp) + beforeEach(process.env.{OPENCLAW_HOME,HOME,USERPROFILE} = …)` for exactly this reason.

When this file runs without that wrapping, `saveExecApprovals` writes to the real `~/.openclaw/exec-approvals.json` on the host (or to whatever `OPENCLAW_HOME` points at). On a developer machine running this gateway, that means `pnpm test` (or any test runner that picks up this file) silently truncates the live approvals to:

```json
{
  "version": 1,
  "agents": {}
}
```

I noticed this on my own host: live `exec-approvals.json` size dropped to 35 bytes (the empty stub). Recovery required restoring from git and re-pushing via `openclaw approvals set --gateway`.

## Fix

Move the cleanup hook inside the `describe` block and add the standard `beforeAll` / `beforeEach` / `afterAll` setup used by the sibling test, so every case runs against a per-case tempdir. **All three** env vars (`OPENCLAW_HOME`, `HOME`, `USERPROFILE`) are saved and restored — `resolveRawHomeDir` prefers `OPENCLAW_HOME` over `HOME`/`USERPROFILE`, so redirecting only the latter two would still leak writes through `OPENCLAW_HOME` if a contributor has it set.

## Real behavior proof

- **Behavior or issue addressed:** running `pnpm exec vitest run src/security/audit-exec-surface.test.ts` on a host with a real `~/.openclaw/exec-approvals.json` truncates that file to `{"version":1,"agents":{}}`. The clobber happened on my live gateway machine on 2026-05-08 18:02 PT and was traced to this test via the `/private/tmp/openclaw-exec-approvals-*` fixture dirs sibling tests leave behind.
- **Real environment tested:** macOS (Darwin 25.4.0, M1) running an active OpenClaw gateway against my own `~/.openclaw/exec-approvals.json` (11722 bytes, 7 configured agents, file mode 0600). Tested both with `OPENCLAW_HOME` unset (real `~/.openclaw` resolved through `HOME`) and with `OPENCLAW_HOME=/tmp/oc-home-clobber-test` set (covers the precedence path that ClawSweeper flagged as P2).
- **Exact steps or command run after this patch:** captured `shasum -a 256` of both the live `~/.openclaw/exec-approvals.json` and a sentinel file under `/tmp/oc-home-clobber-test/.openclaw/exec-approvals.json` before the run, then executed `OPENCLAW_HOME=/tmp/oc-home-clobber-test pnpm exec vitest run src/security/audit-exec-surface.test.ts`, then re-captured the hashes.
- **Evidence after fix:**

  ```
  live (HOME path) before: sha256 a7e18e14efc575a8914ffe8fc6d0d491bf35cc3b4a91056d2e10802a470292ee
  sentinel (OPENCLAW_HOME)
                  before: sha256 f2725470d341dfbaad928b52f3ab2ebb12de2ccf82f6a9327764f826fb8218f5

  vitest:  Test Files  1 passed (1)
                Tests  7 passed (7)
              Duration  458ms

  live (HOME path) after:  sha256 a7e18e14efc575a8914ffe8fc6d0d491bf35cc3b4a91056d2e10802a470292ee  ✓ unchanged
  sentinel (OPENCLAW_HOME)
                  after:  sha256 f2725470d341dfbaad928b52f3ab2ebb12de2ccf82f6a9327764f826fb8218f5  ✓ unchanged
  ```

- **Observed result after fix:** all 7 cases pass and both files are byte-identical (same SHA-256) before vs after the run, even with `OPENCLAW_HOME` pointing at a real `.openclaw` dir. Re-running the unpatched test file on the same host reproducibly truncates whichever file the resolved OpenClaw home points at; running the patched file does not.
- **What was not tested:** Windows `USERPROFILE` parity (the redirect mirrors the sibling test pattern but I do not have a Windows host to exercise it on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
