### PR TITLE
Fix fallback timeout response delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents: surface concise default-visible warnings when `exec`/`bash` tool calls fail after the assistant claims success, while keeping raw stderr hidden unless verbose details are enabled. Fixes #60497. (#80003) Thanks @jbetala7.
+- Auto-reply/TUI: keep fallback timeout recovery deliverable after a primary model lifecycle error by emitting fallback progress and deferring terminal TUI errors until recovery has a chance to finish. Fixes #80000. (#80009) Thanks @TurboTheTurtle.
 - CLI/agent: let `openclaw agent --model` use the backend/admin Gateway scope without cached device-token scopes silently downscoping the request. (#78837) Thanks @VACInc.
 - Ollama: keep DeepSeek V4 cloud models thinking-capable even when Ollama Cloud `/api/show` omits the `thinking` capability, so `/think high` no longer rejects `ollama/deepseek-v4-*:cloud`.
 - ACPX/Claude ACP: keep foreground prompts waiting for their own result when autonomous task-notification results arrive during the same session, and retarget the patch for Claude Agent ACP `0.33.1`.

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1010,6 +1010,22 @@ function createEmbeddedLifecycleTerminalBackstop(params: { runId: string; sessio
   return { emit, note };
 }
 
+function emitModelFallbackStepLifecycle(params: {
+  runId: string;
+  sessionKey?: string;
+  step: Record<string, unknown>;
+}) {
+  emitAgentEvent({
+    runId: params.runId,
+    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+    stream: "lifecycle",
+    data: {
+      phase: "fallback_step",
+      ...params.step,
+    },
+  });
+}
+
 export async function runAgentTurnWithFallback(params: {
   commandBody: string;
   transcriptCommandBody?: string;
@@ -1362,6 +1378,13 @@ export async function runAgentTurnWithFallback(params: {
         runId,
         sessionId: params.followupRun.run.sessionId,
         lane: runLane,
+        onFallbackStep: (step) => {
+          emitModelFallbackStepLifecycle({
+            runId,
+            sessionKey: params.sessionKey,
+            step,
+          });
+        },
         classifyResult: async ({ result, provider, model }) => {
           const classification = outcomePlan.classifyRunResult({
             result,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -764,8 +764,16 @@ describe("runReplyAgent typing (heartbeat)", () => {
         payloads: [{ text: "final" }],
         meta: {},
       });
-      vi.spyOn(modelFallbackModule, "runWithModelFallback").mockImplementationOnce(
-        async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+      vi.spyOn(modelFallbackModule, "runWithModelFallback").mockImplementationOnce(async (args) => {
+        const { run, onFallbackStep } = args;
+        await onFallbackStep?.({
+          fallbackStepType: "fallback_step",
+          fallbackStepFromModel: "fireworks/fireworks/accounts/fireworks/routers/kimi-k2p5-turbo",
+          fallbackStepToModel: "deepinfra/moonshotai/Kimi-K2.5",
+          fallbackStepFromFailureReason: "rate_limit",
+          fallbackStepFinalOutcome: "succeeded",
+        });
+        return {
           result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
           provider: "deepinfra",
           model: "moonshotai/Kimi-K2.5",
@@ -777,8 +785,8 @@ describe("runReplyAgent typing (heartbeat)", () => {
               reason: "rate_limit",
             },
           ],
-        }),
-      );
+        };
+      });
 
       const { run } = createMinimalRun({
         resolvedVerboseLevel: testCase.verbose,
@@ -809,6 +817,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
         phases.filter((phase) => phase === "fallback"),
         testCase.name,
       ).toHaveLength(1);
+      expect(phases, testCase.name).toContain("fallback_step");
     }
   });
 

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -303,6 +303,77 @@ describe("EmbeddedTuiBackend", () => {
     });
   });
 
+  it("keeps a fallback response deliverable after a retryable lifecycle error", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const pending = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
+
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = (evt) => {
+      events.push({ event: evt.event, payload: evt.payload });
+    };
+
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "recover after timeout",
+      runId: "run-local-fallback",
+    });
+
+    registeredListener?.({
+      runId: "run-local-fallback",
+      stream: "lifecycle",
+      data: { phase: "error", error: "primary model timed out" },
+    });
+    await flushMicrotasks();
+    expect(
+      events.some(
+        (entry) =>
+          entry.event === "chat" && (entry.payload as { state?: string }).state === "error",
+      ),
+    ).toBe(false);
+
+    registeredListener?.({
+      runId: "run-local-fallback",
+      stream: "lifecycle",
+      data: {
+        phase: "fallback_step",
+        fallbackStepFinalOutcome: "succeeded",
+        fallbackStepFromModel: "anthropic/claude-sonnet-4-6",
+        fallbackStepToModel: "anthropic/claude-sonnet-4-5",
+      },
+    });
+    registeredListener?.({
+      runId: "run-local-fallback",
+      stream: "assistant",
+      data: { text: "fallback answer", delta: "fallback answer" },
+    });
+    registeredListener?.({
+      runId: "run-local-fallback",
+      stream: "lifecycle",
+      data: { phase: "end", stopReason: "stop" },
+    });
+
+    pending.resolve({ payloads: [{ text: "fallback answer" }], meta: {} });
+    await flushMicrotasks();
+    vi.advanceTimersByTime(15_001);
+
+    const chatPayloads = events
+      .filter((entry) => entry.event === "chat")
+      .map((entry) => entry.payload as { state?: string; message?: { content?: unknown } });
+    expect(chatPayloads.some((payload) => payload.state === "error")).toBe(false);
+    expect(chatPayloads.at(-1)).toMatchObject({
+      state: "final",
+      message: {
+        content: [{ text: "fallback answer" }],
+      },
+    });
+  });
+
   it("emits side-result events for local /btw runs", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     agentCommandFromIngressMock.mockResolvedValueOnce({

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -66,6 +66,8 @@ type LocalRunState = {
   registered: boolean;
 };
 
+const LIFECYCLE_ERROR_RETRY_GRACE_MS = 15_000;
+
 const silentRuntime = {
   log: (..._args: unknown[]) => undefined,
   error: (..._args: unknown[]) => undefined,
@@ -118,6 +120,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
   private previousRuntimeLog?: typeof defaultRuntime.log;
   private previousRuntimeError?: typeof defaultRuntime.error;
   private seq = 0;
+  private readonly pendingLifecycleErrors = new Map<string, ReturnType<typeof setTimeout>>();
 
   start() {
     if (this.unsubscribe) {
@@ -144,6 +147,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     for (const run of this.runs.values()) {
       run.controller.abort();
     }
+    this.clearPendingLifecycleErrors();
     this.runs.clear();
     defaultRuntime.log = this.previousRuntimeLog ?? defaultRuntime.log;
     defaultRuntime.error = this.previousRuntimeError ?? defaultRuntime.error;
@@ -358,6 +362,32 @@ export class EmbeddedTuiBackend implements TuiBackend {
     });
   }
 
+  private clearPendingLifecycleError(runId: string) {
+    const pending = this.pendingLifecycleErrors.get(runId);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending);
+    this.pendingLifecycleErrors.delete(runId);
+  }
+
+  private clearPendingLifecycleErrors() {
+    for (const pending of this.pendingLifecycleErrors.values()) {
+      clearTimeout(pending);
+    }
+    this.pendingLifecycleErrors.clear();
+  }
+
+  private scheduleChatError(runId: string, run: LocalRunState, errorMessage?: string) {
+    this.clearPendingLifecycleError(runId);
+    const timer = setTimeout(() => {
+      this.pendingLifecycleErrors.delete(runId);
+      this.emitChatError(runId, run, errorMessage);
+    }, LIFECYCLE_ERROR_RETRY_GRACE_MS);
+    timer.unref?.();
+    this.pendingLifecycleErrors.set(runId, timer);
+  }
+
   private emitChatDelta(runId: string, run: LocalRunState) {
     const projected = projectLiveAssistantBufferedText(run.buffer.trim(), {
       suppressLeadFragments: true,
@@ -380,6 +410,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
   }
 
   private emitChatFinal(runId: string, run: LocalRunState, stopReason?: string) {
+    this.clearPendingLifecycleError(runId);
     if (run.finalSent) {
       return;
     }
@@ -408,6 +439,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
   }
 
   private emitChatAborted(runId: string, run: LocalRunState) {
+    this.clearPendingLifecycleError(runId);
     if (run.finalSent) {
       return;
     }
@@ -421,6 +453,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
   }
 
   private emitChatError(runId: string, run: LocalRunState, errorMessage?: string) {
+    this.clearPendingLifecycleError(runId);
     if (run.finalSent) {
       return;
     }
@@ -457,6 +490,12 @@ export class EmbeddedTuiBackend implements TuiBackend {
       return;
     }
 
+    const lifecyclePhase =
+      evt.stream === "lifecycle" && typeof evt.data?.phase === "string" ? evt.data.phase : "";
+    if (evt.stream !== "lifecycle" || lifecyclePhase !== "error") {
+      this.clearPendingLifecycleError(evt.runId);
+    }
+
     if (evt.stream !== "assistant") {
       this.ensureRunRegistered(evt.runId, run);
     }
@@ -490,7 +529,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       return;
     }
 
-    const phase = typeof evt.data?.phase === "string" ? evt.data.phase : "";
+    const phase = lifecyclePhase;
     const aborted = evt.data?.aborted === true || run.controller.signal.aborted;
     if (phase === "end") {
       if (aborted) {
@@ -511,7 +550,8 @@ export class EmbeddedTuiBackend implements TuiBackend {
         return;
       }
       const errorMessage = typeof evt.data?.error === "string" ? evt.data.error : undefined;
-      this.emitChatError(evt.runId, run, errorMessage);
+      run.buffer = "";
+      this.scheduleChatError(evt.runId, run, errorMessage);
     }
   }
 


### PR DESCRIPTION
## Summary
- Land #80009 from @TurboTheTurtle on a maintainer-owned branch because the source fork has `maintainerCanModify=false`.
- Emit fallback progress from auto-reply and keep embedded TUI lifecycle errors non-terminal long enough for fallback recovery to deliver the answer.
- Add the release-note attribution for the user-facing fallback delivery fix.

Fixes #80000.
Supersedes #80009.

## Real behavior proof

Behavior or issue addressed:
A primary model timeout/error for one attempt should not finalize an embedded TUI/WebChat run while model fallback for the same run can still recover. The after-fix behavior is that fallback progress keeps the run non-terminal and the fallback answer is delivered to the user-facing chat stream.

Real environment tested:
Local OpenClaw source checkout on macOS with Node/pnpm, running the real embedded TUI backend event handling and auto-reply fallback execution code paths from this PR branch after rebasing onto current `origin/main`.

Exact steps or command run after this patch:
1. Ran `pnpm test src/tui/embedded-backend.test.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`.
2. Ran `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/tui/embedded-backend.ts src/tui/embedded-backend.test.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`.
3. Ran `pnpm check:architecture`.
4. Ran `git diff --check`.
5. Ran `OPENCLAW_TESTBOX_ID=tbx_01kr7rt3by6hnzfa560j3tnjhy pnpm check:changed --base origin/main`.

Evidence after fix:
Copied local/Testbox terminal results from the after-fix OpenClaw proof run:

```text
pnpm test src/tui/embedded-backend.test.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts

Test Files  1 passed (1)
     Tests  9 passed (9)

Test Files  1 passed (1)
     Tests  33 passed (33)

[test] passed 2 Vitest shards in 11.29s

pnpm check:architecture
Import cycle check: 0 runtime value cycle(s).
Madge import cycle check: 0 cycle(s).
deprecated API usage guard passed
deprecated JSDoc guard passed

pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/tui/embedded-backend.ts src/tui/embedded-backend.test.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
All matched files use the correct format.

git diff --check
passed

OPENCLAW_TESTBOX_ID=tbx_01kr7rt3by6hnzfa560j3tnjhy pnpm check:changed --base origin/main
passed in Testbox; lanes: core, coreTests, extensions, extensionTests, docs, tooling
```

Captured event sequence from the embedded TUI fallback-delivery proof run in the regression test:

```text
lifecycle:error primary model timed out
lifecycle:fallback_step succeeded anthropic/claude-sonnet-4-6 -> anthropic/claude-sonnet-4-5
assistant fallback answer
lifecycle:end
embedded-tui chat:error emitted: no
final chat payload: fallback answer
```

Observed result after fix:
The fallback step arrives after the primary timeout/error lifecycle event and before terminal handling. Embedded TUI does not emit a terminal chat error after the 15s grace period, and the final chat payload contains the fallback answer.

What was not tested:
No hosted-provider long-timeout run, browser WebChat recording, or live external-model session was captured in this local environment. The proof above exercises the OpenClaw embedded TUI and reply-runner runtime paths locally with controlled fallback behavior so private provider credentials and long external timeouts are not required.

## Verification
- `pnpm test src/tui/embedded-backend.test.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts` -> 2 shards passed, 42 tests passed
- `pnpm check:architecture` -> passed
- `pnpm exec oxfmt --check --threads=1 ...` -> passed
- `git diff --check` -> passed
- `OPENCLAW_TESTBOX_ID=tbx_01kr7rt3by6hnzfa560j3tnjhy pnpm check:changed --base origin/main` -> passed in Testbox; lanes: core, coreTests, extensions, extensionTests, docs, tooling

Thanks @TurboTheTurtle.
