### PR TITLE
Fix local Docker Compose build and startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
         "${OPENCLAW_GATEWAY_BIND:-lan}",
         "--port",
         "18789",
+        "--allow-unconfigured",
       ]
     healthcheck:
       test:
@@ -86,6 +87,8 @@ services:
 
   openclaw-cli:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
+    profiles:
+      - cli
     network_mode: "service:openclaw-gateway"
     env_file:
       - path: .env

--- a/src/logging/config.ts
+++ b/src/logging/config.ts
@@ -1,10 +1,19 @@
 import fs from "node:fs";
-import JSON5 from "json5";
+import { createRequire } from "node:module";
 import { getCommandPathWithRootOptions } from "../cli/argv.js";
 import { resolveConfigPath } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 type LoggingConfig = OpenClawConfig["logging"];
+type Json5Module = {
+  parse(raw: string): unknown;
+};
+
+const require = createRequire(import.meta.url);
+
+function parseJson5(raw: string): unknown {
+  return (require("json5") as Json5Module).parse(raw);
+}
 
 let cachedLoggingConfig:
   | {
@@ -34,7 +43,7 @@ export function readLoggingConfig(): LoggingConfig | undefined {
     if (!fs.existsSync(configPath)) {
       return undefined;
     }
-    const parsed = JSON5.parse(fs.readFileSync(configPath, "utf8"));
+    const parsed = parseJson5(fs.readFileSync(configPath, "utf8"));
     const logging = isObjectRecord(parsed) ? parsed.logging : undefined;
     const resolved = isObjectRecord(logging) ? (logging as LoggingConfig) : undefined;
     cachedLoggingConfig = {


### PR DESCRIPTION
 Fixed the Docker Compose build/start path.

  Changed:

  - src/logging/config.ts: removed the static json5 import from the CLI bootstrap graph. Docker build now passes scripts/check-cli-bootstrap-imports.mjs.
  - docker-compose.yml: added --allow-unconfigured so a fresh checkout can boot with plain docker compose up -d.
  - docker-compose.yml: moved openclaw-cli behind the cli profile so plain up -d starts only the gateway, while docker compose run --rm openclaw-cli ...
    still works.

  Verified:

  - docker build -t openclaw:local . completed successfully.
  - docker compose up -d completed successfully.
  - docker compose ps shows openclaw-gateway healthy.
  - /healthz returns 200 {"ok":true,"status":"live"}.
  - docker compose run --rm openclaw-cli --version returns OpenClaw 2026.5.6.
  - git diff --check passed.
