### PR TITLE
fix(config): persist explicit default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Cron: let isolated self-cleanup runs inspect their own job run history while keeping other cron jobs and mutation actions blocked. Fixes #80019. Thanks @hclsys.
+- CLI/config: persist explicit `config set` and `config patch` values that equal runtime defaults instead of reporting success while dropping them. Fixes #79856. (#80106) Thanks @abodanty and @hclsys.
 - OpenAI/realtime voice: accept Codex-compatible legacy audio and transcript event aliases so provider protocol drift does not drop assistant audio or captions.
 - Discord/voice: keep default agent-proxy realtime sessions from auto-speaking filler before the forced OpenClaw consult answer, finish Discord playback on realtime response completion, and queue later exact-speech answers until playback idles to avoid mid-sentence replacement.
 - Gateway: return deterministic `400 invalid_request_error` responses for malformed encoded session-kill HTTP paths instead of letting route-shaped requests fall through to later Gateway handlers. (#72439) Thanks @rubencu.

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -220,6 +220,33 @@ describe("config cli", () => {
       expect(written.agents).not.toHaveProperty("defaults");
     });
 
+    it("marks set paths explicit so default-equal writes persist", async () => {
+      const resolved: OpenClawConfig = {
+        channels: {
+          telegram: {
+            botToken: "tok-abc",
+          },
+        },
+      };
+      const runtimeMerged = {
+        ...resolved,
+        channels: {
+          telegram: {
+            botToken: "tok-abc",
+            dmPolicy: "pairing",
+          },
+        },
+      } as OpenClawConfig;
+      setSnapshot(resolved, runtimeMerged);
+
+      await runConfigCommand(["config", "set", "channels.telegram.dmPolicy", "pairing"]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      expect(mockWriteConfigFile.mock.calls[0]?.[1]).toMatchObject({
+        explicitSetPaths: [["channels", "telegram", "dmPolicy"]],
+      });
+    });
+
     it("does not inject runtime defaults into the written config", async () => {
       const resolved: OpenClawConfig = {
         gateway: { port: 18789 },
@@ -1791,7 +1818,7 @@ describe("config cli", () => {
           .channels as Record<string, unknown>,
       ).toEqual({ maintainers: { enabled: true, requireMention: true } });
       expect((written.channels as Record<string, unknown>).slack).not.toHaveProperty("appToken");
-      expect(mockWriteConfigFile.mock.calls[0]?.[1]).toEqual({
+      expect(mockWriteConfigFile.mock.calls[0]?.[1]).toMatchObject({
         unsetPaths: [["channels", "slack", "appToken"]],
       });
     });

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -247,6 +247,39 @@ describe("config cli", () => {
       });
     });
 
+    it("marks object set paths explicit so nested default-equal writes persist", async () => {
+      const resolved: OpenClawConfig = {
+        channels: {
+          telegram: {
+            botToken: "tok-abc",
+          },
+        },
+      };
+      const runtimeMerged = {
+        ...resolved,
+        channels: {
+          telegram: {
+            botToken: "tok-abc",
+            dmPolicy: "pairing",
+          },
+        },
+      } as OpenClawConfig;
+      setSnapshot(resolved, runtimeMerged);
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "channels.telegram",
+        '{"botToken":"tok-abc","dmPolicy":"pairing"}',
+        "--strict-json",
+      ]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      expect(mockWriteConfigFile.mock.calls[0]?.[1]).toMatchObject({
+        explicitSetPaths: [["channels", "telegram"]],
+      });
+    });
+
     it("does not inject runtime defaults into the written config", async () => {
       const resolved: OpenClawConfig = {
         gateway: { port: 18789 },

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -14,7 +14,10 @@ import { createCliRuntimeCapture, mockRuntimeModule } from "./test-runtime-captu
 
 const mockReadConfigFileSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>();
 const mockWriteConfigFile = vi.fn<
-  (cfg: OpenClawConfig, options?: { unsetPaths?: string[][] }) => Promise<void>
+  (
+    cfg: OpenClawConfig,
+    options?: { unsetPaths?: string[][]; explicitSetPaths?: string[][] },
+  ) => Promise<void>
 >(async () => {});
 const mockResolveSecretRefValue = vi.fn();
 const mockReadBestEffortRuntimeConfigSchema = vi.fn();
@@ -24,11 +27,13 @@ vi.mock("../config/config.js", async (importOriginal) => {
   return {
     ...actual,
     readConfigFileSnapshot: () => mockReadConfigFileSnapshot(),
-    writeConfigFile: (cfg: OpenClawConfig, options?: { unsetPaths?: string[][] }) =>
-      mockWriteConfigFile(cfg, options),
+    writeConfigFile: (
+      cfg: OpenClawConfig,
+      options?: { unsetPaths?: string[][]; explicitSetPaths?: string[][] },
+    ) => mockWriteConfigFile(cfg, options),
     replaceConfigFile: (params: {
       nextConfig: OpenClawConfig;
-      writeOptions?: { unsetPaths?: string[][] };
+      writeOptions?: { unsetPaths?: string[][]; explicitSetPaths?: string[][] };
     }) => mockWriteConfigFile(params.nextConfig, params.writeOptions),
   };
 });
@@ -372,6 +377,37 @@ describe("config cli", () => {
       });
       expect(written.agents?.defaults?.models).toEqual({
         "google/gemini-3.1-pro-preview": { alias: "gemini" },
+      });
+    });
+
+    it("normalizes explicit model-map paths before writing config mutations", async () => {
+      const resolved: OpenClawConfig = {
+        agents: {
+          defaults: {
+            models: {
+              "google/gemini-3-pro-preview": {},
+            },
+          },
+        },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "agents.defaults.models.google/gemini-3-pro-preview.alias",
+        "gemini",
+      ]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = mockWriteConfigFile.mock.calls[0]?.[0];
+      expect(written.agents?.defaults?.models).toEqual({
+        "google/gemini-3.1-pro-preview": { alias: "gemini" },
+      });
+      expect(mockWriteConfigFile.mock.calls[0]?.[1]).toMatchObject({
+        explicitSetPaths: [
+          ["agents", "defaults", "models", "google/gemini-3.1-pro-preview", "alias"],
+        ],
       });
     });
 

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -141,6 +141,16 @@ function normalizeConfigMutationModelRefs(cfg: OpenClawConfig): OpenClawConfig {
   };
 }
 
+function normalizeConfigMutationExplicitSetPath(path: PathSegment[]): PathSegment[] {
+  if (path.length >= 4 && path[0] === "agents" && path[1] === "defaults" && path[2] === "models") {
+    const normalizedModelId = normalizeAgentModelRefForConfig(path[3]);
+    return normalizedModelId === path[3]
+      ? path
+      : [...path.slice(0, 3), normalizedModelId, ...path.slice(4)];
+  }
+  return path;
+}
+
 const GATEWAY_AUTH_MODE_PATH: PathSegment[] = ["gateway", "auth", "mode"];
 const SECRET_PROVIDER_PATH_PREFIX: PathSegment[] = ["secrets", "providers"];
 const PLUGIN_INSTALL_RECORD_PATH_PREFIX: PathSegment[] = ["plugins", "installs"];
@@ -1472,6 +1482,7 @@ async function runConfigOperations(params: {
     operations,
   });
   const nextConfig = normalizeConfigMutationModelRefs(next as OpenClawConfig);
+  const normalizedExplicitSetPaths = explicitSetPaths.map(normalizeConfigMutationExplicitSetPath);
   const policyIssues = collectUnsupportedSecretRefPolicyIssues(nextConfig);
   const policyIssueLines = formatConfigIssueLines(policyIssues, "", { normalizeRoot: true }).map(
     (line) => line.trim(),
@@ -1588,7 +1599,9 @@ async function runConfigOperations(params: {
       ? {
           writeOptions: {
             ...(unsetPaths.length > 0 ? { unsetPaths } : {}),
-            ...(explicitSetPaths.length > 0 ? { explicitSetPaths } : {}),
+            ...(normalizedExplicitSetPaths.length > 0
+              ? { explicitSetPaths: normalizedExplicitSetPaths }
+              : {}),
           },
         }
       : {}),

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1447,12 +1447,14 @@ async function runConfigOperations(params: {
   // This prevents runtime defaults from leaking into the written config file (issue #6070)
   const next = structuredClone(snapshot.resolved) as Record<string, unknown>;
   const unsetPaths: PathSegment[][] = [];
+  const explicitSetPaths: PathSegment[][] = [];
   for (const operation of operations) {
     if (operation.mutation === "delete") {
       unsetAtPath(next, operation.setPath);
       unsetPaths.push(operation.setPath);
       continue;
     }
+    explicitSetPaths.push(operation.setPath);
     if (operation.mutation === "merge" || (options.merge && operation.mutation !== "replace")) {
       mergeAtPath(next, operation.setPath, operation.value);
     } else {
@@ -1582,7 +1584,14 @@ async function runConfigOperations(params: {
   await replaceConfigFile({
     nextConfig,
     ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
-    ...(unsetPaths.length > 0 ? { writeOptions: { unsetPaths } } : {}),
+    ...(unsetPaths.length > 0 || explicitSetPaths.length > 0
+      ? {
+          writeOptions: {
+            ...(unsetPaths.length > 0 ? { unsetPaths } : {}),
+            ...(explicitSetPaths.length > 0 ? { explicitSetPaths } : {}),
+          },
+        }
+      : {}),
   });
   if (removedGatewayAuthPaths.length > 0) {
     runtime.log(

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -197,6 +197,16 @@ export type ConfigWriteOptions = {
    */
   unsetPaths?: string[][];
   /**
+   * Paths that were explicitly set by the caller. Values at these paths are
+   * persisted even when they equal runtime-injected defaults.
+   */
+  explicitSetPaths?: readonly (readonly string[])[];
+  /**
+   * Internal companion for explicitSetPaths after a wrapper has projected a
+   * runtime-shaped config back onto the authored source shape.
+   */
+  explicitSetValueSource?: OpenClawConfig;
+  /**
    * Internal fast path for callers that already hold a fresh config snapshot.
    * Avoids rereading the full config just to prepare an immediate write.
    */
@@ -1995,6 +2005,8 @@ export function createConfigIO(
         nextConfig: cfg,
         rootAuthoredConfig: snapshot.parsed,
         unsetPaths,
+        explicitSetPaths: options.explicitSetPaths,
+        explicitSetValueSource: options.explicitSetValueSource,
       });
       try {
         const resolvedIncludes = resolveConfigIncludes(
@@ -2423,6 +2435,10 @@ export async function writeConfigFile(
       envSnapshotForRestore: options.envSnapshotForRestore,
     }),
     unsetPaths: resolveManagedUnsetPathsForWrite(options.unsetPaths),
+    explicitSetPaths: options.explicitSetPaths,
+    explicitSetValueSource: options.explicitSetPaths
+      ? (options.explicitSetValueSource ?? cfg)
+      : undefined,
     allowDestructiveWrite: options.allowDestructiveWrite,
     allowConfigSizeDrop: options.allowConfigSizeDrop,
     skipRuntimeSnapshotRefresh: options.skipRuntimeSnapshotRefresh,

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1351,6 +1351,74 @@ describe("config io write", () => {
     });
   });
 
+  it("persists explicit default-valued paths through the exported write wrapper", async () => {
+    mockLoadPluginManifestRegistry.mockReturnValue({
+      diagnostics: [],
+      plugins: [
+        {
+          id: "demo",
+          origin: "bundled",
+          channels: [],
+          providers: [],
+          cliBackends: [],
+          skills: [],
+          hooks: [],
+          rootDir: "/tmp/openclaw-test-demo",
+          source: "/tmp/openclaw-test-demo/index.ts",
+          manifestPath: "/tmp/openclaw-test-demo/openclaw.plugin.json",
+          configSchema: {
+            type: "object",
+            properties: {
+              mode: { type: "string", default: "auto" },
+            },
+            additionalProperties: true,
+          },
+        },
+      ],
+    } satisfies PluginManifestRegistry);
+
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const sourceConfig = {
+        gateway: { mode: "local" },
+        plugins: { entries: { demo: { enabled: true, config: {} } } },
+      } satisfies ConfigFileSnapshot["sourceConfig"];
+      await fs.writeFile(configPath, `${JSON.stringify(sourceConfig, null, 2)}\n`, "utf-8");
+      const runtimeConfig = {
+        ...structuredClone(sourceConfig),
+        plugins: {
+          entries: {
+            demo: { enabled: true, config: { mode: "auto" } },
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+
+      try {
+        setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+        await writeConfigFile(runtimeConfig, {
+          explicitSetPaths: [["plugins", "entries", "demo", "config", "mode"]],
+        });
+
+        const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as OpenClawConfig;
+        expect(persisted.plugins?.entries?.demo?.config).toStrictEqual({ mode: "auto" });
+      } finally {
+        mockLoadPluginManifestRegistry.mockReturnValue({
+          diagnostics: [],
+          plugins: [],
+        } satisfies PluginManifestRegistry);
+        if (previousConfigPath === undefined) {
+          delete process.env.OPENCLAW_CONFIG_PATH;
+        } else {
+          process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+        }
+      }
+    });
+  });
+
   it("skipPluginValidation bypasses plugin schema rejection on writeConfigFile (#76800)", async () => {
     await withSuiteHome(async (home) => {
       const configPath = path.join(home, ".openclaw", "openclaw.json");

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1400,7 +1400,7 @@ describe("config io write", () => {
         setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
 
         await writeConfigFile(runtimeConfig, {
-          explicitSetPaths: [["plugins", "entries", "demo", "config", "mode"]],
+          explicitSetPaths: [["plugins", "entries", "demo", "config"]],
         });
 
         const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as OpenClawConfig;

--- a/src/config/io.write-prepare.test.ts
+++ b/src/config/io.write-prepare.test.ts
@@ -793,4 +793,37 @@ describe("config io write prepare", () => {
     expect(persisted.channels?.telegram?.groupPolicy).toBe("allowlist");
     expect(persisted.channels?.telegram?.botToken).toBe("tok-abc");
   });
+
+  it("persists default-valued children inside explicitly set objects", () => {
+    const runtimeConfig = {
+      channels: {
+        telegram: {
+          botToken: "tok-abc",
+          dmPolicy: "pairing",
+          groupPolicy: "allowlist",
+        },
+      },
+    };
+    const sourceConfig = {
+      channels: {
+        telegram: {
+          botToken: "tok-abc",
+        },
+      },
+    };
+
+    const persisted = resolvePersistCandidateForWrite({
+      runtimeConfig,
+      sourceConfig,
+      nextConfig: sourceConfig,
+      explicitSetValueSource: runtimeConfig,
+      explicitSetPaths: [["channels", "telegram"]],
+    }) as { channels?: { telegram?: Record<string, unknown> } };
+
+    expect(persisted.channels?.telegram).toEqual({
+      botToken: "tok-abc",
+      dmPolicy: "pairing",
+      groupPolicy: "allowlist",
+    });
+  });
 });

--- a/src/config/io.write-prepare.test.ts
+++ b/src/config/io.write-prepare.test.ts
@@ -827,6 +827,40 @@ describe("config io write prepare", () => {
     });
   });
 
+  it("persists explicitly set array-index children whose values match runtime defaults", () => {
+    const runtimeConfig = {
+      models: {
+        providers: {
+          openai: {
+            models: [{ id: "gpt-5.5", contextWindow: 128000 }],
+          },
+        },
+      },
+    };
+    const sourceConfig = {
+      models: {
+        providers: {
+          openai: {
+            models: [{ id: "gpt-5.5" }],
+          },
+        },
+      },
+    };
+
+    const persisted = resolvePersistCandidateForWrite({
+      runtimeConfig,
+      sourceConfig,
+      nextConfig: sourceConfig,
+      explicitSetValueSource: runtimeConfig,
+      explicitSetPaths: [["models", "providers", "openai", "models", "0", "contextWindow"]],
+    }) as { models?: { providers?: { openai?: { models?: Array<Record<string, unknown>> } } } };
+
+    expect(persisted.models?.providers?.openai?.models?.[0]).toEqual({
+      id: "gpt-5.5",
+      contextWindow: 128000,
+    });
+  });
+
   it("rejects default-valued explicit writes under include-owned paths", () => {
     expect(() =>
       resolvePersistCandidateForWrite({

--- a/src/config/io.write-prepare.test.ts
+++ b/src/config/io.write-prepare.test.ts
@@ -826,4 +826,41 @@ describe("config io write prepare", () => {
       groupPolicy: "allowlist",
     });
   });
+
+  it("rejects default-valued explicit writes under include-owned paths", () => {
+    expect(() =>
+      resolvePersistCandidateForWrite({
+        runtimeConfig: {
+          agents: {
+            defaults: {
+              params: { temperature: 0 },
+            },
+          },
+        },
+        sourceConfig: {
+          agents: {
+            defaults: {},
+          },
+        },
+        rootAuthoredConfig: {
+          agents: {
+            defaults: { $include: "./agents-defaults.json" },
+          },
+        },
+        nextConfig: {
+          agents: {
+            defaults: {},
+          },
+        },
+        explicitSetValueSource: {
+          agents: {
+            defaults: {
+              params: { temperature: 0 },
+            },
+          },
+        },
+        explicitSetPaths: [["agents", "defaults", "params"]],
+      }),
+    ).toThrow("Config write would flatten $include-owned config at agents.defaults");
+  });
 });

--- a/src/config/io.write-prepare.test.ts
+++ b/src/config/io.write-prepare.test.ts
@@ -757,4 +757,40 @@ describe("config io write prepare", () => {
     expect(persisted.$schema).toBe(123);
     expect(persisted.gateway).toEqual({ mode: "local", port: 18789 });
   });
+
+  it("persists explicitly set keys whose values match runtime defaults", () => {
+    const runtimeConfig = {
+      channels: {
+        telegram: {
+          botToken: "tok-abc",
+          dmPolicy: "pairing",
+          groupPolicy: "allowlist",
+        },
+      },
+      gateway: { port: 18789 },
+    };
+    const sourceConfig = {
+      channels: {
+        telegram: {
+          botToken: "tok-abc",
+        },
+      },
+      gateway: { port: 18789 },
+    };
+
+    const persisted = resolvePersistCandidateForWrite({
+      runtimeConfig,
+      sourceConfig,
+      nextConfig: sourceConfig,
+      explicitSetValueSource: runtimeConfig,
+      explicitSetPaths: [
+        ["channels", "telegram", "dmPolicy"],
+        ["channels", "telegram", "groupPolicy"],
+      ],
+    }) as { channels?: { telegram?: Record<string, unknown> } };
+
+    expect(persisted.channels?.telegram?.dmPolicy).toBe("pairing");
+    expect(persisted.channels?.telegram?.groupPolicy).toBe("allowlist");
+    expect(persisted.channels?.telegram?.botToken).toBe("tok-abc");
+  });
 });

--- a/src/config/io.write-prepare.ts
+++ b/src/config/io.write-prepare.ts
@@ -142,6 +142,15 @@ function isIncludeOwnedPath(rootAuthoredConfig: unknown, path: string[]): boolea
   );
 }
 
+function findOverlappingIncludeOwnedPath(
+  rootAuthoredConfig: unknown,
+  path: string[],
+): string[] | undefined {
+  return collectIncludeOwnedPaths(rootAuthoredConfig).find(
+    (includePath) => pathStartsWith(path, includePath) || pathStartsWith(includePath, path),
+  );
+}
+
 function setPathValueCreatingParents(value: unknown, path: string[], nextValue: unknown): unknown {
   if (path.length === 0) {
     return cloneUnknown(nextValue);
@@ -385,12 +394,18 @@ export function injectExplicitlySetPaths(params: {
 
   let next = params.persistedCandidate;
   for (const path of params.explicitSetPaths) {
-    if (
-      path.length === 0 ||
-      path.some(isBlockedObjectKey) ||
-      (params.rootAuthoredConfig && isIncludeOwnedPath(params.rootAuthoredConfig, [...path]))
-    ) {
+    if (path.length === 0 || path.some(isBlockedObjectKey)) {
       continue;
+    }
+    const includeOwnedPath = params.rootAuthoredConfig
+      ? findOverlappingIncludeOwnedPath(params.rootAuthoredConfig, [...path])
+      : undefined;
+    if (includeOwnedPath) {
+      throw new Error(
+        `Config write would flatten $include-owned config at ${formatConfigPath(
+          includeOwnedPath,
+        )}; edit that include file directly or remove the $include first.`,
+      );
     }
     const nextValue = getPathValue(params.valueSource, [...path]);
     if (nextValue === undefined) {

--- a/src/config/io.write-prepare.ts
+++ b/src/config/io.write-prepare.ts
@@ -343,6 +343,36 @@ function hasPathValue(value: unknown, path: readonly string[]): boolean {
   return tail.length === 0 || hasPathValue(value[head], tail);
 }
 
+function mergeMissingExplicitValues(
+  currentValue: unknown,
+  explicitValue: unknown,
+): {
+  changed: boolean;
+  value: unknown;
+} {
+  if (!isRecord(currentValue) || !isRecord(explicitValue)) {
+    return { changed: false, value: currentValue };
+  }
+  let changed = false;
+  const next: Record<string, unknown> = { ...currentValue };
+  for (const [key, childExplicitValue] of Object.entries(explicitValue)) {
+    if (isBlockedObjectKey(key)) {
+      continue;
+    }
+    if (!Object.prototype.hasOwnProperty.call(next, key)) {
+      next[key] = cloneUnknown(childExplicitValue);
+      changed = true;
+      continue;
+    }
+    const childMerged = mergeMissingExplicitValues(next[key], childExplicitValue);
+    if (childMerged.changed) {
+      next[key] = childMerged.value;
+      changed = true;
+    }
+  }
+  return { changed, value: changed ? next : currentValue };
+}
+
 export function injectExplicitlySetPaths(params: {
   valueSource: unknown;
   persistedCandidate: unknown;
@@ -358,7 +388,6 @@ export function injectExplicitlySetPaths(params: {
     if (
       path.length === 0 ||
       path.some(isBlockedObjectKey) ||
-      hasPathValue(next, path) ||
       (params.rootAuthoredConfig && isIncludeOwnedPath(params.rootAuthoredConfig, [...path]))
     ) {
       continue;
@@ -367,7 +396,14 @@ export function injectExplicitlySetPaths(params: {
     if (nextValue === undefined) {
       continue;
     }
-    next = setPathValueCreatingParents(next, [...path], nextValue);
+    if (!hasPathValue(next, path)) {
+      next = setPathValueCreatingParents(next, [...path], nextValue);
+      continue;
+    }
+    const merged = mergeMissingExplicitValues(getPathValue(next, [...path]), nextValue);
+    if (merged.changed) {
+      next = setPathValue(next, [...path], merged.value);
+    }
   }
   return next;
 }

--- a/src/config/io.write-prepare.ts
+++ b/src/config/io.write-prepare.ts
@@ -102,6 +102,17 @@ function formatConfigPath(path: string[]): string {
 function getPathValue(value: unknown, path: string[]): unknown {
   let current = value;
   for (const segment of path) {
+    if (Array.isArray(current)) {
+      if (!isNumericPathSegment(segment)) {
+        return undefined;
+      }
+      const index = Number.parseInt(segment, 10);
+      if (!Number.isFinite(index) || index < 0 || index >= current.length) {
+        return undefined;
+      }
+      current = current[index];
+      continue;
+    }
     if (!isRecord(current)) {
       return undefined;
     }
@@ -114,10 +125,22 @@ function setPathValue(value: unknown, path: string[], nextValue: unknown): unkno
   if (path.length === 0) {
     return cloneUnknown(nextValue);
   }
+  const [head, ...tail] = path;
+  if (Array.isArray(value)) {
+    if (!isNumericPathSegment(head)) {
+      return value;
+    }
+    const index = Number.parseInt(head, 10);
+    if (!Number.isFinite(index) || index < 0 || index >= value.length) {
+      return value;
+    }
+    const next = [...value];
+    next[index] = setPathValue(value[index], tail, nextValue);
+    return next;
+  }
   if (!isRecord(value)) {
     return value;
   }
-  const [head, ...tail] = path;
   return {
     ...value,
     [head]: setPathValue(value[head], tail, nextValue),
@@ -156,6 +179,18 @@ function setPathValueCreatingParents(value: unknown, path: string[], nextValue: 
     return cloneUnknown(nextValue);
   }
   const [head, ...tail] = path;
+  if (Array.isArray(value) || isNumericPathSegment(head)) {
+    if (!isNumericPathSegment(head)) {
+      return value;
+    }
+    const index = Number.parseInt(head, 10);
+    if (!Number.isFinite(index) || index < 0) {
+      return value;
+    }
+    const next = Array.isArray(value) ? [...value] : [];
+    next[index] = setPathValueCreatingParents(next[index], tail, nextValue);
+    return next;
+  }
   const record = isRecord(value) ? value : {};
   return {
     ...record,
@@ -342,10 +377,20 @@ function hasPathValue(value: unknown, path: readonly string[]): boolean {
   if (path.length === 0) {
     return true;
   }
+  const [head, ...tail] = path;
+  if (Array.isArray(value)) {
+    if (!isNumericPathSegment(head)) {
+      return false;
+    }
+    const index = Number.parseInt(head, 10);
+    if (!Number.isFinite(index) || index < 0 || index >= value.length) {
+      return false;
+    }
+    return tail.length === 0 || hasPathValue(value[index], tail);
+  }
   if (!isRecord(value)) {
     return false;
   }
-  const [head, ...tail] = path;
   if (isBlockedObjectKey(head) || !Object.prototype.hasOwnProperty.call(value, head)) {
     return false;
   }
@@ -360,7 +405,28 @@ function mergeMissingExplicitValues(
   value: unknown;
 } {
   if (!isRecord(currentValue) || !isRecord(explicitValue)) {
-    return { changed: false, value: currentValue };
+    if (!Array.isArray(currentValue) || !Array.isArray(explicitValue)) {
+      return { changed: false, value: currentValue };
+    }
+    let changed = false;
+    const next = [...currentValue];
+    for (const [key, childExplicitValue] of Object.entries(explicitValue)) {
+      const index = Number.parseInt(key, 10);
+      if (!Number.isFinite(index) || index < 0) {
+        continue;
+      }
+      if (index >= next.length || next[index] === undefined) {
+        next[index] = cloneUnknown(childExplicitValue);
+        changed = true;
+        continue;
+      }
+      const childMerged = mergeMissingExplicitValues(next[index], childExplicitValue);
+      if (childMerged.changed) {
+        next[index] = childMerged.value;
+        changed = true;
+      }
+    }
+    return { changed, value: changed ? next : currentValue };
   }
   let changed = false;
   const next: Record<string, unknown> = { ...currentValue };

--- a/src/config/io.write-prepare.ts
+++ b/src/config/io.write-prepare.ts
@@ -329,20 +329,71 @@ function preserveUntouchedIncludes(params: {
   return next;
 }
 
+function hasPathValue(value: unknown, path: readonly string[]): boolean {
+  if (path.length === 0) {
+    return true;
+  }
+  if (!isRecord(value)) {
+    return false;
+  }
+  const [head, ...tail] = path;
+  if (isBlockedObjectKey(head) || !Object.prototype.hasOwnProperty.call(value, head)) {
+    return false;
+  }
+  return tail.length === 0 || hasPathValue(value[head], tail);
+}
+
+export function injectExplicitlySetPaths(params: {
+  valueSource: unknown;
+  persistedCandidate: unknown;
+  explicitSetPaths?: readonly (readonly string[])[];
+  rootAuthoredConfig?: unknown;
+}): unknown {
+  if (!params.explicitSetPaths || params.explicitSetPaths.length === 0) {
+    return params.persistedCandidate;
+  }
+
+  let next = params.persistedCandidate;
+  for (const path of params.explicitSetPaths) {
+    if (
+      path.length === 0 ||
+      path.some(isBlockedObjectKey) ||
+      hasPathValue(next, path) ||
+      (params.rootAuthoredConfig && isIncludeOwnedPath(params.rootAuthoredConfig, [...path]))
+    ) {
+      continue;
+    }
+    const nextValue = getPathValue(params.valueSource, [...path]);
+    if (nextValue === undefined) {
+      continue;
+    }
+    next = setPathValueCreatingParents(next, [...path], nextValue);
+  }
+  return next;
+}
+
 export function resolvePersistCandidateForWrite(params: {
   runtimeConfig: unknown;
   sourceConfig: unknown;
   nextConfig: unknown;
   rootAuthoredConfig?: unknown;
   unsetPaths?: readonly string[][];
+  explicitSetPaths?: readonly (readonly string[])[];
+  explicitSetValueSource?: unknown;
 }): unknown {
   const patch = createMergePatch(params.runtimeConfig, params.nextConfig);
   const projectedSource = projectSourceOntoRuntimeShape(params.sourceConfig, params.runtimeConfig);
   const rootAuthoredConfig = params.rootAuthoredConfig ?? params.sourceConfig;
-  const persisted = preserveUntouchedIncludes({
+  const persistedBase = preserveUntouchedIncludes({
     patch,
     rootAuthoredConfig,
     persistedCandidate: applyMergePatch(projectedSource, patch),
+  });
+  const persisted = injectExplicitlySetPaths({
+    valueSource: params.explicitSetValueSource ?? params.nextConfig,
+    persistedCandidate: persistedBase,
+    explicitSetPaths: params.explicitSetPaths,
+    rootAuthoredConfig,
   });
   const withSchema = preserveRootSchemaUri({
     rootAuthoredConfig,


### PR DESCRIPTION
## Summary

- Fixes #79856 by carrying explicit `config set` / `config patch` paths through config writes so default-equal user writes are persisted instead of silently dropped.
- Preserves explicit values through the exported `writeConfigFile` runtime-snapshot projection, where default-equal diffs can otherwise disappear before the inner writer sees them.
- Adds helper, CLI, and exported writer regression coverage, and records the user-facing fix in the changelog.

This keeps the existing default-stripping behavior for implicit runtime/schema defaults; only caller-declared paths are injected. This also addresses the missing public-writer plumbing identified while reviewing #80020.

## Verification

- `pnpm test src/cli/config-cli.test.ts src/config/io.write-prepare.test.ts src/config/io.write-config.test.ts -- --run`
- `pnpm exec oxfmt --check --threads=1 src/cli/config-cli.ts src/cli/config-cli.test.ts src/config/io.ts src/config/io.write-prepare.ts src/config/io.write-prepare.test.ts src/config/io.write-config.test.ts CHANGELOG.md`
- `OPENCLAW_TESTBOX=0 pnpm check:changed`

Note: attempted delegated Testbox `pnpm check:changed`, but the remote checkout selected unrelated app lanes and failed on missing `swiftlint` in the Testbox image. Local `changed:lanes --json` for this branch selected only `core`, `coreTests`, and `docs`, and the local changed gate passed for those lanes.

## Real behavior proof

- Behavior or issue addressed: `openclaw config set` previously reported success while dropping explicit values that matched runtime defaults; this patch must persist the explicit default-equal write.
- Real environment tested: Local macOS checkout, Node via `pnpm openclaw`, temp `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR`, after rebase to `origin/main` `1d65f965e8`.
- Exact steps or command run after this patch:

```bash
tmp=$(mktemp -d)
mkdir -p "$tmp/state"
printf '{"channels":{"telegram":{"botToken":"123:abc"}}}\n' > "$tmp/openclaw.json"
OPENCLAW_CONFIG_PATH="$tmp/openclaw.json" OPENCLAW_STATE_DIR="$tmp/state" pnpm openclaw config set channels.telegram.dmPolicy pairing
node -e 'const fs=require("fs"); const cfg=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); console.log(JSON.stringify({dmPolicy: cfg.channels.telegram.dmPolicy, telegram: cfg.channels.telegram}, null, 2));' "$tmp/openclaw.json"
```

- Evidence after fix: Terminal output from the live `pnpm openclaw config set` run:

```text
Config overwrite: .../openclaw.json (... -> ..., backup=.../openclaw.json.bak)
Config write anomaly: .../openclaw.json (missing-meta-before-write)
Updated channels.telegram.dmPolicy. Restart the gateway to apply.
{
  "dmPolicy": "pairing",
  "telegram": {
    "botToken": "123:abc",
    "dmPolicy": "pairing"
  }
}
```

- Observed result after fix: The config file still contains the explicit default-equal `channels.telegram.dmPolicy: "pairing"` value after the command exits successfully, so the write is no longer silently discarded.
- What was not tested: No additional gaps.
