### PR TITLE
fix(agents): surface exec failures after claimed success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: surface concise default-visible warnings when `exec`/`bash` tool calls fail after the assistant claims success, while keeping raw stderr hidden unless verbose details are enabled. Fixes #60497. (#80003) Thanks @jbetala7.
 - CLI/agent: let `openclaw agent --model` use the backend/admin Gateway scope without cached device-token scopes silently downscoping the request. (#78837) Thanks @VACInc.
 - Ollama: keep DeepSeek V4 cloud models thinking-capable even when Ollama Cloud `/api/show` omits the `thinking` capability, so `/think high` no longer rejects `ollama/deepseek-v4-*:cloud`.
 - ACPX/Claude ACP: keep foreground prompts waiting for their own result when autonomous task-notification results arrive during the same session, and retarget the patch for Claude Agent ACP `0.33.1`.

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -378,6 +378,23 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[1]?.text).not.toContain("missing");
   });
 
+  it("shows exec tool errors when assistant output claims success", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["The script is ready to use and saved in your workspace."],
+      lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
+      lastToolError: {
+        toolName: "exec",
+        error: "/bin/bash: line 1: python: command not found",
+      },
+    });
+
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]?.text).toBe("The script is ready to use and saved in your workspace.");
+    expect(payloads[1]?.isError).toBe(true);
+    expect(payloads[1]?.text).toContain("Exec");
+    expect(payloads[1]?.text).not.toContain("python: command not found");
+  });
+
   it("shows mutating tool errors when assistant output does not acknowledge the failure", () => {
     const payloads = buildPayloads({
       assistantTexts: ["No issues found. The update is complete."],
@@ -430,6 +447,17 @@ describe("buildEmbeddedRunPayloads", () => {
       assistantTexts: [text],
       lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
       lastToolError: { toolName: "edit", error: "file missing" },
+    });
+
+    expectSinglePayloadSummary(payloads, { text });
+  });
+
+  it("suppresses exec warnings when assistant output explicitly acknowledges the command failure", () => {
+    const text = "I couldn't run the command because python was not found.";
+    const payloads = buildPayloads({
+      assistantTexts: [text],
+      lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
+      lastToolError: { toolName: "exec", error: "/bin/bash: line 1: python: command not found" },
     });
 
     expectSinglePayloadSummary(payloads, { text });

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -88,10 +88,27 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expectSinglePayloadText(payloads, "Fixed.");
   });
 
-  it("suppresses exec tool errors when verbose mode is off", () => {
-    expectNoPayloads({
+  it("surfaces concise exec tool errors when verbose mode is off", () => {
+    const payloads = buildPayloads({
       lastToolError: { toolName: "exec", error: "command failed" },
       verboseLevel: "off",
+    });
+
+    expectSingleToolErrorPayload(payloads, {
+      title: "Exec",
+      absentDetail: "command failed",
+    });
+  });
+
+  it("surfaces concise bash tool errors when verbose mode is off", () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "bash", error: "command failed" },
+      verboseLevel: "off",
+    });
+
+    expectSingleToolErrorPayload(payloads, {
+      title: "Bash",
+      absentDetail: "command failed",
     });
   });
 
@@ -132,11 +149,16 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
-  it("keeps non-timeout exec tool errors suppressed for cron sessions when verbose mode is off", () => {
-    expectNoPayloads({
+  it("surfaces non-timeout exec tool errors for cron sessions without raw details", () => {
+    const payloads = buildPayloads({
       lastToolError: { toolName: "exec", error: "Command not found" },
       sessionKey: "agent:main:cron:job-1",
       verboseLevel: "off",
+    });
+
+    expectSingleToolErrorPayload(payloads, {
+      title: "Exec",
+      absentDetail: "Command not found",
     });
   });
 

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -24,10 +24,7 @@ import {
   normalizeTextForComparison,
 } from "../../pi-embedded-helpers.js";
 import type { ToolResultFormat } from "../../pi-embedded-subscribe.shared-types.js";
-import {
-  extractAssistantThinking,
-  extractAssistantVisibleText,
-} from "../../pi-embedded-utils.js";
+import { extractAssistantThinking, extractAssistantVisibleText } from "../../pi-embedded-utils.js";
 import { isExecLikeToolName, type ToolErrorSummary } from "../../tool-error-summary.js";
 import { isLikelyMutatingToolName } from "../../tool-mutation.js";
 
@@ -48,7 +45,7 @@ const RECOVERABLE_TOOL_ERROR_KEYWORDS = [
 ] as const;
 
 const MUTATING_FAILURE_ACTION_PATTERN =
-  "(?:write|edit|update|save|create|delete|remove|modify|change|apply|patch|move|rename|send|reply|message|tool|action|operation)";
+  "(?:write|edit|update|save|create|delete|remove|modify|change|apply|patch|move|rename|send|reply|message|run|execute|execution|command|script|shell|bash|exec|tool|action|operation)";
 
 const MUTATING_FAILURE_INABILITY_PATTERN = new RegExp(
   `\\b(?:couldn't|could not|can't|cannot|unable to|am unable to|wasn't able to|was not able to|were unable to)\\b.{0,100}\\b${MUTATING_FAILURE_ACTION_PATTERN}\\b`,
@@ -143,9 +140,6 @@ function resolveToolErrorWarningPolicy(params: {
   if (params.suppressToolErrorWarnings) {
     return { showWarning: false, includeDetails };
   }
-  if (isExecLikeToolName(params.lastToolError.toolName) && !includeDetails) {
-    return { showWarning: false, includeDetails };
-  }
   // sessions_send timeouts and errors are transient inter-session communication
   // issues — the message may still have been delivered. Suppress warnings to
   // prevent raw error text from leaking into the chat surface (#23989).
@@ -159,6 +153,9 @@ function resolveToolErrorWarningPolicy(params: {
       showWarning: !params.hasUserFacingErrorReply && !params.hasUserFacingFailureAcknowledgement,
       includeDetails,
     };
+  }
+  if (isExecLikeToolName(params.lastToolError.toolName) && !includeDetails) {
+    return { showWarning: false, includeDetails };
   }
   if (params.suppressToolErrors) {
     return { showWarning: false, includeDetails };


### PR DESCRIPTION
## Summary

- Surface default-visible concise warnings for failed `exec`/`bash` tool calls instead of suppressing them before mutating-tool handling.
- Keep raw exec stderr hidden unless verbose details are enabled, preserving the existing low-noise behavior.
- Add regression coverage for default exec/bash failures, cron non-timeout exec failures, and the reported "assistant claimed success after exec failed" path.

Fixes #60497.

## Real behavior proof

- Behavior or issue addressed: Failed `exec`/`bash` tool calls were hidden at default verbosity, so a channel could receive only the assistant's claimed-success text even when the last tool call failed.
- Real environment tested: Local OpenClaw checkout on macOS, rebased on current `origin/main` (`c58e01569b`), Node `v24.11.1`, pnpm `10.33.2`.
- Exact steps or command run after this patch: Ran the OpenClaw payload policy path directly with `node --import tsx`, using an assistant success message plus `lastToolError` for `exec` with `/bin/bash: line 1: python: command not found`.
- Evidence after fix: Terminal transcript from the local OpenClaw checkout.

  ```text
  $ node --import tsx -e "import('./src/agents/pi-embedded-runner/run/payloads.ts').then(({buildEmbeddedRunPayloads})=>console.log(JSON.stringify(buildEmbeddedRunPayloads({assistantTexts:['The script is ready to use and saved in your workspace.'],toolMetas:[],lastAssistant:{role:'assistant',stopReason:'end_turn',content:[]},lastToolError:{toolName:'exec',error:'/bin/bash: line 1: python: command not found'},sessionKey:'session:telegram',inlineToolResultsAllowed:false,verboseLevel:'off',reasoningLevel:'off',toolResultFormat:'plain'}),null,2)))"
  [
    {
      "text": "The script is ready to use and saved in your workspace.",
      "replyToTag": false,
      "audioAsVoice": false
    },
    {
      "text": "⚠️ 🛠️ Exec failed",
      "isError": true,
      "audioAsVoice": false
    }
  ]
  ```
- Observed result after fix: The user-facing payload preserves the assistant text and also appends a concise `Exec failed` warning, while omitting raw `python: command not found` stderr at default verbosity.
- What was not tested: The original NemoClaw/NVIDIA live provider setup from the issue. The fix is in the deterministic OpenClaw payload policy path that decides whether failed exec tool state becomes user-visible.

## Verification

```sh
pnpm test src/agents/pi-embedded-runner/run/payloads.test.ts src/agents/pi-embedded-runner/run/payloads.errors.test.ts src/agents/bash-tools.exec-runtime.test.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts src/agents/tool-mutation.test.ts
pnpm check:changed
git diff --check
```

## AI assistance

This PR is AI-assisted. I used Codex to inspect the issue, make the targeted change, and run the verification above. I reviewed the final diff and understand the change: the exec/bash suppression fallback now runs after mutating-tool warnings have a chance to add a concise user-visible failure notice.
