### PR TITLE
[codex] Mirror Codex tool calls in transcripts

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -731,6 +731,86 @@ describe("CodexAppServerEventProjector", () => {
         result: expect.objectContaining({ exitCode: 0, durationMs: 42 }),
       }),
     });
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.messagesSnapshot.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+    ]);
+    expect(result.messagesSnapshot[1]).toMatchObject({
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "cmd-1",
+          name: "bash",
+          arguments: { command: "pnpm test extensions/codex", cwd: "/workspace" },
+        },
+      ],
+    });
+    expect(result.messagesSnapshot[2]).toMatchObject({
+      role: "toolResult",
+      toolCallId: "cmd-1",
+      toolName: "bash",
+      isError: false,
+      content: [
+        expect.objectContaining({
+          type: "toolResult",
+          toolCallId: "cmd-1",
+          content: "ok",
+        }),
+      ],
+    });
+  });
+
+  it("records dynamic OpenClaw tool calls in mirrored transcript snapshots", async () => {
+    const projector = await createProjector();
+
+    projector.recordDynamicToolCall({
+      callId: "call-browser-1",
+      tool: "browser",
+      arguments: { action: "open", url: "http://127.0.0.1:3000" },
+    });
+    projector.recordDynamicToolResult({
+      callId: "call-browser-1",
+      tool: "browser",
+      success: true,
+      contentItems: [{ type: "inputText", text: "opened" }],
+    });
+    await projector.handleNotification(agentMessageDelta("done"));
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.messagesSnapshot.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "assistant",
+    ]);
+    expect(result.messagesSnapshot[1]).toMatchObject({
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call-browser-1",
+          name: "browser",
+          arguments: { action: "open", url: "http://127.0.0.1:3000" },
+        },
+      ],
+    });
+    expect(result.messagesSnapshot[2]).toMatchObject({
+      role: "toolResult",
+      toolCallId: "call-browser-1",
+      toolName: "browser",
+      isError: false,
+      content: [
+        expect.objectContaining({
+          type: "toolResult",
+          toolCallId: "call-browser-1",
+          content: "opened",
+        }),
+      ],
+    });
   });
 
   it("marks declined Codex-native tool results as non-success", async () => {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -21,6 +21,7 @@ import {
 import { readCodexTurn } from "./protocol-validators.js";
 import {
   isJsonObject,
+  type CodexDynamicToolCallOutputContentItem,
   type CodexServerNotification,
   type CodexThreadItem,
   type CodexTurn,
@@ -80,6 +81,20 @@ const CODEX_PROMPT_TOTAL_INPUT_KEYS = [
 ] as const;
 
 const MAX_TOOL_OUTPUT_DELTA_MESSAGES_PER_ITEM = 20;
+const TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS = 12_000;
+
+type ToolTranscriptCallInput = {
+  id: string;
+  name: string;
+  arguments?: unknown;
+};
+
+type ToolTranscriptResultInput = {
+  id: string;
+  name: string;
+  text?: string;
+  isError: boolean;
+};
 
 export class CodexAppServerEventProjector {
   private readonly assistantTextByItem = new Map<string, string>();
@@ -97,6 +112,9 @@ export class CodexAppServerEventProjector {
     { chars: number; messages: number; truncated: boolean }
   >();
   private readonly toolMetas = new Map<string, { toolName: string; meta?: string }>();
+  private readonly toolTranscriptMessages: AgentMessage[] = [];
+  private readonly toolTranscriptCallIds = new Set<string>();
+  private readonly toolTranscriptResultIds = new Set<string>();
   private assistantStarted = false;
   private reasoningStarted = false;
   private reasoningEnded = false;
@@ -238,6 +256,7 @@ export class CodexAppServerEventProjector {
         ),
       );
     }
+    messagesSnapshot.push(...this.toolTranscriptMessages);
     if (lastAssistant) {
       messagesSnapshot.push(attachCodexMirrorIdentity(lastAssistant, `${turnId}:assistant`));
     }
@@ -295,6 +314,28 @@ export class CodexAppServerEventProjector {
       yieldDetected: options?.yieldDetected || false,
       didSendDeterministicApprovalPrompt: this.guardianReviewCount > 0 ? false : undefined,
     };
+  }
+
+  recordDynamicToolCall(params: { callId: string; tool: string; arguments?: JsonValue }): void {
+    this.recordToolTranscriptCall({
+      id: params.callId,
+      name: params.tool,
+      arguments: sanitizeCodexToolArguments(params.arguments),
+    });
+  }
+
+  recordDynamicToolResult(params: {
+    callId: string;
+    tool: string;
+    success: boolean;
+    contentItems: CodexDynamicToolCallOutputContentItem[];
+  }): void {
+    this.recordToolTranscriptResult({
+      id: params.callId,
+      name: params.tool,
+      text: collectDynamicToolContentText(params.contentItems),
+      isError: !params.success,
+    });
   }
 
   markTimedOut(): void {
@@ -402,6 +443,7 @@ export class CodexAppServerEventProjector {
     }
     this.emitStandardItemEvent({ phase: "start", item });
     this.emitNormalizedToolItemEvent({ phase: "start", item });
+    this.recordNativeToolTranscriptCall(item);
     this.emitToolResultSummary(item);
     this.emitAgentEvent({
       stream: "codex_app_server.item",
@@ -456,6 +498,8 @@ export class CodexAppServerEventProjector {
     this.recordToolMeta(item);
     this.emitStandardItemEvent({ phase: "end", item });
     this.emitNormalizedToolItemEvent({ phase: "result", item });
+    this.recordNativeToolTranscriptCall(item);
+    this.recordNativeToolTranscriptResult(item);
     this.emitToolResultSummary(item);
     this.emitToolResultOutput(item);
     this.emitAgentEvent({
@@ -558,6 +602,8 @@ export class CodexAppServerEventProjector {
         this.emitPlanUpdate({ explanation: undefined, steps: splitPlanText(item.text) });
       }
       this.recordToolMeta(item);
+      this.recordNativeToolTranscriptCall(item);
+      this.recordNativeToolTranscriptResult(item);
       this.emitToolResultSummary(item);
       this.emitToolResultOutput(item);
     }
@@ -805,6 +851,63 @@ export class CodexAppServerEventProjector {
     });
   }
 
+  private recordNativeToolTranscriptCall(item: CodexThreadItem | undefined): void {
+    if (!item || !shouldSynthesizeToolProgressForItem(item)) {
+      return;
+    }
+    const name = itemName(item);
+    if (!name) {
+      return;
+    }
+    this.recordToolTranscriptCall({
+      id: item.id,
+      name,
+      arguments: itemToolArgs(item),
+    });
+  }
+
+  private recordNativeToolTranscriptResult(item: CodexThreadItem | undefined): void {
+    if (!item || !shouldSynthesizeToolProgressForItem(item)) {
+      return;
+    }
+    const name = itemName(item);
+    if (!name) {
+      return;
+    }
+    this.recordToolTranscriptResult({
+      id: item.id,
+      name,
+      text: itemTranscriptResultText(item),
+      isError: isNonSuccessItemStatus(itemStatus(item)),
+    });
+  }
+
+  private recordToolTranscriptCall(params: ToolTranscriptCallInput): void {
+    if (!params.id || !params.name || this.toolTranscriptCallIds.has(params.id)) {
+      return;
+    }
+    this.toolTranscriptCallIds.add(params.id);
+    this.toolTranscriptMessages.push(
+      attachCodexMirrorIdentity(
+        this.createToolCallMessage(params),
+        `${this.turnId}:tool:${params.id}:call`,
+      ),
+    );
+  }
+
+  private recordToolTranscriptResult(params: ToolTranscriptResultInput): void {
+    if (!params.id || !params.name || this.toolTranscriptResultIds.has(params.id)) {
+      return;
+    }
+    this.toolTranscriptResultIds.add(params.id);
+    this.toolTranscriptMessages.push(
+      attachCodexMirrorIdentity(
+        this.createToolResultMessage(params),
+        `${this.turnId}:tool:${params.id}:result`,
+      ),
+    );
+  }
+
   private formatCodexErrorMessage(params: JsonObject): string | undefined {
     const error = isJsonObject(params.error) ? params.error : undefined;
     return (
@@ -910,6 +1013,47 @@ export class CodexAppServerEventProjector {
       stopReason: "stop",
       timestamp: Date.now(),
     };
+  }
+
+  private createToolCallMessage(params: ToolTranscriptCallInput): AgentMessage {
+    return {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: params.id,
+          name: params.name,
+          arguments: normalizeToolTranscriptArguments(params.arguments),
+        },
+      ],
+      api: this.params.model.api ?? "openai-codex-responses",
+      provider: this.params.provider,
+      model: this.params.modelId,
+      usage: ZERO_USAGE,
+      stopReason: "toolUse",
+      timestamp: Date.now(),
+    } as unknown as AgentMessage;
+  }
+
+  private createToolResultMessage(params: ToolTranscriptResultInput): AgentMessage {
+    const text = truncateToolTranscriptText(params.text?.trim() || toolResultStatusText(params));
+    return {
+      role: "toolResult",
+      toolCallId: params.id,
+      toolName: params.name,
+      isError: params.isError,
+      content: [
+        {
+          type: "toolResult",
+          toolCallId: params.id,
+          toolUseId: params.id,
+          tool_use_id: params.id,
+          content: text,
+          text,
+        },
+      ],
+      timestamp: Date.now(),
+    } as unknown as AgentMessage;
   }
 
   private isNotificationForTurn(params: JsonObject): boolean {
@@ -1268,6 +1412,22 @@ function itemOutputText(item: CodexThreadItem): string | undefined {
   return undefined;
 }
 
+function itemTranscriptResultText(item: CodexThreadItem): string | undefined {
+  const output = itemOutputText(item);
+  if (output) {
+    return output;
+  }
+  const result = itemToolResult(item).result;
+  return result ? stringifyJsonValue(result) : itemStatus(item);
+}
+
+function normalizeToolTranscriptArguments(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
 function collectDynamicToolContentText(contentItems: CodexThreadItem["contentItems"]): string {
   if (!Array.isArray(contentItems)) {
     return "";
@@ -1281,6 +1441,17 @@ function collectDynamicToolContentText(contentItems: CodexThreadItem["contentIte
       return text ? [text] : [];
     })
     .join("\n");
+}
+
+function truncateToolTranscriptText(text: string): string {
+  if (text.length <= TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS) {
+    return text;
+  }
+  return `${text.slice(0, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS)}\n...(truncated)...`;
+}
+
+function toolResultStatusText(params: ToolTranscriptResultInput): string {
+  return params.isError ? `${params.name} failed` : `${params.name} completed`;
 }
 
 function stringifyJsonValue(value: unknown): string | undefined {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1175,6 +1175,11 @@ export async function runCodexAppServerAttempt(
         name: call.tool,
         arguments: call.arguments,
       });
+      projector?.recordDynamicToolCall({
+        callId: call.callId,
+        tool: call.tool,
+        arguments: call.arguments,
+      });
       const toolProgressDetailMode = resolveCodexToolProgressDetailMode(params.toolProgressDetail);
       const toolMeta = inferCodexDynamicToolMeta(call, toolProgressDetailMode);
       const toolArgs = sanitizeCodexToolArguments(call.arguments);
@@ -1212,6 +1217,12 @@ export async function runCodexAppServerAttempt(
         turnId: call.turnId,
         toolCallId: call.callId,
         name: call.tool,
+        success: response.success,
+        contentItems: response.contentItems,
+      });
+      projector?.recordDynamicToolResult({
+        callId: call.callId,
+        tool: call.tool,
         success: response.success,
         contentItems: response.contentItems,
       });

--- a/extensions/codex/src/app-server/transcript-mirror.test.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.test.ts
@@ -16,7 +16,7 @@ import {
 import { afterEach, describe, expect, it } from "vitest";
 import { attachCodexMirrorIdentity, mirrorCodexAppServerTranscript } from "./transcript-mirror.js";
 
-type MirroredAgentMessage = Extract<AgentMessage, { role: "user" | "assistant" }>;
+type MirroredAgentMessage = Extract<AgentMessage, { role: "user" | "assistant" | "toolResult" }>;
 
 // Mirrors transcript-mirror.ts's fallback fingerprint exactly so test
 // expectations stay in sync without exposing the helper publicly.
@@ -57,7 +57,7 @@ function parseJsonLines<T>(raw: string): T[] {
 }
 
 describe("mirrorCodexAppServerTranscript", () => {
-  it("mirrors user and assistant messages into the Pi transcript", async () => {
+  it("mirrors user, assistant, and tool result messages into the Pi transcript", async () => {
     const sessionFile = await createTempSessionFile();
     const userMessage = makeAgentUserMessage({
       content: [{ type: "text", text: "hello" }],
@@ -67,11 +67,24 @@ describe("mirrorCodexAppServerTranscript", () => {
       content: [{ type: "text", text: "hi there" }],
       timestamp: Date.now() + 1,
     });
+    const toolResultMessage = castAgentMessage({
+      role: "toolResult",
+      toolCallId: "call-1",
+      toolName: "read",
+      content: [
+        {
+          type: "toolResult",
+          toolCallId: "call-1",
+          content: "read output",
+        },
+      ],
+      timestamp: Date.now() + 2,
+    }) as MirroredAgentMessage;
 
     await mirrorCodexAppServerTranscript({
       sessionFile,
       sessionKey: "session-1",
-      messages: [userMessage, assistantMessage],
+      messages: [userMessage, assistantMessage, toolResultMessage],
       idempotencyScope: "scope-1",
     });
 
@@ -80,9 +93,15 @@ describe("mirrorCodexAppServerTranscript", () => {
     expect(raw).toContain('"content":[{"type":"text","text":"hello"}]');
     expect(raw).toContain('"role":"assistant"');
     expect(raw).toContain('"content":[{"type":"text","text":"hi there"}]');
+    expect(raw).toContain('"role":"toolResult"');
+    expect(raw).toContain('"toolCallId":"call-1"');
+    expect(raw).toContain('"content":"read output"');
     expect(raw).toContain(`"idempotencyKey":"scope-1:user:${expectedFingerprint(userMessage)}"`);
     expect(raw).toContain(
       `"idempotencyKey":"scope-1:assistant:${expectedFingerprint(assistantMessage)}"`,
+    );
+    expect(raw).toContain(
+      `"idempotencyKey":"scope-1:toolResult:${expectedFingerprint(toolResultMessage)}"`,
     );
   });
 

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -10,7 +10,7 @@ import {
   type SessionWriteLockAcquireTimeoutConfig,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 
-type MirroredAgentMessage = Extract<AgentMessage, { role: "user" | "assistant" }>;
+type MirroredAgentMessage = Extract<AgentMessage, { role: "user" | "assistant" | "toolResult" }>;
 
 const MIRROR_IDENTITY_META_KEY = "mirrorIdentity" as const;
 
@@ -75,7 +75,7 @@ export async function mirrorCodexAppServerTranscript(params: {
 }): Promise<void> {
   const messages = params.messages.filter(
     (message): message is MirroredAgentMessage =>
-      message.role === "user" || message.role === "assistant",
+      message.role === "user" || message.role === "assistant" || message.role === "toolResult",
   );
   if (messages.length === 0) {
     return;


### PR DESCRIPTION
## Summary

- mirror Codex tool calls/results into the canonical OpenClaw session transcript instead of leaving them only in sidecar/runtime telemetry
- persist `toolResult` messages through the Codex transcript mirror
- cover Codex-native tool items and dynamic OpenClaw tool calls with focused app-server tests

## Why

ClawBench and other transcript consumers read OpenClaw session messages. The Codex app-server path was returning user/final assistant messages while tool activity was only visible through separate trajectory/runtime events. That made tool-using Codex runs look like they skipped reads, edits, browser actions, or verification even when the runtime actually executed them.

This makes the OpenClaw transcript API the source of truth: Codex shell/file/search/MCP items and dynamic OpenClaw tools now project assistant `toolCall` blocks with matching `toolResult` records.

## Validation

- `pnpm exec vitest run extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/transcript-mirror.test.ts`
- `pnpm tsgo:extensions:test`
- `pnpm tsgo:extensions`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/transcript-mirror.ts extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/transcript-mirror.test.ts`

## Real behavior proof

- **Behavior or issue addressed:** Codex-native runs now expose tool calls and tool results through the canonical OpenClaw session transcript that ClawBench reads, instead of only sidecar/runtime telemetry.
- **Real environment tested:** Built a Docker image from this PR branch (`codex/codex-transcript-tools`) at `8d0bcad1445b7ecfa4211fa93446bbd66f34a3ff`, then built the ClawBench image on top of it in Blacksmith Testbox.
- **Exact steps or command run after this patch:** Ran ClawBench against the PR image with native Codex runtime config using model `openai/gpt-5.5`, adapter `openclaw`, and task `t2-add-tests-normalizer`.
- **After-fix evidence:** Redacted terminal output from the real OpenClaw/ClawBench run:

```text
OpenClaw 2026.5.8
Gateway healthy after 3s
ClawBench v0.4.0.dev1 — 1 tasks x 1 runs
Model: openai/gpt-5.5
Adapter: openclaw
[1/1] t2-add-tests-normalizer (tier2/coding) run 1: + 0.99 C=1.00 T=0.98 B=1.00
Score: 0.993
  Completion: 1.000  Trajectory: 0.977  Behavior: 1.000  Reliability: 1.000
  Latency p50=82372ms p95=82372ms  Tokens/pass=42171
```

  Runtime transcript proof from the same run: run cache contained `36` canonical OpenClaw transcript messages with `17` mirrored tool calls and `17` matching `toolResult` messages. Tool calls included `bash` (14) and `apply_patch` (3).
- **Observed result after fix:** The transcript included a failed `pytest -q`, an `apply_patch` edit to `normalizer.py`, a second `pytest -q`, and final success: `3 passed in 0.00s`. Final eval metrics were score `0.993`, completion `1.000`, trajectory `0.977`, behavior `1.000`, reliability `1.000`.
- **What was not tested:** The broader multi-model/full-task sweep was not rerun for this PR landing; the changed transcript behavior was verified with the image-backed Codex harness eval above.
