### PR TITLE
Keep migrated OpenAI Codex OAuth runs on native Codex auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - ACP sessions: map canonical runtime options to backend-advertised ACP config keys like Claude's `effort` while keeping persisted OpenClaw state canonical. (#79926) Thanks @InTheCloudDan.
 - Gateway/watch: rebuild or restage missing bundled-plugin dist and runtime-postbuild outputs before launching the Gateway from a source checkout, preventing incomplete watch-mode runtime trees. (#70805) Thanks @rubencu.
 - CLI/update: allow restart health probes from the previous gateway protocol during self-update, and make plugin dry-runs report exact npm target versions instead of `unknown` while preserving unchanged status.
+- OpenAI/Codex: forward persisted `openai-codex` OAuth profile metadata into Codex plugin harness attempts after canonical `openai/*` migration, so OAuth-only installs keep using native Codex auth instead of falling through to direct OpenAI API-key auth. Fixes #79978.
 - OpenAI/Codex: point gateway missing-key recovery and wizard docs at the canonical `openai/gpt-5.5` plus Codex OAuth route, and fix trajectory export errors so they suggest the valid `openclaw sessions` command.
 - Google/Gemini: normalize retired `google/gemini-3-pro-preview` primary, fallback, and model-map refs during config load and unrelated config writes so saved config keeps targeting Gemini 3.1 Pro Preview.
 - Discord/voice: synthesize realtime playback timestamps from emitted Discord PCM so OpenAI realtime barge-in truncation no longer sees `audioEndMs=0` and skips legitimate interruptions.

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -286,6 +286,18 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
           refresh: "refresh",
           expires: Date.now() + 60_000,
         },
+        "openai-codex:other": {
+          type: "oauth" as const,
+          provider: "openai-codex",
+          access: "other-access",
+          refresh: "other-refresh",
+          expires: Date.now() + 60_000,
+        },
+        "anthropic:work": {
+          type: "api_key" as const,
+          provider: "anthropic",
+          key: "sk-ant",
+        },
       },
     };
     mockedEnsureAuthProfileStoreWithoutExternalProfiles.mockReturnValueOnce(codexAuthStore);
@@ -333,7 +345,9 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     );
     const harnessParams = pluginRunAttempt.mock.calls[0]?.[0];
     expect(harnessParams?.runtimePlan).toBe(runtimePlan);
-    expect(harnessParams?.authProfileStore).toBe(codexAuthStore);
+    expect(Object.keys(harnessParams?.authProfileStore.profiles ?? {})).toEqual([
+      "openai-codex:work",
+    ]);
     expect(harnessParams?.authProfileStore.profiles["openai-codex:work"]).toMatchObject({
       provider: "openai-codex",
     });

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -276,6 +276,19 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     });
     mockedBuildAgentRuntimePlan.mockReturnValueOnce(runtimePlan);
     mockedGetApiKeyForModel.mockRejectedValueOnce(new Error("generic auth should be skipped"));
+    const codexAuthStore = {
+      version: 1,
+      profiles: {
+        "openai-codex:work": {
+          type: "oauth" as const,
+          provider: "openai-codex",
+          access: "access",
+          refresh: "refresh",
+          expires: Date.now() + 60_000,
+        },
+      },
+    };
+    mockedEnsureAuthProfileStoreWithoutExternalProfiles.mockReturnValueOnce(codexAuthStore);
 
     try {
       await runEmbeddedPiAgent({
@@ -320,6 +333,10 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     );
     const harnessParams = pluginRunAttempt.mock.calls[0]?.[0];
     expect(harnessParams?.runtimePlan).toBe(runtimePlan);
+    expect(harnessParams?.authProfileStore).toBe(codexAuthStore);
+    expect(harnessParams?.authProfileStore.profiles["openai-codex:work"]).toMatchObject({
+      provider: "openai-codex",
+    });
   });
 
   it("forwards OpenAI Codex auth profiles when openai/* is forced through codex", async () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -262,6 +262,23 @@ function createEmptyAuthProfileStore(): AuthProfileStore {
   };
 }
 
+function createScopedAuthProfileStore(
+  store: AuthProfileStore,
+  profileId: string | undefined,
+): AuthProfileStore {
+  const normalizedProfileId = profileId?.trim();
+  const profiles = store.profiles ?? {};
+  const credential = normalizedProfileId ? profiles[normalizedProfileId] : undefined;
+  return credential && normalizedProfileId
+    ? {
+        version: store.version,
+        profiles: {
+          [normalizedProfileId]: credential,
+        },
+      }
+    : createEmptyAuthProfileStore();
+}
+
 function buildTraceToolSummary(params: {
   toolMetas?: Array<{ toolName: string; meta?: string }>;
   hadFailure: boolean;
@@ -779,6 +796,9 @@ export async function runEmbeddedPiAgent(
         lastProfileId = forwardedPluginHarnessProfileId;
       }
       startupStages.mark("auth");
+      const runAttemptAuthProfileStore = pluginHarnessOwnsTransport
+        ? createScopedAuthProfileStore(attemptAuthProfileStore, lastProfileId)
+        : attemptAuthProfileStore;
       const { sessionAgentId } = resolveSessionAgentIds({
         sessionKey: params.sessionKey,
         config: params.config,
@@ -1213,7 +1233,7 @@ export async function runEmbeddedPiAgent(
             authProfileIdSource: lockedProfileId ? "user" : "auto",
             initialReplayState: accumulatedReplayState,
             authStorage,
-            authProfileStore: attemptAuthProfileStore,
+            authProfileStore: runAttemptAuthProfileStore,
             modelRegistry,
             agentId: workspaceResolution.agentId,
             legacyBeforeAgentStartResult,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -575,6 +575,11 @@ export async function runEmbeddedPiAgent(
         : ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
             allowKeychainPrompt: false,
           });
+      const attemptAuthProfileStore = pluginHarnessOwnsTransport
+        ? ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+            allowKeychainPrompt: false,
+          })
+        : authStore;
       const requestedProfileId = params.authProfileId?.trim();
       const resolvePluginHarnessPreferredProfileId = (): string | undefined => {
         if (requestedProfileId) {
@@ -595,12 +600,9 @@ export async function runEmbeddedPiAgent(
         if (!harnessAuthProvider) {
           return undefined;
         }
-        const harnessAuthStore = ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
-          allowKeychainPrompt: false,
-        });
         return resolveAuthProfileOrder({
           cfg: params.config,
-          store: harnessAuthStore,
+          store: attemptAuthProfileStore,
           provider: harnessAuthProvider,
         })[0]?.trim();
       };
@@ -1211,7 +1213,7 @@ export async function runEmbeddedPiAgent(
             authProfileIdSource: lockedProfileId ? "user" : "auto",
             initialReplayState: accumulatedReplayState,
             authStorage,
-            authProfileStore: authStore,
+            authProfileStore: attemptAuthProfileStore,
             modelRegistry,
             agentId: workspaceResolution.agentId,
             legacyBeforeAgentStartResult,


### PR DESCRIPTION
This is the follow-up to #79651 and BK's beta report in #79978.

#79651 correctly removed stale whole-agent Codex runtime pins. The remaining failure was a different boundary: once doctor rewrote `openai-codex/gpt-*` to canonical `openai/gpt-*`, the plugin harness path selected the right `openai-codex:*` auth profile id, but passed an intentionally empty auth profile store into the Codex app-server. That let the app-server see the id without the provider metadata it uses to decide native Codex OAuth should own the route, so OAuth-only installs could drift into the direct OpenAI API-key provider and fail with `No API key found for provider openai`.

This keeps PI's generic auth bootstrap disabled for plugin harnesses, but forwards a scoped auth profile store containing only the selected forwarded profile. The Codex app-server can now verify that `openai-codex:*` really belongs to the `openai-codex` provider without handing unrelated persisted credentials to generic plugin harness attempts.

The regression test builds the OAuth-only shape that failed: canonical `openai/gpt-*`, Codex harness, selected `openai-codex:work`, plus unrelated `openai-codex:other` and `anthropic:work` credentials in the persisted store. The plugin harness receives only `openai-codex:work`, so the Codex app-server has the metadata it needs while unrelated credentials stay out of the attempt params.

Behavior proof from the rebased branch:

```text
$ pnpm test src/agents/pi-embedded-runner/run.overflow-compaction.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts
Test Files  1 passed (1)
Tests  20 passed (20)
Test Files  1 passed (1)
Tests  22 passed (22)

$ pnpm check:changed
[check:changed] lanes=core, coreTests, docs
Found 0 warnings and 0 errors.
Import cycle check: 0 runtime value cycle(s).
```

Fixes #79978.
