### PR TITLE
[codex] route Kimi thinking through OpenAI stream

### DIFF
--- a/extensions/kimi-coding/implicit-provider.test.ts
+++ b/extensions/kimi-coding/implicit-provider.test.ts
@@ -49,12 +49,12 @@ describe("Kimi implicit provider (#22409)", () => {
 
     expect(provider).toMatchObject({
       apiKey: "test-key",
-      baseUrl: "https://api.kimi.com/coding/",
-      api: "anthropic-messages",
+      baseUrl: "https://api.kimi.com/coding/v1",
+      api: "openai-completions",
     });
   });
 
-  it("uses explicit legacy kimi-coding baseUrl when provided", async () => {
+  it("migrates explicit legacy kimi-coding baseUrl to the OpenAI-compatible route", async () => {
     const provider = await runKimiCatalogProvider({
       apiKey: "test-key",
       explicitProvider: {
@@ -62,7 +62,7 @@ describe("Kimi implicit provider (#22409)", () => {
       },
     });
 
-    expect(provider.baseUrl).toBe("https://kimi.example.test/coding/");
+    expect(provider.baseUrl).toBe("https://kimi.example.test/coding/v1");
   });
 
   it("merges explicit legacy kimi-coding headers on top of the built-in user agent", async () => {

--- a/extensions/kimi-coding/index.test.ts
+++ b/extensions/kimi-coding/index.test.ts
@@ -14,13 +14,13 @@ describe("kimi provider plugin", () => {
           id: "kimi-code",
           name: "Kimi Code",
           provider: "kimi",
-          api: "anthropic-messages",
+          api: "openai-completions",
         },
       } as never),
     ).toMatchObject({ id: "kimi-for-coding" });
   });
 
-  it("uses binary thinking with thinking off by default", async () => {
+  it("exposes Kimi as binary thinking with default off", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
 
     expect(

--- a/extensions/kimi-coding/index.ts
+++ b/extensions/kimi-coding/index.ts
@@ -4,9 +4,14 @@ import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import type { SecretInput } from "openclaw/plugin-sdk/secret-input";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { applyKimiCodeConfig, KIMI_CODING_MODEL_REF } from "./onboard.js";
-import { buildKimiCodingProvider, normalizeKimiCodingModelId } from "./provider-catalog.js";
+import {
+  buildKimiCodingProvider,
+  normalizeKimiCodingBaseUrl,
+  normalizeKimiCodingModelId,
+} from "./provider-catalog.js";
 import { KIMI_REPLAY_POLICY } from "./replay-policy.js";
 import { wrapKimiProviderStream } from "./stream.js";
+import { resolveKimiThinkingProfile } from "./thinking-policy.js";
 
 const PLUGIN_ID = "kimi";
 const PROVIDER_ID = "kimi";
@@ -81,7 +86,7 @@ export default definePluginEntry({
           return {
             provider: {
               ...builtInProvider,
-              ...(explicitBaseUrl ? { baseUrl: explicitBaseUrl } : {}),
+              ...(explicitBaseUrl ? { baseUrl: normalizeKimiCodingBaseUrl(explicitBaseUrl) } : {}),
               ...(explicitHeaders
                 ? {
                     headers: {
@@ -100,13 +105,7 @@ export default definePluginEntry({
         const normalizedId = normalizeKimiCodingModelId(model.id);
         return normalizedId === model.id ? undefined : { ...model, id: normalizedId };
       },
-      resolveThinkingProfile: () => ({
-        levels: [
-          { id: "off", label: "off" },
-          { id: "low", label: "on" },
-        ],
-        defaultLevel: "off",
-      }),
+      resolveThinkingProfile: resolveKimiThinkingProfile,
       wrapStreamFn: wrapKimiProviderStream,
     });
   },

--- a/extensions/kimi-coding/onboard.test.ts
+++ b/extensions/kimi-coding/onboard.test.ts
@@ -18,8 +18,8 @@ describe("kimi coding onboard", () => {
     const provider = cfg.models?.providers?.kimi;
 
     expect(provider).toMatchObject({
-      api: "anthropic-messages",
-      baseUrl: "https://api.kimi.com/coding/",
+      api: "openai-completions",
+      baseUrl: "https://api.kimi.com/coding/v1",
     });
     expect(provider?.models?.map((model) => model.id)).toEqual(["kimi-for-coding"]);
     expect(cfg.agents?.defaults?.models?.[KIMI_MODEL_REF]?.alias).toBe("Kimi");

--- a/extensions/kimi-coding/onboard.ts
+++ b/extensions/kimi-coding/onboard.ts
@@ -24,7 +24,7 @@ const kimiCodingPresetAppliers = createDefaultModelPresetAppliers({
     }
     return {
       providerId: "kimi",
-      api: "anthropic-messages",
+      api: "openai-completions",
       baseUrl: KIMI_CODING_BASE_URL,
       defaultModel,
       defaultModelId: KIMI_CODING_DEFAULT_MODEL_ID,

--- a/extensions/kimi-coding/provider-catalog.test.ts
+++ b/extensions/kimi-coding/provider-catalog.test.ts
@@ -5,9 +5,18 @@ describe("kimi provider catalog", () => {
   it("builds the bundled Kimi coding defaults", () => {
     const provider = buildKimiCodingProvider();
 
-    expect(provider.api).toBe("anthropic-messages");
-    expect(provider.baseUrl).toBe("https://api.kimi.com/coding/");
+    expect(provider.api).toBe("openai-completions");
+    expect(provider.baseUrl).toBe("https://api.kimi.com/coding/v1");
     expect(provider.headers).toEqual({ "User-Agent": "claude-code/0.1.0" });
+    expect(provider.models[0]?.compat).toMatchObject({
+      maxTokensField: "max_tokens",
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      supportsStore: false,
+      supportsStrictMode: false,
+      supportsUsageInStreaming: true,
+      thinkingFormat: "openai",
+    });
     expect(provider.models.map((model) => model.id)).toEqual([
       "kimi-for-coding",
       "kimi-code",

--- a/extensions/kimi-coding/provider-catalog.ts
+++ b/extensions/kimi-coding/provider-catalog.ts
@@ -3,7 +3,7 @@ import type {
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
 
-const KIMI_BASE_URL = "https://api.kimi.com/coding/";
+const KIMI_BASE_URL = "https://api.kimi.com/coding/v1";
 const KIMI_CODING_USER_AGENT = "claude-code/0.1.0";
 const KIMI_DEFAULT_MODEL_ID = "kimi-for-coding";
 const KIMI_LEGACY_MODEL_IDS = ["kimi-code", "k2p5"] as const;
@@ -16,11 +16,20 @@ const KIMI_CODING_DEFAULT_COST = {
   cacheWrite: 0,
 };
 const KIMI_CODING_INPUT = ["text", "image"] satisfies NonNullable<ModelDefinitionConfig["input"]>;
+const KIMI_OPENAI_COMPAT = {
+  maxTokensField: "max_tokens",
+  supportsDeveloperRole: false,
+  supportsReasoningEffort: false,
+  supportsStore: false,
+  supportsStrictMode: false,
+  supportsUsageInStreaming: true,
+  thinkingFormat: "openai",
+} satisfies NonNullable<ModelDefinitionConfig["compat"]>;
 
 export function buildKimiCodingProvider(): ModelProviderConfig {
   return {
     baseUrl: KIMI_BASE_URL,
-    api: "anthropic-messages",
+    api: "openai-completions",
     headers: {
       "User-Agent": KIMI_CODING_USER_AGENT,
     },
@@ -33,6 +42,7 @@ export function buildKimiCodingProvider(): ModelProviderConfig {
         cost: KIMI_CODING_DEFAULT_COST,
         contextWindow: KIMI_CODING_DEFAULT_CONTEXT_WINDOW,
         maxTokens: KIMI_CODING_DEFAULT_MAX_TOKENS,
+        compat: { ...KIMI_OPENAI_COMPAT },
       },
       ...KIMI_LEGACY_MODEL_IDS.map((id) => ({
         id,
@@ -42,6 +52,7 @@ export function buildKimiCodingProvider(): ModelProviderConfig {
         cost: KIMI_CODING_DEFAULT_COST,
         contextWindow: KIMI_CODING_DEFAULT_CONTEXT_WINDOW,
         maxTokens: KIMI_CODING_DEFAULT_MAX_TOKENS,
+        compat: { ...KIMI_OPENAI_COMPAT },
       })),
     ],
   };
@@ -56,3 +67,15 @@ export function normalizeKimiCodingModelId(modelId: string): string {
 export const KIMI_CODING_BASE_URL = KIMI_BASE_URL;
 export const KIMI_CODING_DEFAULT_MODEL_ID = KIMI_DEFAULT_MODEL_ID;
 export const KIMI_CODING_LEGACY_MODEL_IDS = KIMI_LEGACY_MODEL_IDS;
+
+export function normalizeKimiCodingBaseUrl(baseUrl: string): string {
+  const trimmed = baseUrl.trim();
+  if (!trimmed) {
+    return KIMI_BASE_URL;
+  }
+  const withoutTrailingSlash = trimmed.replace(/\/+$/, "");
+  if (withoutTrailingSlash.endsWith("/coding")) {
+    return `${withoutTrailingSlash}/v1`;
+  }
+  return withoutTrailingSlash;
+}

--- a/extensions/kimi-coding/provider-policy-api.test.ts
+++ b/extensions/kimi-coding/provider-policy-api.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { resolveThinkingProfile } from "./provider-policy-api.js";
+
+describe("kimi provider-policy-api", () => {
+  it("advertises Kimi as binary thinking outside the runtime plugin registry", () => {
+    expect(resolveThinkingProfile()).toEqual({
+      levels: [
+        { id: "off", label: "off" },
+        { id: "low", label: "on" },
+      ],
+      defaultLevel: "off",
+    });
+  });
+});

--- a/extensions/kimi-coding/provider-policy-api.ts
+++ b/extensions/kimi-coding/provider-policy-api.ts
@@ -1,0 +1,5 @@
+import { resolveKimiThinkingProfile } from "./thinking-policy.js";
+
+export function resolveThinkingProfile() {
+  return resolveKimiThinkingProfile();
+}

--- a/extensions/kimi-coding/stream.test.ts
+++ b/extensions/kimi-coding/stream.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   createKimiThinkingWrapper,
   createKimiToolCallMarkupWrapper,
+  resolveKimiThinkingConfig,
   resolveKimiThinkingType,
   wrapKimiProviderStream,
 } from "./stream.js";
@@ -83,7 +84,7 @@ function createPayloadCapturingStream(initialPayload: Record<string, unknown> = 
 }
 
 describe("kimi tool-call markup wrapper", () => {
-  it("defaults Kimi thinking to disabled unless explicitly enabled", () => {
+  it("maps OpenClaw thinking levels to Kimi binary thinking", () => {
     expect(resolveKimiThinkingType({ configuredThinking: undefined })).toBe("disabled");
     expect(resolveKimiThinkingType({ configuredThinking: undefined, thinkingLevel: "high" })).toBe(
       "enabled",
@@ -281,6 +282,40 @@ describe("kimi tool-call markup wrapper", () => {
     });
   });
 
+  it("enables Kimi thinking through an explicit wrapper flag without inventing a budget", () => {
+    const { streamFn: baseStreamFn, getCapturedPayload } = createPayloadCapturingStream();
+
+    const wrapped = createKimiThinkingWrapper(baseStreamFn, "enabled");
+    void wrapped(
+      {
+        api: "anthropic-messages",
+        provider: "kimi",
+        id: "kimi-code",
+      } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(getCapturedPayload()).toEqual({
+      thinking: { type: "enabled" },
+    });
+  });
+
+  it("enables Kimi thinking for non-off OpenClaw thinking levels", () => {
+    const cases = ["minimal", "low", "medium", "adaptive", "high", "xhigh", "max"] as const;
+
+    for (const thinkingLevel of cases) {
+      expect(
+        resolveKimiThinkingConfig({
+          configuredThinking: undefined,
+          thinkingLevel,
+        }),
+      ).toEqual({
+        type: "enabled",
+      });
+    }
+  });
+
   it("lets explicit model params keep Kimi thinking disabled even when session thinking is on", () => {
     const { streamFn: baseStreamFn, getCapturedPayload } = createPayloadCapturingStream();
 
@@ -288,6 +323,32 @@ describe("kimi tool-call markup wrapper", () => {
       provider: "kimi",
       modelId: "kimi-code",
       extraParams: { thinking: "off" },
+      thinkingLevel: "high",
+      streamFn: baseStreamFn,
+    } as never);
+
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "kimi",
+        id: "kimi-code",
+      } as Model<"openai-completions">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(getCapturedPayload()).toEqual({
+      thinking: { type: "disabled" },
+    });
+  });
+
+  it("enables Kimi thinking when explicitly requested by model params", () => {
+    const { streamFn: baseStreamFn, getCapturedPayload } = createPayloadCapturingStream();
+
+    const wrapped = wrapKimiProviderStream({
+      provider: "kimi",
+      modelId: "kimi-code",
+      extraParams: { thinking: { type: "enabled", budget_tokens: 4096 } },
       thinkingLevel: "high",
       streamFn: baseStreamFn,
     } as never);
@@ -303,11 +364,11 @@ describe("kimi tool-call markup wrapper", () => {
     );
 
     expect(getCapturedPayload()).toEqual({
-      thinking: { type: "disabled" },
+      thinking: { type: "enabled" },
     });
   });
 
-  it("enables Kimi thinking only when explicitly requested", () => {
+  it("enables Kimi thinking for generic session thinking levels", () => {
     const { streamFn: baseStreamFn, getCapturedPayload } = createPayloadCapturingStream();
 
     const wrapped = wrapKimiProviderStream({
@@ -319,10 +380,10 @@ describe("kimi tool-call markup wrapper", () => {
 
     void wrapped(
       {
-        api: "anthropic-messages",
+        api: "openai-completions",
         provider: "kimi",
         id: "kimi-code",
-      } as Model<"anthropic-messages">,
+      } as Model<"openai-completions">,
       { messages: [] } as Context,
       {},
     );

--- a/extensions/kimi-coding/stream.ts
+++ b/extensions/kimi-coding/stream.ts
@@ -18,6 +18,9 @@ type KimiToolCallBlock = {
 };
 
 type KimiThinkingType = "enabled" | "disabled";
+type KimiThinkingConfig = {
+  type: KimiThinkingType;
+};
 type KimiThinkingLevel =
   | "off"
   | "minimal"
@@ -51,18 +54,47 @@ function normalizeKimiThinkingType(value: unknown): KimiThinkingType | undefined
   return undefined;
 }
 
+function normalizeKimiThinkingConfig(
+  thinkingConfig: KimiThinkingConfig | KimiThinkingType,
+): KimiThinkingConfig {
+  if (typeof thinkingConfig !== "string") {
+    if (thinkingConfig.type === "disabled") {
+      return { type: "disabled" };
+    }
+    return { type: "enabled" };
+  }
+  if (thinkingConfig === "disabled") {
+    return { type: "disabled" };
+  }
+  return { type: "enabled" };
+}
+
+export function resolveKimiThinkingConfig(params: {
+  configuredThinking: unknown;
+  thinkingLevel?: KimiThinkingLevel;
+}): KimiThinkingConfig {
+  const configured = normalizeKimiThinkingType(params.configuredThinking);
+  if (configured === "disabled") {
+    return { type: "disabled" };
+  }
+  if (configured === "enabled") {
+    return { type: "enabled" };
+  }
+  if (!params.thinkingLevel || params.thinkingLevel === "off") {
+    return { type: "disabled" };
+  }
+  // Kimi's OpenAI-compatible coding endpoint supports binary thinking only.
+  // OpenClaw effort levels therefore map to enabled/disabled without budgets.
+  // The OpenAI stream adapter consumes Kimi's reasoning_content deltas as
+  // thinking activity, so long thinking no longer trips the idle watchdog.
+  return { type: "enabled" };
+}
+
 export function resolveKimiThinkingType(params: {
   configuredThinking: unknown;
   thinkingLevel?: KimiThinkingLevel;
 }): KimiThinkingType {
-  const configured = normalizeKimiThinkingType(params.configuredThinking);
-  if (configured) {
-    return configured;
-  }
-  if (!params.thinkingLevel || params.thinkingLevel === "off") {
-    return "disabled";
-  }
-  return "enabled";
+  return resolveKimiThinkingConfig(params).type;
 }
 
 function stripTaggedToolCallCounter(value: string): string {
@@ -232,12 +264,12 @@ export function createKimiToolCallMarkupWrapper(baseStreamFn: StreamFn | undefin
 
 export function createKimiThinkingWrapper(
   baseStreamFn: StreamFn | undefined,
-  thinkingType: KimiThinkingType,
+  thinkingConfig: KimiThinkingConfig | KimiThinkingType,
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) =>
     streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {
-      payloadObj.thinking = { type: thinkingType };
+      payloadObj.thinking = normalizeKimiThinkingConfig(thinkingConfig);
       delete payloadObj.reasoning;
       delete payloadObj.reasoning_effort;
       delete payloadObj.reasoningEffort;
@@ -245,9 +277,9 @@ export function createKimiThinkingWrapper(
 }
 
 export function wrapKimiProviderStream(ctx: ProviderWrapStreamFnContext): StreamFn {
-  const thinkingType = resolveKimiThinkingType({
+  const thinkingConfig = resolveKimiThinkingConfig({
     configuredThinking: ctx.extraParams?.thinking,
     thinkingLevel: ctx.thinkingLevel,
   });
-  return createKimiToolCallMarkupWrapper(createKimiThinkingWrapper(ctx.streamFn, thinkingType));
+  return createKimiToolCallMarkupWrapper(createKimiThinkingWrapper(ctx.streamFn, thinkingConfig));
 }

--- a/extensions/kimi-coding/thinking-policy.ts
+++ b/extensions/kimi-coding/thinking-policy.ts
@@ -1,0 +1,11 @@
+import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
+
+export function resolveKimiThinkingProfile(): ProviderThinkingProfile {
+  return {
+    levels: [
+      { id: "off", label: "off" },
+      { id: "low", label: "on" },
+    ],
+    defaultLevel: "off",
+  };
+}

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -302,6 +302,7 @@ describe("capability cli", () => {
     mocks.runtime.log.mockClear();
     mocks.runtime.error.mockClear();
     mocks.runtime.writeJson.mockClear();
+    mocks.loadConfig.mockReset().mockReturnValue({});
     mocks.loadModelCatalog
       .mockReset()
       .mockResolvedValue([{ id: "gpt-5.4", provider: "openai", name: "GPT-5.4" }] as never);
@@ -635,6 +636,50 @@ describe("capability cli", () => {
     });
 
     expect(firstCompletionCall()?.options?.reasoning).toBe("high");
+  });
+
+  it("remaps unsupported Kimi thinking high to binary on before local model probes", async () => {
+    mocks.prepareSimpleCompletionModelForAgent.mockResolvedValueOnce({
+      selection: {
+        provider: "kimi-coding",
+        modelId: "k2p5",
+        agentDir: "/tmp/agent",
+      },
+      model: {
+        provider: "kimi",
+        id: "k2p5",
+        maxTokens: 128,
+      },
+      auth: {
+        apiKey: "sk-test",
+        source: "env:TEST_API_KEY",
+        mode: "api-key",
+      },
+    } as never);
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "model",
+        "run",
+        "--model",
+        "kimi-coding/k2p5",
+        "--prompt",
+        "hello",
+        "--thinking",
+        "high",
+        "--json",
+      ],
+    });
+
+    expect(mocks.completeWithPreparedSimpleCompletionModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          reasoning: "low",
+        }),
+      }),
+    );
   });
 
   it("passes image files to gateway model probes as attachments", async () => {
@@ -976,6 +1021,49 @@ describe("capability cli", () => {
     expect(gatewayCall?.params?.thinking).toBe("high");
     expect(gatewayCall?.params?.modelRun).toBe(true);
     expect(gatewayCall?.params?.promptMode).toBe("none");
+  });
+
+  it("remaps unsupported Kimi thinking high to binary on and provider timeout before gateway model probes", async () => {
+    mocks.loadConfig.mockReturnValue({
+      models: {
+        providers: {
+          kimi: {
+            timeoutSeconds: 300,
+          },
+        },
+      },
+    });
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "model",
+        "run",
+        "--model",
+        "kimi-coding/k2p5",
+        "--prompt",
+        "hello",
+        "--gateway",
+        "--thinking",
+        "high",
+        "--json",
+      ],
+    });
+
+    expect(mocks.callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent",
+        params: expect.objectContaining({
+          provider: "kimi-coding",
+          model: "k2p5",
+          thinking: "low",
+          modelRun: true,
+          promptMode: "none",
+        }),
+        timeoutMs: 310000,
+      }),
+    );
   });
 
   it("rejects invalid model run thinking overrides before dispatch", async () => {

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -14,11 +14,16 @@ import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import { canonicalizeCaseOnlyCatalogModelRef } from "../agents/model-selection.js";
+import { normalizeProviderId } from "../agents/provider-id.js";
 import {
   completeWithPreparedSimpleCompletionModel,
   prepareSimpleCompletionModelForAgent,
 } from "../agents/simple-completion-runtime.js";
-import { normalizeThinkLevel, type ThinkLevel } from "../auto-reply/thinking.js";
+import {
+  normalizeThinkLevel,
+  resolveSupportedThinkingLevel,
+  type ThinkLevel,
+} from "../auto-reply/thinking.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -667,6 +672,44 @@ function normalizeModelRunThinking(value: unknown): ThinkLevel | undefined {
   return normalized;
 }
 
+function resolveModelRunThinkingForProvider(params: {
+  thinking?: ThinkLevel;
+  provider?: string;
+  model?: string;
+}): ThinkLevel | undefined {
+  if (!params.thinking || !params.provider || !params.model) {
+    return params.thinking;
+  }
+  return resolveSupportedThinkingLevel({
+    provider: params.provider,
+    model: params.model,
+    level: params.thinking,
+  });
+}
+
+function resolveModelRunGatewayTimeoutMs(params: {
+  cfg: OpenClawConfig;
+  provider?: string;
+}): number {
+  const normalizedProvider = params.provider ? normalizeProviderId(params.provider) : "";
+  const providers = params.cfg.models?.providers;
+  const providerConfig =
+    normalizedProvider && providers
+      ? Object.entries(providers).find(
+          ([providerId]) => normalizeProviderId(providerId) === normalizedProvider,
+        )?.[1]
+      : undefined;
+  const timeoutSeconds = providerConfig?.timeoutSeconds;
+  if (
+    typeof timeoutSeconds !== "number" ||
+    !Number.isFinite(timeoutSeconds) ||
+    timeoutSeconds <= 0
+  ) {
+    return 120_000;
+  }
+  return Math.max(120_000, Math.floor(timeoutSeconds) * 1000 + 10_000);
+}
+
 async function runModelRun(params: {
   prompt: string;
   files?: string[];
@@ -714,6 +757,11 @@ async function runModelRun(params: {
         'The codex provider is served by the Codex app-server agent runtime, not the local simple-completion transport. Use an openai/<model> ref with agents.defaults.agentRuntime.id: "codex", run through the gateway, or use /codex commands.',
       );
     }
+    const effectiveThinking = resolveModelRunThinkingForProvider({
+      thinking: params.thinking,
+      provider: prepared.selection.provider,
+      model: prepared.selection.modelId,
+    });
     const localModelRunSystemPrompt =
       prepared.selection.provider === "openai-codex" ||
       prepared.model.api === "openai-codex-responses"
@@ -738,7 +786,7 @@ async function runModelRun(params: {
           typeof prepared.model.maxTokens === "number" && Number.isFinite(prepared.model.maxTokens)
             ? prepared.model.maxTokens
             : undefined,
-        ...(params.thinking ? { reasoning: params.thinking } : {}),
+        ...(effectiveThinking ? { reasoning: effectiveThinking } : {}),
       },
     });
     const text = collectModelRunText(result.content);
@@ -777,6 +825,12 @@ async function runModelRun(params: {
   }
 
   const { provider, model } = resolveModelRefOverride(modelRef);
+  const effectiveThinking = resolveModelRunThinkingForProvider({
+    thinking: params.thinking,
+    provider,
+    model,
+  });
+  const gatewayTimeoutMs = resolveModelRunGatewayTimeoutMs({ cfg, provider });
   // Provider/model overrides require trusted-operator scope. Use the backend
   // shared-secret lane so local gateway smokes do not depend on paired CLI device scopes.
   const hasModelOverride = Boolean(provider || model);
@@ -807,14 +861,14 @@ async function runModelRun(params: {
           : undefined,
       provider,
       model,
-      ...(params.thinking ? { thinking: params.thinking } : {}),
+      ...(effectiveThinking ? { thinking: effectiveThinking } : {}),
       modelRun: true,
       promptMode: "none",
       cleanupBundleMcpOnRunEnd: true,
       idempotencyKey: randomIdempotencyKey(),
     },
     expectFinal: true,
-    timeoutMs: 120_000,
+    timeoutMs: gatewayTimeoutMs,
     clientName: hasModelOverride ? GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT : GATEWAY_CLIENT_NAMES.CLI,
     mode: hasModelOverride ? GATEWAY_CLIENT_MODES.BACKEND : GATEWAY_CLIENT_MODES.CLI,
     ...(hasModelOverride ? { scopes: [ADMIN_SCOPE] } : {}),

--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -234,6 +234,47 @@ describe("provider public artifacts", () => {
     expect(loadPluginManifestRegistry).not.toHaveBeenCalled();
   });
 
+  it("loads provider policy aliases from the bundled plugin directory when id differs", async () => {
+    const loadBundledPluginPublicArtifactModuleSync = vi.fn(({ dirName }: { dirName: string }) => {
+      if (dirName !== "kimi-coding") {
+        throw new Error(`Unable to resolve bundled plugin public surface ${dirName}`);
+      }
+      return {
+        resolveThinkingProfile: () => ({ levels: [{ id: dirName }] }),
+      };
+    });
+    vi.doMock("./public-surface-loader.js", () => ({
+      loadBundledPluginPublicArtifactModuleSync,
+    }));
+
+    const { resolveBundledProviderPolicySurface: resolvePolicySurface } = await importFreshModule<
+      typeof import("./provider-public-artifacts.js")
+    >(import.meta.url, "./provider-public-artifacts.js?scope=provider-dir-name");
+
+    const surface = resolvePolicySurface("kimi", {
+      manifestRegistry: {
+        plugins: [
+          {
+            id: "kimi",
+            channels: [],
+            cliBackends: [],
+            hooks: [],
+            origin: "bundled",
+            manifestPath: "/tmp/kimi-coding/openclaw.plugin.json",
+            providers: ["kimi"],
+            rootDir: "/tmp/kimi-coding",
+            skills: [],
+            source: "/tmp/kimi-coding/index.js",
+          },
+        ],
+      },
+    });
+
+    expect(surface?.resolveThinkingProfile?.({ provider: "kimi", modelId: "k2p5" })).toEqual({
+      levels: [{ id: "kimi-coding" }],
+    });
+  });
+
   it("loads provider policy surfaces without package-manager repair", async () => {
     const loadBundledPluginPublicArtifactModuleSync = vi.fn(() => ({
       normalizeConfig: (ctx: { providerConfig: ModelProviderConfig }) => ctx.providerConfig,

--- a/src/plugins/provider-public-artifacts.ts
+++ b/src/plugins/provider-public-artifacts.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { normalizeProviderId } from "../agents/provider-id.js";
 import type { ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -63,7 +64,7 @@ function tryLoadBundledProviderPolicySurface(
   return null;
 }
 
-function resolveBundledProviderPolicyPluginId(
+function resolveBundledProviderPolicyPluginDirName(
   providerId: string,
   options: { manifestRegistry?: Pick<PluginManifestRegistry, "plugins"> } = {},
 ): string | null {
@@ -87,7 +88,7 @@ function resolveBundledProviderPolicyPluginId(
       (provider) => normalizeProviderId(provider) === normalizedProviderId,
     );
     if (ownsProvider) {
-      return plugin.id;
+      return path.basename(plugin.rootDir) || plugin.id;
     }
   }
 
@@ -106,9 +107,12 @@ export function resolveBundledProviderPolicySurface(
   if (directSurface) {
     return directSurface;
   }
-  const ownerPluginId = resolveBundledProviderPolicyPluginId(normalizedProviderId, options);
-  if (!ownerPluginId || ownerPluginId === normalizedProviderId) {
+  const ownerPluginDirName = resolveBundledProviderPolicyPluginDirName(
+    normalizedProviderId,
+    options,
+  );
+  if (!ownerPluginDirName || ownerPluginDirName === normalizedProviderId) {
     return null;
   }
-  return tryLoadBundledProviderPolicySurface(ownerPluginId);
+  return tryLoadBundledProviderPolicySurface(ownerPluginDirName);
 }


### PR DESCRIPTION
## Summary

- Route the bundled Kimi coding provider through Kimi's OpenAI-compatible `/coding/v1` chat-completions endpoint instead of the Anthropic-compatible `/coding/` stream.
- Keep Kimi thinking binary: `off` sends `thinking:{"type":"disabled"}`; any supported non-off OpenClaw level remaps to binary on and sends `thinking:{"type":"enabled"}` without inventing a `budget_tokens` value.
- Preserve legacy `kimi-code` / `k2p5` model ids and migrate explicit legacy `/coding/` base URLs to `/coding/v1` so existing configs do not stay on the hanging route.
- Keep the provider policy artifact lookup fix for bundled provider ids whose plugin id differs from their directory name, and keep `infer model run` thinking remap / provider timeout handling.

## Why

The beta regression came from enabling Kimi thinking on the Anthropic-compatible coding stream. Kimi thinking is emitted as OpenAI-style `reasoning_content`; the Anthropic stream path did not count that as model activity, so Slack/TUI/gateway calls could sit until the model idle timeout and then leave the session busy.

Direct live probing showed the same Kimi coding API key does work on `https://api.kimi.com/coding/v1/chat/completions` when OpenClaw sends the existing Coding-Agent user agent. That route streams `delta.reasoning_content`, and OpenClaw's OpenAI adapter already consumes `reasoning_content` as thinking activity.

Docs checked:
- https://platform.kimi.ai/docs/guide/kimi-k2-5-quickstart
- https://platform.kimi.com/docs/guide/use-kimi-k2-thinking-model

## Real behavior proof

Behavior addressed: Slack/TUI and `infer model run` could appear hung after the beta upgrade because Kimi `thinkingLevel: high` produced an enabled-thinking payload on the Anthropic-compatible stream. The model was producing OpenAI-style thinking, but that stream path did not consume it as activity.

Real environment tested: macOS local OpenClaw beta gateway, `openclaw 2026.5.9-beta.1`, LaunchAgent gateway on `127.0.0.1:18789`, patched installed beta bundle under the local nvm Node path, real Kimi coding API key from the local OpenClaw auth profile. Secrets were not printed.

Exact steps or command run after this patch: copied live terminal commands below.

```text
Direct provider probe, counting reasoning_content without printing it:
POST https://api.kimi.com/coding/v1/chat/completions
model=kimi-for-coding stream=true max_tokens=1024 thinking={"type":"enabled"}
headers include User-Agent: claude-code/0.1.0

Real OpenClaw gateway probe:
OPENCLAW_GATEWAY_PORT=18789 openclaw infer model run --gateway --model kimi/kimi-for-coding --thinking high --prompt 'Reply with exactly OK.' --json

Post-run health checks:
openclaw tasks list --status running --json
find ~/.openclaw/agents/main/sessions -maxdepth 1 -name '*.lock' -print | wc -l
```

Evidence after fix: copied live terminal output from the real local OpenClaw setup.

Direct provider probe showed OpenAI-style thinking is present and arrives before final content:

```json
{"ok":true,"status":200,"chunks":25,"reasoningChars":95,"content":"OK","firstReasoningMs":1044,"firstContentMs":1430,"ms":1431}
```

Real OpenClaw gateway output with `--thinking high`:

```json
{
  "ok": true,
  "capability": "model.run",
  "transport": "gateway",
  "provider": "kimi",
  "model": "kimi-for-coding",
  "attempts": [],
  "outputs": [
    {
      "text": "OK.",
      "mediaUrl": null
    }
  ]
}
```

Gateway/runtime status for the same setup:

```text
Gateway version: 2026.5.9-beta.1
Runtime: running (pid 77151)
Connectivity probe: ok
```

Post-run cleanup checks:

```json
{"running":0}
```

```text
0
```

Observed result after fix: `--thinking high` now remaps to Kimi binary thinking-on (`low` / label `on` in the provider profile), uses the OpenAI-compatible Kimi coding endpoint, receives `reasoning_content`, returns `OK.`, and leaves no running tasks or session lock files.

What was not tested: I did not test Slack message delivery end to end in this PR body. The real gateway transport used by Slack/TUI was tested with the live Kimi provider and the same local gateway process.

Before evidence optional: copied runtime evidence from the same real OpenClaw gateway setup before switching to the OpenAI-compatible route:

```text
2026-05-10T12:23:11.807Z stage=request provider=kimi modelId=k2p5 thinking={"type":"enabled","budget_tokens":1024}
2026-05-10T12:28:13.871Z stage=usage error="LLM idle timeout (300s): no response from model"
2026-05-10T12:28:13.991Z stage=request provider=kimi modelId=k2p5 thinking={"type":"enabled","budget_tokens":1024}
```

Operational before evidence after the client timed out:

```text
openclaw tasks list --status running --json
count: 2, both ownerKey=agent:main:main, task="Reply with exactly OK."
a follow-up thinking-off probe did not reach the provider until those runs were cancelled/restarted
```

## Validation

```text
OPENCLAW_TEST_PROJECTS_SERIAL=1 pnpm exec node scripts/test-projects.mjs extensions/kimi-coding/stream.test.ts extensions/kimi-coding/provider-catalog.test.ts extensions/kimi-coding/implicit-provider.test.ts extensions/kimi-coding/onboard.test.ts extensions/kimi-coding/provider-policy-api.test.ts extensions/kimi-coding/index.test.ts extensions/kimi-coding/replay-policy.test.ts src/plugins/provider-public-artifacts.test.ts src/cli/capability-cli.test.ts
# passed 3 Vitest shards; 9 test files, 100 tests

pnpm tsgo:core
# passed

pnpm tsgo:extensions
# passed

pnpm exec oxfmt --check --threads=1 extensions/kimi-coding/implicit-provider.test.ts extensions/kimi-coding/index.test.ts extensions/kimi-coding/index.ts extensions/kimi-coding/onboard.test.ts extensions/kimi-coding/onboard.ts extensions/kimi-coding/provider-catalog.test.ts extensions/kimi-coding/provider-catalog.ts extensions/kimi-coding/provider-policy-api.test.ts extensions/kimi-coding/stream.test.ts extensions/kimi-coding/stream.ts extensions/kimi-coding/thinking-policy.ts src/cli/capability-cli.test.ts src/cli/capability-cli.ts src/plugins/provider-public-artifacts.ts src/plugins/provider-public-artifacts.test.ts
# All matched files use the correct format.

git diff --check
# passed
```
