### PR TITLE
fix(onboard): custom provider context window vs compaction floor (#79428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/onboarding: give non-Azure custom providers a safe generated context window and heal legacy 4k wizard entries without overwriting explicit valid small model limits, preventing first-turn compaction loops. Fixes #79428. (#79911) Thanks @Jefsky.
 - Ollama: stop native `/api/chat` requests from copying catalog `contextWindow` or `maxTokens` into `options.num_ctx` unless `params.num_ctx` is explicitly configured, avoiding pathological prompt-ingestion latency on local large-context models. Fixes #62267. Thanks @BenSHPD.
 - Ollama: keep the model idle watchdog enabled for `*:cloud` models routed through a local Ollama host, so cloud-backed tool-loop stalls fail over visibly instead of inheriting local-model no-idle behavior. Fixes #79350. Thanks @geek111.
 - Voice/Ollama: honor routed voice agent `tools.allow` for classic embedded voice responses, including empty allowlists, so no-tool Ollama agents do not receive tool schemas. Fixes #79506. Thanks @donkeykong91.

--- a/src/commands/onboard-custom-config.test.ts
+++ b/src/commands/onboard-custom-config.test.ts
@@ -5,6 +5,7 @@ import {
   applyCustomApiConfig,
   buildAnthropicVerificationProbeRequest,
   buildOpenAiVerificationProbeRequest,
+  CUSTOM_PROVIDER_DEFAULT_CONTEXT_WINDOW_TOKENS,
   inferCustomModelSupportsImageInput,
   parseNonInteractiveCustomApiFlags,
   resolveCustomModelImageInputInference,
@@ -106,14 +107,19 @@ it("uses expanded max_tokens for anthropic verification probes", () => {
 describe("applyCustomApiConfig", () => {
   it.each([
     {
-      name: "uses hard-min context window for newly added custom models",
+      name: "uses stable default context window for newly added custom models",
       existingContextWindow: undefined,
-      expectedContextWindow: CONTEXT_WINDOW_HARD_MIN_TOKENS,
+      expectedContextWindow: CUSTOM_PROVIDER_DEFAULT_CONTEXT_WINDOW_TOKENS,
     },
     {
       name: "upgrades existing custom model context window when below hard minimum",
       existingContextWindow: 2048,
-      expectedContextWindow: CONTEXT_WINDOW_HARD_MIN_TOKENS,
+      expectedContextWindow: CUSTOM_PROVIDER_DEFAULT_CONTEXT_WINDOW_TOKENS,
+    },
+    {
+      name: "raises context window below stable default compaction floor (#79428)",
+      existingContextWindow: CONTEXT_WINDOW_HARD_MIN_TOKENS,
+      expectedContextWindow: CUSTOM_PROVIDER_DEFAULT_CONTEXT_WINDOW_TOKENS,
     },
     {
       name: "preserves existing custom model context window when already above minimum",

--- a/src/commands/onboard-custom-config.test.ts
+++ b/src/commands/onboard-custom-config.test.ts
@@ -117,9 +117,14 @@ describe("applyCustomApiConfig", () => {
       expectedContextWindow: CUSTOM_PROVIDER_DEFAULT_CONTEXT_WINDOW_TOKENS,
     },
     {
-      name: "raises context window below stable default compaction floor (#79428)",
+      name: "raises legacy generated hard-min context window (#79428)",
       existingContextWindow: CONTEXT_WINDOW_HARD_MIN_TOKENS,
       expectedContextWindow: CUSTOM_PROVIDER_DEFAULT_CONTEXT_WINDOW_TOKENS,
+    },
+    {
+      name: "preserves explicit small context window when already valid",
+      existingContextWindow: 8192,
+      expectedContextWindow: 8192,
     },
     {
       name: "preserves existing custom model context window when already above minimum",

--- a/src/commands/onboard-custom-config.ts
+++ b/src/commands/onboard-custom-config.ts
@@ -13,7 +13,13 @@ import {
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
 import { normalizeAlias } from "./models/alias-name.js";
 
-const DEFAULT_CONTEXT_WINDOW = CONTEXT_WINDOW_HARD_MIN_TOKENS;
+/**
+ * Wizard default for non-Azure custom APIs when context length is unknown.
+ * Must exceed the compaction `reserveTokensFloor` default (20000 tokens) in
+ * `agent-runner-memory.ts`, or the first turns enter an infinite compact loop (#79428).
+ */
+export const CUSTOM_PROVIDER_DEFAULT_CONTEXT_WINDOW_TOKENS = 32_768;
+const DEFAULT_CONTEXT_WINDOW = CUSTOM_PROVIDER_DEFAULT_CONTEXT_WINDOW_TOKENS;
 const DEFAULT_MAX_TOKENS = 4096;
 // Azure OpenAI uses the Responses API which supports larger defaults
 const AZURE_DEFAULT_CONTEXT_WINDOW = 400_000;
@@ -26,7 +32,11 @@ export type CustomModelImageInputInference = {
 
 function normalizeContextWindowForCustomModel(value: unknown): number {
   const parsed = typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : 0;
-  return parsed >= CONTEXT_WINDOW_HARD_MIN_TOKENS ? parsed : CONTEXT_WINDOW_HARD_MIN_TOKENS;
+  const atLeastHardMin =
+    parsed >= CONTEXT_WINDOW_HARD_MIN_TOKENS
+      ? parsed
+      : CUSTOM_PROVIDER_DEFAULT_CONTEXT_WINDOW_TOKENS;
+  return Math.max(atLeastHardMin, CUSTOM_PROVIDER_DEFAULT_CONTEXT_WINDOW_TOKENS);
 }
 
 function customModelInputs(supportsImageInput: boolean): CustomModelInput[] {

--- a/src/commands/onboard-custom-config.ts
+++ b/src/commands/onboard-custom-config.ts
@@ -15,10 +15,10 @@ import { normalizeAlias } from "./models/alias-name.js";
 
 /**
  * Wizard default for non-Azure custom APIs when context length is unknown.
- * Must exceed the compaction `reserveTokensFloor` default (20000 tokens) in
- * `agent-runner-memory.ts`, or the first turns enter an infinite compact loop (#79428).
+ * Mirrors the generic persisted custom-model catalog fallback and leaves enough
+ * room above the default compaction reserve floor in `pi-settings.ts`.
  */
-export const CUSTOM_PROVIDER_DEFAULT_CONTEXT_WINDOW_TOKENS = 32_768;
+export const CUSTOM_PROVIDER_DEFAULT_CONTEXT_WINDOW_TOKENS = 128_000;
 const DEFAULT_CONTEXT_WINDOW = CUSTOM_PROVIDER_DEFAULT_CONTEXT_WINDOW_TOKENS;
 const DEFAULT_MAX_TOKENS = 4096;
 // Azure OpenAI uses the Responses API which supports larger defaults
@@ -32,11 +32,12 @@ export type CustomModelImageInputInference = {
 
 function normalizeContextWindowForCustomModel(value: unknown): number {
   const parsed = typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : 0;
-  const atLeastHardMin =
-    parsed >= CONTEXT_WINDOW_HARD_MIN_TOKENS
-      ? parsed
-      : CUSTOM_PROVIDER_DEFAULT_CONTEXT_WINDOW_TOKENS;
-  return Math.max(atLeastHardMin, CUSTOM_PROVIDER_DEFAULT_CONTEXT_WINDOW_TOKENS);
+  if (parsed <= 0 || parsed === CONTEXT_WINDOW_HARD_MIN_TOKENS) {
+    return CUSTOM_PROVIDER_DEFAULT_CONTEXT_WINDOW_TOKENS;
+  }
+  return parsed >= CONTEXT_WINDOW_HARD_MIN_TOKENS
+    ? parsed
+    : CUSTOM_PROVIDER_DEFAULT_CONTEXT_WINDOW_TOKENS;
 }
 
 function customModelInputs(supportsImageInput: boolean): CustomModelInput[] {


### PR DESCRIPTION
## Summary
- Raise the generated non-Azure Custom Provider context window above the default compaction reserve floor so fresh onboarding no longer creates a first-turn compaction loop.
- Heal legacy wizard-generated `4000` token custom model entries during reconfiguration.
- Preserve explicit valid small model limits such as `8192`, so local/proxy setups are not silently expanded past their real capacity.

Fixes #79428

## Verification
- `pnpm test src/commands/onboard-custom-config.test.ts` — 1 file, 37 tests passed.
- `env -u OPENCLAW_TESTBOX -u OPENCLAW_TESTBOX_ID pnpm check:changed` — passed core/core-test/docs lanes.
- `git diff --check` — clean.

## Real behavior proof

**Behavior or issue addressed:** Non-Azure Custom Provider onboarding no longer writes a generated `contextWindow` below the default compaction reserve floor, and re-onboarding heals legacy wizard-generated `4000` token entries without overwriting explicit valid smaller model limits.

**Real environment tested:** macOS source checkout of this PR branch, Node/pnpm repo runtime, OpenClaw onboarding config helper loaded through `tsx` from `src/commands/onboard-custom-config.ts`.

**Exact steps or command run after this patch:** Ran the patched OpenClaw config path with `pnpm exec tsx` to create three custom-provider configs: fresh model, legacy `4000` model, and explicit `8192` model, then printed the resulting `contextWindow` values.

**Evidence after fix:** Actual terminal output from the patched branch:

```json
{
  "fresh": 128000,
  "legacy4000": 128000,
  "explicit8192": 8192
}
```

**Observed result after fix:** Fresh non-Azure custom models now get `128000`; legacy wizard-generated `4000` entries are raised to `128000`; explicit valid `8192` entries remain `8192`, proving the fix avoids the compaction deadlock without broad-clamping small real model limits.

**What was not tested:** Full Windows 11 DashScope/Qwen gateway chat round-trip was not run in this maintainer patch; the changed behavior is the deterministic onboarding config write/merge path exercised above and by the focused regression test.
