### PR TITLE
[codex] Fix chat bubble action overlap

### DIFF
--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -443,6 +443,26 @@ describe("grouped chat rendering", () => {
     expect(container.querySelector('[aria-label="Read aloud"]')).toBeNull();
   });
 
+  it("adds spacing class when assistant bubble actions are rendered", () => {
+    const container = document.createElement("div");
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: "Short answer",
+        timestamp: 1000,
+      },
+      { onOpenSidebar: vi.fn() },
+    );
+
+    const bubble = expectElement(container, ".chat-group.assistant .chat-bubble", HTMLElement);
+
+    expect(bubble.classList.contains("has-copy")).toBe(true);
+    expect(bubble.querySelector(".chat-bubble-actions")).toBeInstanceOf(HTMLDivElement);
+    expect(bubble.querySelector(".chat-expand-btn")).toBeInstanceOf(HTMLButtonElement);
+    expect(bubble.querySelector(".chat-copy-btn")).toBeInstanceOf(HTMLButtonElement);
+  });
+
   it("positions delete confirm by message side", () => {
     const container = document.createElement("div");
     clearDeleteConfirmSkip();

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -1435,6 +1435,7 @@ function renderGroupedMessage(
   const markdown = markdownBase;
   const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
   const canExpand = role === "assistant" && Boolean(onOpenSidebar && markdown?.trim());
+  const hasActions = canCopyMarkdown || canExpand;
 
   // Detect pure-JSON messages and render as collapsible block
   const jsonResult = markdown && !opts.isStreaming ? detectJson(markdown) : null;
@@ -1442,6 +1443,7 @@ function renderGroupedMessage(
   const isToolMessage = normalizedRole === "tool" || isToolResult;
   const bubbleClasses = [
     "chat-bubble",
+    hasActions ? "has-copy" : "",
     isToolMessage ? "chat-bubble--tool-shell" : "",
     opts.isStreaming ? "streaming" : "",
     "fade-in",
@@ -1479,7 +1481,6 @@ function renderGroupedMessage(
         : "Tool call"
       : "Tool output";
 
-  const hasActions = canCopyMarkdown || canExpand;
   const duplicateCount = Math.max(1, Math.floor(opts.duplicateCount ?? 1));
 
   return html`


### PR DESCRIPTION
## Summary

Fixes a Control UI chat layout bug where assistant message action buttons can overlap the response text.

Assistant bubbles can render a top-right action cluster for actions like opening the message in the sidebar and copying the assistant response as markdown. The stylesheet already reserves horizontal room for that cluster with `.chat-bubble.has-copy { padding-right: 70px; }`, but the grouped chat renderer never applied the `has-copy` class when those actions were present. As a result, the absolutely positioned `.chat-bubble-actions` container could sit directly on top of short or medium assistant responses.

## Root Cause

`renderGroupedMessage` computed whether copy/expand actions should be rendered, but the bubble class list did not include the existing spacing class that the CSS expects.

Before this change:

- assistant text could render `.chat-bubble-actions`
- the bubble stayed as `.chat-bubble ...`
- `.chat-bubble.has-copy` never matched
- the actions were positioned at `top: 6px; right: 8px` without reserved inline space

This made the overlap visible in the Control UI chat view, especially for short assistant messages.

## Changes

- Compute `hasActions` before building `bubbleClasses`.
- Add `has-copy` to assistant bubbles when copy/expand actions are rendered.
- Add a regression test that renders an assistant message with both expand and copy actions and verifies:
  - the assistant bubble receives `has-copy`
  - `.chat-bubble-actions` is rendered
  - the expand and copy buttons are present

## Real behavior proof

- **Behavior or issue addressed:** In the OpenClaw Control UI chat view, the assistant message copy/expand action buttons were overlaying the assistant response text because the action cluster rendered without the existing `has-copy` spacing class.

- **Real environment tested:** Windows 11 local OpenClaw install, installed npm package `openclaw@2026.5.7`, Control UI bundled at `C:\Users\Falcon\AppData\Roaming\npm\node_modules\openclaw\dist\control-ui`. The source PR was made against current `main`; the real setup proof used the equivalent one-line compiled-bundle patch on the local Windows install before submitting the upstream source fix.

- **Exact steps or command run after this patch:** Applied the equivalent local package patch to the installed Control UI bundle, then verified the real installed bundle emitted `has-copy` on chat bubbles that render action buttons and still parsed successfully:

```powershell
Select-String -Path 'C:\Users\Falcon\AppData\Roaming\npm\node_modules\openclaw\dist\control-ui\assets\index-NYVkUQrq.js' -Pattern 'chat-bubble-actions|has-copy|class="\$\{w\}' -Context 1,1
node --check 'C:\Users\Falcon\AppData\Roaming\npm\node_modules\openclaw\dist\control-ui\assets\index-NYVkUQrq.js'
```

- **Evidence after fix:** Copied terminal output from the real Windows OpenClaw install after the equivalent patch:

```text
LineNumber : 1101
Line       :     <div class="${w} ${A?`has-copy`:``}">

LineNumber : 1103
Line       :       ${A?s`<div class="chat-bubble-actions">

node --check C:\Users\Falcon\AppData\Roaming\npm\node_modules\openclaw\dist\control-ui\assets\index-NYVkUQrq.js
Exit code: 0
```

- **Observed result after fix:** The real installed bundle now renders assistant bubbles with the `has-copy` class whenever `.chat-bubble-actions` is present, so the existing `.chat-bubble.has-copy { padding-right: 70px; }` CSS path is activated and reserves space for the two top-right action buttons instead of letting them sit over the response text.

- **What was not tested:** I reproduced and verified this on Windows only. I did not personally verify the visual behavior on macOS or Linux. The change is platform-neutral UI source, but the real setup proof above is Windows-only.

## Validation

Tested on Windows:

- OS/environment: Windows local checkout
- Observed issue in the packaged Control UI from `openclaw@2026.5.7`
- Applied source fix in this branch against current `main`

Commands run:

```powershell
pnpm install --frozen-lockfile
pnpm --dir ui test src/ui/chat/grouped-render.test.ts
pnpm exec oxfmt --check ui/src/ui/chat/grouped-render.ts ui/src/ui/chat/grouped-render.test.ts
git diff --check
```

Results:

- Focused UI test passes: `36 passed`
- Formatting check passes for changed files
- `git diff --check` passes

I also verified the new regression test fails before the source fix with:

```text
AssertionError: expected false to be true
```

for `bubble.classList.contains("has-copy")`.

## Notes / Platform Scope

This was reproduced and tested on Windows. I have not personally verified the visual behavior on macOS or Linux. The fix is platform-neutral UI source code, but the manual reproduction and validation were done on Windows only.

## Risk

Low. This reuses an existing CSS class and only applies it when the same action buttons are already being rendered. It does not change action behavior, copy behavior, markdown rendering, or chat message content.

## Related Context

There is already CSS intended to reserve space for these actions. This PR wires the renderer up to that existing CSS path so the layout and rendered actions agree.