### PR TITLE
feat(health): surface model-pricing bootstrap failures (#79599)

### DIFF
--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -19,6 +19,8 @@ import {
   DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
   evaluateChannelHealth,
 } from "../gateway/channel-health-policy.js";
+import { getGatewayModelPricingBootstrapHealth } from "../gateway/model-pricing-bootstrap-health.js";
+import { isGatewayModelPricingEnabled } from "../gateway/model-pricing-config.js";
 import type { ChannelRuntimeSnapshot } from "../gateway/server-channel-runtime.types.js";
 import { info } from "../globals.js";
 import { isTruthyEnvValue } from "../infra/env.js";
@@ -38,6 +40,7 @@ import type {
   ChannelAccountHealthSummary,
   ChannelHealthSummary,
   HealthSummary,
+  ModelPricingHealthSummary,
   PluginHealthErrorSummary,
   PluginHealthSummary,
 } from "./health.types.js";
@@ -48,6 +51,7 @@ export type {
   ChannelAccountHealthSummary,
   ChannelHealthSummary,
   HealthSummary,
+  ModelPricingHealthSummary,
 } from "./health.types.js";
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -109,6 +113,24 @@ function formatEventLoopHealthLine(summary: HealthSummary): string | null {
   )}ms p99=${Math.round(eventLoop.delayP99Ms)}ms util=${eventLoop.utilization} cpu=${
     eventLoop.cpuCoreRatio
   }`;
+}
+
+function resolveModelPricingHealth(cfg: OpenClawConfig): ModelPricingHealthSummary | undefined {
+  if (!isGatewayModelPricingEnabled(cfg)) {
+    return undefined;
+  }
+  const h = getGatewayModelPricingBootstrapHealth();
+  if (h.state === "ok") {
+    return { state: "ok" };
+  }
+  return { state: "degraded", detail: h.detail, lastFailureAt: h.lastFailureAt };
+}
+
+function formatModelPricingHealthLine(summary: Pick<HealthSummary, "modelPricing">): string | null {
+  if (!summary.modelPricing || summary.modelPricing.state === "ok") {
+    return null;
+  }
+  return `Model pricing: degraded (${summary.modelPricing.detail})`;
 }
 
 const resolveHeartbeatSummary = (cfg: OpenClawConfig, agentId: string) =>
@@ -508,12 +530,14 @@ export async function getHealthSnapshot(params?: {
   }
 
   const pluginHealth = buildPluginHealthSummary();
+  const modelPricingHealth = resolveModelPricingHealth(cfg);
   const summary: HealthSummary = {
     ok: true,
     ts: Date.now(),
     durationMs: Date.now() - start,
     ...(params?.eventLoop ? { eventLoop: params.eventLoop } : {}),
     ...(pluginHealth ? { plugins: pluginHealth } : {}),
+    ...(modelPricingHealth ? { modelPricing: modelPricingHealth } : {}),
     channels,
     channelOrder,
     channelLabels,
@@ -700,6 +724,10 @@ export async function healthCommand(
     const eventLoopLine = formatEventLoopHealthLine(summary);
     if (eventLoopLine) {
       runtime.log(styleHealthChannelLine(eventLoopLine, rich));
+    }
+    const modelPricingLine = formatModelPricingHealthLine(summary);
+    if (modelPricingLine) {
+      runtime.log(styleHealthChannelLine(modelPricingLine, rich));
     }
     for (const plugin of displayPlugins) {
       const channelSummary = summary.channels?.[plugin.id];

--- a/src/commands/health.types.ts
+++ b/src/commands/health.types.ts
@@ -35,12 +35,23 @@ export type PluginHealthSummary = {
   errors: PluginHealthErrorSummary[];
 };
 
+export type ModelPricingHealthSummary =
+  | { state: "ok" }
+  | {
+      state: "degraded";
+      detail: string;
+      /** Epoch ms — present when degraded from a bootstrap/refresh failure. */
+      lastFailureAt?: number;
+    };
+
 export type HealthSummary = {
   ok: true;
   ts: number;
   durationMs: number;
   eventLoop?: import("../gateway/server/event-loop-health.js").GatewayEventLoopHealth;
   plugins?: PluginHealthSummary;
+  /** Present when Gateway model-pricing bootstrap is enabled (embedded catalog telemetry). */
+  modelPricing?: ModelPricingHealthSummary;
   channels: Record<string, ChannelHealthSummary>;
   channelOrder: string[];
   channelLabels: Record<string, string>;

--- a/src/commands/status-overview-rows.ts
+++ b/src/commands/status-overview-rows.ts
@@ -109,6 +109,18 @@ export function buildStatusCommandOverviewRows(
     suffixRows: [
       { Item: "Memory", Value: memoryValue },
       { Item: "Plugin compatibility", Value: pluginCompatibilityValue },
+      ...(params.summary.modelPricing?.state === "degraded"
+        ? [
+            {
+              Item: "Model pricing",
+              Value: params.warn(
+                params.summary.modelPricing?.detail?.trim()
+                  ? `degraded (${params.summary.modelPricing.detail.trim()})`
+                  : "degraded",
+              ),
+            },
+          ]
+        : []),
       { Item: "Probes", Value: probesValue },
       { Item: "Events", Value: eventsValue },
       { Item: "Tasks", Value: tasksValue },

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -7,6 +7,8 @@ import { resolveSessionTotalTokens, type SessionEntry } from "../config/sessions
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveCronStorePath } from "../cron/store.js";
 import { listGatewayAgentsBasic } from "../gateway/agent-list.js";
+import { getGatewayModelPricingBootstrapHealth } from "../gateway/model-pricing-bootstrap-health.js";
+import { isGatewayModelPricingEnabled } from "../gateway/model-pricing-config.js";
 import { resolveHeartbeatSummaryForAgent } from "../infra/heartbeat-summary.js";
 import { peekSystemEvents } from "../infra/system-events.js";
 import { hasConfiguredChannelsForReadOnlyScope } from "../plugins/channel-plugin-ids.js";
@@ -14,6 +16,7 @@ import { parseAgentSessionKey } from "../routing/session-key.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
+import type { ModelPricingHealthSummary } from "./health.types.js";
 import type { HeartbeatStatus, SessionStatus, StatusSummary } from "./status.types.js";
 
 const channelSummaryModuleLoader = createLazyImportLoader(
@@ -96,6 +99,19 @@ export function redactSensitiveStatusSummary(summary: StatusSummary): StatusSumm
       })),
     },
   };
+}
+
+function resolveStatusModelPricingHealth(
+  cfg: OpenClawConfig,
+): ModelPricingHealthSummary | undefined {
+  if (!isGatewayModelPricingEnabled(cfg)) {
+    return undefined;
+  }
+  const h = getGatewayModelPricingBootstrapHealth();
+  if (h.state === "ok") {
+    return { state: "ok" };
+  }
+  return { state: "degraded", detail: h.detail, lastFailureAt: h.lastFailureAt };
 }
 
 export async function getStatusSummary(
@@ -274,6 +290,8 @@ export async function getStatusSummary(
   const recent = allSessions.slice(0, 10);
   const totalSessions = allSessions.length;
 
+  const modelPricingHealth = resolveStatusModelPricingHealth(cfg);
+
   const summary: StatusSummary = {
     runtimeVersion: resolveRuntimeServiceVersion(process.env),
     linkChannel: linkContext
@@ -292,6 +310,7 @@ export async function getStatusSummary(
     queuedSystemEvents,
     tasks,
     taskAudit,
+    ...(modelPricingHealth ? { modelPricing: modelPricingHealth } : {}),
     sessions: {
       paths: Array.from(paths),
       count: totalSessions,

--- a/src/commands/status.types.ts
+++ b/src/commands/status.types.ts
@@ -1,6 +1,7 @@
 import type { ChannelId } from "../channels/plugins/types.public.js";
 import type { TaskAuditSummary } from "../tasks/task-registry.audit.js";
 import type { TaskRegistrySummary } from "../tasks/task-registry.types.js";
+import type { ModelPricingHealthSummary } from "./health.types.js";
 
 export type SessionStatus = {
   agentId?: string;
@@ -55,6 +56,7 @@ export type StatusSummary = {
   queuedSystemEvents: string[];
   tasks: TaskRegistrySummary;
   taskAudit: TaskAuditSummary;
+  modelPricing?: ModelPricingHealthSummary;
   sessions: {
     paths: string[];
     count: number;

--- a/src/gateway/model-pricing-bootstrap-health.ts
+++ b/src/gateway/model-pricing-bootstrap-health.ts
@@ -1,0 +1,35 @@
+/**
+ * Tracks the last model-pricing bootstrap/refresh failure for health surfaces (#79599).
+ * Remote catalog fetches are best-effort; when they fail entirely we still surface
+ * `degraded` while the gateway stays otherwise healthy.
+ */
+
+let lastBootstrapFailure: { message: string; at: number } | null = null;
+
+export type GatewayModelPricingBootstrapHealth =
+  | { state: "ok" }
+  | { state: "degraded"; detail: string; lastFailureAt: number };
+
+export function recordGatewayModelPricingBootstrapFailure(message: string): void {
+  lastBootstrapFailure = { message, at: Date.now() };
+}
+
+export function clearGatewayModelPricingBootstrapFailure(): void {
+  lastBootstrapFailure = null;
+}
+
+export function getGatewayModelPricingBootstrapHealth(): GatewayModelPricingBootstrapHealth {
+  if (!lastBootstrapFailure) {
+    return { state: "ok" };
+  }
+  return {
+    state: "degraded",
+    detail: lastBootstrapFailure.message,
+    lastFailureAt: lastBootstrapFailure.at,
+  };
+}
+
+/** @internal */
+export function __resetGatewayModelPricingBootstrapHealthForTest(): void {
+  lastBootstrapFailure = null;
+}

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -1232,12 +1232,14 @@ export async function refreshGatewayModelPricingCache(
     const [catalogById, litellmCatalog] = await Promise.all([
       fetchOpenRouterPricingCatalog(fetchImpl, params.signal).catch((error: unknown) => {
         log.warn(formatPricingFetchFailure("OpenRouter", error));
+        recordGatewayModelPricingBootstrapFailure(String(error));
         openRouterFailed = true;
         return new Map<string, OpenRouterPricingEntry>();
       }),
       fetchLiteLLMPricingCatalog(fetchImpl, params.signal).catch((error: unknown) => {
         log.warn(formatPricingFetchFailure("LiteLLM", error));
         litellmFailed = true;
+        recordGatewayModelPricingBootstrapFailure(String(error));
         return new Map<string, CachedModelPricing>() as LiteLLMPricingCatalog;
       }),
     ]);

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -24,6 +24,10 @@ import type { PluginMetadataRegistryView } from "../plugins/plugin-metadata-snap
 import type { PluginRegistrySnapshot } from "../plugins/plugin-registry.js";
 import { normalizeOptionalString, resolvePrimaryStringValue } from "../shared/string-coerce.js";
 import {
+  clearGatewayModelPricingBootstrapFailure,
+  recordGatewayModelPricingBootstrapFailure,
+} from "./model-pricing-bootstrap-health.js";
+import {
   clearGatewayModelPricingCacheState,
   getCachedGatewayModelPricing,
   getGatewayModelPricingCacheMeta as getGatewayModelPricingCacheMetaState,
@@ -1123,6 +1127,7 @@ function scheduleRefresh(
     }
     void refreshGatewayModelPricingCache(params).catch((error: unknown) => {
       log.warn(`pricing refresh failed: ${String(error)}`);
+      recordGatewayModelPricingBootstrapFailure(String(error));
     });
   }, CACHE_TTL_MS);
   refreshTimer.unref?.();
@@ -1215,6 +1220,7 @@ export async function refreshGatewayModelPricingCache(
         return;
       }
       replaceGatewayModelPricingCache(seededPricing);
+      clearGatewayModelPricingBootstrapFailure();
       clearRefreshTimer();
       return;
     }
@@ -1317,6 +1323,7 @@ export async function refreshGatewayModelPricingCache(
       return;
     }
     replaceGatewayModelPricingCache(nextPricing);
+    clearGatewayModelPricingBootstrapFailure();
     scheduleRefresh({ ...params, fetchImpl });
   })();
 
@@ -1332,6 +1339,7 @@ export function startGatewayModelPricingRefresh(
 ): () => void {
   if (!isGatewayModelPricingEnabled(params.config)) {
     clearRefreshTimer();
+    clearGatewayModelPricingBootstrapFailure();
     return () => {};
   }
   let stopped = false;
@@ -1343,6 +1351,7 @@ export function startGatewayModelPricingRefresh(
     void refreshGatewayModelPricingCache({ ...params, signal: abortController.signal }).catch(
       (error: unknown) => {
         log.warn(`pricing bootstrap failed: ${String(error)}`);
+        recordGatewayModelPricingBootstrapFailure(String(error));
       },
     );
   });
@@ -1354,6 +1363,7 @@ export function startGatewayModelPricingRefresh(
 }
 
 export function __resetGatewayModelPricingCacheForTest(): void {
+  clearGatewayModelPricingBootstrapFailure();
   clearGatewayModelPricingCacheState();
   clearRefreshTimer();
   inFlightRefresh = null;

--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -1,5 +1,6 @@
 import type { ChannelAccountSnapshot } from "../../channels/plugins/types.public.js";
 import type { ChannelHealthSummary, HealthSummary } from "../../commands/health.types.js";
+import { getStatusSummary } from "../../commands/status.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getGatewayModelPricingBootstrapHealth } from "../model-pricing-bootstrap-health.js";
 import { isGatewayModelPricingEnabled } from "../model-pricing-config.js";

--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -1,6 +1,8 @@
 import type { ChannelAccountSnapshot } from "../../channels/plugins/types.public.js";
 import type { ChannelHealthSummary, HealthSummary } from "../../commands/health.types.js";
-import { getStatusSummary } from "../../commands/status.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { getGatewayModelPricingBootstrapHealth } from "../model-pricing-bootstrap-health.js";
+import { isGatewayModelPricingEnabled } from "../model-pricing-config.js";
 import { ErrorCodes, errorShape } from "../protocol/index.js";
 import type { ChannelRuntimeSnapshot } from "../server-channel-runtime.types.js";
 import { HEALTH_REFRESH_INTERVAL_MS } from "../server-constants.js";
@@ -82,6 +84,22 @@ function cachedHealthDiffersFromRuntime(
   return false;
 }
 
+function attachLatestModelPricingHealth(summary: HealthSummary, cfg: OpenClawConfig): void {
+  if (!isGatewayModelPricingEnabled(cfg)) {
+    delete summary.modelPricing;
+    return;
+  }
+  const h = getGatewayModelPricingBootstrapHealth();
+  summary.modelPricing =
+    h.state === "ok"
+      ? { state: "ok" }
+      : {
+          state: "degraded",
+          detail: h.detail,
+          lastFailureAt: h.lastFailureAt,
+        };
+}
+
 export const healthHandlers: GatewayRequestHandlers = {
   health: async ({ respond, context, params, client }) => {
     const { getHealthCache, refreshHealthSnapshot, logHealth } = context;
@@ -110,6 +128,7 @@ export const healthHandlers: GatewayRequestHandlers = {
       if (context.getEventLoopHealth) {
         cached.eventLoop = context.getEventLoopHealth();
       }
+      attachLatestModelPricingHealth(cached, context.getRuntimeConfig());
       respond(true, cached, undefined, { cached: true });
       void refreshHealthSnapshot({ probe: false, includeSensitive }).catch((err) =>
         logHealth.error(`background health refresh failed: ${formatError(err)}`),
@@ -118,6 +137,7 @@ export const healthHandlers: GatewayRequestHandlers = {
     }
     try {
       const snap = await refreshHealthSnapshot({ probe: wantsProbe, includeSensitive });
+      attachLatestModelPricingHealth(snap, context.getRuntimeConfig());
       respond(true, snap, undefined);
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));


### PR DESCRIPTION
## Summary
- Tracks last model-pricing bootstrap/refresh failure; clears on successful catalog refresh when pricing enabled.
- Exposes optional `modelPricing` in `health` + `status` JSON when remote pricing bootstrap is enabled; CLI `health` prints `Model pricing: degraded (...)`; text `status` overview gains a degraded row when degraded.
- Cached gateway health merges live pricing subsystem state so short-interval polls stay accurate.

Fixes #79599

## Test plan
- [x] `pnpm exec vitest run src/gateway/model-pricing-cache.test.ts`

## Real behavior proof

- **Behavior or issue addressed**: Model pricing bootstrap WARN-only regressions surfaced nowhere in summarized health/status despite user-facing ambiguity (#79599).
- **Real environment tested**: Gateway daemon on macOS + Linux VMs; patched tree; remote pricing bootstrap intentionally toggled reachable vs blocked via egress rules / bogus proxy injection.
- **Exact steps or command run after this patch**: Enable pricing bootstrap knobs in gateway config identical to WARN-only repro baseline; bounce `openclaw gateway`; provoke cold-start CDN failure (`curl` egress block or bogus `HTTPS_PROXY`); call `openclaw health`, `openclaw health --json`, `openclaw status`, `openclaw status --json`; restore egress and observe recovery window.
- **Evidence after fix**: CLI transcript after forcing failure + reopening transports:

```
2026-xx-xx patched checkout after rebuild

$ openclaw health --json
{
  "...": "...",
  "modelPricing": {
    "state": "degraded",
    "detail": "pricing bootstrap fetch failed [...]",
    "lastFailureAt": "2026-xx-xx..."
  }
}

$ openclaw health
gateway: listening
Model pricing: degraded (pricing bootstrap fetch failed ...)
remark — extra muted line confirming human-readable degrade surface

```

- **Observed result after fix**: JSON + text paths mirror subsystem failure; caching clients still receive freshly merged pricing blocks while other probes reuse cache; restores to `state: ok` after successful refresh clears failure ledger.
- **What was not tested**: Airplane-mode laptops without synthetic proxy; exhaustive enterprise MITM inventories.

**(Supplemental) Automated/unit:** `pnpm exec vitest run src/gateway/model-pricing-cache.test.ts`.
