### PR TITLE
fix(openai): type compatible stream choice deltas

### DIFF
--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1519,8 +1519,11 @@ async function processOpenAICompletionsStream(
         output.errorMessage = finishReasonResult.errorMessage;
       }
     }
-    const choiceDelta =
-      choice.delta ?? (choice as unknown as { message?: ChatCompletionChunk["delta"] }).message;
+    const choiceDeltaFields = choice as unknown as {
+      delta?: ChatCompletionChunk.Choice.Delta;
+      message?: ChatCompletionChunk.Choice.Delta;
+    };
+    const choiceDelta = choiceDeltaFields.delta ?? choiceDeltaFields.message;
     if (!choiceDelta) {
       continue;
     }


### PR DESCRIPTION
## Summary\n- normalize OpenAI-compatible stream choices through a small typed delta/message shape\n- keep message fallback for compatible providers while satisfying declaration emit\n\n## Test\n- pnpm build:plugin-sdk:dts\n- pnpm exec vitest run src/agents/transcript-policy.test.ts --reporter=dot\n- pnpm exec vitest run src/agents/openai-transport-stream.test.ts --reporter=dot