### PR TITLE
feat(telegram): add native sendMessageDraft transport for stream previews

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -546,6 +546,11 @@ export const dispatchTelegramMessage = async ({
   const draftMinInitialChars = streamMode === "progress" ? 0 : DRAFT_MIN_INITIAL_CHARS;
   const progressSeed = `${route.accountId}:${chatId}:${threadSpec.id ?? ""}`;
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
+  // Draft transport only applies to DM partial/progress previews (Telegram API restriction).
+  const canUseNativeDraftTransport =
+    telegramCfg.streaming?.nativeTransport === true && !isGroup && streamDeliveryEnabled;
+  const draftPreviewTransport: "message" | "draft" | undefined =
+    canUseNativeDraftTransport ? "draft" : undefined;
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
     const stream = enabled
       ? (telegramDeps.createTelegramDraftStream ?? createTelegramDraftStream)({
@@ -555,6 +560,7 @@ export const dispatchTelegramMessage = async ({
           thread: threadSpec,
           replyToMessageId: draftReplyToMessageId,
           minInitialChars: draftMinInitialChars,
+          previewTransport: draftPreviewTransport,
           renderText: renderStreamText,
           onSupersededPreview: (superseded) => {
             if (superseded.retain) {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -588,3 +588,196 @@ describe("draft stream initial message debounce", () => {
     });
   });
 });
+
+describe("sendMessageDraft transport", () => {
+  function createMockApiWithDraft() {
+    return {
+      sendMessage: vi.fn().mockResolvedValue({ message_id: 17 }),
+      editMessageText: vi.fn().mockResolvedValue(true),
+      deleteMessage: vi.fn().mockResolvedValue(true),
+      sendMessageDraft: vi.fn().mockResolvedValue(true),
+    };
+  }
+
+  it("uses sendMessageDraft when previewTransport is 'draft'", async () => {
+    const api = createMockApiWithDraft();
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      previewTransport: "draft",
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+
+    expect(api.sendMessageDraft).toHaveBeenCalledWith(123, expect.any(Number), "Hello", undefined);
+    expect(api.sendMessage).not.toHaveBeenCalled();
+    expect(api.editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("updates draft on subsequent text changes", async () => {
+    const api = createMockApiWithDraft();
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      previewTransport: "draft",
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+    stream.update("Hello world");
+    await stream.flush();
+
+    expect(api.sendMessageDraft).toHaveBeenCalledTimes(2);
+    expect(api.sendMessageDraft).toHaveBeenLastCalledWith(
+      123,
+      expect.any(Number),
+      "Hello world",
+      undefined,
+    );
+    expect(api.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("includes parse_mode in draft when renderText provides HTML", async () => {
+    const api = createMockApiWithDraft();
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      previewTransport: "draft",
+      renderText: (text) => ({ text, parseMode: "HTML" }),
+    });
+
+    stream.update("text");
+    await stream.flush();
+
+    expect(api.sendMessageDraft).toHaveBeenCalledWith(123, expect.any(Number), "text", {
+      parse_mode: "HTML",
+    });
+  });
+
+  it("rotates draftId on forceNewMessage", async () => {
+    const api = createMockApiWithDraft();
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      previewTransport: "draft",
+    });
+
+    stream.update("First");
+    await stream.flush();
+    const firstDraftId = api.sendMessageDraft.mock.calls[0][1];
+
+    stream.forceNewMessage();
+    stream.update("Second");
+    await stream.flush();
+    const secondDraftId = api.sendMessageDraft.mock.calls[1][1];
+
+    expect(secondDraftId).not.toBe(firstDraftId);
+  });
+
+  it("falls back to message transport when sendMessageDraft is unavailable", async () => {
+    const api = createMockDraftApi();
+    const warn = vi.fn();
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      previewTransport: "draft",
+      warn,
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      "telegram stream preview: sendMessageDraft unavailable; falling back to sendMessage/editMessageText",
+    );
+  });
+
+  it("reports correct previewMode", () => {
+    const api = createMockApiWithDraft();
+    const draftStream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      previewTransport: "draft",
+    });
+    expect(draftStream.previewMode?.()).toBe("draft");
+
+    const messageStream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+    });
+    expect(messageStream.previewMode?.()).toBe("message");
+  });
+
+  it("passes message_thread_id to draft when in threaded context", async () => {
+    const api = createMockApiWithDraft();
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      thread: { id: 42, scope: "dm" },
+      previewTransport: "draft",
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+
+    expect(api.sendMessageDraft).toHaveBeenCalledWith(123, expect.any(Number), "Hello", {
+      message_thread_id: 42,
+    });
+  });
+
+  it("sets sendMayHaveLanded after draft send for lane-delivery contract", async () => {
+    const api = createMockApiWithDraft();
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      previewTransport: "draft",
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+
+    // sendMayHaveLanded must be true so lane delivery treats draft as "streamed".
+    expect(stream.sendMayHaveLanded?.()).toBe(true);
+  });
+
+  it("materializes native drafts with durable sendMessage on stop", async () => {
+    const api = createMockApiWithDraft();
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      previewTransport: "draft",
+    });
+
+    stream.update("Partial");
+    await stream.flush();
+    stream.update("Final answer");
+    await stream.stop();
+
+    expect(api.sendMessageDraft).toHaveBeenCalledWith(
+      123,
+      expect.any(Number),
+      "Partial",
+      undefined,
+    );
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "Final answer", undefined);
+    expect(stream.messageId()).toBe(17);
+    expect(stream.sendMayHaveLanded?.()).toBe(false);
+  });
+
+  it("does not mark drafts as landed after failed draft send", async () => {
+    const api = createMockApiWithDraft();
+    api.sendMessageDraft.mockRejectedValueOnce(new Error("400: Bad Request"));
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      previewTransport: "draft",
+    });
+
+    stream.update("Partial");
+    await stream.flush();
+
+    expect(stream.sendMayHaveLanded?.()).toBe(false);
+  });
+});

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -10,7 +10,38 @@ import { normalizeTelegramReplyToMessageId } from "./outbound-params.js";
 
 const TELEGRAM_STREAM_MAX_CHARS = 4096;
 const DEFAULT_THROTTLE_MS = 1000;
+const TELEGRAM_DRAFT_ID_MAX = 2_147_483_647;
 const THREAD_NOT_FOUND_RE = /400:\s*Bad Request:\s*message thread not found/i;
+
+/** sendMessageDraft API signature exposed by grammY / Bot API 9.3+. */
+type TelegramSendMessageDraft = (
+  chatId: Parameters<Bot["api"]["sendMessage"]>[0],
+  draftId: number,
+  text: string,
+  params?: {
+    message_thread_id?: number;
+    parse_mode?: "HTML";
+  },
+) => Promise<true>;
+
+let nextDraftId = 0;
+
+function allocateTelegramDraftId(): number {
+  nextDraftId = nextDraftId >= TELEGRAM_DRAFT_ID_MAX ? 1 : nextDraftId + 1;
+  return nextDraftId;
+}
+
+function resolveSendMessageDraftApi(
+  api: Bot["api"],
+): TelegramSendMessageDraft | undefined {
+  const sendMessageDraft = (
+    api as Bot["api"] & { sendMessageDraft?: TelegramSendMessageDraft }
+  ).sendMessageDraft;
+  if (typeof sendMessageDraft !== "function") {
+    return undefined;
+  }
+  return sendMessageDraft.bind(api as object);
+}
 
 type TelegramSendMessageParams = Parameters<Bot["api"]["sendMessage"]>[2];
 
@@ -28,6 +59,7 @@ export type TelegramDraftStream = {
   update: (text: string) => void;
   flush: () => Promise<void>;
   messageId: () => number | undefined;
+  previewMode?: () => "message" | "draft";
   visibleSinceMs?: () => number | undefined;
   previewRevision?: () => number;
   lastDeliveredText?: () => string;
@@ -98,6 +130,12 @@ export function createTelegramDraftStream(params: {
   renderText?: (text: string) => TelegramDraftPreview;
   /** Called when a late send resolves after forceNewMessage() switched generations. */
   onSupersededPreview?: (preview: SupersededTelegramPreview) => void;
+  /**
+   * Preview transport mode:
+   * - "message" (default): sendMessage + editMessageText
+   * - "draft": Telegram native sendMessageDraft (private chats only, opt-in)
+   */
+  previewTransport?: "message" | "draft";
   log?: (message: string) => void;
   warn?: (message: string) => void;
 }): TelegramDraftStream {
@@ -108,6 +146,17 @@ export function createTelegramDraftStream(params: {
   const throttleMs = Math.max(250, params.throttleMs ?? DEFAULT_THROTTLE_MS);
   const minInitialChars = params.minInitialChars;
   const chatId = params.chatId;
+  const requestedPreviewTransport = params.previewTransport ?? "message";
+  const prefersDraftTransport = requestedPreviewTransport === "draft";
+  const resolvedDraftApi = prefersDraftTransport
+    ? resolveSendMessageDraftApi(params.api)
+    : undefined;
+  const usesDraftTransport = Boolean(prefersDraftTransport && resolvedDraftApi);
+  if (prefersDraftTransport && !usesDraftTransport) {
+    params.warn?.(
+      "telegram stream preview: sendMessageDraft unavailable; falling back to sendMessage/editMessageText",
+    );
+  }
   const threadParams = buildTelegramThreadParams(params.thread);
   const allowThreadlessRetry = params.thread?.scope !== "dm";
   const replyToMessageId = normalizeTelegramReplyToMessageId(params.replyToMessageId);
@@ -123,6 +172,7 @@ export function createTelegramDraftStream(params: {
   const streamState = { stopped: false, final: false };
   let messageSendAttempted = false;
   let streamMessageId: number | undefined;
+  let streamDraftId = usesDraftTransport ? allocateTelegramDraftId() : undefined;
   let streamVisibleSinceMs: number | undefined;
   let lastSentText = "";
   let lastDeliveredText = "";
@@ -135,6 +185,32 @@ export function createTelegramDraftStream(params: {
     renderedText: string;
     renderedParseMode: "HTML" | undefined;
     sendGeneration: number;
+  };
+  const sendDraftTransportPreview = async (preview: PreviewSendParams): Promise<boolean> => {
+    const { renderedText, renderedParseMode } = preview;
+    if (streamState.final) {
+      return await sendMessageTransportPreview(preview);
+    }
+
+    const draftId = streamDraftId ?? allocateTelegramDraftId();
+    streamDraftId = draftId;
+    const draftParams: Record<string, unknown> = {};
+    if (renderedParseMode) {
+      draftParams.parse_mode = renderedParseMode;
+    }
+    if (threadParams?.message_thread_id != null) {
+      draftParams.message_thread_id = threadParams.message_thread_id;
+    }
+    await resolvedDraftApi!(
+      chatId,
+      draftId,
+      renderedText,
+      Object.keys(draftParams).length > 0
+        ? (draftParams as Parameters<TelegramSendMessageDraft>[3])
+        : undefined,
+    );
+    messageSendAttempted = true;
+    return true;
   };
   const sendRenderedMessageWithThreadFallback = async (sendArgs: {
     renderedText: string;
@@ -290,7 +366,10 @@ export function createTelegramDraftStream(params: {
     lastSentText = renderedText;
     lastSentParseMode = renderedParseMode;
     try {
-      const sent = await sendMessageTransportPreview({
+      const transportSender = usesDraftTransport
+        ? sendDraftTransportPreview
+        : sendMessageTransportPreview;
+      const sent = await transportSender({
         renderedText,
         renderedParseMode,
         sendGeneration,
@@ -319,6 +398,9 @@ export function createTelegramDraftStream(params: {
     generation += 1;
     messageSendAttempted = false;
     streamMessageId = undefined;
+    if (usesDraftTransport) {
+      streamDraftId = allocateTelegramDraftId();
+    }
     streamVisibleSinceMs = undefined;
     lastSentText = "";
     lastSentParseMode = undefined;
@@ -363,12 +445,15 @@ export function createTelegramDraftStream(params: {
     return streamMessageId;
   };
 
-  params.log?.(`telegram stream preview ready (maxChars=${maxChars}, throttleMs=${throttleMs})`);
+  params.log?.(
+    `telegram stream preview ready (maxChars=${maxChars}, throttleMs=${throttleMs}, transport=${usesDraftTransport ? "draft" : "message"})`,
+  );
 
   return {
     update,
     flush: loop.flush,
     messageId: () => streamMessageId,
+    previewMode: () => (usesDraftTransport ? "draft" : "message") as "draft" | "message",
     visibleSinceMs: () => streamVisibleSinceMs,
     previewRevision: () => previewRevision,
     lastDeliveredText: () => lastDeliveredText,

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -95,7 +95,7 @@ export type ChannelDeliveryStreamingConfig = Pick<ChannelStreamingConfig, "chunk
 
 export type ChannelPreviewStreamingConfig = Pick<
   ChannelStreamingConfig,
-  "mode" | "chunkMode" | "preview" | "progress" | "block"
+  "mode" | "chunkMode" | "preview" | "progress" | "block" | "nativeTransport"
 >;
 
 export type SlackChannelStreamingConfig = Pick<

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -104,6 +104,7 @@ const ChannelPreviewStreamingConfigSchema = z
     preview: ChannelStreamingPreviewSchema.optional(),
     progress: ChannelStreamingProgressSchema.optional(),
     block: ChannelStreamingBlockSchema.optional(),
+    nativeTransport: z.boolean().optional(),
   })
   .strict();
 const SlackStreamingConfigSchema = ChannelPreviewStreamingConfigSchema.extend({


### PR DESCRIPTION
## Summary

Add opt-in native Telegram `sendMessageDraft` preview transport for stream previews via `channels.telegram.streaming.nativeTransport: true`.

## Motivation

Telegram Bot API 9.3+ provides `sendMessageDraft` for native typewriter-style draft updates in private chats. This can improve DM streaming UX compared with the current `sendMessage` + `editMessageText` preview path.

Related: #79784

## Changes

- `draft-stream.ts`: add `previewTransport?: "message" | "draft"`, `sendMessageDraft` API detection, draft-id allocation/rotation, and graceful fallback to message transport.
- `bot-message-dispatch.ts`: enable draft transport only when `channels.telegram.streaming.nativeTransport === true`, only outside groups, and only when preview streaming is enabled.
- Config schema/types: allow `streaming.nativeTransport` in `ChannelPreviewStreamingConfig`.
- Tests: cover draft send/update, HTML parse mode, draft-id rotation, fallback when the API method is unavailable, previewMode, thread context, and lane-delivery contract via `sendMayHaveLanded()`.

## Design Decisions

- Default behavior unchanged: message/edit transport remains the default.
- Native draft transport is opt-in: `channels.telegram.streaming.nativeTransport: true`.
- Group/topic routes fall back to message transport because Telegram native drafts are private-chat oriented.
- When using draft transport, successful draft sends set `messageSendAttempted` so lane delivery treats the preview as already streamed even though `sendMessageDraft` returns no message id.

## Real behavior proof

**Behavior or issue addressed:** Verify Telegram accepts repeated native draft updates with the same `draft_id` from a real OpenClaw Telegram bot in a real private chat. This is the platform behavior this PR wires into the stream preview transport.

**Real environment tested:** Local OpenClaw Mac setup using real Telegram bot `@igniscow_bot`, Telegram private chat, token redacted. Target chat id was Leo's private Telegram chat id in the terminal proof.

**Exact steps or command run after this patch:** Read the configured OpenClaw Telegram bot token from local OpenClaw config; call Telegram `getMe` to confirm bot identity; call Telegram Bot API `sendMessageDraft` twice with the same `draft_id` and increasing text; confirm both calls return `{ "ok": true, "result": true }`.

**Evidence after fix:** Terminal output from real Telegram Bot API calls:

```text
Real Telegram Bot API proof (token redacted)
bot=igniscow_bot
chat_id=5327562878 draft_id=91444
sendMessageDraft #1:
{
    "ok": true,
    "result": true
}
sendMessageDraft #2:
{
    "ok": true,
    "result": true
}
```

Local unit test attempt could not run on this checkout because dependencies are not installed:

```text
pnpm test extensions/telegram/src/draft-stream.test.ts
Error: Cannot find module 'vitest/package.json'
WARN Local package.json exists, but node_modules missing, did you mean to install?
```

**Observed result after fix:** The real Telegram Bot API accepted two consecutive `sendMessageDraft` updates from the configured OpenClaw bot using the same draft id. This confirms the live API path needed by the opt-in draft preview transport is available for the bot/private chat setup.

**What was not tested:** End-to-end OpenClaw gateway streaming with this branch loaded into the running gateway was not tested locally. Group/topic native draft behavior was not tested because this PR intentionally gates native draft transport away from groups. CI should run the added unit/config/type tests in the repository environment.

## Test Plan

- CI: `pnpm test extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/lane-delivery.test.ts`
- CI: config/schema checks should accept `channels.telegram.streaming.nativeTransport`.
- Manual: set `channels.telegram.streaming.nativeTransport: true`, verify private Telegram DM draft updates use native draft behavior and groups still use message transport.
