### PR TITLE
fix(installer): silence node activation wrapper shellcheck

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1435,7 +1435,7 @@ promote_supported_node_binary() {
 }
 
 activate_supported_node_on_path() {
-    promote_supported_node_binary "$@"
+    promote_supported_node_binary
 }
 
 print_active_node_paths() {


### PR DESCRIPTION
## Summary
- call promote_supported_node_binary directly from activate_supported_node_on_path without forwarding unused args
- restores Website Installer Sync static ShellCheck on current main

## Test
- bash -n scripts/install.sh scripts/install-cli.sh
- /opt/homebrew/bin/shellcheck -e SC1091 scripts/install.sh scripts/install-cli.sh
- pnpm exec vitest run test/scripts/install-sh.test.ts --reporter=dot

## Real behavior proof
- Behavior or issue addressed: current main Website Installer Sync failed in static before reaching sync because ShellCheck flagged activate_supported_node_on_path argument forwarding in scripts/install.sh.
- Real environment tested: local macOS checkout plus GitHub Actions Website Installer Sync workflow_dispatch on current openclaw main.
- Exact steps or command run after this patch: bash -n scripts/install.sh scripts/install-cli.sh; /opt/homebrew/bin/shellcheck -e SC1091 scripts/install.sh scripts/install-cli.sh; pnpm exec vitest run test/scripts/install-sh.test.ts --reporter=dot.
- Evidence after fix: terminal output showed ShellCheck completed with no diagnostics and Vitest 1 file passed / 16 tests passed. Before-fix real run https://github.com/openclaw/openclaw/actions/runs/25619496205 failed in static after the same ShellCheck command.
- Observed result after fix: activate_supported_node_on_path no longer references unused arguments, so the installer script passes ShellCheck and preserves runtime behavior.
- What was not tested: post-merge workflow_dispatch is still pending this PR landing.