### PR TITLE
ci: use Node 24 for website installer sync

### DIFF
--- a/.github/workflows/website-installer-sync.yml
+++ b/.github/workflows/website-installer-sync.yml
@@ -164,6 +164,12 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Setup Node.js
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
       - name: Install ShellCheck
         if: steps.changes.outputs.changed == 'true'
         run: sudo apt-get update -y && sudo apt-get install -y shellcheck


### PR DESCRIPTION
## Summary
- set up Node 24 before verifying openclaw.ai in the website installer sync job
- keeps Astro build verification on the same supported Node line as the installer proof

## Test
- /opt/homebrew/bin/actionlint .github/workflows/website-installer-sync.yml
- pnpm exec vitest run test/scripts/website-installer-sync-workflow.test.ts --reporter=dot

## Real behavior proof
- Behavior or issue addressed: Manual Website Installer Sync proved installer static/macOS/Linux Docker/Windows jobs, then failed in sync-website because the openclaw.ai Astro build ran on GitHub runner Node v20.20.2 while Astro requires Node >=22.12.0.
- Real environment tested: GitHub Actions ubuntu-24.04 Website Installer Sync run on openclaw/openclaw, plus local macOS checkout for actionlint/workflow regression test.
- Exact steps or command run after this patch: /opt/homebrew/bin/actionlint .github/workflows/website-installer-sync.yml; pnpm exec vitest run test/scripts/website-installer-sync-workflow.test.ts --reporter=dot. The failing real command being fixed is bun run build inside sync-website after checkout of openclaw.ai.
- Evidence after fix: terminal output from local checks showed actionlint success and Vitest 1 file passed / 3 tests passed; the before-fix real GitHub Actions run is https://github.com/openclaw/openclaw/actions/runs/25619142873 with sync-website failing on Node.js v20.20.2 during bun run build.
- Observed result after fix: workflow now installs actions/setup-node@v6 with node-version 24 before bun install and bun run build, so the sync-website verification runs on supported Node instead of runner Node 20.
- What was not tested: full post-merge workflow_dispatch after this PR is still pending this PR landing.