### PR TITLE
fix(browser): honor cdpUrl for user default profile

### DIFF
--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -759,6 +759,39 @@ describe("browser config", () => {
     expect(profile?.mcpArgs).toEqual(["--no-usage-statistics", "--performanceCrux", "false"]);
   });
 
+  it("applies top-level cdpUrl to an existing-session default profile", () => {
+    const resolved = resolveBrowserConfig({
+      defaultProfile: "user",
+      cdpUrl: "http://127.0.0.1:9222/",
+    });
+
+    const profile = resolveProfile(resolved, resolved.defaultProfile);
+    expect(resolved.defaultProfile).toBe("user");
+    expect(profile?.driver).toBe("existing-session");
+    expect(profile?.cdpUrl).toBe("http://127.0.0.1:9222");
+    expect(profile?.cdpHost).toBe("127.0.0.1");
+    expect(profile?.cdpIsLoopback).toBe(true);
+  });
+
+  it("keeps explicit existing-session profile cdpUrl over the top-level cdpUrl", () => {
+    const resolved = resolveBrowserConfig({
+      defaultProfile: "chrome-live",
+      cdpUrl: "http://127.0.0.1:9222",
+      profiles: {
+        "chrome-live": {
+          driver: "existing-session",
+          attachOnly: true,
+          cdpUrl: "http://127.0.0.1:9333",
+          color: "#00AA00",
+        },
+      },
+    });
+
+    const profile = resolveProfile(resolved, resolved.defaultProfile);
+    expect(profile?.driver).toBe("existing-session");
+    expect(profile?.cdpUrl).toBe("http://127.0.0.1:9333");
+  });
+
   it("preserves direct websocket cdpUrl for existing-session profiles", () => {
     const resolved = resolveBrowserConfig({
       profiles: {

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -326,6 +326,31 @@ function ensureDefaultUserBrowserProfile(
   return result;
 }
 
+function applyLegacyCdpUrlToExistingSessionDefaultProfile(
+  profiles: Record<string, BrowserProfileConfig>,
+  defaultProfile: string,
+  legacyCdpUrl: string | undefined,
+): Record<string, BrowserProfileConfig> {
+  if (!legacyCdpUrl) {
+    return profiles;
+  }
+  const profile = profiles[defaultProfile];
+  if (
+    !profile ||
+    profile.driver !== "existing-session" ||
+    normalizeOptionalString(profile.cdpUrl)
+  ) {
+    return profiles;
+  }
+  return {
+    ...profiles,
+    [defaultProfile]: {
+      ...profile,
+      cdpUrl: legacyCdpUrl,
+    },
+  };
+}
+
 export function resolveBrowserConfig(
   cfg: BrowserConfig | undefined,
   rootConfig?: OpenClawConfig,
@@ -397,7 +422,7 @@ export function resolveBrowserConfig(
   const legacyCdpPort = rawCdpUrl ? cdpInfo.port : undefined;
   const isWsUrl = cdpInfo.parsed.protocol === "ws:" || cdpInfo.parsed.protocol === "wss:";
   const legacyCdpUrl = rawCdpUrl && isWsUrl ? cdpInfo.normalized : undefined;
-  const profiles = ensureDefaultUserBrowserProfile(
+  let profiles = ensureDefaultUserBrowserProfile(
     ensureDefaultProfile(
       cfg?.profiles,
       defaultColor,
@@ -415,6 +440,11 @@ export function resolveBrowserConfig(
       : profiles[DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME]
         ? DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME
         : "user");
+  profiles = applyLegacyCdpUrlToExistingSessionDefaultProfile(
+    profiles,
+    defaultProfile,
+    rawCdpUrl ? cdpInfo.normalized : undefined,
+  );
 
   const extraArgs = Array.isArray(cfg?.extraArgs)
     ? cfg.extraArgs.filter(


### PR DESCRIPTION
Fixes #48042

## Problem summary
`browser.cdpUrl` was ignored when `browser.defaultProfile` selected an `existing-session` profile such as the built-in `user` profile. Chrome MCP then launched through its default auto-connect path and could still look for `DevToolsActivePort` instead of using the configured endpoint.

## Root cause
`resolveBrowserConfig` only carried the legacy top-level `browser.cdpUrl` into the managed `openclaw` profile. `resolveProfile` handles `existing-session` profiles from their profile-local `cdpUrl`, so an explicit `defaultProfile: "user"` left the selected profile with an empty endpoint.

## Architectural reasoning
The fix stays inside browser profile resolution, where the legacy single-profile config is normalized. When the selected default profile is `existing-session` and has no explicit endpoint, the resolver now applies the normalized top-level `browser.cdpUrl` to that profile. Explicit per-profile `cdpUrl` still wins. Chrome MCP session creation, caching, cleanup, gateway routes, and action behavior are unchanged; the existing Chrome MCP argument builder already converts HTTP endpoints to `--browserUrl` and websocket endpoints to `--wsEndpoint` without combining them with `userDataDir`.

## Testing performed
- `pnpm test extensions/browser/src/browser/config.test.ts`
- `pnpm test extensions/browser/src/browser/chrome-mcp.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/browser/src/browser/config.ts extensions/browser/src/browser/config.test.ts`
- `pnpm lint:extensions`
- `pnpm tsgo:extensions` from temporary `P:\` mapping because the local checkout path contains a space and the direct Windows command split `C:\Projects\Personal Project`.
- `pnpm tsgo:extensions:test` from temporary `P:\` mapping for the same path reason.
- `git diff --check`
- `pnpm check:changed` exited 0 in this checkout, but printed no lane details.
- `pnpm test extensions/browser` was attempted. It failed on existing local Windows environment assumptions outside this patch: unsupported local browser discovery in `chrome.internal.test.ts`, LaunchServices default-browser expectations, and POSIX `/tmp` path expectations resolving as `C:\tmp`.

## Real behavior proof
- Behavior or issue addressed: `browser.defaultProfile: "user"` plus top-level `browser.cdpUrl` now resolves to an existing-session profile with that endpoint, so Chrome MCP receives endpoint flags instead of `--autoConnect`.
- Real environment tested: local Windows checkout, pnpm 10.33.2, Node v22.15.0. The repo warns it wants Node >=22.16.0, but targeted tests, lint, and typechecks completed as listed above.
- Exact steps or command run after this patch:

```sh
pnpm exec tsx -e "import { resolveBrowserConfig, resolveProfile } from './extensions/browser/src/browser/config.ts'; import { buildChromeMcpArgs } from './extensions/browser/src/browser/chrome-mcp.ts'; const resolved = resolveBrowserConfig({ defaultProfile: 'user', cdpUrl: 'http://127.0.0.1:9222/' } as any); const profile = resolveProfile(resolved, resolved.defaultProfile); if (!profile) throw new Error('profile missing'); const args = buildChromeMcpArgs(profile); console.log(JSON.stringify({ defaultProfile: resolved.defaultProfile, driver: profile.driver, cdpUrl: profile.cdpUrl, args }, null, 2)); if (!args.includes('--browserUrl') || args.includes('--autoConnect') || args.includes('--userDataDir')) throw new Error('Chrome MCP args did not use configured cdpUrl cleanly');"
```

- Evidence after fix:

```json
{
  "defaultProfile": "user",
  "driver": "existing-session",
  "cdpUrl": "http://127.0.0.1:9222",
  "args": [
    "-y",
    "chrome-devtools-mcp@latest",
    "--browserUrl",
    "http://127.0.0.1:9222",
    "--experimentalStructuredContent",
    "--experimental-page-id-routing"
  ]
}
```

- Observed result after fix: the selected `user` existing-session profile carries `http://127.0.0.1:9222`, and Chrome MCP launch args contain `--browserUrl` with no `--autoConnect` or `--userDataDir` fallback.
- What was not tested: live attachment to a real Chrome v145 instance on port 9222 was not run in this environment.

## Risk analysis
Risk is low to medium. The change is limited to config normalization and only affects an existing-session default profile with a top-level `browser.cdpUrl` and no profile-local endpoint. It does not modify session caching, concurrency, gateway protocol, route behavior, cleanup logic, or managed browser launch semantics. The main compatibility risk is users who accidentally had both `defaultProfile: "user"` and `browser.cdpUrl`; that config now follows the documented endpoint instead of silently ignoring it.

## Backward compatibility
Existing defaults are preserved: the built-in `user` profile still has no endpoint unless selected as the default with a top-level `browser.cdpUrl`, and explicit `browser.profiles.<name>.cdpUrl` continues to take precedence. No public API shape, config schema, gateway payload, or protocol version changes are introduced.
