### PR TITLE
fix: canonicalize embedded reply payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Browser: wait longer for existing-session Chrome MCP status and non-deep doctor probes so slow first attaches do not falsely report offline while keeping raw CDP status probes short. (#77473) Thanks @rubencu.
 - Exec approvals: keep `exec.approval.list` on the lightweight policy-summary path so listing pending approvals no longer loads the rich tree-sitter command explainer. (#76943) Thanks @rubencu.
 - Agents: surface concise default-visible warnings when `exec`/`bash` tool calls fail after the assistant claims success, while keeping raw stderr hidden unless verbose details are enabled. Fixes #60497. (#80003) Thanks @jbetala7.
+- Agents/Telegram: deliver the canonical final assistant answer instead of replaying accumulated pre-tool text blocks, preventing duplicate Telegram replies and raw-looking tool-output fragments from leaking into chat delivery. Fixes #79621 and #79986. Thanks @nonzeroclaw and @dudaefj.
 - Auto-reply/TUI: keep fallback timeout recovery deliverable after a primary model lifecycle error by emitting fallback progress and deferring terminal TUI errors until recovery has a chance to finish. Fixes #80000. (#80009) Thanks @TurboTheTurtle.
 - CLI/agent: let `openclaw agent --model` use the backend/admin Gateway scope without cached device-token scopes silently downscoping the request. (#78837) Thanks @VACInc.
 - CLI/help: keep help and version invocations configless while improving shared port, channel, plugin, task, session, message, pairing, and auth recovery text.

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -1099,7 +1099,7 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     // When the model successfully produces post-tool text, lastAssistant has
     // stopReason=end_turn. The incomplete-turn guard should not fire.
     const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 2,
+      payloadCount: 1,
       aborted: false,
       timedOut: false,
       attempt: makeAttemptResult({

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -88,6 +88,81 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expectSinglePayloadText(payloads, "Fixed.");
   });
 
+  it("delivers only the final assistant answer when accumulated text includes pre-tool progress", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["I'll inspect that first.", "Done."],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          {
+            type: "text",
+            text: "Done.",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "item_final",
+              phase: "final_answer",
+            }),
+          },
+        ],
+      } as AssistantMessage,
+    });
+
+    expectSinglePayloadText(payloads, "Done.");
+  });
+
+  it("does not replay raw-looking accumulated tool output when final answer text is available", () => {
+    const payloads = buildPayloads({
+      assistantTexts: [
+        "/root/openclaw/src/gateway/protocol/schema/protocol-schemas.ts:181:  PluginControlUiDescriptorSchema,",
+        "The schema export is fixed.",
+      ],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          {
+            type: "text",
+            text: "The schema export is fixed.",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "item_final",
+              phase: "final_answer",
+            }),
+          },
+        ],
+      } as AssistantMessage,
+    });
+
+    expectSinglePayloadText(payloads, "The schema export is fixed.");
+  });
+
+  it("ignores accumulated internal/status text after the final answer", () => {
+    const payloads = buildPayloads({
+      assistantTexts: [
+        "Done.",
+        "Background task done: Context engine turn maintenance. Rewrote 0 transcript entries and freed 0 bytes.",
+      ],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          {
+            type: "text",
+            text: "Done.",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "item_final",
+              phase: "final_answer",
+            }),
+          },
+        ],
+      } as AssistantMessage,
+    });
+
+    expectSinglePayloadText(payloads, "Done.");
+  });
+
   it("surfaces concise exec tool errors when verbose mode is off", () => {
     const payloads = buildPayloads({
       lastToolError: { toolName: "exec", error: "command failed" },
@@ -260,6 +335,32 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
   it("preserves media directives when stored assistant text was reduced to visible text only", () => {
     const payloads = buildPayloads({
       assistantTexts: ["Attached image"],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          {
+            type: "text",
+            text: "MEDIA:/tmp/reply-image.png\nAttached image",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "item_final",
+              phase: "final_answer",
+            }),
+          },
+        ],
+      } as AssistantMessage,
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Attached image");
+    expect(payloads[0]?.mediaUrl).toBe("/tmp/reply-image.png");
+    expect(payloads[0]?.mediaUrls).toEqual(["/tmp/reply-image.png"]);
+  });
+
+  it("keeps media directives when collapsing accumulated pre-tool text to the final answer", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Preparing the image...", "Attached image"],
       lastAssistant: {
         role: "assistant",
         stopReason: "stop",

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -108,6 +108,10 @@ function resolveRawAssistantAnswerText(lastAssistant: AssistantMessage | undefin
   );
 }
 
+function normalizeReplyTextForComparison(text: string): string {
+  return normalizeTextForComparison(parseReplyDirectives(text).text ?? "");
+}
+
 function shouldIncludeToolErrorDetails(params: {
   lastToolError: ToolErrorSummary;
   isCronTrigger?: boolean;
@@ -357,16 +361,27 @@ export function buildEmbeddedRunPayloads(params: {
       (!assistantTextsHaveMedia &&
         normalizedAssistantTexts.length > 0 &&
         normalizedAssistantTexts === normalizedRawAnswerText));
+  const fallbackAnswerSourceText =
+    shouldPreferRawAnswerText && fallbackRawAnswerText ? fallbackRawAnswerText : fallbackAnswerText;
+  const normalizedFallbackAnswerSourceText = fallbackAnswerSourceText
+    ? normalizeReplyTextForComparison(fallbackAnswerSourceText)
+    : "";
+  const shouldUseCanonicalFinalAnswer =
+    nonEmptyAssistantTexts.length > 1 &&
+    fallbackAnswerSourceText.length > 0 &&
+    normalizedFallbackAnswerSourceText.length > 0;
   const hasAssistantTextPayload = nonEmptyAssistantTexts.length > 0;
   const answerTexts = suppressAssistantArtifacts
     ? []
-    : (shouldPreferRawAnswerText && fallbackRawAnswerText
-        ? [fallbackRawAnswerText]
-        : hasAssistantTextPayload
-          ? nonEmptyAssistantTexts
-          : fallbackAnswerText
-            ? [fallbackAnswerText]
-            : []
+    : (shouldUseCanonicalFinalAnswer
+        ? [fallbackAnswerSourceText]
+        : shouldPreferRawAnswerText && fallbackRawAnswerText
+          ? [fallbackRawAnswerText]
+          : hasAssistantTextPayload
+            ? nonEmptyAssistantTexts
+            : fallbackAnswerText
+              ? [fallbackAnswerText]
+              : []
       ).filter((text) => !shouldSuppressRawErrorText(text));
 
   let hasUserFacingAssistantReply = false;


### PR DESCRIPTION
## Summary

- Fixes the embedded runner payload boundary so final chat delivery uses the canonical final assistant answer when accumulated assistant text also contains pre-tool progress, internal/status text, or raw-looking tool output.
- Preserves raw final reply directives when they carry media/audio metadata, so canonicalization does not drop attachments.
- Adds regressions for Telegram-visible duplicate/progress replay, raw path-like output replay, trailing context-maintenance status text, and media directive preservation.
- Updates the incomplete-turn guard expectation now that a completed tool-use turn emits one canonical final payload.

## Real behavior proof

- Behavior or issue addressed: one assistant turn could produce multiple Telegram-visible replies because accumulated `assistantTexts` entries were emitted as separate final payloads; this covers #79621 duplicate replies and the #79986 raw path/status leakage shape.
- Real environment tested: local OpenClaw source checkout on macOS arm64, Node 22 via repo `node --import tsx`, branch `codex/chat-delivery-hygiene` at `23214e22bd1d6cdb7635ae1f4ebd818352468662`.
- Exact steps or command run after this patch: `node --import tsx -e 'import { buildEmbeddedRunPayloads } from "./src/agents/pi-embedded-runner/run/payloads.ts"; const payloads = buildEmbeddedRunPayloads({ assistantTexts:["Done.", "Background task done: Context engine turn maintenance. Rewrote 0 transcript entries and freed 0 bytes."], toolMetas:[], lastAssistant:{ role:"assistant", stopReason:"stop", content:[{ type:"text", text:"Done." }] }, sessionKey:"session:telegram", inlineToolResultsAllowed:false, verboseLevel:"off", reasoningLevel:"off", toolResultFormat:"plain" }); console.log(JSON.stringify(payloads));'`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): console output: `[ { "text": "Done.", "replyToTag": false, "audioAsVoice": false } ]` (JSON minified by the command as `[{"text":"Done.","replyToTag":false,"audioAsVoice":false}]`).
- Observed result after fix: the accumulated internal/status text is not emitted as a second payload; the same helper also returns one final payload for the raw `/root/openclaw/...protocol-schemas.ts:181...` repro shape.
- What was not tested: live Telegram Bot API delivery from a real chat, because the shared payload helper now proves the channel-facing payload list before Telegram transport receives it.
- Before evidence (optional but encouraged): before the patch, the same helper returned one payload per accumulated `assistantTexts` entry, which would hand Telegram two final sends for the status-text repro and two final sends for the raw path-like repro.

## Root Cause

`buildEmbeddedRunPayloads` treated every non-empty `assistantTexts` entry as a separately deliverable final reply. The subscriber intentionally accumulates intermediate assistant text for streaming/block-reply bookkeeping, and Telegram then delivered each entry as its own outbound message. That made pre-tool progress, internal maintenance/status strings, or raw-looking subagent/tool fragments visible as duplicate Telegram replies.

## What Went Well

- The best fix was at the shared payload-selection boundary, not in Telegram-specific regex/dedupe logic. That makes the behavior consistent for all final delivery surfaces while keeping Telegram adapters focused on transport.
- The existing final-answer extraction and reply-directive parser already gave us a trustworthy canonical source; the patch reuses those contracts instead of adding a downstream filter.
- The #80003 exec-failure warning path remains intact: failed mutating tools still get a concise visible warning when the final assistant answer claims success, but raw stderr stays hidden unless verbose details are enabled.
- The #80021 draft pointed at the visible symptom, but the stronger upstream fix avoids over-deduping successful media sends or recording delivery attempts before transport success.

## Verification

- `pnpm docs:list`
- `pnpm test src/agents/pi-embedded-runner/run/payloads.test.ts src/agents/pi-embedded-runner/run.incomplete-turn.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.does-not-append-text-end-content-is.test.ts`
- `pnpm test:changed`
- `git diff --check`
- Testbox `pnpm check:changed` on `tbx_01kr7yhs5tfp3xxk4cp7f73rfc`
- Manual `node --import tsx` repro: raw path/status accumulated text now produces one final payload

Fixes #79621.
Fixes #79986.
