### PR TITLE
[codex] Map ACP thinking to advertised effort key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- ACP sessions: map canonical runtime options to backend-advertised ACP config keys like Claude's `effort` while keeping persisted OpenClaw state canonical. (#79926) Thanks @InTheCloudDan.
 - OpenAI/Codex: point gateway missing-key recovery and wizard docs at the canonical `openai/gpt-5.5` plus Codex OAuth route, and fix trajectory export errors so they suggest the valid `openclaw sessions` command.
 - Google/Gemini: normalize retired `google/gemini-3-pro-preview` primary, fallback, and model-map refs during config load and unrelated config writes so saved config keeps targeting Gemini 3.1 Pro Preview.
 - Discord/voice: synthesize realtime playback timestamps from emitted Discord PCM so OpenAI realtime barge-in truncation no longer sees `audioEndMs=0` and skips legitimate interruptions.

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -790,15 +790,15 @@ roots.
 `/acp` has convenience commands and a generic setter. Equivalent
 operations:
 
-| Command                      | Maps to                              | Notes                                                                                                                                                                          |
-| ---------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `/acp model <id>`            | runtime config key `model`           | For Codex ACP, OpenClaw normalizes `openai-codex/<model>` to the adapter model id and maps slash reasoning suffixes such as `openai-codex/gpt-5.4/high` to `reasoning_effort`. |
-| `/acp set thinking <level>`  | runtime config key `thinking`        | For Codex ACP, OpenClaw sends the corresponding `reasoning_effort` where the adapter supports one.                                                                             |
-| `/acp permissions <profile>` | runtime config key `approval_policy` | -                                                                                                                                                                              |
-| `/acp timeout <seconds>`     | runtime config key `timeout`         | -                                                                                                                                                                              |
-| `/acp cwd <path>`            | runtime cwd override                 | Direct update.                                                                                                                                                                 |
-| `/acp set <key> <value>`     | generic                              | `key=cwd` uses the cwd override path.                                                                                                                                          |
-| `/acp reset-options`         | clears all runtime overrides         | -                                                                                                                                                                              |
+| Command                      | Maps to                              | Notes                                                                                                                                                                                                      |
+| ---------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/acp model <id>`            | runtime config key `model`           | For Codex ACP, OpenClaw normalizes `openai-codex/<model>` to the adapter model id and maps slash reasoning suffixes such as `openai-codex/gpt-5.4/high` to `reasoning_effort`.                             |
+| `/acp set thinking <level>`  | canonical option `thinking`          | OpenClaw sends the backend-advertised equivalent when present, preferring `thinking`, then `effort`, `reasoning_effort`, or `thought_level`. For Codex ACP, the adapter maps values to `reasoning_effort`. |
+| `/acp permissions <profile>` | canonical option `permissionProfile` | OpenClaw sends the backend-advertised equivalent when present, such as `approval_policy`, `permission_profile`, `permissions`, or `permission_mode`.                                                       |
+| `/acp timeout <seconds>`     | canonical option `timeoutSeconds`    | OpenClaw sends the backend-advertised equivalent when present, such as `timeout` or `timeout_seconds`.                                                                                                     |
+| `/acp cwd <path>`            | runtime cwd override                 | Direct update.                                                                                                                                                                                             |
+| `/acp set <key> <value>`     | generic                              | `key=cwd` uses the cwd override path.                                                                                                                                                                      |
+| `/acp reset-options`         | clears all runtime overrides         | -                                                                                                                                                                                                          |
 
 ## acpx harness, plugin setup, and permissions
 

--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -6,8 +6,8 @@ import {
   buildPluginApi,
   registerSingleProviderPlugin,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { withEnvAsync } from "../../src/test-utils/env.js";
 import { setAwsSharedIniFileLoaderForTest } from "./aws-credential-refresh.js";
 import { resetBedrockDiscoveryCacheForTest } from "./discovery.js";
 import amazonBedrockPlugin from "./index.js";

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -75,6 +75,7 @@ import {
   mergeRuntimeOptions,
   normalizeRuntimeOptions,
   normalizeText,
+  resolveRuntimeConfigOptionKey,
   resolveRuntimeOptionsFromMeta,
   runtimeOptionsEqual,
   validateRuntimeConfigOptionInput,
@@ -588,7 +589,11 @@ export class AcpSessionManager {
         meta: resolvedMeta,
       });
       const inferredPatch = inferRuntimeOptionPatchFromConfigOption(key, value);
-      const capabilities = await this.resolveRuntimeCapabilities({ runtime, handle });
+      const capabilities = await this.resolveRuntimeCapabilities({
+        runtime,
+        handle,
+        includeStatusConfigOptionKeys: true,
+      });
       if (
         !capabilities.controls.includes("session/set_config_option") ||
         !runtime.setConfigOption
@@ -601,13 +606,17 @@ export class AcpSessionManager {
 
       const advertisedKeys = new Set(
         (capabilities.configOptionKeys ?? [])
-          .map((entry) => normalizeText(entry))
-          .filter(Boolean) as string[],
+          .map((entry) => normalizeLowercaseStringOrEmpty(entry))
+          .filter(Boolean),
       );
-      if (advertisedKeys.size > 0 && !advertisedKeys.has(key)) {
+      const wireKey = resolveRuntimeConfigOptionKey(key, capabilities.configOptionKeys);
+      if (
+        advertisedKeys.size > 0 &&
+        !advertisedKeys.has(normalizeLowercaseStringOrEmpty(wireKey))
+      ) {
         throw new AcpRuntimeError(
           "ACP_BACKEND_UNSUPPORTED_CONTROL",
-          `ACP backend "${handle.backend || meta.backend}" does not accept config key "${key}".`,
+          `ACP backend "${handle.backend || meta.backend}" does not accept config key "${wireKey}".`,
         );
       }
 
@@ -615,7 +624,7 @@ export class AcpSessionManager {
         run: async () =>
           await runtime.setConfigOption!({
             handle,
-            key,
+            key: wireKey,
             value,
           }),
         fallbackCode: "ACP_TURN_FAILED",
@@ -1879,6 +1888,7 @@ export class AcpSessionManager {
   private async resolveRuntimeCapabilities(params: {
     runtime: AcpRuntime;
     handle: AcpRuntimeHandle;
+    includeStatusConfigOptionKeys?: boolean;
   }): Promise<AcpRuntimeCapabilities> {
     return await resolveManagerRuntimeCapabilities(params);
   }

--- a/src/acp/control-plane/manager.runtime-controls.ts
+++ b/src/acp/control-plane/manager.runtime-controls.ts
@@ -1,5 +1,11 @@
+import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { AcpRuntimeError, withAcpRuntimeErrorBoundary } from "../runtime/errors.js";
-import type { AcpRuntime, AcpRuntimeCapabilities, AcpRuntimeHandle } from "../runtime/types.js";
+import type {
+  AcpRuntime,
+  AcpRuntimeCapabilities,
+  AcpRuntimeHandle,
+  AcpRuntimeStatus,
+} from "../runtime/types.js";
 import type { SessionAcpMeta } from "./manager.types.js";
 import { createUnsupportedControlError } from "./manager.utils.js";
 import type { CachedRuntimeState } from "./runtime-cache.js";
@@ -10,9 +16,39 @@ import {
   resolveRuntimeOptionsFromMeta,
 } from "./runtime-options.js";
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function extractConfigOptionKeys(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => {
+      if (typeof entry === "string") {
+        return normalizeText(entry);
+      }
+      const record = asRecord(entry);
+      return normalizeText(record?.id ?? record?.key);
+    })
+    .filter(Boolean) as string[];
+}
+
+function extractRuntimeStatusConfigOptionKeys(status: AcpRuntimeStatus | undefined): string[] {
+  const details = asRecord(status?.details);
+  return [
+    ...extractConfigOptionKeys(details?.configOptions),
+    ...extractConfigOptionKeys(details?.config_options),
+  ];
+}
+
 export async function resolveManagerRuntimeCapabilities(params: {
   runtime: AcpRuntime;
   handle: AcpRuntimeHandle;
+  includeStatusConfigOptionKeys?: boolean;
 }): Promise<AcpRuntimeCapabilities> {
   let reported: AcpRuntimeCapabilities | undefined;
   if (params.runtime.getCapabilities) {
@@ -32,12 +68,30 @@ export async function resolveManagerRuntimeCapabilities(params: {
   if (params.runtime.getStatus) {
     controls.add("session/status");
   }
-  const normalizedKeys = (reported?.configOptionKeys ?? [])
-    .map((entry) => normalizeText(entry))
-    .filter(Boolean) as string[];
+  const normalizedKeys = new Set(
+    (reported?.configOptionKeys ?? [])
+      .map((entry) => normalizeText(entry))
+      .filter(Boolean) as string[],
+  );
+  if (
+    normalizedKeys.size === 0 &&
+    params.includeStatusConfigOptionKeys &&
+    params.runtime.getStatus
+  ) {
+    try {
+      const status = await params.runtime.getStatus({ handle: params.handle });
+      for (const key of extractRuntimeStatusConfigOptionKeys(status)) {
+        normalizedKeys.add(key);
+      }
+    } catch {
+      // Status-derived option keys are an optional refinement. Keep the
+      // capability result usable for runtimes that expose controls but cannot
+      // answer status before a turn.
+    }
+  }
   return {
     controls: [...controls].toSorted(),
-    ...(normalizedKeys.length > 0 ? { configOptionKeys: normalizedKeys } : {}),
+    ...(normalizedKeys.size > 0 ? { configOptionKeys: [...normalizedKeys] } : {}),
   };
 }
 
@@ -55,17 +109,19 @@ export async function applyManagerRuntimeControls(params: {
     return;
   }
 
+  const needsConfigOptionKeys = buildRuntimeConfigOptionPairs(options).length > 0;
   const capabilities = await resolveManagerRuntimeCapabilities({
     runtime: params.runtime,
     handle: params.handle,
+    includeStatusConfigOptionKeys: needsConfigOptionKeys,
   });
   const backend = params.handle.backend || params.meta.backend;
   const runtimeMode = normalizeText(options.runtimeMode);
-  const configOptions = buildRuntimeConfigOptionPairs(options);
+  const configOptions = buildRuntimeConfigOptionPairs(options, capabilities.configOptionKeys);
   const advertisedKeys = new Set(
     (capabilities.configOptionKeys ?? [])
-      .map((entry) => normalizeText(entry))
-      .filter(Boolean) as string[],
+      .map((entry) => normalizeLowercaseStringOrEmpty(entry))
+      .filter(Boolean),
   );
 
   await withAcpRuntimeErrorBoundary({
@@ -94,7 +150,10 @@ export async function applyManagerRuntimeControls(params: {
           });
         }
         for (const [key, value] of configOptions) {
-          if (advertisedKeys.size > 0 && !advertisedKeys.has(key)) {
+          if (
+            advertisedKeys.size > 0 &&
+            !advertisedKeys.has(normalizeLowercaseStringOrEmpty(key))
+          ) {
             throw new AcpRuntimeError(
               "ACP_BACKEND_UNSUPPORTED_CONTROL",
               `ACP backend "${backend}" does not accept config key "${key}".`,

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -3326,6 +3326,39 @@ describe("AcpSessionManager", () => {
     expect(nextOptions).toEqual({ thinking: "high" });
   });
 
+  it("persists explicit native permission_mode config updates as canonical permission profiles", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_config_option", "session/status"],
+      configOptionKeys: ["permission_mode"],
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:claude:acp:session-1",
+      storeSessionKey: "agent:claude:acp:session-1",
+      acp: readySessionMeta({ agent: "claude" }),
+    });
+
+    const manager = new AcpSessionManager();
+    const nextOptions = await manager.setSessionConfigOption({
+      cfg: baseCfg,
+      sessionKey: "agent:claude:acp:session-1",
+      key: "permission_mode",
+      value: "strict",
+    });
+
+    expect(runtimeState.setConfigOption).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "permission_mode",
+        value: "strict",
+      }),
+    );
+    expect(nextOptions).toEqual({ permissionProfile: "strict" });
+  });
+
   it("rejects invalid runtime option values before backend controls run", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -3005,6 +3005,117 @@ describe("AcpSessionManager", () => {
     );
   });
 
+  it("maps persisted thinking runtime options to advertised effort config keys before running turns", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_mode", "session/set_config_option", "session/status"],
+      configOptionKeys: ["mode", "model", "effort"],
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:claude:acp:session-1",
+      storeSessionKey: "agent:claude:acp:session-1",
+      acp: {
+        ...readySessionMeta({ agent: "claude" }),
+        runtimeOptions: {
+          thinking: "high",
+        },
+      },
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:claude:acp:session-1",
+      text: "do work",
+      mode: "prompt",
+      requestId: "run-1",
+    });
+
+    expect(runtimeState.setConfigOption).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "effort",
+        value: "high",
+      }),
+    );
+    expect(runtimeState.setConfigOption).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "thinking",
+      }),
+    );
+  });
+
+  it("maps persisted runtime options to backend-advertised aliases before running turns", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_config_option", "session/status"],
+      configOptionKeys: ["model", "thought_level", "permissions", "timeout_seconds"],
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:gemini:acp:session-1",
+      storeSessionKey: "agent:gemini:acp:session-1",
+      acp: {
+        ...readySessionMeta({ agent: "gemini" }),
+        runtimeOptions: {
+          model: "gemini-3-flash-preview",
+          thinking: "high",
+          permissionProfile: "strict",
+          timeoutSeconds: 120,
+        },
+      },
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:gemini:acp:session-1",
+      text: "do work",
+      mode: "prompt",
+      requestId: "run-1",
+    });
+
+    expect(runtimeState.setConfigOption).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "thought_level",
+        value: "high",
+      }),
+    );
+    expect(runtimeState.setConfigOption).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "permissions",
+        value: "strict",
+      }),
+    );
+    expect(runtimeState.setConfigOption).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "timeout_seconds",
+        value: "120",
+      }),
+    );
+    expect(runtimeState.setConfigOption).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "thinking",
+      }),
+    );
+    expect(runtimeState.setConfigOption).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "approval_policy",
+      }),
+    );
+    expect(runtimeState.setConfigOption).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "timeout",
+      }),
+    );
+  });
+
   it("re-ensures runtime handles after cwd runtime option updates", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
@@ -3108,6 +3219,111 @@ describe("AcpSessionManager", () => {
     ).rejects.toMatchObject({
       code: "ACP_BACKEND_UNSUPPORTED_CONTROL",
     });
+  });
+
+  it("maps explicit thinking config updates to advertised effort keys", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_config_option", "session/status"],
+      configOptionKeys: ["effort"],
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:claude:acp:session-1",
+      storeSessionKey: "agent:claude:acp:session-1",
+      acp: readySessionMeta({ agent: "claude" }),
+    });
+
+    const manager = new AcpSessionManager();
+    const nextOptions = await manager.setSessionConfigOption({
+      cfg: baseCfg,
+      sessionKey: "agent:claude:acp:session-1",
+      key: "thinking",
+      value: "high",
+    });
+
+    expect(runtimeState.setConfigOption).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "effort",
+        value: "high",
+      }),
+    );
+    expect(nextOptions).toEqual({ thinking: "high" });
+  });
+
+  it("maps thinking config updates using status config options when capabilities omit keys", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_config_option", "session/status"],
+    });
+    runtimeState.getStatus.mockResolvedValue({
+      summary: "status=alive",
+      details: {
+        configOptions: [{ id: "mode" }, { id: "model" }, { id: "effort" }],
+      },
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:claude:acp:session-1",
+      storeSessionKey: "agent:claude:acp:session-1",
+      acp: readySessionMeta({ agent: "claude" }),
+    });
+
+    const manager = new AcpSessionManager();
+    const nextOptions = await manager.setSessionConfigOption({
+      cfg: baseCfg,
+      sessionKey: "agent:claude:acp:session-1",
+      key: "thinking",
+      value: "high",
+    });
+
+    expect(runtimeState.getStatus).toHaveBeenCalled();
+    expect(runtimeState.setConfigOption).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "effort",
+        value: "high",
+      }),
+    );
+    expect(nextOptions).toEqual({ thinking: "high" });
+  });
+
+  it("persists explicit native effort config updates as canonical thinking options", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_config_option", "session/status"],
+      configOptionKeys: ["effort"],
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:claude:acp:session-1",
+      storeSessionKey: "agent:claude:acp:session-1",
+      acp: readySessionMeta({ agent: "claude" }),
+    });
+
+    const manager = new AcpSessionManager();
+    const nextOptions = await manager.setSessionConfigOption({
+      cfg: baseCfg,
+      sessionKey: "agent:claude:acp:session-1",
+      key: "effort",
+      value: "high",
+    });
+
+    expect(runtimeState.setConfigOption).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "effort",
+        value: "high",
+      }),
+    );
+    expect(nextOptions).toEqual({ thinking: "high" });
   });
 
   it("rejects invalid runtime option values before backend controls run", async () => {

--- a/src/acp/control-plane/runtime-options.ts
+++ b/src/acp/control-plane/runtime-options.ts
@@ -422,7 +422,8 @@ export function inferRuntimeOptionPatchFromConfigOption(
   if (
     normalizedKey === "approval_policy" ||
     normalizedKey === "permission_profile" ||
-    normalizedKey === "permissions"
+    normalizedKey === "permissions" ||
+    normalizedKey === "permission_mode"
   ) {
     return { permissionProfile: validateRuntimePermissionProfileInput(validated.value) };
   }

--- a/src/acp/control-plane/runtime-options.ts
+++ b/src/acp/control-plane/runtime-options.ts
@@ -18,6 +18,12 @@ const MAX_BACKEND_OPTION_VALUE_LENGTH = 512;
 const MAX_BACKEND_EXTRAS = 32;
 
 const SAFE_OPTION_KEY_RE = /^[a-z0-9][a-z0-9._:-]*$/i;
+const RUNTIME_CONFIG_OPTION_ALIASES = {
+  model: ["model"],
+  thinking: ["thinking", "effort", "reasoning_effort", "thought_level"],
+  permissionProfile: ["approval_policy", "permission_profile", "permissions", "permission_mode"],
+  timeoutSeconds: ["timeout", "timeout_seconds"],
+} as const;
 
 function failInvalidOption(message: string): never {
   throw new AcpRuntimeError("ACP_INVALID_RUNTIME_OPTION", message);
@@ -315,27 +321,85 @@ export function buildRuntimeControlSignature(options: AcpSessionRuntimeOptions):
 
 export function buildRuntimeConfigOptionPairs(
   options: AcpSessionRuntimeOptions,
+  advertisedConfigOptionKeys?: readonly string[],
 ): Array<[string, string]> {
   const normalized = normalizeRuntimeOptions(options);
   const pairs = new Map<string, string>();
   if (normalized.model) {
-    pairs.set("model", normalized.model);
+    pairs.set(resolveRuntimeConfigOptionKey("model", advertisedConfigOptionKeys), normalized.model);
   }
   if (normalized.thinking) {
-    pairs.set("thinking", normalized.thinking);
+    pairs.set(
+      resolveRuntimeConfigOptionKey("thinking", advertisedConfigOptionKeys),
+      normalized.thinking,
+    );
   }
   if (normalized.permissionProfile) {
-    pairs.set("approval_policy", normalized.permissionProfile);
+    pairs.set(
+      resolveRuntimeConfigOptionKey("approval_policy", advertisedConfigOptionKeys),
+      normalized.permissionProfile,
+    );
   }
   if (typeof normalized.timeoutSeconds === "number") {
-    pairs.set("timeout", String(normalized.timeoutSeconds));
+    pairs.set(
+      resolveRuntimeConfigOptionKey("timeout", advertisedConfigOptionKeys),
+      String(normalized.timeoutSeconds),
+    );
   }
   for (const [key, value] of Object.entries(normalized.backendExtras ?? {})) {
-    if (!pairs.has(key)) {
-      pairs.set(key, value);
+    const wireKey = resolveRuntimeConfigOptionKey(key, advertisedConfigOptionKeys);
+    if (!pairs.has(wireKey)) {
+      pairs.set(wireKey, value);
     }
   }
   return [...pairs.entries()];
+}
+
+function buildAdvertisedConfigOptionKeyMap(
+  advertisedConfigOptionKeys?: readonly string[],
+): Map<string, string> {
+  const advertisedKeys = new Map<string, string>();
+  for (const rawKey of advertisedConfigOptionKeys ?? []) {
+    const key = normalizeText(rawKey);
+    const normalizedKey = normalizeLowercaseStringOrEmpty(key);
+    if (key && normalizedKey && !advertisedKeys.has(normalizedKey)) {
+      advertisedKeys.set(normalizedKey, key);
+    }
+  }
+  return advertisedKeys;
+}
+
+function resolveRuntimeConfigOptionAliases(key: string): readonly string[] {
+  const normalizedKey = normalizeLowercaseStringOrEmpty(key);
+  for (const aliases of Object.values(RUNTIME_CONFIG_OPTION_ALIASES)) {
+    if (aliases.some((alias) => normalizeLowercaseStringOrEmpty(alias) === normalizedKey)) {
+      return aliases;
+    }
+  }
+  return [key];
+}
+
+export function resolveRuntimeConfigOptionKey(
+  key: string,
+  advertisedConfigOptionKeys?: readonly string[],
+): string {
+  const normalizedKey = normalizeText(key) ?? "";
+  const normalizedLookupKey = normalizeLowercaseStringOrEmpty(normalizedKey);
+  const advertisedKeys = buildAdvertisedConfigOptionKeyMap(advertisedConfigOptionKeys);
+  if (!normalizedKey || advertisedKeys.size === 0) {
+    return normalizedKey;
+  }
+  const exactAdvertisedKey = advertisedKeys.get(normalizedLookupKey);
+  if (exactAdvertisedKey) {
+    return exactAdvertisedKey;
+  }
+  for (const alias of resolveRuntimeConfigOptionAliases(normalizedKey)) {
+    const advertisedAlias = advertisedKeys.get(normalizeLowercaseStringOrEmpty(alias));
+    if (advertisedAlias) {
+      return advertisedAlias;
+    }
+  }
+  return normalizedKey;
 }
 
 export function inferRuntimeOptionPatchFromConfigOption(
@@ -349,6 +413,7 @@ export function inferRuntimeOptionPatchFromConfigOption(
   }
   if (
     normalizedKey === "thinking" ||
+    normalizedKey === "effort" ||
     normalizedKey === "thought_level" ||
     normalizedKey === "reasoning_effort"
   ) {


### PR DESCRIPTION
## Summary

- Add a canonical ACP runtime-option mapping layer that resolves OpenClaw options to backend-advertised config keys before calling `session/set_config_option`.
- Keep OpenClaw state canonical (`thinking`, `permissionProfile`, `timeoutSeconds`) while supporting backend wire aliases such as `effort`, `reasoning_effort`, `thought_level`, `permissions`, and `timeout_seconds`.
- Apply the mapping for both automatic pre-turn runtime controls and explicit `setSessionConfigOption` updates.
- Document the canonical option mapping and add regression coverage for Claude/Codex/Gemini-style config key dialects.

## Root Cause

Claude ACP advertises `effort` instead of `thinking`. OpenClaw persisted the abstract runtime option as `thinking`, then rejected the pre-turn config update because the backend advertised a strict key list that did not contain `thinking`. In a fresh real acpx Claude session, capabilities can also omit `configOptionKeys` while `session/status.details.configOptions` advertises `mode`, `model`, and `effort`; this path still needed the same canonical-to-wire-key translation. The inverse parser also treated plain `effort` as an opaque backend extra instead of canonical thinking state.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:
  Claude ACP/acpx rejects the OpenClaw canonical runtime option key `thinking` because the real adapter advertises `effort` instead. This patch maps canonical OpenClaw thinking state to the backend-advertised wire key while keeping persisted OpenClaw runtime options canonical.
- Real environment tested:
  Local OpenClaw gateway/install on May 9, 2026 after hot-patching the installed `2026.5.9-beta.1` bundle with this branch's ACP control-plane changes and restarting the LaunchAgent gateway. `openclaw --version` reported `OpenClaw 2026.5.9-beta.1 (0d3141e)`. Gateway was `2026.5.9-beta.1`, LaunchAgent pid `14036`, using the NVM install at `/Users/danobrien/.nvm/versions/node/v24.13.0/lib/node_modules/openclaw/dist/index.js`. The acpx plugin was `@openclaw/acpx@2026.5.9-beta.1`, dependency `acpx@0.7.0`, with `@agentclientprotocol/claude-agent-acp@0.32.0`.
- Exact steps or command run after this patch:
  Patched the installed OpenClaw gateway bundle with this branch's control-plane changes, ran `node --check /Users/danobrien/.nvm/versions/node/v24.13.0/lib/node_modules/openclaw/dist/manager-CgmKcnsi.js`, restarted the real gateway with `/Users/danobrien/.nvm/versions/node/v24.13.0/bin/openclaw gateway restart`, then ran a one-off `node --input-type=module` script that imported the installed OpenClaw config/session manager, loaded the installed `@openclaw/acpx` runtime service, initialized a fresh real Claude ACP session, called `manager.setSessionConfigOption({ key: "thinking", value: "low" })`, called `manager.setSessionConfigOption({ key: "thinking", value: "high" })`, read status, and closed/cleared the proof session.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  Copied live terminal output from the fresh real Claude ACP session:

  ```json
  {
    "proofTimestamp": "2026-05-09T19:10:04.918Z",
    "openclawVersion": "2026.5.9-beta.1 (installed gateway package)",
    "acpxPluginVersion": "2026.5.9-beta.1",
    "acpxDependencyVersion": "0.7.0",
    "sessionKey": "agent:claude:acp:proof-thinking-4fc9ed05-b157-411e-89f8-bc1a58650560",
    "backend": "acpx",
    "agent": "claude",
    "runtimeSessionName": "acpx:v2:<redacted>",
    "acpxRecordId": "agent:claude:acp:proof-thinking-4fc9ed05-b157-411e-89f8-bc1a58650560",
    "backendSessionId": "de61dc19-2381-4773-8a31-3eede62f57c7",
    "advertisedConfigKeysFromStatus": [
      "mode",
      "model",
      "effort"
    ],
    "beforeRuntimeOptions": {
      "cwd": "/Users/danobrien/.openclaw/workspace"
    },
    "setThinkingLowReturned": {
      "thinking": "low",
      "cwd": "/Users/danobrien/.openclaw/workspace"
    },
    "setThinkingHighReturned": {
      "thinking": "high",
      "cwd": "/Users/danobrien/.openclaw/workspace"
    },
    "afterRuntimeOptions": {
      "thinking": "high",
      "cwd": "/Users/danobrien/.openclaw/workspace"
    },
    "runtimeStatusSummary": "session=agent:claude:acp:proof-thinking-4fc9ed05-b157-411e-89f8-bc1a58650560 backendSessionId=de61dc19-2381-4773-8a31-3eede62f57c7 pid=14549 open",
    "cleanup": {
      "runtimeClosed": true,
      "metaCleared": true
    }
  }
  ```
- Observed result after fix:
  The real Claude ACP adapter advertised `effort`, not `thinking`, while both `setSessionConfigOption({ key: "thinking" })` calls completed successfully. OpenClaw returned and persisted canonical `thinking` runtime state (`low`, then `high`) instead of surfacing the previous ACP `Internal error` / `Unknown config option: thinking` failure. The proof session was closed and metadata was cleared after the check.
- What was not tested:
  No known gaps for the Claude/acpx regression path. Gemini and Codex provider dialects were covered by manager regression tests, but I did not run live Gemini or Codex ACP sessions in this local proof.
- Before evidence (optional but encouraged):
  Before the status-derived key refinement, the same real local Claude/acpx path reproduced the original failure as `AcpRuntimeError: Internal error`, caused by ACP data `{ details: "Unknown config option: thinking" }`.

## Validation

- `pnpm exec oxfmt --check src/acp/control-plane/manager.core.ts src/acp/control-plane/manager.runtime-controls.ts src/acp/control-plane/manager.test.ts`
- `git diff --check`
- `pnpm vitest src/acp/control-plane/manager.test.ts`
- `pnpm tsgo:core:test`