### PR TITLE
fix(agents): stop raw tool output leaking into subagent completion announces

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -94,7 +94,7 @@ requester chat when the run finishes.
     The completion handoff to the requester session is runtime-generated
     internal context (not user-authored text) and includes:
 
-    - `Result` — latest visible `assistant` reply text, otherwise sanitized latest tool/toolResult text. Terminal failed runs do not reuse captured reply text.
+    - `Result` — latest visible `assistant` reply text, otherwise `(no output)`. Terminal failed runs do not reuse captured reply text.
     - `Status` — `completed successfully` / `failed` / `timed out` / `unknown`.
     - Compact runtime/token stats.
     - A delivery instruction telling the requester agent to rewrite in normal assistant voice (not forward raw internal metadata).
@@ -432,7 +432,7 @@ Announce context is normalized to a stable internal event block:
 | Session ids    | Child session key/id                                                                                          |
 | Type           | Announce type + task label                                                                                    |
 | Status         | Derived from runtime outcome (`success`, `error`, `timeout`, or `unknown`) — **not** inferred from model text |
-| Result content | Latest visible assistant text, otherwise sanitized latest tool/toolResult text                                |
+| Result content | Latest visible assistant text; `(no output)` if no assistant text is available                                |
 | Follow-up      | Instruction describing when to reply vs stay silent                                                           |
 
 Terminal failed runs report failure status without replaying captured

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -301,7 +301,12 @@ function selectSubagentOutputText(
   if (partialProgress) {
     return partialProgress;
   }
-  return snapshot.latestRawText;
+  // Do not fall through to snapshot.latestRawText — raw tool output is not
+  // user-facing content and must not be delivered as completion text.  If no
+  // assistant-produced text is available, the caller should fall back to
+  // readLatestAssistantReply (post-compaction result) or synthesize a bounded
+  // failure summary.
+  return undefined;
 }
 
 export async function readSubagentOutput(

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -634,7 +634,7 @@ describe("subagent announce formatting", () => {
 
       const call = agentSpy.mock.calls[0]?.[0] as { params?: { message?: string } };
       const msg = call?.params?.message as string;
-      expect(msg).toContain(testCase.toolOutput);
+      expect(msg).toContain("(no output)");
     },
   );
 
@@ -2022,7 +2022,7 @@ describe("subagent announce formatting", () => {
     expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = agentSpy.mock.calls[0]?.[0] as { params?: { message?: string } };
     const msg = call?.params?.message as string;
-    expect(msg).toContain("tool output only");
+    expect(msg).toContain("(no output)");
   });
 
   it("ignores user text when deriving fallback completion output", async () => {


### PR DESCRIPTION
## Summary

Fixes #79986 — Subagent announce leaks raw tool output to Telegram and duplicates parent progress reply.

**Root cause:** `selectSubagentOutputText()` in `src/agents/subagent-announce-output.ts` was falling through to `snapshot.latestRawText` (from tool/toolResult messages) when no assistant-produced text was available. Raw tool output is not user-facing content and must not be delivered as completion text.

**Fix:** Return `undefined` instead of `snapshot.latestRawText` so the caller falls back to `readLatestAssistantReply()` (post-compaction result) or synthesizes a bounded failure summary.

## Files changed

- `src/agents/subagent-announce-output.ts` — Stop `selectSubagentOutputText` from returning raw tool output
- `src/agents/subagent-announce.format.e2e.test.ts` — Updated tests that expected raw tool output to be announced to correctly expect `(no output)`

## Acceptance criteria

- [x] `pnpm test --run src/agents/subagent-announce.format.e2e.test.ts src/agents/subagent-announce-output.test.ts src/agents/subagent-announce-delivery.test.ts src/gateway/server-methods/agent.test.ts` ✅
- [x] `pnpm test --run src/gateway/server-chat.agent-events.test.ts` ✅  
- [x] `pnpm exec oxfmt --check --threads=1 on: ...` ✅

---

## Real Behavior Proof

**Before fix (buggy behavior):**

A subagent completes a task with tool-only output (no assistant text). The completion announce sends raw tool output to Telegram:

```
[Subagent] /exec completed
/root/openclaw/src/gateway/protocol/schema/protocol-schemas.ts:181:  PluginControlUiDescriptorSchema,
/root/openclaw/src/gateway/protocol/schema/protocol-schemas.ts:182:  PluginRuntimeConfigSchema,
... (raw tool result content visible to user)
```

**After fix (correct behavior):**

Same scenario now produces a bounded `(no output)` summary instead of raw tool text:

```
[Subagent] completed with result: (no output)
```

**How to reproduce:**
1. Start a Telegram DM session with a parent agent
2. Spawn a subagent (`sessions_spawn runtime="subagent"`) that runs a task producing tool-only output (e.g., a file write with no assistant reply)
3. Observe the completion message — before fix: raw tool content visible; after fix: `(no output)`
