### PR TITLE
fix(browser): time out remote tab enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Browser: time out remote CDP Playwright tab enumeration and evict stuck scoped connections so unstable remote browsers fail fast instead of blocking Gateway browser requests. Fixes #58968. Thanks @KeaneYan.
 - Feishu: auto-thread `message(action="send")` replies inside the topic when the active session is group_topic or group_topic_sender, and propagate `replyInThread` through text, card, and media outbound adapters so topic-scoped sessions no longer post at the group root. Fixes #74903. (#77151) Thanks @ai-hpc.
 - WhatsApp: pass routing context into voice-note transcript echo preflight so echoed transcripts can deliver to the originating chat. Fixes #79778. (#79788) Thanks @hclsys.
 - Cron/failover: classify structured OpenAI-compatible `server_error` payloads as `server_error`, expose that reason in cron state, and let one-shot cron retry policy honor `retryOn: ["server_error"]` without requiring raw `5xx` text. (#45594) Thanks @clovericbot.

--- a/extensions/browser/src/browser/pw-session.connections.test.ts
+++ b/extensions/browser/src/browser/pw-session.connections.test.ts
@@ -97,6 +97,32 @@ function makeDisconnectedReadBrowser(): BrowserMockBundle {
   return { browser, browserClose };
 }
 
+function makeStuckPageTargetBrowser(): BrowserMockBundle {
+  let context: import("playwright-core").BrowserContext;
+  const browserClose = vi.fn(async () => {});
+  const page = {
+    on: vi.fn(),
+    context: () => context,
+    title: vi.fn(async () => "never reached"),
+    url: vi.fn(() => "https://stuck.example"),
+  } as unknown as import("playwright-core").Page;
+
+  context = {
+    pages: () => [page],
+    on: vi.fn(),
+    newCDPSession: vi.fn(() => new Promise(() => {})),
+  } as unknown as import("playwright-core").BrowserContext;
+
+  const browser = {
+    contexts: () => [context],
+    on: vi.fn(),
+    off: vi.fn(),
+    close: browserClose,
+  } as unknown as import("playwright-core").Browser;
+
+  return { browser, browserClose };
+}
+
 function makeMutatingDisconnectBrowser(): BrowserMockBundle & {
   newPage: ReturnType<typeof vi.fn>;
 } {
@@ -249,6 +275,37 @@ describe("pw-session connection scoping", () => {
     expect(pages.map((page) => page.targetId)).toEqual(["A"]);
     expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
     await vi.waitFor(() => expect(stale.browserClose).toHaveBeenCalledTimes(1));
+    expect(refreshed.browserClose).not.toHaveBeenCalled();
+  });
+
+  it("times out stuck page enumeration and evicts the scoped connection", async () => {
+    const stuck = makeStuckPageTargetBrowser();
+    const refreshed = makeBrowser("A", "https://a.example/recovered");
+    let connectCalls = 0;
+
+    connectOverCdpSpy.mockImplementation((async (...args: unknown[]) => {
+      const endpointText = String(args[0]);
+      if (endpointText !== "http://127.0.0.1:9222") {
+        throw new Error(`unexpected endpoint: ${endpointText}`);
+      }
+      connectCalls += 1;
+      return connectCalls === 1 ? stuck.browser : refreshed.browser;
+    }) as never);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    await expect(
+      listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222", timeoutMs: 20 }),
+    ).rejects.toThrow(/Playwright page enumeration timed out after 20ms/);
+
+    await vi.waitFor(() => expect(stuck.browserClose).toHaveBeenCalledTimes(1));
+
+    const pages = await listPagesViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      timeoutMs: 1000,
+    });
+
+    expect(pages.map((page) => page.targetId)).toEqual(["A"]);
+    expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
     expect(refreshed.browserClose).not.toHaveBeenCalled();
   });
 

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -1240,6 +1240,53 @@ async function withPlaywrightSafeReadReconnect<T>(
   }
 }
 
+function normalizePlaywrightOperationTimeoutMs(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return Math.max(1, Math.floor(value));
+}
+
+async function withPlaywrightOperationTimeout<T>(opts: {
+  cdpUrl: string;
+  timeoutMs?: number;
+  label: string;
+  ssrfPolicy?: SsrFPolicy;
+  run: () => Promise<T>;
+}): Promise<T> {
+  const timeoutMs = normalizePlaywrightOperationTimeoutMs(opts.timeoutMs);
+  if (timeoutMs === undefined) {
+    return await opts.run();
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timeoutError: Error | undefined;
+  const work = opts.run();
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      timeoutError = new Error(`${opts.label} timed out after ${timeoutMs}ms`);
+      reject(timeoutError);
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([work, timeout]);
+  } catch (err) {
+    if (err === timeoutError) {
+      await forceDisconnectPlaywrightForTarget({
+        cdpUrl: opts.cdpUrl,
+        ssrfPolicy: opts.ssrfPolicy,
+        reason: opts.label,
+      }).catch(() => {});
+    }
+    throw err;
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 /**
  * List all pages/tabs from the persistent Playwright connection.
  * Used for remote profiles where HTTP-based /json/list is ephemeral.
@@ -1247,6 +1294,7 @@ async function withPlaywrightSafeReadReconnect<T>(
 export async function listPagesViaPlaywright(opts: {
   cdpUrl: string;
   ssrfPolicy?: SsrFPolicy;
+  timeoutMs?: number;
 }): Promise<
   Array<{
     targetId: string;
@@ -1255,55 +1303,64 @@ export async function listPagesViaPlaywright(opts: {
     type: string;
   }>
 > {
-  return await withPlaywrightSafeReadReconnect(opts.cdpUrl, async () => {
-    const { browser } = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
-    const pages = await getAllPages(browser);
-    const results: Array<{
-      targetId: string;
-      title: string;
-      url: string;
-      type: string;
-    }> = [];
+  const readPages = async () =>
+    await withPlaywrightSafeReadReconnect(opts.cdpUrl, async () => {
+      const { browser } = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
+      const pages = await getAllPages(browser);
+      const results: Array<{
+        targetId: string;
+        title: string;
+        url: string;
+        type: string;
+      }> = [];
 
-    for (const page of pages) {
-      if (isBlockedPageRef(opts.cdpUrl, page)) {
-        continue;
-      }
-      let tid: string | null;
-      try {
-        tid = await pageTargetId(page);
-      } catch (err) {
-        if (isRecoverablePlaywrightDisconnectError(err)) {
-          throw err;
+      for (const page of pages) {
+        if (isBlockedPageRef(opts.cdpUrl, page)) {
+          continue;
         }
-        tid = null;
-      }
-      if (tid && !isBlockedTarget(opts.cdpUrl, tid)) {
-        let title = "";
+        let tid: string | null;
         try {
-          title = await page.title();
+          tid = await pageTargetId(page);
         } catch (err) {
           if (isRecoverablePlaywrightDisconnectError(err)) {
             throw err;
           }
+          tid = null;
         }
-        let url = "";
-        try {
-          url = page.url();
-        } catch (err) {
-          if (isRecoverablePlaywrightDisconnectError(err)) {
-            throw err;
+        if (tid && !isBlockedTarget(opts.cdpUrl, tid)) {
+          let title = "";
+          try {
+            title = await page.title();
+          } catch (err) {
+            if (isRecoverablePlaywrightDisconnectError(err)) {
+              throw err;
+            }
           }
+          let url = "";
+          try {
+            url = page.url();
+          } catch (err) {
+            if (isRecoverablePlaywrightDisconnectError(err)) {
+              throw err;
+            }
+          }
+          results.push({
+            targetId: tid,
+            title,
+            url,
+            type: "page",
+          });
         }
-        results.push({
-          targetId: tid,
-          title,
-          url,
-          type: "page",
-        });
       }
-    }
-    return results;
+      return results;
+    });
+
+  return await withPlaywrightOperationTimeout({
+    cdpUrl: opts.cdpUrl,
+    timeoutMs: opts.timeoutMs,
+    label: "Playwright page enumeration",
+    ssrfPolicy: opts.ssrfPolicy,
+    run: readPages,
   });
 }
 

--- a/extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts
+++ b/extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts
@@ -40,6 +40,11 @@ describe("browser remote profile tab ops via Playwright", () => {
 
     const tabs = await remote.listTabs();
     expect(tabs.map((t) => t.targetId)).toEqual(["T1"]);
+    expect(listPagesViaPlaywright).toHaveBeenCalledWith({
+      cdpUrl: "https://1.1.1.1:9222/chrome?token=abc",
+      ssrfPolicy: { allowPrivateNetwork: true },
+      timeoutMs: 3000,
+    });
 
     const opened = await remote.openTab("http://127.0.0.1:3000");
     expect(opened.targetId).toBe("T2");

--- a/extensions/browser/src/browser/server-context.tab-ops.ts
+++ b/extensions/browser/src/browser/server-context.tab-ops.ts
@@ -206,8 +206,17 @@ export function createProfileTabOps({
       const listPagesViaPlaywright = (mod as Partial<PwAiModule> | null)?.listPagesViaPlaywright;
       if (typeof listPagesViaPlaywright === "function") {
         const ssrfPolicy = getCdpControlPolicy();
+        const resolved = state().resolved;
+        const timeoutMs = Math.max(
+          resolved.remoteCdpTimeoutMs,
+          resolved.remoteCdpHandshakeTimeoutMs,
+        );
         await assertCdpEndpointAllowed(profile.cdpUrl, ssrfPolicy);
-        const pages = await listPagesViaPlaywright({ cdpUrl: profile.cdpUrl, ssrfPolicy });
+        const pages = await listPagesViaPlaywright({
+          cdpUrl: profile.cdpUrl,
+          ssrfPolicy,
+          timeoutMs,
+        });
         return pages.map((p) => ({
           targetId: p.targetId,
           title: p.title,


### PR DESCRIPTION
## Summary
- Fixes #58968 by bounding remote CDP Playwright tab enumeration with the existing remote CDP timeout budget.
- Evicts the scoped cached/in-flight Playwright connection on enumeration timeout so the next request can reconnect instead of reusing a stuck pipe.
- Adds regression coverage for a stuck page-target lookup and verifies remote profile tab listing passes the resolved timeout into the Playwright path.

## Problem
Remote CDP profiles use a persistent Playwright connection for tab listing because HTTP `/json/list` is ephemeral for those providers. When that Playwright-backed enumeration stalls, browser requests can hang behind the stuck CDP operation instead of failing fast.

## Root Cause
`createProfileTabOps().readTabs()` passed only `cdpUrl` and SSRF policy to `listPagesViaPlaywright()`. The lower-level Playwright enumeration path had no operation-level timeout around `connectBrowser()`, `getAllPages()`, or per-page target/title/url reads, and a stuck scoped connection could remain cached or in-flight.

## Architectural Reasoning
The fix reuses the existing browser remote CDP timeout contract rather than adding a new config key. Remote tab listing now uses `max(remoteCdpTimeoutMs, remoteCdpHandshakeTimeoutMs)`, which matches the existing distinction between HTTP discovery and WebSocket handshake budgets. Timeout cleanup goes through the existing scoped Playwright disconnect helper, preserving per-CDP URL isolation and avoiding hidden coupling to other browser profiles.

## Real behavior proof
- **Behavior or issue addressed:** Remote CDP Playwright tab enumeration now returns a bounded timeout error instead of waiting indefinitely on a stalled CDP discovery/enumeration path.
- **Real environment tested:** Windows 11 worktree, Node `v22.15.0`, `pnpm 10.33.2`, branch `codex/issue-triage-20260509`, commit `9aba9b405ae5c4601211fd0b2b428d9640425b8b`.
- **Exact steps or command run after this patch:** Started a real loopback HTTP endpoint that accepts CDP discovery connections and deliberately never responds; called production `listPagesViaPlaywright()` through `node --import tsx` with `timeoutMs: 100` and an SSRF policy allowing loopback/private access; closed the scoped Playwright connection and destroyed the held socket after the call.
- **Evidence after fix:**

```console
$ node --import tsx - < hanging-cdp-smoke.mjs
{"ok":true,"error":"Playwright page enumeration timed out after 100ms","elapsedMs":309}
```

- **Observed result after fix:** The production browser module returned `Playwright page enumeration timed out after 100ms` and the script exited cleanly instead of hanging on the held CDP request.
- **What was not tested:** I did not use a real remote Chrome host because the failure mode is a stalled CDP endpoint; the local loopback endpoint exercises the same production timeout path with deterministic cleanup. Full `pnpm test extensions/browser` still has unrelated Windows environment failures noted below.

## Testing
- `pnpm test extensions/browser/src/browser/pw-session.connections.test.ts extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/browser/src/browser/pw-session.ts extensions/browser/src/browser/server-context.tab-ops.ts extensions/browser/src/browser/pw-session.connections.test.ts extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts`
- `pnpm tsgo:extensions` from `O:\` subst drive to avoid the repo path-with-spaces launcher bug
- `pnpm tsgo:extensions:test` from `O:\`
- `pnpm lint:extensions` from `O:\`
- `pnpm check:changelog-attributions`
- `git diff --check upstream/main...HEAD`
- `pnpm check:changed --staged` exited 0 with no lane output

Full `pnpm test extensions/browser` was also run locally. It failed on unrelated Windows environment assumptions: local browser auto-detection / missing supported browser launch fixtures and existing `/tmp` path expectations being normalized to `C:\tmp`. The two touched regression test files pass.

## Risk Analysis
Risk is medium because this touches async browser/CDP lifecycle behavior. The change is scoped to remote Playwright tab enumeration, does not alter local managed browser JSON tab listing, and does not change navigation, action, or screenshot behavior. On timeout, OpenClaw drops only the scoped Playwright connection for that CDP URL and leaves the actual remote browser tabs intact.

## Backward Compatibility
No config, API, or response-shape changes. Existing `browser.remoteCdpTimeoutMs` and `browser.remoteCdpHandshakeTimeoutMs` now also bound remote Playwright tab enumeration.

## Screenshots / Logs
The real behavior proof above is terminal output from the after-fix smoke; no UI screenshot is applicable.