### PR TITLE
fix(imessage): WARN-log when private API bridge is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@ Docs: https://docs.openclaw.ai
 - Kimi Code: use Kimi's stable `kimi-for-coding` API model id in bundled catalog, onboarding, and docs while normalizing legacy `kimi-code` and `k2p5` refs. Fixes #79965.
 - Volcengine/Kimi: strip provider-unsupported tool schema length and item constraint keywords for direct and coding-plan models so hosted Kimi runs do not reject message tools with `minLength`. Fixes #38817.
 - DeepSeek: backfill V4 `reasoning_content` replay fields for unowned OpenAI-compatible proxy providers, preventing follow-up request failures outside the bundled DeepSeek and OpenRouter routes. Fixes #79608.
+- iMessage: emit a WARN log when an action is blocked because the imsg private API bridge is not attached, so operators see the silent-drop in `~/.openclaw/logs/openclaw.log` instead of having to read per-session trajectory JSONL `tool.result` payloads. Common after a gateway restart un-injects the dylib from Messages.app. (#80035) Thanks @omarshahine.
 
 ## 2026.5.9
 

--- a/extensions/imessage/src/actions.test.ts
+++ b/extensions/imessage/src/actions.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const probeMock = vi.hoisted(() => ({
   getCachedIMessagePrivateApiStatus: vi.fn(),
+  probeIMessagePrivateApi: vi.fn(),
 }));
 
 const runtimeMock = vi.hoisted(() => ({
@@ -13,8 +14,28 @@ const runtimeMock = vi.hoisted(() => ({
   sendAttachment: vi.fn(),
 }));
 
+const loggerMock = vi.hoisted(() => ({
+  warn: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  fatal: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
+    "openclaw/plugin-sdk/runtime-env",
+  );
+  return {
+    ...actual,
+    createSubsystemLogger: () => loggerMock,
+  };
+});
+
 vi.mock("./probe.js", () => ({
   getCachedIMessagePrivateApiStatus: probeMock.getCachedIMessagePrivateApiStatus,
+  probeIMessagePrivateApi: probeMock.probeIMessagePrivateApi,
 }));
 
 vi.mock("./private-api-status.js", () => ({
@@ -48,6 +69,8 @@ describe("imessage message actions", () => {
     runtimeMock.sendRichMessage.mockReset();
     runtimeMock.sendAttachment.mockReset();
     probeMock.getCachedIMessagePrivateApiStatus.mockReset();
+    probeMock.probeIMessagePrivateApi.mockReset();
+    loggerMock.warn.mockReset();
   });
 
   it("does not advertise private API actions when the bridge is known unavailable", () => {
@@ -128,6 +151,33 @@ describe("imessage message actions", () => {
     expect(described?.actions).not.toContain("react");
     expect(described?.actions).not.toContain("reply");
     expect(described?.actions).toContain("edit");
+  });
+
+  it("emits a channels/imessage WARN when the private API bridge is unavailable", async () => {
+    probeMock.getCachedIMessagePrivateApiStatus.mockReturnValue(undefined);
+    probeMock.probeIMessagePrivateApi.mockResolvedValue({
+      available: false,
+      v2Ready: false,
+      selectors: {},
+    });
+
+    await expect(
+      imessageMessageActions.handleAction?.({
+        action: "react",
+        cfg: cfg(),
+        params: {
+          chatGuid: "iMessage;+;chat0000",
+          messageId: "message-guid",
+          emoji: "👍",
+        },
+      } as never),
+    ).rejects.toThrow(/imsg private API bridge/);
+
+    expect(loggerMock.warn).toHaveBeenCalledTimes(1);
+    const warnArg = String(loggerMock.warn.mock.calls[0][0]);
+    expect(warnArg).toMatch(/iMessage react blocked: private API bridge unavailable/);
+    expect(warnArg).toMatch(/imsg launch/);
+    expect(runtimeMock.sendReaction).not.toHaveBeenCalled();
   });
 
   it("rejects configured-off actions at execution time", async () => {

--- a/extensions/imessage/src/actions.ts
+++ b/extensions/imessage/src/actions.ts
@@ -11,6 +11,7 @@ import type {
   ChannelMessageActionName,
 } from "openclaw/plugin-sdk/channel-contract";
 import { createLazyRuntimeNamedExport } from "openclaw/plugin-sdk/lazy-runtime";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { extractToolSend } from "openclaw/plugin-sdk/tool-send";
 import { resolveIMessageAccount } from "./accounts.js";
@@ -25,6 +26,8 @@ const loadIMessageActionsRuntime = createLazyRuntimeNamedExport(
   () => import("./actions.runtime.js"),
   "imessageActionsRuntime",
 );
+
+const log = createSubsystemLogger("channels/imessage");
 
 const providerId = "imessage";
 
@@ -398,6 +401,15 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
         );
       }
       if (!privateApiStatus?.available) {
+        // Surface the silent-drop case: the throw becomes a tool-result
+        // `success:false`, which the model may or may not relay clearly to the
+        // user. Without a log line, an operator has no signal that a reply
+        // disappeared — they only see "channel: running" in `channels status`.
+        // Common cause: gateway restart un-injects the imsg-bridge-helper.dylib
+        // from Messages.app while imsg rpc keeps running.
+        log.warn(
+          `iMessage ${action} blocked: private API bridge unavailable (accountId=${account.accountId}, cliPath=${cliPathForProbe}). Run \`imsg launch\` to re-inject the dylib, then \`openclaw channels status\` to refresh.`,
+        );
         throw new Error(
           `iMessage ${action} requires the imsg private API bridge. Run imsg launch, then openclaw channels status to refresh capability detection.`,
         );


### PR DESCRIPTION
## Problem

When the imsg private API bridge is not attached to Messages.app, the iMessage tool action throws:

```
iMessage <action> requires the imsg private API bridge.
Run imsg launch, then openclaw channels status to refresh capability detection.
```

This becomes a `success:false` tool result. The model relays it as best it can, but the throw never reaches the gateway log. Operators have **no signal** in `~/.openclaw/logs/openclaw.log` that an outbound reply was silently dropped, and `openclaw channels status` continues to report the channel as `enabled, configured, running`.

## Trigger seen in production

Gateway restart un-injects the `imsg-bridge-helper.dylib` from Messages.app while `imsg rpc` keeps running. Inbound polling continues, capability detection just goes stale. The detached state can persist for hours before being noticed because every other surface looks healthy.

## Fix

Add a `channels/imessage` subsystem WARN log immediately before the throw in `extensions/imessage/src/actions.ts`. Operators get a single grep-friendly signal. Thrown `Error` and tool-result shape are unchanged, so model-facing behavior is identical. No new dependencies — uses the existing `createSubsystemLogger` SDK helper that other channel extensions already use.

## Real behavior proof

**Behavior or issue addressed**: iMessage outbound reply silently fails when the imsg private API bridge is not injected into Messages.app. The `handleAction` throw becomes a tool result `success:false`, the session ends with `status:"success"`, and no log line of any level reaches `~/.openclaw/logs/openclaw.log`. `openclaw channels status` continues to advertise the channel as healthy.

**Real environment tested**: macOS 26.4.1 arm64 (MacBookAir.local, redacted), node 25.6.0, openclaw `2026.5.8` built from this branch via `pnpm build` (full repo build). imsg fork `0.8.1` (`/Users/.../imsg/bin/imsg`) is the live-deployment binary; for the proof a deliberately-broken `cliPath=/tmp/no-such-imsg` is used so the real probe runs, fails to exec, and returns `available:false`. Live `lobster` agent on this host hit the silent-drop earlier today (2026-05-09 ~22:47Z); same deployment used here.

**Exact steps or command run after this patch**:

```
$ pnpm build                            # full openclaw build
$ grep -l 'blocked: private API' dist/*.js
dist/group-policy-CgkcWBCa.js

$ node /tmp/proof-80035-handleaction.mjs
```

The `proof-80035-handleaction.mjs` script imports `imessageMessageActions` from the BUILT `dist/group-policy-CgkcWBCa.js` chunk — the same module the gateway loads at runtime — and invokes `imessageMessageActions.handleAction(...)` directly with a non-existent `cliPath`. The real probe code (`extensions/imessage/src/probe.ts`) runs against that path through the real openclaw runtime, fails to exec, returns `{available:false}`, and the patched assertion in the same `handleAction` then routes the new WARN through the real `createSubsystemLogger("channels/imessage")` from the built runtime SDK before the unchanged `throw new Error(...)` fires. No mocking — the only dependency injection is the broken cliPath that simulates a detached bridge.

**Evidence after fix**: terminal capture from running `node /tmp/proof-80035-handleaction.mjs` against the rebased + rebuilt branch. The bracketed `[imessage]` prefix is the runtime subsystem stripper acting on the `channels/imessage` logger — exactly the format an operator sees in `openclaw.log`:

```
$ node /tmp/proof-80035-handleaction.mjs
[proof] patched chunk: /Users/lobster/GitHub/openclaw/dist/group-policy-CgkcWBCa.js
[proof] runtime SDK loaded
[proof] adapter loaded
[imessage] react blocked: private API bridge unavailable (accountId=default, cliPath=/tmp/no-such-imsg). Run `imsg launch` to re-inject the dylib, then `openclaw channels status` to refresh.
[proof] caught expected throw: iMessage react requires the imsg private API bridge. Run imsg launch, then openclaw channels status to refresh capability detection.
```

For comparison — the BEFORE state, captured today from the live lobster agent's `~/.openclaw/agents/lobster/sessions/<sid>.trajectory.jsonl` while the bridge was detached (sole observable signal of the silent drop pre-patch):

```
22:47:18 prompt.submitted
22:47:42 tool.call    name=message    action=reply
22:47:42 tool.result  name=message    success=false
              contentItems[0].text:
                "iMessage reply requires the imsg private API bridge.
                 Run imsg launch, then openclaw channels status to
                 refresh capability detection."
22:48:36 model.completed
22:48:36 session.ended  status=success
```

`grep -E '(imsg|imessage)' ~/.openclaw/logs/openclaw.log` for the same window returned no rows of any level — the silent drop the patch addresses.

**Observed result after fix**: the patched `handleAction` invocation emits a `channels/imessage` WARN through the real openclaw runtime logger before throwing, in the format an operator can grep `~/.openclaw/logs/openclaw.log` for, with the action name, accountId, resolved cliPath, and the `imsg launch` recovery hint embedded. The throw still fires and the tool-result shape is byte-identical to prior behavior, so model-facing output and any downstream consumers are unaffected. Full `extensions/imessage/src/**` assertion suite stays green (337/337) including a new assertion in `actions.test.ts` that the WARN fires once with the documented format and that the underlying send adapter is never called on the failure path.

**What was not tested**: a full live gateway restart cycle producing the WARN line through the launchd-managed gateway process and out into the user-visible iMessage flow. The lobster deployment is currently in active use; rather than disrupt it for a deliberate bridge-detached repro, the patched runtime was exercised via direct `handleAction` invocation against a broken cliPath, which routes through the same probe code, the same WARN call site, and the same runtime logger as the gateway path. Localized environments other than macOS arm64 were not exercised.

## Out of scope

- Auto-recovery (running `imsg launch` from the gateway) — kept out so the gateway doesn't make UI choices on its own. Local ops tooling can act on the new log line.
- Probing send capability inside `openclaw channels status` so it reports `running (degraded — bridge detached)` instead of plain `running`. Worth a follow-up; left for a separate PR.

## CHANGELOG

Added bullet under `## Unreleased` › `### Fixes`.
