### PR TITLE
fix: restore current iOS simulator builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iOS: fix simulator builds after Gateway errors moved to the generated `ErrorShape` model by importing shared deep-link helpers in onboarding and splitting the settings view so Swift can type-check it.
 - Plugin SDK: keep activated linked plugin runtime facades loadable when bundled plugin fallback is disabled. Thanks @shakkernerd.
 - Feishu: auto-thread `message(action="send")` replies inside the topic when the active session is group_topic or group_topic_sender, and propagate `replyInThread` through text, card, and media outbound adapters so topic-scoped sessions no longer post at the group root. Fixes #74903. (#77151) Thanks @ai-hpc.
 - WhatsApp: pass routing context into voice-note transcript echo preflight so echoed transcripts can deliver to the originating chat. Fixes #79778. (#79788) Thanks @hclsys.

--- a/apps/ios/Sources/Onboarding/GatewayOnboardingView.swift
+++ b/apps/ios/Sources/Onboarding/GatewayOnboardingView.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawKit
 import SwiftUI
 
 struct GatewayOnboardingView: View {

--- a/apps/ios/Sources/Settings/SettingsTab.swift
+++ b/apps/ios/Sources/Settings/SettingsTab.swift
@@ -65,358 +65,8 @@ struct SettingsTab: View {
     var body: some View {
         NavigationStack {
             Form {
-                Section {
-                    DisclosureGroup(isExpanded: self.$gatewayExpanded) {
-                        if let gatewayProblem = self.appModel.lastGatewayProblem,
-                           !self.isGatewayConnected
-                        {
-                            GatewayProblemBanner(
-                                problem: gatewayProblem,
-                                primaryActionTitle: "Retry connection",
-                                onPrimaryAction: {
-                                    Task { await self.retryGatewayConnectionFromProblem() }
-                                },
-                                onShowDetails: {
-                                    self.showGatewayProblemDetails = true
-                                })
-                        }
-
-                        if !self.isGatewayConnected {
-                            Text(
-                                "1. Open a chat with your OpenClaw agent and send /pair\n"
-                                    + "2. Copy the setup code it returns\n"
-                                    + "3. Paste here and tap Connect\n"
-                                    + "4. Back in that chat, run /pair approve")
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-
-                            if let warning = self.tailnetWarningText {
-                                Text(warning)
-                                    .font(.footnote.weight(.semibold))
-                                    .foregroundStyle(.orange)
-                            }
-
-                            TextField("Paste setup code", text: self.$setupCode)
-                                .textInputAutocapitalization(.never)
-                                .autocorrectionDisabled()
-
-                            Button {
-                                self.openGatewayQRScanner()
-                            } label: {
-                                Label("Scan QR Code", systemImage: "qrcode.viewfinder")
-                            }
-                            .disabled(self.connectingGatewayID != nil)
-
-                            Button {
-                                Task { await self.applySetupCodeAndConnect() }
-                            } label: {
-                                if self.connectingGatewayID == "manual" {
-                                    HStack(spacing: 8) {
-                                        ProgressView()
-                                            .progressViewStyle(.circular)
-                                        Text("Connecting…")
-                                    }
-                                } else {
-                                    Text("Connect with setup code")
-                                }
-                            }
-                            .disabled(self.connectingGatewayID != nil
-                                || self.setupCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-
-                            if let status = self.setupStatusLine {
-                                Text(status)
-                                    .font(.footnote)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-
-                        if self.isGatewayConnected {
-                            Picker("Bot", selection: self.$selectedAgentPickerId) {
-                                Text("Default").tag("")
-                                let defaultId = (self.appModel.gatewayDefaultAgentId ?? "")
-                                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                                ForEach(self.appModel.gatewayAgents.filter { $0.id != defaultId }, id: \.id) { agent in
-                                    let name = (agent.name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-                                    Text(name.isEmpty ? agent.id : name).tag(agent.id)
-                                }
-                            }
-                            Text("Controls which bot Chat and Talk speak to.")
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                        }
-
-                        if self.appModel.gatewayServerName == nil {
-                            LabeledContent("Discovery", value: self.gatewayController.discoveryStatusText)
-                        }
-                        LabeledContent("Status", value: self.appModel.gatewayDisplayStatusText)
-                        Toggle("Auto-connect on launch", isOn: self.$gatewayAutoConnect)
-
-                        if let serverName = self.appModel.gatewayServerName {
-                            LabeledContent("Server", value: serverName)
-                            if let addr = self.appModel.gatewayRemoteAddress {
-                                let parts = Self.parseHostPort(from: addr)
-                                let urlString = Self.httpURLString(host: parts?.host, port: parts?.port, fallback: addr)
-                                LabeledContent("Address") {
-                                    Text(urlString)
-                                }
-                                .contextMenu {
-                                    Button {
-                                        UIPasteboard.general.string = urlString
-                                    } label: {
-                                        Label("Copy URL", systemImage: "doc.on.doc")
-                                    }
-
-                                    if let parts {
-                                        Button {
-                                            UIPasteboard.general.string = parts.host
-                                        } label: {
-                                            Label("Copy Host", systemImage: "doc.on.doc")
-                                        }
-
-                                        Button {
-                                            UIPasteboard.general.string = "\(parts.port)"
-                                        } label: {
-                                            Label("Copy Port", systemImage: "doc.on.doc")
-                                        }
-                                    }
-                                }
-                            }
-
-                            Button("Disconnect", role: .destructive) {
-                                self.appModel.disconnectGateway()
-                            }
-                        } else {
-                            self.gatewayList(showing: .all)
-                        }
-
-                        DisclosureGroup("Advanced") {
-                            Toggle("Use Manual Gateway", isOn: self.$manualGatewayEnabled)
-
-                            TextField("Host", text: self.$manualGatewayHost)
-                                .textInputAutocapitalization(.never)
-                                .autocorrectionDisabled()
-
-                            TextField("Port (optional)", text: self.manualPortBinding)
-                                .keyboardType(.numberPad)
-
-                            Toggle("Use TLS", isOn: self.$manualGatewayTLS)
-
-                            Button {
-                                Task { await self.connectManual() }
-                            } label: {
-                                if self.connectingGatewayID == "manual" {
-                                    HStack(spacing: 8) {
-                                        ProgressView()
-                                            .progressViewStyle(.circular)
-                                        Text("Connecting…")
-                                    }
-                                } else {
-                                    Text("Connect (Manual)")
-                                }
-                            }
-                            .disabled(self.connectingGatewayID != nil || self.manualGatewayHost
-                                .trimmingCharacters(in: .whitespacesAndNewlines)
-                                .isEmpty || !self.manualPortIsValid)
-
-                            Text(
-                                "Use this when mDNS/Bonjour discovery is blocked. "
-                                    + "Leave port empty for 443 on tailnet DNS (TLS) or 18789 otherwise.")
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-
-                            Toggle("Discovery Debug Logs", isOn: self.$discoveryDebugLogsEnabled)
-                                .onChange(of: self.discoveryDebugLogsEnabled) { _, newValue in
-                                    self.gatewayController.setDiscoveryDebugLoggingEnabled(newValue)
-                                }
-
-                            NavigationLink("Discovery Logs") {
-                                GatewayDiscoveryDebugLogView()
-                            }
-
-                            Toggle("Debug Canvas Status", isOn: self.$canvasDebugStatusEnabled)
-
-                            TextField("Gateway Auth Token", text: self.$gatewayToken)
-                                .textInputAutocapitalization(.never)
-                                .autocorrectionDisabled()
-
-                            SecureField("Gateway Password", text: self.$gatewayPassword)
-
-                            Button("Reset Onboarding", role: .destructive) {
-                                self.showResetOnboardingAlert = true
-                            }
-
-                            VStack(alignment: .leading, spacing: 6) {
-                                Text("Debug")
-                                    .font(.footnote.weight(.semibold))
-                                    .foregroundStyle(.secondary)
-                                Text(self.gatewayDebugText())
-                                    .font(.system(size: 12, weight: .regular, design: .monospaced))
-                                    .foregroundStyle(.secondary)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(10)
-                                    .background(
-                                        .thinMaterial,
-                                        in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-                            }
-                        }
-                    } label: {
-                        HStack(spacing: 10) {
-                            Circle()
-                                .fill(self.isGatewayConnected ? Color.green : Color.secondary.opacity(0.35))
-                                .frame(width: 10, height: 10)
-                            Text("Gateway")
-                            Spacer()
-                            Text(self.gatewaySummaryText)
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
-
-                Section("Device") {
-                    DisclosureGroup("Features") {
-                        self.featureToggle(
-                            "Voice Wake",
-                            isOn: self.$voiceWakeEnabled,
-                            help: "Enables wake-word activation to start a hands-free session.")
-                        { newValue in
-                            self.appModel.setVoiceWakeEnabled(newValue)
-                        }
-                        self.featureToggle(
-                            "Talk Mode",
-                            isOn: self.$talkEnabled,
-                            help: "Enables voice conversation mode with your connected OpenClaw agent.")
-                        { newValue in
-                            self.appModel.setTalkEnabled(newValue)
-                        }
-                        Picker("Speech Language", selection: self.$talkSpeechLocale) {
-                            ForEach(TalkSpeechLocale.supportedOptions()) { option in
-                                Text(option.label).tag(option.id)
-                            }
-                        }
-                        self.featureToggle(
-                            "Background Listening",
-                            isOn: self.$talkBackgroundEnabled,
-                            help: "Keeps listening while the app is backgrounded. Uses more battery.")
-
-                        NavigationLink {
-                            VoiceWakeWordsSettingsView()
-                        } label: {
-                            LabeledContent(
-                                "Wake Words",
-                                value: VoiceWakePreferences.displayString(for: self.voiceWake.triggerWords))
-                        }
-
-                        self.featureToggle(
-                            "Allow Camera",
-                            isOn: self.$cameraEnabled,
-                            help: "Allows the gateway to request photos or short video clips "
-                                + "while OpenClaw is foregrounded.")
-
-                        HStack(spacing: 8) {
-                            Text("Location Access")
-                            Spacer()
-                            Button {
-                                self.activeFeatureHelp = FeatureHelp(
-                                    title: "Location Access",
-                                    message: "Controls location permissions for OpenClaw. "
-                                        + "Off disables location tools, While Using enables "
-                                        + "foreground location, and Always enables "
-                                        + "background location.")
-                            } label: {
-                                Image(systemName: "info.circle")
-                                    .foregroundStyle(.secondary)
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityLabel("Location Access info")
-                        }
-                        Picker("Location Access", selection: self.$locationEnabledModeRaw) {
-                            Text("Off").tag(OpenClawLocationMode.off.rawValue)
-                            Text("While Using").tag(OpenClawLocationMode.whileUsing.rawValue)
-                            Text("Always").tag(OpenClawLocationMode.always.rawValue)
-                        }
-                        .labelsHidden()
-                        .pickerStyle(.segmented)
-
-                        self.featureToggle(
-                            "Prevent Sleep",
-                            isOn: self.$preventSleep,
-                            help: "Keeps the screen awake while OpenClaw is open.")
-
-                        DisclosureGroup("Advanced") {
-                            VStack(alignment: .leading, spacing: 8) {
-                                Text("Talk Voice (Gateway)")
-                                    .font(.footnote.weight(.semibold))
-                                    .foregroundStyle(.secondary)
-                                LabeledContent("Provider", value: "ElevenLabs")
-                                LabeledContent(
-                                    "API Key",
-                                    value: self.appModel.talkMode.gatewayTalkConfigLoaded
-                                        ? (
-                                            self.appModel.talkMode.gatewayTalkApiKeyConfigured
-                                                ? "Configured"
-                                                : "Not configured")
-                                        : "Not loaded")
-                                LabeledContent(
-                                    "Default Model",
-                                    value: self.appModel.talkMode.gatewayTalkDefaultModelId ?? "eleven_v3 (fallback)")
-                                LabeledContent(
-                                    "Default Voice",
-                                    value: self.appModel.talkMode.gatewayTalkDefaultVoiceId ?? "auto (first available)")
-                                Text("Configured on gateway via talk.apiKey, talk.modelId, and talk.voiceId.")
-                                    .font(.footnote)
-                                    .foregroundStyle(.secondary)
-                            }
-                            self.featureToggle(
-                                "Show Talk Control",
-                                isOn: self.$talkButtonEnabled,
-                                help: "Shows the Talk control in the main toolbar.")
-                            TextField("Default Share Instruction", text: self.$defaultShareInstruction, axis: .vertical)
-                                .lineLimit(2...6)
-                                .textInputAutocapitalization(.sentences)
-                            HStack(spacing: 8) {
-                                Text("Default Share Instruction")
-                                    .font(.footnote)
-                                    .foregroundStyle(.secondary)
-                                Spacer()
-                                Button {
-                                    self.activeFeatureHelp = FeatureHelp(
-                                        title: "Default Share Instruction",
-                                        message: "Appends this instruction when sharing content "
-                                            + "into OpenClaw from iOS.")
-                                } label: {
-                                    Image(systemName: "info.circle")
-                                        .foregroundStyle(.secondary)
-                                }
-                                .buttonStyle(.plain)
-                                .accessibilityLabel("Default Share Instruction info")
-                            }
-
-                            VStack(alignment: .leading, spacing: 8) {
-                                Button {
-                                    Task { await self.appModel.runSharePipelineSelfTest() }
-                                } label: {
-                                    Label("Run Share Self-Test", systemImage: "checkmark.seal")
-                                }
-                                Text(self.appModel.lastShareEventText)
-                                    .font(.footnote)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                    }
-
-                    DisclosureGroup("Device Info") {
-                        TextField("Name", text: self.$displayName)
-                        Text(self.instanceId)
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                        LabeledContent("Device", value: DeviceInfoHelper.deviceFamily())
-                        LabeledContent("Platform", value: DeviceInfoHelper.platformStringForDisplay())
-                        LabeledContent("OpenClaw", value: DeviceInfoHelper.openClawVersionString())
-                    }
-                }
+                self.gatewaySettingsSection
+                self.deviceSettingsSection
             }
             .navigationTitle("Settings")
             .toolbar {
@@ -488,92 +138,450 @@ struct SettingsTab: View {
                 Text(self.scannerError ?? "")
             }
             .onAppear {
-                self.lastLocationModeRaw = self.locationEnabledModeRaw
-                self.syncManualPortText()
-                let trimmedInstanceId = self.instanceId.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !trimmedInstanceId.isEmpty {
-                    self.gatewayToken = GatewaySettingsStore.loadGatewayToken(instanceId: trimmedInstanceId) ?? ""
-                    self.gatewayPassword = GatewaySettingsStore.loadGatewayPassword(instanceId: trimmedInstanceId) ?? ""
+                    self.lastLocationModeRaw = self.locationEnabledModeRaw
+                    self.syncManualPortText()
+                    let trimmedInstanceId = self.instanceId.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !trimmedInstanceId.isEmpty {
+                        self.gatewayToken = GatewaySettingsStore.loadGatewayToken(instanceId: trimmedInstanceId) ?? ""
+                        self.gatewayPassword = GatewaySettingsStore
+                            .loadGatewayPassword(instanceId: trimmedInstanceId) ?? ""
+                    }
+                    self.defaultShareInstruction = ShareToAgentSettings.loadDefaultInstruction()
+                    self.appModel.refreshLastShareEventFromRelay()
+                    // Keep setup front-and-center when disconnected; keep things compact once connected.
+                    self.gatewayExpanded = !self.isGatewayConnected
+                    self.selectedAgentPickerId = self.appModel.selectedAgentId ?? ""
+                    if self.isGatewayConnected {
+                        self.appModel.reloadTalkConfig()
+                    }
                 }
-                self.defaultShareInstruction = ShareToAgentSettings.loadDefaultInstruction()
-                self.appModel.refreshLastShareEventFromRelay()
-                // Keep setup front-and-center when disconnected; keep things compact once connected.
-                self.gatewayExpanded = !self.isGatewayConnected
-                self.selectedAgentPickerId = self.appModel.selectedAgentId ?? ""
-                if self.isGatewayConnected {
-                    self.appModel.reloadTalkConfig()
+                .onChange(of: self.selectedAgentPickerId) { _, newValue in
+                    let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                    self.appModel.setSelectedAgentId(trimmed.isEmpty ? nil : trimmed)
                 }
-            }
-            .onChange(of: self.selectedAgentPickerId) { _, newValue in
-                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                self.appModel.setSelectedAgentId(trimmed.isEmpty ? nil : trimmed)
-            }
-            .onChange(of: self.appModel.selectedAgentId ?? "") { _, newValue in
-                if newValue != self.selectedAgentPickerId {
-                    self.selectedAgentPickerId = newValue
+                .onChange(of: self.appModel.selectedAgentId ?? "") { _, newValue in
+                    if newValue != self.selectedAgentPickerId {
+                        self.selectedAgentPickerId = newValue
+                    }
                 }
-            }
-            .onChange(of: self.preferredGatewayStableID) { _, newValue in
-                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !trimmed.isEmpty else { return }
-                GatewaySettingsStore.savePreferredGatewayStableID(trimmed)
-            }
-            .onChange(of: self.gatewayToken) { _, newValue in
-                guard !self.suppressCredentialPersist else { return }
-                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                let instanceId = self.instanceId.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !instanceId.isEmpty else { return }
-                GatewaySettingsStore.saveGatewayToken(trimmed, instanceId: instanceId)
-            }
-            .onChange(of: self.gatewayPassword) { _, newValue in
-                guard !self.suppressCredentialPersist else { return }
-                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                let instanceId = self.instanceId.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !instanceId.isEmpty else { return }
-                GatewaySettingsStore.saveGatewayPassword(trimmed, instanceId: instanceId)
-            }
-            .onChange(of: self.defaultShareInstruction) { _, newValue in
-                ShareToAgentSettings.saveDefaultInstruction(newValue)
-            }
-            .onChange(of: self.manualGatewayPort) { _, _ in
-                self.syncManualPortText()
-            }
-            .onChange(of: self.appModel.gatewayServerName) { _, newValue in
-                if newValue != nil {
-                    self.setupCode = ""
-                    self.setupStatusText = nil
-                    return
+                .onChange(of: self.preferredGatewayStableID) { _, newValue in
+                    let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty else { return }
+                    GatewaySettingsStore.savePreferredGatewayStableID(trimmed)
                 }
-                if self.manualGatewayEnabled {
-                    self.setupStatusText = self.appModel.gatewayStatusText
+                .onChange(of: self.gatewayToken) { _, newValue in
+                    guard !self.suppressCredentialPersist else { return }
+                    let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let instanceId = self.instanceId.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !instanceId.isEmpty else { return }
+                    GatewaySettingsStore.saveGatewayToken(trimmed, instanceId: instanceId)
                 }
-            }
-            .onChange(of: self.appModel.gatewayStatusText) { _, newValue in
-                guard self.manualGatewayEnabled || self.connectingGatewayID == "manual" else { return }
-                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !trimmed.isEmpty else { return }
-                self.setupStatusText = trimmed
-            }
-            .onChange(of: self.locationEnabledModeRaw) { _, newValue in
-                let previous = self.lastLocationModeRaw
-                self.lastLocationModeRaw = newValue
-                guard let mode = OpenClawLocationMode(rawValue: newValue) else { return }
-                Task {
-                    let granted = await self.appModel.requestLocationPermissions(mode: mode)
-                    if !granted {
-                        await MainActor.run {
-                            self.locationEnabledModeRaw = previous
-                            self.lastLocationModeRaw = previous
-                        }
+                .onChange(of: self.gatewayPassword) { _, newValue in
+                    guard !self.suppressCredentialPersist else { return }
+                    let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let instanceId = self.instanceId.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !instanceId.isEmpty else { return }
+                    GatewaySettingsStore.saveGatewayPassword(trimmed, instanceId: instanceId)
+                }
+                .onChange(of: self.defaultShareInstruction) { _, newValue in
+                    ShareToAgentSettings.saveDefaultInstruction(newValue)
+                }
+                .onChange(of: self.manualGatewayPort) { _, _ in
+                    self.syncManualPortText()
+                }
+                .onChange(of: self.appModel.gatewayServerName) { _, newValue in
+                    if newValue != nil {
+                        self.setupCode = ""
+                        self.setupStatusText = nil
                         return
                     }
-                    await MainActor.run {
-                        self.gatewayController.refreshActiveGatewayRegistrationFromSettings()
+                    if self.manualGatewayEnabled {
+                        self.setupStatusText = self.appModel.gatewayStatusText
                     }
+                }
+                .onChange(of: self.appModel.gatewayStatusText) { _, newValue in
+                    guard self.manualGatewayEnabled || self.connectingGatewayID == "manual" else { return }
+                    let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty else { return }
+                    self.setupStatusText = trimmed
+                }
+                .onChange(of: self.locationEnabledModeRaw) { _, newValue in
+                    let previous = self.lastLocationModeRaw
+                    self.lastLocationModeRaw = newValue
+                    guard let mode = OpenClawLocationMode(rawValue: newValue) else { return }
+                    Task {
+                        let granted = await self.appModel.requestLocationPermissions(mode: mode)
+                        if !granted {
+                            await MainActor.run {
+                                self.locationEnabledModeRaw = previous
+                                self.lastLocationModeRaw = previous
+                            }
+                            return
+                        }
+                        await MainActor.run {
+                            self.gatewayController.refreshActiveGatewayRegistrationFromSettings()
+                        }
+                    }
+                }
+        }
+        .gatewayTrustPromptAlert()
+    }
+
+    private var gatewaySettingsSection: some View {
+        Section {
+            DisclosureGroup(isExpanded: self.$gatewayExpanded) {
+                if let gatewayProblem = self.appModel.lastGatewayProblem,
+                   !self.isGatewayConnected
+                {
+                    GatewayProblemBanner(
+                        problem: gatewayProblem,
+                        primaryActionTitle: "Retry connection",
+                        onPrimaryAction: {
+                            Task { await self.retryGatewayConnectionFromProblem() }
+                        },
+                        onShowDetails: {
+                            self.showGatewayProblemDetails = true
+                        })
+                }
+
+                if !self.isGatewayConnected {
+                    Text(
+                        "1. Open a chat with your OpenClaw agent and send /pair\n"
+                            + "2. Copy the setup code it returns\n"
+                            + "3. Paste here and tap Connect\n"
+                            + "4. Back in that chat, run /pair approve")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+
+                    if let warning = self.tailnetWarningText {
+                        Text(warning)
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(.orange)
+                    }
+
+                    TextField("Paste setup code", text: self.$setupCode)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+
+                    Button {
+                        self.openGatewayQRScanner()
+                    } label: {
+                        Label("Scan QR Code", systemImage: "qrcode.viewfinder")
+                    }
+                    .disabled(self.connectingGatewayID != nil)
+
+                    Button {
+                        Task { await self.applySetupCodeAndConnect() }
+                    } label: {
+                        if self.connectingGatewayID == "manual" {
+                            HStack(spacing: 8) {
+                                ProgressView()
+                                    .progressViewStyle(.circular)
+                                Text("Connecting…")
+                            }
+                        } else {
+                            Text("Connect with setup code")
+                        }
+                    }
+                    .disabled(self.connectingGatewayID != nil
+                        || self.setupCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                    if let status = self.setupStatusLine {
+                        Text(status)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if self.isGatewayConnected {
+                    Picker("Bot", selection: self.$selectedAgentPickerId) {
+                        Text("Default").tag("")
+                        let defaultId = (self.appModel.gatewayDefaultAgentId ?? "")
+                            .trimmingCharacters(in: .whitespacesAndNewlines)
+                        ForEach(self.appModel.gatewayAgents.filter { $0.id != defaultId }, id: \.id) { agent in
+                            let name = (agent.name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+                            Text(name.isEmpty ? agent.id : name).tag(agent.id)
+                        }
+                    }
+                    Text("Controls which bot Chat and Talk speak to.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                if self.appModel.gatewayServerName == nil {
+                    LabeledContent("Discovery", value: self.gatewayController.discoveryStatusText)
+                }
+                LabeledContent("Status", value: self.appModel.gatewayDisplayStatusText)
+                Toggle("Auto-connect on launch", isOn: self.$gatewayAutoConnect)
+
+                if let serverName = self.appModel.gatewayServerName {
+                    LabeledContent("Server", value: serverName)
+                    if let addr = self.appModel.gatewayRemoteAddress {
+                        let parts = Self.parseHostPort(from: addr)
+                        let urlString = Self.httpURLString(host: parts?.host, port: parts?.port, fallback: addr)
+                        LabeledContent("Address") {
+                            Text(urlString)
+                        }
+                        .contextMenu {
+                            Button {
+                                UIPasteboard.general.string = urlString
+                            } label: {
+                                Label("Copy URL", systemImage: "doc.on.doc")
+                            }
+
+                            if let parts {
+                                Button {
+                                    UIPasteboard.general.string = parts.host
+                                } label: {
+                                    Label("Copy Host", systemImage: "doc.on.doc")
+                                }
+
+                                Button {
+                                    UIPasteboard.general.string = "\(parts.port)"
+                                } label: {
+                                    Label("Copy Port", systemImage: "doc.on.doc")
+                                }
+                            }
+                        }
+                    }
+
+                    Button("Disconnect", role: .destructive) {
+                        self.appModel.disconnectGateway()
+                    }
+                } else {
+                    self.gatewayList(showing: .all)
+                }
+
+                DisclosureGroup("Advanced") {
+                    Toggle("Use Manual Gateway", isOn: self.$manualGatewayEnabled)
+
+                    TextField("Host", text: self.$manualGatewayHost)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+
+                    TextField("Port (optional)", text: self.manualPortBinding)
+                        .keyboardType(.numberPad)
+
+                    Toggle("Use TLS", isOn: self.$manualGatewayTLS)
+
+                    Button {
+                        Task { await self.connectManual() }
+                    } label: {
+                        if self.connectingGatewayID == "manual" {
+                            HStack(spacing: 8) {
+                                ProgressView()
+                                    .progressViewStyle(.circular)
+                                Text("Connecting…")
+                            }
+                        } else {
+                            Text("Connect (Manual)")
+                        }
+                    }
+                    .disabled(self.connectingGatewayID != nil || self.manualGatewayHost
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .isEmpty || !self.manualPortIsValid)
+
+                    Text(
+                        "Use this when mDNS/Bonjour discovery is blocked. "
+                            + "Leave port empty for 443 on tailnet DNS (TLS) or 18789 otherwise.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+
+                    Toggle("Discovery Debug Logs", isOn: self.$discoveryDebugLogsEnabled)
+                        .onChange(of: self.discoveryDebugLogsEnabled) { _, newValue in
+                            self.gatewayController.setDiscoveryDebugLoggingEnabled(newValue)
+                        }
+
+                    NavigationLink("Discovery Logs") {
+                        GatewayDiscoveryDebugLogView()
+                    }
+
+                    Toggle("Debug Canvas Status", isOn: self.$canvasDebugStatusEnabled)
+
+                    TextField("Gateway Auth Token", text: self.$gatewayToken)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+
+                    SecureField("Gateway Password", text: self.$gatewayPassword)
+
+                    Button("Reset Onboarding", role: .destructive) {
+                        self.showResetOnboardingAlert = true
+                    }
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Debug")
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Text(self.gatewayDebugText())
+                            .font(.system(size: 12, weight: .regular, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(10)
+                            .background(
+                                .thinMaterial,
+                                in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                    }
+                }
+            } label: {
+                HStack(spacing: 10) {
+                    Circle()
+                        .fill(self.isGatewayConnected ? Color.green : Color.secondary.opacity(0.35))
+                        .frame(width: 10, height: 10)
+                    Text("Gateway")
+                    Spacer()
+                    Text(self.gatewaySummaryText)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
                 }
             }
         }
-        .gatewayTrustPromptAlert()
+    }
+
+    private var deviceSettingsSection: some View {
+        Section("Device") {
+            DisclosureGroup("Features") {
+                self.featureToggle(
+                    "Voice Wake",
+                    isOn: self.$voiceWakeEnabled,
+                    help: "Enables wake-word activation to start a hands-free session.")
+                { newValue in
+                    self.appModel.setVoiceWakeEnabled(newValue)
+                }
+                self.featureToggle(
+                    "Talk Mode",
+                    isOn: self.$talkEnabled,
+                    help: "Enables voice conversation mode with your connected OpenClaw agent.")
+                { newValue in
+                    self.appModel.setTalkEnabled(newValue)
+                }
+                Picker("Speech Language", selection: self.$talkSpeechLocale) {
+                    ForEach(TalkSpeechLocale.supportedOptions()) { option in
+                        Text(option.label).tag(option.id)
+                    }
+                }
+                self.featureToggle(
+                    "Background Listening",
+                    isOn: self.$talkBackgroundEnabled,
+                    help: "Keeps listening while the app is backgrounded. Uses more battery.")
+
+                NavigationLink {
+                    VoiceWakeWordsSettingsView()
+                } label: {
+                    LabeledContent(
+                        "Wake Words",
+                        value: VoiceWakePreferences.displayString(for: self.voiceWake.triggerWords))
+                }
+
+                self.featureToggle(
+                    "Allow Camera",
+                    isOn: self.$cameraEnabled,
+                    help: "Allows the gateway to request photos or short video clips "
+                        + "while OpenClaw is foregrounded.")
+
+                HStack(spacing: 8) {
+                    Text("Location Access")
+                    Spacer()
+                    Button {
+                        self.activeFeatureHelp = FeatureHelp(
+                            title: "Location Access",
+                            message: "Controls location permissions for OpenClaw. "
+                                + "Off disables location tools, While Using enables "
+                                + "foreground location, and Always enables "
+                                + "background location.")
+                    } label: {
+                        Image(systemName: "info.circle")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Location Access info")
+                }
+                Picker("Location Access", selection: self.$locationEnabledModeRaw) {
+                    Text("Off").tag(OpenClawLocationMode.off.rawValue)
+                    Text("While Using").tag(OpenClawLocationMode.whileUsing.rawValue)
+                    Text("Always").tag(OpenClawLocationMode.always.rawValue)
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+
+                self.featureToggle(
+                    "Prevent Sleep",
+                    isOn: self.$preventSleep,
+                    help: "Keeps the screen awake while OpenClaw is open.")
+
+                DisclosureGroup("Advanced") {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Talk Voice (Gateway)")
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        LabeledContent("Provider", value: "ElevenLabs")
+                        LabeledContent(
+                            "API Key",
+                            value: self.appModel.talkMode.gatewayTalkConfigLoaded
+                                ? (
+                                    self.appModel.talkMode.gatewayTalkApiKeyConfigured
+                                        ? "Configured"
+                                        : "Not configured")
+                                : "Not loaded")
+                        LabeledContent(
+                            "Default Model",
+                            value: self.appModel.talkMode.gatewayTalkDefaultModelId ?? "eleven_v3 (fallback)")
+                        LabeledContent(
+                            "Default Voice",
+                            value: self.appModel.talkMode.gatewayTalkDefaultVoiceId ?? "auto (first available)")
+                        Text("Configured on gateway via talk.apiKey, talk.modelId, and talk.voiceId.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                    self.featureToggle(
+                        "Show Talk Control",
+                        isOn: self.$talkButtonEnabled,
+                        help: "Shows the Talk control in the main toolbar.")
+                    TextField("Default Share Instruction", text: self.$defaultShareInstruction, axis: .vertical)
+                        .lineLimit(2...6)
+                        .textInputAutocapitalization(.sentences)
+                    HStack(spacing: 8) {
+                        Text("Default Share Instruction")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button {
+                            self.activeFeatureHelp = FeatureHelp(
+                                title: "Default Share Instruction",
+                                message: "Appends this instruction when sharing content "
+                                    + "into OpenClaw from iOS.")
+                        } label: {
+                            Image(systemName: "info.circle")
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Default Share Instruction info")
+                    }
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Button {
+                            Task { await self.appModel.runSharePipelineSelfTest() }
+                        } label: {
+                            Label("Run Share Self-Test", systemImage: "checkmark.seal")
+                        }
+                        Text(self.appModel.lastShareEventText)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            DisclosureGroup("Device Info") {
+                TextField("Name", text: self.$displayName)
+                Text(self.instanceId)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                LabeledContent("Device", value: DeviceInfoHelper.deviceFamily())
+                LabeledContent("Platform", value: DeviceInfoHelper.platformStringForDisplay())
+                LabeledContent("OpenClaw", value: DeviceInfoHelper.openClawVersionString())
+            }
+        }
     }
 
     @ViewBuilder

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
@@ -57,7 +57,7 @@ public struct GatewayConnectDeepLink: Codable, Sendable, Equatable {
         {
             return link
         }
-        return fromGatewayURLString(
+        return self.fromGatewayURLString(
             trimmed,
             bootstrapToken: nil,
             token: nil,
@@ -89,7 +89,7 @@ public struct GatewayConnectDeepLink: Codable, Sendable, Equatable {
         {
             return link
         }
-        for candidate in setupCodeCandidates(in: trimmed) where candidate != trimmed {
+        for candidate in self.setupCodeCandidates(in: trimmed) where candidate != trimmed {
             if let data = decodeBase64Url(candidate),
                let link = decodeSetupPayload(from: data)
             {
@@ -104,7 +104,7 @@ public struct GatewayConnectDeepLink: Codable, Sendable, Equatable {
         if let urlString = payload.url?.trimmingCharacters(in: .whitespacesAndNewlines),
            !urlString.isEmpty
         {
-            return fromGatewayURLString(
+            return self.fromGatewayURLString(
                 urlString,
                 bootstrapToken: payload.bootstrapToken,
                 token: payload.token,

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -623,21 +623,21 @@ public actor GatewayChannelActor {
         role: String) async throws
     {
         if res.ok == false {
-            let msg = (res.error?["message"]?.value as? String) ?? "gateway connect failed"
-            let details = res.error?["details"]?.value as? [String: ProtoAnyCodable]
-            let detailCode = details?["code"]?.value as? String
-            let canRetryWithDeviceToken = details?["canRetryWithDeviceToken"]?.value as? Bool ?? false
-            let recommendedNextStep = details?["recommendedNextStep"]?.value as? String
-            let requestId = details?["requestId"]?.value as? String
-            let reason = details?["reason"]?.value as? String
-            let owner = details?["owner"]?.value as? String
-            let title = details?["title"]?.value as? String
-            let userMessage = details?["userMessage"]?.value as? String
-            let actionLabel = details?["actionLabel"]?.value as? String
-            let actionCommand = details?["actionCommand"]?.value as? String
-            let docsURLString = details?["docsUrl"]?.value as? String
-            let retryableOverride = details?["retryable"]?.value as? Bool
-            let pauseReconnectOverride = details?["pauseReconnect"]?.value as? Bool
+            let details = self.errorDetailsDictionary(res.error)
+            let msg = res.error?.message ?? "gateway connect failed"
+            let detailCode = details["code"]?.value as? String
+            let canRetryWithDeviceToken = details["canRetryWithDeviceToken"]?.value as? Bool ?? false
+            let recommendedNextStep = details["recommendedNextStep"]?.value as? String
+            let requestId = details["requestId"]?.value as? String
+            let reason = details["reason"]?.value as? String
+            let owner = details["owner"]?.value as? String
+            let title = details["title"]?.value as? String
+            let userMessage = details["userMessage"]?.value as? String
+            let actionLabel = details["actionLabel"]?.value as? String
+            let actionCommand = details["actionCommand"]?.value as? String
+            let docsURLString = details["docsUrl"]?.value as? String
+            let retryableOverride = details["retryable"]?.value as? Bool
+            let pauseReconnectOverride = details["pauseReconnect"]?.value as? Bool
             throw GatewayConnectAuthError(
                 message: msg,
                 detailCodeRaw: detailCode,
@@ -974,11 +974,9 @@ public actor GatewayChannelActor {
             throw NSError(domain: "Gateway", code: 2, userInfo: [NSLocalizedDescriptionKey: "unexpected frame"])
         }
         if res.ok == false {
-            let code = res.error?["code"]?.value as? String
-            let msg = res.error?["message"]?.value as? String
-            let details: [String: AnyCodable] = (res.error ?? [:]).reduce(into: [:]) { acc, pair in
-                acc[pair.key] = AnyCodable(pair.value.value)
-            }
+            let code = res.error?.code
+            let msg = res.error?.message
+            let details = self.errorDetailsDictionary(res.error)
             throw GatewayResponseError(method: method, code: code, message: msg, details: details)
         }
         if let payload = res.payload {
@@ -986,6 +984,34 @@ public actor GatewayChannelActor {
             return try self.encoder.encode(payload)
         }
         return Data() // Should not happen, but tolerate empty payloads.
+    }
+
+    private func errorDetailsDictionary(_ error: ErrorShape?) -> [String: AnyCodable] {
+        guard let error else { return [:] }
+        var details: [String: AnyCodable] = [:]
+
+        switch error.details?.value {
+        case let nested as [String: AnyCodable]:
+            details.merge(nested) { current, _ in current }
+        case let nested as [String: Any]:
+            for (key, value) in nested {
+                details[key] = AnyCodable(value)
+            }
+        case let value?:
+            details["details"] = AnyCodable(value)
+        case nil:
+            break
+        }
+
+        details["code"] = AnyCodable(error.code)
+        details["message"] = AnyCodable(error.message)
+        if let retryable = error.retryable {
+            details["retryable"] = AnyCodable(retryable)
+        }
+        if let retryAfterMs = error.retryafterms {
+            details["retryAfterMs"] = AnyCodable(retryAfterMs)
+        }
+        return details
     }
 
     public func send(method: String, params: [String: AnyCodable]?) async throws {
@@ -1013,7 +1039,9 @@ public actor GatewayChannelActor {
 
     /// Wrap low-level URLSession/WebSocket errors with context so UI can surface them.
     private func wrap(_ error: Error, context: String) -> Error {
-        if error is GatewayConnectAuthError || error is GatewayResponseError || error is GatewayDecodingError || error is GatewayTLSValidationError {
+        if error is GatewayConnectAuthError || error is GatewayResponseError || error is GatewayDecodingError ||
+            error is GatewayTLSValidationError
+        {
             return error
         }
         if let urlError = error as? URLError {

--- a/apps/swabble/Package.resolved
+++ b/apps/swabble/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "646c710cf04fdf9e6c6ca935f3184924db3397a816848a7f8a8a3c10a4d8e9c8",
+  "originHash" : "1d395bda9de2d5c05f30bb424b65327e2b4f507343d9d94271e573bcbcbc05f3",
   "pins" : [
     {
       "identity" : "commander",
@@ -8,6 +8,24 @@
       "state" : {
         "revision" : "ae2ce746b386ff94b26648cfe5625cfa8d02639b",
         "version" : "0.2.2"
+      }
+    },
+    {
+      "identity" : "elevenlabskit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/steipete/ElevenLabsKit",
+      "state" : {
+        "revision" : "0f1e4c039bd0e22b03c0cb7f43c00c1865858f0b",
+        "version" : "0.1.1"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
       }
     },
     {
@@ -26,6 +44,24 @@
       "state" : {
         "revision" : "937120cbc281cf29727fdfb8734482158508b4fc",
         "version" : "6.3.1"
+      }
+    },
+    {
+      "identity" : "swiftui-math",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/swiftui-math",
+      "state" : {
+        "revision" : "0b5c2cfaaec8d6193db206f675048eeb5ce95f71",
+        "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "textual",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/textual",
+      "state" : {
+        "revision" : "5b06b811c0f5313b6b84bbef98c635a630638c38",
+        "version" : "0.3.1"
       }
     }
   ],


### PR DESCRIPTION
## Summary

- fixes the current iOS simulator build after Gateway protocol errors became generated `ErrorShape` values instead of dictionary payloads
- imports the shared deep-link helper in onboarding and splits the settings view into smaller sections so Swift 6.2 can type-check it
- refreshes the Swabble Swift package resolution needed by the current iOS project graph

## Verification

- `git diff --check origin/main...HEAD`
- `nix shell nixpkgs#swiftformat nixpkgs#swiftlint --command xcodebuildmcp simulator build --project-path apps/ios/OpenClaw.xcodeproj --scheme OpenClaw --simulator-name 'iPhone 17' --output json`
- `xcodebuildmcp simulator install --simulator-id BCF776A3-2095-45F8-987F-EB059463F9FD --app-path /Users/josh/Library/Developer/Xcode/DerivedData/OpenClaw-bzhxdvzhsenqcdebiakgwfekhzsu/Build/Products/Debug-iphonesimulator/OpenClaw.app`
- `xcodebuildmcp simulator launch-app --simulator-id BCF776A3-2095-45F8-987F-EB059463F9FD --bundle-id ai.openclaw.ios.test.josh-7m8br7r488`
- `nix shell nixpkgs#swiftformat nixpkgs#swiftlint --command bash -lc 'cd apps/shared/OpenClawKit && swift test --filter GatewayErrorsTests'`

## Notes

- Full `swift test` for `apps/shared/OpenClawKit` still has a pre-existing `TalkConfigContractTests.selectionFixtures` failure unrelated to this iOS build fix.
