### PR TITLE
ci: rebase website installer sync before push

### DIFF
--- a/.github/workflows/website-installer-sync.yml
+++ b/.github/workflows/website-installer-sync.yml
@@ -191,4 +191,5 @@ jobs:
           git config user.email "openclaw-installer-sync[bot]@users.noreply.github.com"
           git add public/install.sh public/install-cli.sh public/install.ps1 public/install.cmd
           git commit -m "chore: sync installers from openclaw ${GITHUB_SHA::12}"
+          git pull --rebase origin main
           git push origin HEAD:main


### PR DESCRIPTION
## Summary
- rebase openclaw.ai checkout on fresh origin/main before the installer sync bot pushes
- prevents sync failure when openclaw.ai main moves while the verification build is running

## Test
- /opt/homebrew/bin/actionlint .github/workflows/website-installer-sync.yml
- pnpm exec vitest run test/scripts/website-installer-sync-workflow.test.ts --reporter=dot

## Real behavior proof
- Behavior or issue addressed: manual Website Installer Sync reached sync-website and created a valid openclaw.ai sync commit, but push was rejected because openclaw.ai main moved during the build.
- Real environment tested: GitHub Actions Website Installer Sync workflow_dispatch on openclaw/openclaw main, syncing into openclaw/openclaw.ai main.
- Exact steps or command run after this patch: /opt/homebrew/bin/actionlint .github/workflows/website-installer-sync.yml; pnpm exec vitest run test/scripts/website-installer-sync-workflow.test.ts --reporter=dot. The failing real command being fixed is git push origin HEAD:main in sync-website.
- Evidence after fix: terminal output from local checks showed actionlint success and Vitest 1 file passed / 3 tests passed; before-fix real run https://github.com/openclaw/openclaw/actions/runs/25619287980 shows sync-website commit succeeded then git push rejected with fetch first.
- Observed result after fix: workflow now runs git pull --rebase origin main after committing and before pushing, so the bot integrates any website main movement before git push origin HEAD:main.
- What was not tested: full post-merge workflow_dispatch after this PR is still pending this PR landing.