### PR TITLE
fix: record cron delivery failures as warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 - ACPX/Claude ACP: keep foreground prompts waiting for their own result when autonomous task-notification results arrive during the same session, and retarget the patch for Claude Agent ACP `0.33.1`.
 - WhatsApp: keep Baileys media uploads from passing non-Dispatcher agents to undici in `7.0.0-rc10`, and patch the bundled Baileys declaration so the latest tsdown build stays warning-clean.
 - Build: keep tsdown `0.22.0` warning-clean by externalizing known third-party declaration edges and replacing relative channel config module augmentations with explicit built-in channel fields.
+- Cron: record successful isolated runs with failed final delivery as warning runs so notification failures keep delivery diagnostics without triggering execution backoff or failure state. Fixes #49190. Thanks @NorthernDream.
 - ACP sessions: map canonical runtime options to backend-advertised ACP config keys like Claude's `effort` while keeping persisted OpenClaw state canonical. (#79926) Thanks @InTheCloudDan.
 - Models/Discord: support `provider/*` entries in `agents.defaults.models` so `/model`, `/models`, and model pickers can show dynamically discovered models for selected providers without exact model allowlists. Fixes #79485. Thanks @rendrag-git.
 - Gateway/watch: rebuild or restage missing bundled-plugin dist and runtime-postbuild outputs before launching the Gateway from a source checkout, preventing incomplete watch-mode runtime trees. (#70805) Thanks @rubencu.

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -149,6 +149,8 @@ If an isolated run hits a live model-switch handoff, cron retries with the switc
 
 Before an isolated cron run enters the agent runner, OpenClaw checks reachable local provider endpoints for configured `api: "ollama"` and `api: "openai-completions"` providers whose `baseUrl` is loopback, private-network, or `.local`. If that endpoint is down, the run is recorded as `skipped` with a clear provider/model error instead of starting a model call. The endpoint result is cached for 5 minutes, so many due jobs using the same dead local Ollama, vLLM, SGLang, or LM Studio server share one small probe instead of creating a request storm. Skipped provider-preflight runs do not increment execution-error backoff; enable `failureAlert.includeSkipped` when you want repeated skip notifications.
 
+If the agent run succeeds but the runner cannot deliver the final reply, cron records the run as `warning` instead of `error`. The run state still keeps `deliveryStatus: "not-delivered"` and `deliveryError` for inspection, but execution-error counters, retry backoff, and failure alerts are not triggered by the delivery-only failure.
+
 ## Delivery and output
 
 | Mode       | What happens                                                        |
@@ -426,6 +428,8 @@ Disable cron: `cron.enabled: false` or `OPENCLAW_SKIP_CRON=1`.
     **One-shot retry**: transient errors (rate limit, overload, network, server error) retry up to 3 times with exponential backoff. Permanent errors disable immediately.
 
     **Recurring retry**: exponential backoff (30s to 60m) between retries. Backoff resets after the next successful run.
+
+    **Delivery warnings**: successful runs whose final reply could not be delivered are terminal `warning` runs. They keep delivery error details but do not retry as execution failures.
 
   </Accordion>
   <Accordion title="Maintenance">

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -70,6 +70,11 @@ Note: isolated cron runs treat run-level agent failures as job errors even when
 no reply payload is produced, so model/provider failures still increment error
 counters and trigger failure notifications.
 
+Delivery-only failures after a successful isolated run are recorded as
+`warning` runs with `deliveryStatus: "not-delivered"` and `deliveryError`
+details. They do not increment execution-error counters or trigger retry
+backoff.
+
 ## Scheduling
 
 ### One-shot jobs
@@ -220,7 +225,7 @@ openclaw cron runs --id <job-id> --limit 50
 
 `openclaw cron list` shows all matching jobs by default. Pass `--agent <id>` to show only jobs whose effective normalized agent id matches; jobs without a stored agent id count as the configured default agent.
 
-`cron list --json` and `cron show <job-id> --json` include a top-level `status` field on each job, computed from `enabled`, `state.runningAtMs`, and `state.lastRunStatus`. Values: `disabled`, `running`, `ok`, `error`, `skipped`, or `idle`. This mirrors the human-readable status column so external tooling can read job state without re-deriving it.
+`cron list --json` and `cron show <job-id> --json` include a top-level `status` field on each job, computed from `enabled`, `state.runningAtMs`, and `state.lastRunStatus`. Values: `disabled`, `running`, `ok`, `error`, `skipped`, `warning`, or `idle`. This mirrors the human-readable status column so external tooling can read job state without re-deriving it.
 
 `cron runs` entries include delivery diagnostics with the intended cron target, the resolved target, message-tool sends, fallback use, and delivered state.
 

--- a/extensions/qa-lab/src/cron-run-wait.ts
+++ b/extensions/qa-lab/src/cron-run-wait.ts
@@ -3,7 +3,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 type QaCronRunLogEntry = {
   ts?: number;
-  status?: "ok" | "error" | "skipped";
+  status?: "ok" | "error" | "skipped" | "warning";
   summary?: string;
   error?: string;
   deliveryStatus?: "delivered" | "not-delivered" | "unknown" | "not-requested";
@@ -42,9 +42,10 @@ export async function waitForCronRunCompletion(params: {
     lastEntries = entries;
     const completed = entries.find(
       (entry) =>
-        typeof entry.ts === "number" &&
-        entry.ts >= params.afterTs &&
-        (entry.status === "ok" || entry.status === "error" || entry.status === "skipped"),
+        (typeof entry.ts === "number" && entry.ts >= params.afterTs && entry.status === "ok") ||
+        entry.status === "error" ||
+        entry.status === "skipped" ||
+        entry.status === "warning",
     );
     if (completed) {
       return completed;

--- a/scripts/cron_usage_report.ts
+++ b/scripts/cron_usage_report.ts
@@ -13,7 +13,7 @@ type CronRunLogEntry = {
   ts: number;
   jobId: string;
   action: "finished";
-  status?: "ok" | "error" | "skipped";
+  status?: "ok" | "error" | "skipped" | "warning";
   model?: string;
   provider?: string;
   usage?: Usage;

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -57,6 +57,8 @@ import { stripSystemPromptCacheBoundary } from "./system-prompt-cache-boundary.j
 import { transformTransportMessages } from "./transport-message-transform.js";
 import { mergeTransportMetadata, sanitizeTransportPayloadText } from "./transport-stream-shared.js";
 
+type ChatCompletionChoiceDelta = NonNullable<ChatCompletionChunk["choices"][number]["delta"]>;
+
 const DEFAULT_AZURE_OPENAI_API_VERSION = "2024-12-01-preview";
 const OPENAI_CODEX_RESPONSES_EMPTY_INPUT_TEXT = " ";
 const GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP = "skip_thought_signature_validator";
@@ -1520,8 +1522,7 @@ async function processOpenAICompletionsStream(
       }
     }
     const choiceDelta =
-      choice.delta ??
-      (choice as unknown as { message?: ChatCompletionChunk["choices"][number]["delta"] }).message;
+      choice.delta ?? (choice as unknown as { message?: ChatCompletionChoiceDelta }).message;
     if (!choiceDelta) {
       continue;
     }

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -367,6 +367,9 @@ export function printCronList(
       if (statusRaw === "running") {
         return colorize(rich, theme.warn, statusLabel);
       }
+      if (statusRaw === "warning") {
+        return colorize(rich, theme.warn, statusLabel);
+      }
       if (statusRaw === "skipped") {
         return colorize(rich, theme.muted, statusLabel);
       }

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -813,7 +813,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(getCompletedDirectCronDeliveriesCountForTests()).toBe(2000);
   });
 
-  it("does not retry permanent direct announce failures", async () => {
+  it("records permanent direct announce failures as delivery warnings", async () => {
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
     vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
@@ -825,14 +825,15 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
     expect(state.result).toEqual(
       expect.objectContaining({
-        status: "error",
+        status: "warning",
         error: "Error: chat not found",
+        delivered: false,
         deliveryAttempted: true,
       }),
     );
   });
 
-  it("surfaces structured direct delivery failures without retry when best-effort is disabled", async () => {
+  it("surfaces structured direct delivery failures as warnings when best-effort is disabled", async () => {
     vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
     vi.mocked(deliverOutboundPayloads).mockRejectedValue(new Error("boom"));
@@ -844,8 +845,9 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
     expect(state.result).toEqual(
       expect.objectContaining({
-        status: "error",
+        status: "warning",
         error: "Error: boom",
+        delivered: false,
         deliveryAttempted: true,
       }),
     );
@@ -1026,8 +1028,9 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(state.deliveryAttempted).toBe(false);
     expect(state.result).toEqual(
       expect.objectContaining({
-        status: "error",
+        status: "warning",
         errorKind: "delivery-target",
+        delivered: false,
         deliveryAttempted: false,
       }),
     );

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -118,6 +118,7 @@ type DispatchCronDeliveryParams = {
   skipHeartbeatDelivery: boolean;
   skipMessagingToolDelivery?: boolean;
   unverifiedMessagingToolDelivery?: boolean;
+  deliveryFailureStatus?: "error" | "warning";
   deliveryBestEffort: boolean;
   deliveryPayloadHasStructuredContent: boolean;
   deliveryPayloads: ReplyPayload[];
@@ -498,17 +499,19 @@ export async function dispatchCronDelivery(
   let delivered = skipMessagingToolDelivery;
   let deliveryAttempted = skipMessagingToolDelivery;
   let directCronSessionDeleted = false;
+  const deliveryFailureStatus = params.deliveryFailureStatus ?? "warning";
   const formatDeliveryTargetError = (error: string) =>
     params.unverifiedMessagingToolDelivery === true
       ? `${error}; the agent used the message tool, but OpenClaw could not verify that message matched the cron delivery target`
       : error;
-  const failDeliveryTarget = (error: string) =>
+  const buildDeliveryTargetFailure = (error: string) =>
     params.withRunSession({
-      status: "error",
+      status: deliveryFailureStatus,
       error: formatDeliveryTargetError(error),
       errorKind: "delivery-target",
       summary,
       outputText,
+      ...(deliveryFailureStatus === "warning" ? { delivered: false } : {}),
       deliveryAttempted,
       ...params.telemetry,
     });
@@ -730,10 +733,11 @@ export async function dispatchCronDelivery(
     } catch (err) {
       if (!params.deliveryBestEffort) {
         return params.withRunSession({
-          status: "error",
+          status: deliveryFailureStatus,
           summary,
           outputText,
           error: String(err),
+          ...(deliveryFailureStatus === "warning" ? { delivered: false } : {}),
           deliveryAttempted,
           ...params.telemetry,
         });
@@ -874,7 +878,7 @@ export async function dispatchCronDelivery(
     if (!params.resolvedDelivery.ok) {
       if (!params.deliveryBestEffort) {
         return {
-          result: failDeliveryTarget(params.resolvedDelivery.error.message),
+          result: buildDeliveryTargetFailure(params.resolvedDelivery.error.message),
           delivered,
           deliveryAttempted,
           summary,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -995,6 +995,7 @@ async function finalizeCronRun(params: {
     skipHeartbeatDelivery,
     skipMessagingToolDelivery,
     unverifiedMessagingToolDelivery: didSendViaMessagingTool && !prepared.resolvedDelivery.ok,
+    deliveryFailureStatus: hasFatalErrorPayload ? "error" : "warning",
     deliveryBestEffort: resolveCronDeliveryBestEffort(prepared.input.job),
     deliveryPayloadHasStructuredContent,
     deliveryPayloads,
@@ -1025,8 +1026,11 @@ async function finalizeCronRun(params: {
       diagnostics: mergeCronRunDiagnostics(
         agentDiagnostics,
         deliveryResult.result.diagnostics,
-        deliveryResult.result.status === "error" && deliveryResult.result.error
-          ? createCronRunDiagnosticsFromError("delivery", deliveryResult.result.error)
+        (deliveryResult.result.status === "error" || deliveryResult.result.status === "warning") &&
+          deliveryResult.result.error
+          ? createCronRunDiagnosticsFromError("delivery", deliveryResult.result.error, {
+              severity: deliveryResult.result.status === "warning" ? "warn" : "error",
+            })
           : undefined,
       ),
     };

--- a/src/cron/run-diagnostics.ts
+++ b/src/cron/run-diagnostics.ts
@@ -260,7 +260,7 @@ export function createCronRunDiagnosticsFromExecDetails(
 
 export function createCronRunDiagnosticsFromToolPayload(
   payload: unknown,
-  opts?: { nowMs?: () => number; finalStatus?: "ok" | "error" | "skipped" },
+  opts?: { nowMs?: () => number; finalStatus?: "ok" | "error" | "skipped" | "warning" },
 ): CronRunDiagnostics | undefined {
   if (!isRecord(payload)) {
     return undefined;
@@ -285,7 +285,7 @@ export function createCronRunDiagnosticsFromToolPayload(
 
 export function createCronRunDiagnosticsFromAgentResult(
   result: unknown,
-  opts?: { nowMs?: () => number; finalStatus?: "ok" | "error" | "skipped" },
+  opts?: { nowMs?: () => number; finalStatus?: "ok" | "error" | "skipped" | "warning" },
 ): CronRunDiagnostics | undefined {
   const record = isRecord(result) ? result : {};
   const meta =

--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -227,6 +227,43 @@ describe("cron run log", () => {
     });
   });
 
+  it("filters warning run-log entries", async () => {
+    await withRunLogDir("openclaw-cron-log-warning-", async (dir) => {
+      const logPath = path.join(dir, "runs", "job-1.jsonl");
+      await fs.mkdir(path.dirname(logPath), { recursive: true });
+      await fs.writeFile(
+        logPath,
+        [
+          JSON.stringify({
+            ts: 1,
+            jobId: "job-1",
+            action: "finished",
+            status: "ok",
+          }),
+          JSON.stringify({
+            ts: 2,
+            jobId: "job-1",
+            action: "finished",
+            status: "warning",
+            summary: "done",
+            deliveryStatus: "not-delivered",
+            deliveryError: "announce failed",
+          }),
+        ].join("\n") + "\n",
+        "utf-8",
+      );
+
+      const page = await readCronRunLogEntriesPage(logPath, {
+        limit: 10,
+        jobId: "job-1",
+        status: "warning",
+      });
+      expect(page.entries).toHaveLength(1);
+      expect(page.entries[0]?.status).toBe("warning");
+      expect(page.entries[0]?.deliveryError).toBe("announce failed");
+    });
+  });
+
   it("ignores invalid and non-finished lines while preserving delivery fields", async () => {
     await withRunLogDir("openclaw-cron-log-filter-", async (dir) => {
       const logPath = path.join(dir, "runs", "job-1.jsonl");

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -40,7 +40,7 @@ export type CronRunLogEntry = {
 } & CronRunTelemetry;
 
 type CronRunLogSortDir = "asc" | "desc";
-type CronRunLogStatusFilter = "all" | "ok" | "error" | "skipped";
+type CronRunLogStatusFilter = "all" | "ok" | "error" | "skipped" | "warning";
 
 type ReadCronRunLogPageOptions = {
   limit?: number;
@@ -222,7 +222,13 @@ export function readCronRunLogEntriesSync(
 }
 
 function normalizeRunStatusFilter(status?: string): CronRunLogStatusFilter {
-  if (status === "ok" || status === "error" || status === "skipped" || status === "all") {
+  if (
+    status === "ok" ||
+    status === "error" ||
+    status === "skipped" ||
+    status === "warning" ||
+    status === "all"
+  ) {
     return status;
   }
   return "all";
@@ -235,7 +241,7 @@ function normalizeRunStatuses(opts?: {
   if (Array.isArray(opts?.statuses) && opts.statuses.length > 0) {
     const filtered = opts.statuses.filter(
       (status): status is CronRunStatus =>
-        status === "ok" || status === "error" || status === "skipped",
+        status === "ok" || status === "error" || status === "skipped" || status === "warning",
     );
     if (filtered.length > 0) {
       return Array.from(new Set(filtered));

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -3,7 +3,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { parseByteSize } from "../cli/parse-bytes.js";
 import type { CronConfig } from "../config/types.cron.js";
-import { appendRegularFile, isPathInside, pathExists, root as fsRoot } from "../infra/fs-safe.js";
+import { assertNoSymlinkParents } from "../infra/fs-safe-advanced.js";
+import { isPathInside, pathExists, root as fsRoot } from "../infra/fs-safe.js";
 import { privateFileStore } from "../infra/private-file-store.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -154,6 +155,24 @@ async function pruneIfNeeded(filePath: string, opts: { maxBytes: number; keepLin
   );
 }
 
+async function appendRunLogLine(filePath: string, content: string) {
+  const runDir = path.dirname(filePath);
+  await assertNoSymlinkParents({
+    rootDir: path.parse(runDir).root,
+    targetPath: runDir,
+    allowMissing: false,
+    allowRootChildSymlink: true,
+    requireDirectories: true,
+    messagePrefix: "Refusing to append under",
+  });
+  await (
+    await fsRoot(runDir, { mode: 0o600 })
+  ).append(path.basename(filePath), content, {
+    mkdir: false,
+    mode: 0o600,
+  });
+}
+
 export async function appendCronRunLog(
   filePath: string,
   entry: CronRunLogEntry,
@@ -167,11 +186,7 @@ export async function appendCronRunLog(
       const runDir = path.dirname(resolved);
       await fs.mkdir(runDir, { recursive: true, mode: 0o700 });
       await fs.chmod(runDir, 0o700).catch(() => undefined);
-      await appendRegularFile({
-        filePath: resolved,
-        content: `${JSON.stringify(entry)}\n`,
-        rejectSymlinkParents: true,
-      });
+      await appendRunLogLine(resolved, `${JSON.stringify(entry)}\n`);
       await setSecureFileMode(resolved);
       await pruneIfNeeded(resolved, {
         maxBytes: opts?.maxBytes ?? DEFAULT_CRON_RUN_LOG_MAX_BYTES,

--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -46,6 +46,7 @@ function buildMainSessionSystemEventJob(name: string): CronAddInput {
 
 function createIsolatedCronWithFinishedBarrier(params: {
   storePath: string;
+  status?: "ok" | "error" | "skipped" | "warning";
   delivered?: boolean;
   error?: string;
   onFinished?: (evt: { jobId: string; delivered?: boolean; deliveryStatus?: string }) => void;
@@ -58,7 +59,7 @@ function createIsolatedCronWithFinishedBarrier(params: {
     enqueueSystemEvent: vi.fn(),
     requestHeartbeat: vi.fn(),
     runIsolatedAgentJob: vi.fn(async () => ({
-      status: "ok" as const,
+      status: params.status ?? ("ok" as const),
       summary: "done",
       ...(params.error === undefined ? {} : { error: params.error }),
       ...(params.delivered === undefined ? {} : { delivered: params.delivered }),
@@ -81,11 +82,12 @@ async function runSingleJobAndReadState(params: {
   cron: CronService;
   finished: ReturnType<typeof createFinishedBarrier>;
   job: CronAddInput;
+  expectedStatus?: "ok" | "error" | "skipped" | "warning";
 }) {
   const job = await params.cron.add(params.job);
   vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
   await vi.runOnlyPendingTimersAsync();
-  await params.finished.waitForOk(job.id);
+  await params.finished.waitForStatus(job.id, params.expectedStatus ?? "ok");
 
   const jobs = await params.cron.list({ includeDisabled: true });
   return { job, updated: jobs.find((entry) => entry.id === job.id) };
@@ -125,6 +127,7 @@ function expectDeliveryNotRequested(
 
 async function runIsolatedJobAndReadState(params: {
   job: CronAddInput;
+  status?: "ok" | "error" | "skipped" | "warning";
   delivered?: boolean;
   error?: string;
   onFinished?: (evt: { jobId: string; delivered?: boolean; deliveryStatus?: string }) => void;
@@ -132,6 +135,7 @@ async function runIsolatedJobAndReadState(params: {
   const store = await makeStorePath();
   const { cron, finished } = createIsolatedCronWithFinishedBarrier({
     storePath: store.storePath,
+    ...(params.status !== undefined ? { status: params.status } : {}),
     ...(params.delivered !== undefined ? { delivered: params.delivered } : {}),
     ...(params.error !== undefined ? { error: params.error } : {}),
     ...(params.onFinished ? { onFinished: params.onFinished } : {}),
@@ -143,6 +147,7 @@ async function runIsolatedJobAndReadState(params: {
       cron,
       finished,
       job: params.job,
+      expectedStatus: params.status,
     });
     return updated;
   } finally {
@@ -189,6 +194,22 @@ describe("CronService persists delivered status", () => {
       error: "Message failed",
     });
     expectSuccessfulCronRun(updated);
+    expect(updated?.state.lastDelivered).toBe(false);
+    expect(updated?.state.lastDeliveryStatus).toBe("not-delivered");
+    expect(updated?.state.lastDeliveryError).toBe("Message failed");
+  });
+
+  it("persists warning status for delivery-only failures without execution error state", async () => {
+    const updated = await runIsolatedJobAndReadState({
+      job: buildAnnounceIsolatedAgentTurnJob("delivery-warning"),
+      status: "warning",
+      delivered: false,
+      error: "Message failed",
+    });
+    expect(updated?.state.lastStatus).toBe("warning");
+    expect(updated?.state.lastRunStatus).toBe("warning");
+    expect(updated?.state.lastError).toBeUndefined();
+    expect(updated?.state.consecutiveErrors).toBe(0);
     expect(updated?.state.lastDelivered).toBe(false);
     expect(updated?.state.lastDeliveryStatus).toBe("not-delivered");
     expect(updated?.state.lastDeliveryError).toBe("Message failed");

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -6,7 +6,7 @@ import type { MockFn } from "../test-utils/vitest-mock-fn.js";
 import type { CronEvent, CronServiceDeps } from "./service.js";
 import { CronService } from "./service.js";
 import { createCronServiceState, type CronServiceState } from "./service/state.js";
-import type { CronJob } from "./types.js";
+import type { CronJob, CronRunStatus } from "./types.js";
 
 type NoopLogger = {
   debug: MockFn;
@@ -101,22 +101,26 @@ export function setupCronServiceSuite(options?: { prefix?: string; baseTimeIso?:
 }
 
 export function createFinishedBarrier() {
-  const resolvers = new Map<string, (evt: CronEvent) => void>();
+  const resolvers = new Map<string, { status: CronRunStatus; resolve: (evt: CronEvent) => void }>();
   return {
     waitForOk: (jobId: string) =>
       new Promise<CronEvent>((resolve) => {
-        resolvers.set(jobId, resolve);
+        resolvers.set(jobId, { status: "ok", resolve });
+      }),
+    waitForStatus: (jobId: string, status: CronRunStatus) =>
+      new Promise<CronEvent>((resolve) => {
+        resolvers.set(jobId, { status, resolve });
       }),
     onEvent: (evt: CronEvent) => {
-      if (evt.action !== "finished" || evt.status !== "ok") {
+      if (evt.action !== "finished") {
         return;
       }
-      const resolve = resolvers.get(evt.jobId);
-      if (!resolve) {
+      const resolver = resolvers.get(evt.jobId);
+      if (!resolver || evt.status !== resolver.status) {
         return;
       }
       resolvers.delete(evt.jobId);
-      resolve(evt);
+      resolver.resolve(evt);
     },
   };
 }

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -572,7 +572,11 @@ function tryFinishManualTaskRun(
     return;
   }
   try {
-    if (params.coreResult.status === "ok" || params.coreResult.status === "skipped") {
+    if (
+      params.coreResult.status === "ok" ||
+      params.coreResult.status === "skipped" ||
+      params.coreResult.status === "warning"
+    ) {
       completeTaskRunByRunId({
         runId: params.taskRunId,
         runtime: "cron",

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -1387,6 +1387,46 @@ describe("cron service timer regressions", () => {
     expect(job.enabled).toBe(true);
   });
 
+  it("treats one-shot warning runs as terminal without deleting inspection state", () => {
+    const startedAt = Date.parse("2026-03-02T12:02:00.000Z");
+    const endedAt = startedAt + 75;
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: "/tmp/cron-warning-one-shot.json",
+      log: noopLogger,
+      nowMs: () => endedAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+    const job = createIsolatedRegressionJob({
+      id: "apply-result-warning-one-shot",
+      name: "apply-result-warning-one-shot",
+      scheduledAt: startedAt,
+      schedule: { kind: "at", at: new Date(startedAt).toISOString() },
+      payload: { kind: "agentTurn", message: "ping" },
+      state: { nextRunAtMs: startedAt - 1_000, runningAtMs: startedAt - 500 },
+    });
+    job.deleteAfterRun = true;
+
+    const shouldDelete = applyJobResult(state, job, {
+      status: "warning",
+      error: "announce failed",
+      delivered: false,
+      startedAt,
+      endedAt,
+    });
+
+    expect(shouldDelete).toBe(false);
+    expect(job.enabled).toBe(false);
+    expect(job.state.nextRunAtMs).toBeUndefined();
+    expect(job.state.lastStatus).toBe("warning");
+    expect(job.state.lastError).toBeUndefined();
+    expect(job.state.consecutiveErrors).toBe(0);
+    expect(job.state.lastDeliveryStatus).toBe("not-delivered");
+    expect(job.state.lastDeliveryError).toBe("announce failed");
+  });
+
   it("keeps state updates when cron next-run computation throws on error path (#30905)", () => {
     const startedAt = Date.parse("2026-03-02T12:05:00.000Z");
     const endedAt = startedAt + 25;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -266,7 +266,7 @@ function tryFinishCronTaskRun(
     return;
   }
   try {
-    if (result.status === "ok" || result.status === "skipped") {
+    if (result.status === "ok" || result.status === "skipped" || result.status === "warning") {
       completeTaskRunByRunId({
         runId: result.taskRunId,
         runtime: "cron",
@@ -552,7 +552,7 @@ export function applyJobResult(
   job.state.lastRunStatus = result.status;
   job.state.lastStatus = result.status;
   job.state.lastDurationMs = Math.max(0, result.endedAt - result.startedAt);
-  job.state.lastError = result.error;
+  job.state.lastError = result.status === "warning" ? undefined : result.error;
   job.state.lastDiagnostics = normalizeCronRunDiagnostics(result.diagnostics);
   job.state.lastDiagnosticSummary = summarizeCronRunDiagnostics(job.state.lastDiagnostics);
   job.state.lastErrorReason =
@@ -568,6 +568,16 @@ export function applyJobResult(
         diagnosticsSummary: job.state.lastDiagnosticSummary,
       },
       "cron: job run returned error status",
+    );
+  } else if (result.status === "warning") {
+    state.deps.log.warn(
+      {
+        jobId: job.id,
+        jobName: job.name,
+        warning: result.error,
+        diagnosticsSummary: job.state.lastDiagnosticSummary,
+      },
+      "cron: job run returned warning status",
     );
   }
   const deliveryState = resolveDeliveryState({ job, delivered: result.delivered });
@@ -615,8 +625,8 @@ export function applyJobResult(
 
   if (!shouldDelete) {
     if (job.schedule.kind === "at") {
-      if (result.status === "ok" || result.status === "skipped") {
-        // One-shot done or skipped: disable to prevent tight-loop (#11452).
+      if (result.status === "ok" || result.status === "skipped" || result.status === "warning") {
+        // One-shot done, skipped, or warning: disable to prevent tight-loop (#11452).
         job.enabled = false;
         job.state.nextRunAtMs = undefined;
       } else if (result.status === "error") {
@@ -1631,7 +1641,7 @@ function emitJobFinished(
     action: "finished",
     job,
     status: result.status,
-    error: result.error,
+    error: result.status === "warning" ? undefined : result.error,
     summary: result.summary,
     diagnostics: result.diagnostics,
     delivered: result.delivered,

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -43,7 +43,7 @@ export type CronFailureDestination = {
 
 export type CronDeliveryPatch = Partial<CronDelivery>;
 
-export type CronRunStatus = "ok" | "error" | "skipped";
+export type CronRunStatus = "ok" | "error" | "skipped" | "warning";
 export type CronDeliveryStatus = "delivered" | "not-delivered" | "unknown" | "not-requested";
 
 export type CronDeliveryTraceTarget = {
@@ -182,7 +182,7 @@ export type CronJobState = {
   /** Preferred execution outcome field. */
   lastRunStatus?: CronRunStatus;
   /** @deprecated Use lastRunStatus. */
-  lastStatus?: "ok" | "error" | "skipped";
+  lastStatus?: CronRunStatus;
   lastError?: string;
   lastDiagnostics?: CronRunDiagnostics;
   lastDiagnosticSummary?: string;

--- a/src/gateway/protocol/cron-validators.test.ts
+++ b/src/gateway/protocol/cron-validators.test.ts
@@ -138,7 +138,7 @@ describe("cron protocol validators", () => {
         id: "job-1",
         limit: 50,
         offset: 0,
-        status: "error",
+        status: "warning",
         query: "timeout",
         sortDir: "desc",
       }),
@@ -151,7 +151,7 @@ describe("cron protocol validators", () => {
       validateCronRunsParams({
         scope: "all",
         limit: 25,
-        statuses: ["ok", "error"],
+        statuses: ["ok", "error", "warning"],
         deliveryStatuses: ["delivered", "not-requested"],
         query: "fail",
         sortDir: "desc",

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -26,7 +26,10 @@ const CronSessionTargetSchema = Type.Union([
 ]);
 const CronWakeModeSchema = Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")]);
 function cronRunStatusSchema(options: Record<string, unknown> = {}) {
-  return Type.Union([Type.Literal("ok"), Type.Literal("error"), Type.Literal("skipped")], options);
+  return Type.Union(
+    [Type.Literal("ok"), Type.Literal("error"), Type.Literal("skipped"), Type.Literal("warning")],
+    options,
+  );
 }
 
 const CronRunStatusSchema = cronRunStatusSchema();
@@ -50,11 +53,13 @@ const CronRunsStatusFilterSchema = Type.Union([
   Type.Literal("ok"),
   Type.Literal("error"),
   Type.Literal("skipped"),
+  Type.Literal("warning"),
 ]);
 const CronRunsStatusValueSchema = Type.Union([
   Type.Literal("ok"),
   Type.Literal("error"),
   Type.Literal("skipped"),
+  Type.Literal("warning"),
 ]);
 const CronDeliveryStatusSchema = Type.Union([
   Type.Literal("delivered"),
@@ -397,7 +402,7 @@ export const CronRunsParamsSchema = Type.Object(
     jobId: Type.Optional(CronRunLogJobIdSchema),
     limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200 })),
     offset: Type.Optional(Type.Integer({ minimum: 0 })),
-    statuses: Type.Optional(Type.Array(CronRunsStatusValueSchema, { minItems: 1, maxItems: 3 })),
+    statuses: Type.Optional(Type.Array(CronRunsStatusValueSchema, { minItems: 1, maxItems: 4 })),
     status: Type.Optional(CronRunsStatusFilterSchema),
     deliveryStatuses: Type.Optional(
       Type.Array(CronDeliveryStatusSchema, { minItems: 1, maxItems: 4 }),

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -485,8 +485,8 @@ export const cronHandlers: GatewayRequestHandlers = {
       jobId?: string;
       limit?: number;
       offset?: number;
-      statuses?: Array<"ok" | "error" | "skipped">;
-      status?: "all" | "ok" | "error" | "skipped";
+      statuses?: Array<"ok" | "error" | "skipped" | "warning">;
+      status?: "all" | "ok" | "error" | "skipped" | "warning";
       deliveryStatuses?: Array<"delivered" | "not-delivered" | "unknown" | "not-requested">;
       deliveryStatus?: "delivered" | "not-delivered" | "unknown" | "not-requested";
       query?: string;

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -624,7 +624,7 @@ export type PluginHookGatewayStopEvent = {
   reason?: string;
 };
 
-export type PluginHookGatewayCronRunStatus = "ok" | "error" | "skipped";
+export type PluginHookGatewayCronRunStatus = "ok" | "error" | "skipped" | "warning";
 
 export type PluginHookGatewayCronDeliveryStatus =
   | "not-requested"

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -318,7 +318,7 @@ function isTimeoutCronError(error: string | undefined): boolean {
 }
 
 function mapCronTerminalStatus(status: unknown, error?: string): CronTerminalRecovery["status"] {
-  if (status === "ok" || status === "skipped") {
+  if (status === "ok" || status === "skipped" || status === "warning") {
     return "succeeded";
   }
   return isTimeoutCronError(error) ? "timed_out" : "failed";
@@ -368,7 +368,10 @@ function resolveCronRunLogRecovery(
       candidate.jobId === execution.jobId &&
       candidate.action === "finished" &&
       candidate.runAtMs === execution.startedAt &&
-      (candidate.status === "ok" || candidate.status === "skipped" || candidate.status === "error"),
+      (candidate.status === "ok" ||
+        candidate.status === "skipped" ||
+        candidate.status === "warning" ||
+        candidate.status === "error"),
   );
   if (!entry) {
     return undefined;
@@ -397,7 +400,7 @@ function resolveCronJobStateRecovery(
     return undefined;
   }
   const status = job.state.lastRunStatus ?? job.state.lastStatus;
-  if (status !== "ok" && status !== "skipped" && status !== "error") {
+  if (status !== "ok" && status !== "skipped" && status !== "warning" && status !== "error") {
     return undefined;
   }
   const durationMs =

--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-08T04:13:40.051Z",
+  "fallbackKeys": [
+    "cron.runs.runStatusWarning"
+  ],
+  "generatedAt": "2026-05-10T00:58:46.260Z",
   "locale": "ar",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7d7cad2651bd1851b841b8db7129002ce05770e93d3469d0111b445c5d03ca97",
-  "totalKeys": 1074,
+  "sourceHash": "024d3edcebc8e559c1c78e71023214af67f8397a2ed88f11d38c26a939b8085c",
+  "totalKeys": 1075,
   "translatedKeys": 1074,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-08T04:13:38.691Z",
+  "fallbackKeys": [
+    "cron.runs.runStatusWarning"
+  ],
+  "generatedAt": "2026-05-10T00:58:36.025Z",
   "locale": "de",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7d7cad2651bd1851b841b8db7129002ce05770e93d3469d0111b445c5d03ca97",
-  "totalKeys": 1074,
+  "sourceHash": "024d3edcebc8e559c1c78e71023214af67f8397a2ed88f11d38c26a939b8085c",
+  "totalKeys": 1075,
   "translatedKeys": 1074,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-08T04:13:38.962Z",
+  "fallbackKeys": [
+    "cron.runs.runStatusWarning"
+  ],
+  "generatedAt": "2026-05-10T00:58:38.147Z",
   "locale": "es",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7d7cad2651bd1851b841b8db7129002ce05770e93d3469d0111b445c5d03ca97",
-  "totalKeys": 1074,
+  "sourceHash": "024d3edcebc8e559c1c78e71023214af67f8397a2ed88f11d38c26a939b8085c",
+  "totalKeys": 1075,
   "translatedKeys": 1074,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-08T04:13:42.501Z",
+  "fallbackKeys": [
+    "cron.runs.runStatusWarning"
+  ],
+  "generatedAt": "2026-05-10T00:59:04.109Z",
   "locale": "fa",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7d7cad2651bd1851b841b8db7129002ce05770e93d3469d0111b445c5d03ca97",
-  "totalKeys": 1074,
+  "sourceHash": "024d3edcebc8e559c1c78e71023214af67f8397a2ed88f11d38c26a939b8085c",
+  "totalKeys": 1075,
   "translatedKeys": 1074,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-08T04:13:39.779Z",
+  "fallbackKeys": [
+    "cron.runs.runStatusWarning"
+  ],
+  "generatedAt": "2026-05-10T00:58:44.351Z",
   "locale": "fr",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7d7cad2651bd1851b841b8db7129002ce05770e93d3469d0111b445c5d03ca97",
-  "totalKeys": 1074,
+  "sourceHash": "024d3edcebc8e559c1c78e71023214af67f8397a2ed88f11d38c26a939b8085c",
+  "totalKeys": 1075,
   "translatedKeys": 1074,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-08T04:13:41.135Z",
+  "fallbackKeys": [
+    "cron.runs.runStatusWarning"
+  ],
+  "generatedAt": "2026-05-10T00:58:53.989Z",
   "locale": "id",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7d7cad2651bd1851b841b8db7129002ce05770e93d3469d0111b445c5d03ca97",
-  "totalKeys": 1074,
+  "sourceHash": "024d3edcebc8e559c1c78e71023214af67f8397a2ed88f11d38c26a939b8085c",
+  "totalKeys": 1075,
   "translatedKeys": 1074,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-08T04:13:40.326Z",
+  "fallbackKeys": [
+    "cron.runs.runStatusWarning"
+  ],
+  "generatedAt": "2026-05-10T00:58:48.167Z",
   "locale": "it",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7d7cad2651bd1851b841b8db7129002ce05770e93d3469d0111b445c5d03ca97",
-  "totalKeys": 1074,
+  "sourceHash": "024d3edcebc8e559c1c78e71023214af67f8397a2ed88f11d38c26a939b8085c",
+  "totalKeys": 1075,
   "translatedKeys": 1074,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-08T04:13:39.234Z",
+  "fallbackKeys": [
+    "cron.runs.runStatusWarning"
+  ],
+  "generatedAt": "2026-05-10T00:58:40.114Z",
   "locale": "ja-JP",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7d7cad2651bd1851b841b8db7129002ce05770e93d3469d0111b445c5d03ca97",
-  "totalKeys": 1074,
+  "sourceHash": "024d3edcebc8e559c1c78e71023214af67f8397a2ed88f11d38c26a939b8085c",
+  "totalKeys": 1075,
   "translatedKeys": 1074,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-08T04:13:39.508Z",
+  "fallbackKeys": [
+    "cron.runs.runStatusWarning"
+  ],
+  "generatedAt": "2026-05-10T00:58:42.111Z",
   "locale": "ko",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7d7cad2651bd1851b841b8db7129002ce05770e93d3469d0111b445c5d03ca97",
-  "totalKeys": 1074,
+  "sourceHash": "024d3edcebc8e559c1c78e71023214af67f8397a2ed88f11d38c26a939b8085c",
+  "totalKeys": 1075,
   "translatedKeys": 1074,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-08T04:13:42.224Z",
+  "fallbackKeys": [
+    "cron.runs.runStatusWarning"
+  ],
+  "generatedAt": "2026-05-10T00:59:02.154Z",
   "locale": "nl",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7d7cad2651bd1851b841b8db7129002ce05770e93d3469d0111b445c5d03ca97",
-  "totalKeys": 1074,
+  "sourceHash": "024d3edcebc8e559c1c78e71023214af67f8397a2ed88f11d38c26a939b8085c",
+  "totalKeys": 1075,
   "translatedKeys": 1074,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-08T04:13:41.406Z",
+  "fallbackKeys": [
+    "cron.runs.runStatusWarning"
+  ],
+  "generatedAt": "2026-05-10T00:58:56.158Z",
   "locale": "pl",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7d7cad2651bd1851b841b8db7129002ce05770e93d3469d0111b445c5d03ca97",
-  "totalKeys": 1074,
+  "sourceHash": "024d3edcebc8e559c1c78e71023214af67f8397a2ed88f11d38c26a939b8085c",
+  "totalKeys": 1075,
   "translatedKeys": 1074,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-08T04:13:38.421Z",
+  "fallbackKeys": [
+    "cron.runs.runStatusWarning"
+  ],
+  "generatedAt": "2026-05-10T00:58:33.897Z",
   "locale": "pt-BR",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7d7cad2651bd1851b841b8db7129002ce05770e93d3469d0111b445c5d03ca97",
-  "totalKeys": 1074,
+  "sourceHash": "024d3edcebc8e559c1c78e71023214af67f8397a2ed88f11d38c26a939b8085c",
+  "totalKeys": 1075,
   "translatedKeys": 1074,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-08T04:13:41.675Z",
+  "fallbackKeys": [
+    "cron.runs.runStatusWarning"
+  ],
+  "generatedAt": "2026-05-10T00:58:58.011Z",
   "locale": "th",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7d7cad2651bd1851b841b8db7129002ce05770e93d3469d0111b445c5d03ca97",
-  "totalKeys": 1074,
+  "sourceHash": "024d3edcebc8e559c1c78e71023214af67f8397a2ed88f11d38c26a939b8085c",
+  "totalKeys": 1075,
   "translatedKeys": 1074,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-08T04:13:40.595Z",
+  "fallbackKeys": [
+    "cron.runs.runStatusWarning"
+  ],
+  "generatedAt": "2026-05-10T00:58:50.348Z",
   "locale": "tr",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7d7cad2651bd1851b841b8db7129002ce05770e93d3469d0111b445c5d03ca97",
-  "totalKeys": 1074,
+  "sourceHash": "024d3edcebc8e559c1c78e71023214af67f8397a2ed88f11d38c26a939b8085c",
+  "totalKeys": 1075,
   "translatedKeys": 1074,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-08T04:13:40.867Z",
+  "fallbackKeys": [
+    "cron.runs.runStatusWarning"
+  ],
+  "generatedAt": "2026-05-10T00:58:52.085Z",
   "locale": "uk",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7d7cad2651bd1851b841b8db7129002ce05770e93d3469d0111b445c5d03ca97",
-  "totalKeys": 1074,
+  "sourceHash": "024d3edcebc8e559c1c78e71023214af67f8397a2ed88f11d38c26a939b8085c",
+  "totalKeys": 1075,
   "translatedKeys": 1074,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-08T04:13:41.948Z",
+  "fallbackKeys": [
+    "cron.runs.runStatusWarning"
+  ],
+  "generatedAt": "2026-05-10T00:59:00.017Z",
   "locale": "vi",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7d7cad2651bd1851b841b8db7129002ce05770e93d3469d0111b445c5d03ca97",
-  "totalKeys": 1074,
+  "sourceHash": "024d3edcebc8e559c1c78e71023214af67f8397a2ed88f11d38c26a939b8085c",
+  "totalKeys": 1075,
   "translatedKeys": 1074,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-08T04:13:37.835Z",
+  "fallbackKeys": [
+    "cron.runs.runStatusWarning"
+  ],
+  "generatedAt": "2026-05-10T00:58:29.543Z",
   "locale": "zh-CN",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7d7cad2651bd1851b841b8db7129002ce05770e93d3469d0111b445c5d03ca97",
-  "totalKeys": 1074,
+  "sourceHash": "024d3edcebc8e559c1c78e71023214af67f8397a2ed88f11d38c26a939b8085c",
+  "totalKeys": 1075,
   "translatedKeys": 1074,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-08T04:13:38.148Z",
+  "fallbackKeys": [
+    "cron.runs.runStatusWarning"
+  ],
+  "generatedAt": "2026-05-10T00:58:31.875Z",
   "locale": "zh-TW",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7d7cad2651bd1851b841b8db7129002ce05770e93d3469d0111b445c5d03ca97",
-  "totalKeys": 1074,
+  "sourceHash": "024d3edcebc8e559c1c78e71023214af67f8397a2ed88f11d38c26a939b8085c",
+  "totalKeys": 1075,
   "translatedKeys": 1074,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -1167,6 +1167,7 @@ export const ar: TranslationMap = {
       runStatusOk: "حسنًا",
       runStatusError: "خطأ",
       runStatusSkipped: "تم التخطي",
+      runStatusWarning: "Warning",
       runStatusUnknown: "غير معروف",
       deliveryDelivered: "تم التسليم",
       deliveryNotDelivered: "لم يتم التسليم",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -1193,6 +1193,7 @@ export const de: TranslationMap = {
       runStatusOk: "OK",
       runStatusError: "Fehler",
       runStatusSkipped: "Übersprungen",
+      runStatusWarning: "Warning",
       runStatusUnknown: "Unbekannt",
       deliveryDelivered: "Zugestellt",
       deliveryNotDelivered: "Nicht zugestellt",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1173,6 +1173,7 @@ export const en: TranslationMap = {
       runStatusOk: "OK",
       runStatusError: "Error",
       runStatusSkipped: "Skipped",
+      runStatusWarning: "Warning",
       runStatusUnknown: "Unknown",
       deliveryDelivered: "Delivered",
       deliveryNotDelivered: "Not delivered",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -1190,6 +1190,7 @@ export const es: TranslationMap = {
       runStatusOk: "OK",
       runStatusError: "Error",
       runStatusSkipped: "Omitida",
+      runStatusWarning: "Warning",
       runStatusUnknown: "Desconocido",
       deliveryDelivered: "Entregado",
       deliveryNotDelivered: "No entregado",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -1185,6 +1185,7 @@ export const fa: TranslationMap = {
       runStatusOk: "تأیید",
       runStatusError: "خطا",
       runStatusSkipped: "ردشده",
+      runStatusWarning: "Warning",
       runStatusUnknown: "نامشخص",
       deliveryDelivered: "تحویل‌شده",
       deliveryNotDelivered: "تحویل‌نشده",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -1198,6 +1198,7 @@ export const fr: TranslationMap = {
       runStatusOk: "OK",
       runStatusError: "Erreur",
       runStatusSkipped: "Ignoré",
+      runStatusWarning: "Warning",
       runStatusUnknown: "Inconnu",
       deliveryDelivered: "Distribué",
       deliveryNotDelivered: "Non distribué",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -1182,6 +1182,7 @@ export const id: TranslationMap = {
       runStatusOk: "OK",
       runStatusError: "Kesalahan",
       runStatusSkipped: "Dilewati",
+      runStatusWarning: "Warning",
       runStatusUnknown: "Tidak diketahui",
       deliveryDelivered: "Terkirim",
       deliveryNotDelivered: "Tidak terkirim",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -1192,6 +1192,7 @@ export const it: TranslationMap = {
       runStatusOk: "OK",
       runStatusError: "Errore",
       runStatusSkipped: "Saltato",
+      runStatusWarning: "Warning",
       runStatusUnknown: "Sconosciuto",
       deliveryDelivered: "Consegnato",
       deliveryNotDelivered: "Non consegnato",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -1187,6 +1187,7 @@ export const ja_JP: TranslationMap = {
       runStatusOk: "OK",
       runStatusError: "エラー",
       runStatusSkipped: "スキップ",
+      runStatusWarning: "Warning",
       runStatusUnknown: "不明",
       deliveryDelivered: "配信済み",
       deliveryNotDelivered: "未配信",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -1176,6 +1176,7 @@ export const ko: TranslationMap = {
       runStatusOk: "확인",
       runStatusError: "오류",
       runStatusSkipped: "건너뜀",
+      runStatusWarning: "Warning",
       runStatusUnknown: "알 수 없음",
       deliveryDelivered: "전달됨",
       deliveryNotDelivered: "전달되지 않음",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -1187,6 +1187,7 @@ export const nl: TranslationMap = {
       runStatusOk: "OK",
       runStatusError: "Fout",
       runStatusSkipped: "Overgeslagen",
+      runStatusWarning: "Warning",
       runStatusUnknown: "Onbekend",
       deliveryDelivered: "Geleverd",
       deliveryNotDelivered: "Niet geleverd",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -1188,6 +1188,7 @@ export const pl: TranslationMap = {
       runStatusOk: "OK",
       runStatusError: "Błąd",
       runStatusSkipped: "Pominięto",
+      runStatusWarning: "Warning",
       runStatusUnknown: "Nieznane",
       deliveryDelivered: "Dostarczono",
       deliveryNotDelivered: "Nie dostarczono",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -1185,6 +1185,7 @@ export const pt_BR: TranslationMap = {
       runStatusOk: "OK",
       runStatusError: "Erro",
       runStatusSkipped: "Ignorado",
+      runStatusWarning: "Warning",
       runStatusUnknown: "Desconhecido",
       deliveryDelivered: "Entregue",
       deliveryNotDelivered: "Não entregue",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -1152,6 +1152,7 @@ export const th: TranslationMap = {
       runStatusOk: "ตกลง",
       runStatusError: "ข้อผิดพลาด",
       runStatusSkipped: "ข้ามแล้ว",
+      runStatusWarning: "Warning",
       runStatusUnknown: "ไม่ทราบ",
       deliveryDelivered: "ส่งแล้ว",
       deliveryNotDelivered: "ยังไม่ส่ง",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -1189,6 +1189,7 @@ export const tr: TranslationMap = {
       runStatusOk: "Tamam",
       runStatusError: "Hata",
       runStatusSkipped: "Atlandı",
+      runStatusWarning: "Warning",
       runStatusUnknown: "Bilinmiyor",
       deliveryDelivered: "Teslim edildi",
       deliveryNotDelivered: "Teslim edilmedi",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -1186,6 +1186,7 @@ export const uk: TranslationMap = {
       runStatusOk: "OK",
       runStatusError: "Помилка",
       runStatusSkipped: "Пропущено",
+      runStatusWarning: "Warning",
       runStatusUnknown: "Невідомо",
       deliveryDelivered: "Доставлено",
       deliveryNotDelivered: "Не доставлено",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -1175,6 +1175,7 @@ export const vi: TranslationMap = {
       runStatusOk: "OK",
       runStatusError: "Lỗi",
       runStatusSkipped: "Đã bỏ qua",
+      runStatusWarning: "Warning",
       runStatusUnknown: "Không rõ",
       deliveryDelivered: "Đã gửi",
       deliveryNotDelivered: "Chưa gửi",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -1148,6 +1148,7 @@ export const zh_CN: TranslationMap = {
       runStatusOk: "成功",
       runStatusError: "错误",
       runStatusSkipped: "已跳过",
+      runStatusWarning: "Warning",
       runStatusUnknown: "未知",
       deliveryDelivered: "已投递",
       deliveryNotDelivered: "未投递",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -1150,6 +1150,7 @@ export const zh_TW: TranslationMap = {
       runStatusOk: "OK",
       runStatusError: "錯誤",
       runStatusSkipped: "已略過",
+      runStatusWarning: "Warning",
       runStatusUnknown: "未知",
       deliveryDelivered: "已傳送",
       deliveryNotDelivered: "未傳送",

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2263,6 +2263,12 @@
   background: var(--warn-subtle);
 }
 
+.cron-job-status-warning {
+  color: var(--warn);
+  border-color: rgba(245, 158, 11, 0.35);
+  background: var(--warn-subtle);
+}
+
 .cron-job-status-na {
   color: var(--muted);
 }

--- a/ui/src/ui/controllers/cron-filters.test.ts
+++ b/ui/src/ui/controllers/cron-filters.test.ts
@@ -46,6 +46,7 @@ describe("getVisibleCronJobs", () => {
     const jobs = [
       job("ok", { state: { lastStatus: "ok", lastRunAtMs: 1 } }),
       job("error", { state: { lastStatus: "error", lastRunAtMs: 2 } }),
+      job("warning", { state: { lastStatus: "warning", lastRunAtMs: 3 } }),
       job("unknown"),
     ];
     const visible = getVisibleCronJobs({
@@ -54,6 +55,13 @@ describe("getVisibleCronJobs", () => {
       cronJobsLastStatusFilter: "error",
     });
     expect(visible.map((entry) => entry.id)).toEqual(["error"]);
+
+    const warnings = getVisibleCronJobs({
+      cronJobs: jobs,
+      cronJobsScheduleKindFilter: "all",
+      cronJobsLastStatusFilter: "warning",
+    });
+    expect(warnings.map((entry) => entry.id)).toEqual(["warning"]);
   });
 
   it("combines schedule and last-status filters", () => {

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -42,7 +42,7 @@ export type CronFieldKey =
 export type CronFieldErrors = Partial<Record<CronFieldKey, string>>;
 
 export type CronJobsScheduleKindFilter = "all" | "at" | "every" | "cron";
-export type CronJobsLastStatusFilter = "all" | "ok" | "error" | "skipped";
+export type CronJobsLastStatusFilter = "all" | "ok" | "error" | "skipped" | "warning";
 export type CronRunsLoadStatus = "ok" | "error" | "skipped";
 
 export type CronState = {

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -522,7 +522,7 @@ export type {
   SessionUsageTimeSeries,
 } from "./usage-types.ts";
 
-export type CronRunStatus = "ok" | "error" | "skipped";
+export type CronRunStatus = "ok" | "error" | "skipped" | "warning";
 export type CronDeliveryStatus = "delivered" | "not-delivered" | "unknown" | "not-requested";
 export type CronJobsEnabledFilter = "all" | "enabled" | "disabled";
 export type CronJobsSortBy = "nextRunAtMs" | "updatedAtMs" | "name";

--- a/ui/src/ui/views/cron.test.ts
+++ b/ui/src/ui/views/cron.test.ts
@@ -141,6 +141,7 @@ describe("cron view", () => {
     expect(container.textContent).toContain("Latest runs across all jobs.");
     expect(container.textContent).toContain("Status");
     expect(container.textContent).toContain("All statuses");
+    expect(container.textContent).toContain("Warning");
     expect(container.textContent).toContain("Delivery");
     expect(container.textContent).toContain("All delivery");
     expect(container.textContent).not.toContain("multi-select");
@@ -177,6 +178,7 @@ describe("cron view", () => {
     lastRunSelect.dispatchEvent(new Event("change", { bubbles: true }));
 
     expect(onJobsFiltersChange).toHaveBeenCalledWith({ cronJobsLastStatusFilter: "error" });
+    expect(Array.from(lastRunSelect.options).map((option) => option.value)).toContain("warning");
 
     render(
       renderCron(

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -106,6 +106,7 @@ function getRunStatusOptions(): Array<{ value: CronRunsStatusValue; label: strin
     { value: "ok", label: t("cron.runs.runStatusOk") },
     { value: "error", label: t("cron.runs.runStatusError") },
     { value: "skipped", label: t("cron.runs.runStatusSkipped") },
+    { value: "warning", label: t("cron.runs.runStatusWarning") },
   ];
 }
 
@@ -519,6 +520,7 @@ export function renderCron(props: CronProps) {
                 <option value="ok">${t("cron.runs.runStatusOk")}</option>
                 <option value="error">${t("cron.runs.runStatusError")}</option>
                 <option value="skipped">${t("cron.runs.runStatusSkipped")}</option>
+                <option value="warning">${t("cron.runs.runStatusWarning")}</option>
               </select>
             </label>
             <label class="field">
@@ -1685,7 +1687,9 @@ function renderJobState(job: CronJob) {
         ? "cron-job-status-error"
         : rawStatus === "skipped"
           ? "cron-job-status-skipped"
-          : "cron-job-status-na";
+          : rawStatus === "warning"
+            ? "cron-job-status-warning"
+            : "cron-job-status-na";
   const statusLabel =
     rawStatus === "ok"
       ? t("cron.runs.runStatusOk")
@@ -1693,9 +1697,13 @@ function renderJobState(job: CronJob) {
         ? t("cron.runs.runStatusError")
         : rawStatus === "skipped"
           ? t("cron.runs.runStatusSkipped")
-          : t("common.na");
+          : rawStatus === "warning"
+            ? t("cron.runs.runStatusWarning")
+            : t("common.na");
   const nextRunAtMs = job.state?.nextRunAtMs;
   const lastRunAtMs = job.state?.lastRunAtMs;
+  const deliveryStatus = job.state?.lastDeliveryStatus;
+  const deliveryError = job.state?.lastDeliveryError;
 
   return html`
     <div class="cron-job-state">
@@ -1715,6 +1723,14 @@ function renderJobState(job: CronJob) {
           ${formatStateRelative(lastRunAtMs)}
         </span>
       </div>
+      ${deliveryStatus && deliveryStatus !== "not-requested"
+        ? html`<div class="cron-job-state-row">
+            <span class="cron-job-state-key">${t("cron.runs.delivery")}</span>
+            <span class="cron-job-state-value" title=${deliveryError ?? ""}>
+              ${runDeliveryLabel(deliveryStatus)}
+            </span>
+          </div>`
+        : nothing}
     </div>
   `;
 }
@@ -1727,6 +1743,8 @@ function runStatusLabel(value: string): string {
       return t("cron.runs.runStatusError");
     case "skipped":
       return t("cron.runs.runStatusSkipped");
+    case "warning":
+      return t("cron.runs.runStatusWarning");
     default:
       return t("cron.runs.runStatusUnknown");
   }


### PR DESCRIPTION
Fixes #49190.

## Problem summary
Cron isolated-agent runs currently collapse final delivery failures into the primary `error` run status even when the agent execution itself succeeded. That makes notification/channel failures look like execution failures, increments error/backoff state, can mark task records failed, and leaves the Control UI without a first-class status filter for this partial-success case.

## Root cause
The isolated delivery dispatcher returned `status: "error"` for unresolved delivery targets and direct outbound send failures. `applyJobResult` only distinguished `ok`, `skipped`, and `error`, so delivery-only failures used the same scheduler path as model/tool/runtime failures.

## Architectural reasoning
This keeps the change additive and follows the existing cron contract surface:

- Adds `warning` to the cron run status union, gateway validation schema, run-log filters, plugin hook type, CLI/UI mirrors, and QA helper wait logic.
- Leaves real agent/runtime failures as `error`; `finalizeCronRun` only asks delivery dispatch to downgrade delivery failures to `warning` when the agent payload did not already indicate a fatal execution failure.
- Keeps delivery diagnostics in the delivery-specific fields: warning runs set `delivered: false`, persist `lastDeliveryStatus: "not-delivered"`, and keep `lastDeliveryError`.
- Keeps scheduler behavior aligned with partial success: warning runs reset execution-error counters, do not trigger error backoff/failure alerts, complete task-ledger records as successful execution, and terminal one-shot warning runs are disabled but not auto-deleted so operators can inspect state.
- Extends Control UI filters/status labels and CLI coloring without changing existing `ok`, `error`, or `skipped` semantics.

## Real behavior proof
- Behavior or issue addressed: Cron isolated-agent runs whose agent execution completes but final announce delivery cannot resolve/send now persist as `warning` instead of `error`.
- Real environment tested: Windows 11 local OpenClaw source checkout on branch `codex/49190-cron-warning-status` after rebasing onto `upstream/main` (`6e18c8ec15`). Runtime used Node 24.14.0 through `node --import tsx`; no live Slack credentials or private endpoints were used.
- Exact steps or command run after this patch: Ran a one-off local Node script from the repo root with `node --import tsx --input-type=module`. The script loaded the real `CronService` and `dispatchCronDelivery` modules, created an isolated cron job with Slack announce delivery, simulated the delivery target failure `outbound not configured for channel slack`, ran the job with `cron.run(job.id, "force")`, and printed the persisted job state plus dispatcher result.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output from the local run:

```json
{
  "proof": "cron delivery warning status after patch",
  "manualRunOk": true,
  "jobState": {
    "enabled": false,
    "lastRunStatus": "warning",
    "lastStatus": "warning",
    "consecutiveErrors": 0,
    "lastDelivered": false,
    "lastDeliveryStatus": "not-delivered",
    "lastDeliveryError": "outbound not configured for channel slack"
  },
  "finishedEvent": {
    "status": "warning",
    "delivered": false,
    "deliveryStatus": "not-delivered",
    "deliveryError": "outbound not configured for channel slack"
  },
  "dispatchResult": {
    "status": "warning",
    "errorKind": "delivery-target",
    "delivered": false,
    "deliveryAttempted": false,
    "error": "outbound not configured for channel slack"
  }
}
```

- Observed result after fix: The cron run completed with `manualRunOk: true`, persisted `lastRunStatus: "warning"`, kept `consecutiveErrors: 0`, marked delivery as `not-delivered`, and returned the dispatcher delivery-target failure as `warning` with `delivered: false`.
- What was not tested: No live Slack workspace send was attempted because this proof intentionally used a redacted local setup without channel credentials. Live channel sends remain covered by existing channel runtime paths; this PR only changes the status classification after delivery failure.

## Testing performed
- `pnpm test src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts src/cron/service.persists-delivered-status.test.ts src/cron/service/timer.regression.test.ts src/gateway/protocol/cron-validators.test.ts ui/src/ui/views/cron.test.ts ui/src/ui/controllers/cron-filters.test.ts src/tasks/task-registry.test.ts`
- `pnpm test src/cron/service.persists-delivered-status.test.ts src/cron/run-log.test.ts -- -t "persists warning|filters warning"`
- `pnpm test src/cron/cron-protocol-conformance.test.ts src/cron/cron-protocol-schema.test.ts`
- `pnpm lint:core`
- `pnpm lint:scripts`
- `pnpm lint:extensions`
- `pnpm lint:ui:no-raw-window-open`
- `pnpm docs:check-mdx`
- `pnpm lint:docs -- docs/cli/cron.md docs/automation/cron-jobs.md`
- `pnpm exec oxfmt --check --threads=1 ...changed files...`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm tsgo:test:ui`
- `pnpm tsgo:extensions`
- `pnpm tsgo:core` (after rebasing onto latest `upstream/main`, to verify the OpenAI stream type CI repair)
- `pnpm tsgo:extensions:test`
- `pnpm check:madge-import-cycles` (after rebasing onto latest `upstream/main`)
- `pnpm test src/cron/run-log.test.ts -- --reporter=dot`
- `pnpm test src/cron/run-log.test.ts src/cron/service.persists-delivered-status.test.ts src/cron/service/timer.regression.test.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts src/gateway/protocol/cron-validators.test.ts ui/src/ui/controllers/cron-filters.test.ts ui/src/ui/views/cron.test.ts src/agents/openai-transport-stream.test.ts -- --reporter=dot`
- `pnpm exec oxfmt --check --threads=1 src/cron/run-log.ts src/agents/openai-transport-stream.ts`- `pnpm ui:i18n:check` (after rebasing onto latest `upstream/main`; local Windows run reached translation subprocess `spawn EINVAL` after raw-copy baseline passed)
- `pnpm check:changed`
- `git diff --check`

Local note: the full `pnpm test src/cron/run-log.test.ts -- --reporter=dot` initially reproduced a Windows append-path failure from `appendRegularFile` (`Refusing to append after file changed`). I fixed the run-log writer to keep the symlink-parent guard while appending through the fs-safe root writer, then reran `pnpm test src/cron/run-log.test.ts -- --reporter=dot` and the grouped cron/OpenAI targeted command successfully. Also, `ui:i18n:sync` initially failed because the configured translation subprocess could not spawn in this Windows shell; I reran the repo sync/check path with translation keys falling back to English for the new `cron.runs.runStatusWarning` key, which updated the locale metadata fallback keys and passed `control-ui-i18n` check.

## Risk analysis
Risk is medium-low. The protocol change is additive, existing statuses keep their behavior, and the scheduler continues to apply error retry/backoff only to `error`. The main compatibility surface is clients that exhaustively switch on cron run statuses; this PR updates repo-owned TS/UI/plugin helper surfaces and leaves generated Swift/openclaw-kit fields as `AnyCodable`/string-compatible where applicable.

## Backward compatibility
Existing stored `ok`, `error`, and `skipped` run records remain valid. New `warning` records are accepted by the gateway schema, CLI/UI type mirrors, run-log filters, and plugin hooks. Older external clients that do not know `warning` will see a new string status but can still inspect `deliveryStatus`/`deliveryError` for details.

## Screenshots/logs
No screenshots; this is a scheduler/protocol/UI-state change. Relevant command logs are summarized above.
