### PR TITLE
ci(installer): add macOS install proof

### DIFF
--- a/.github/workflows/website-installer-sync.yml
+++ b/.github/workflows/website-installer-sync.yml
@@ -99,8 +99,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - name: install.sh dry run
         run: bash scripts/install.sh --dry-run --no-onboard --no-prompt
+
+      - name: install.sh on macOS
+        env:
+          OPENCLAW_NO_ONBOARD: "1"
+          OPENCLAW_NO_PROMPT: "1"
+        run: |
+          bash scripts/install.sh --no-onboard --no-prompt --version latest
+          openclaw --version
 
   windows-installer:
     runs-on: windows-latest

--- a/extensions/volcengine/index.test.ts
+++ b/extensions/volcengine/index.test.ts
@@ -68,7 +68,10 @@ describe("volcengine plugin", () => {
       },
     } as never);
 
-    expect(normalized?.compat?.unsupportedToolSchemaKeywords).toEqual([
+    const normalizedCompat = normalized?.compat as
+      | { unsupportedToolSchemaKeywords?: string[] }
+      | undefined;
+    expect(normalizedCompat?.unsupportedToolSchemaKeywords).toEqual([
       "not",
       ...VOLCENGINE_UNSUPPORTED_TOOL_SCHEMA_KEYWORDS,
     ]);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1762,6 +1762,7 @@ fix_npm_permissions() {
     npm config set prefix "$HOME/.npm-global"
     ui_warn "Avoid sudo npm i -g for future OpenClaw updates; use npm i -g openclaw@latest so npm keeps using this user prefix instead of a different global prefix."
 
+    # shellcheck disable=SC2016
     persist_shell_path_prepend "$HOME/.npm-global/bin" '$HOME/.npm-global/bin' || true
 
     export PATH="$HOME/.npm-global/bin:$PATH"

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -461,7 +461,7 @@ describe("/model chat UX", () => {
             cfg: {
               ...baseConfig(),
               plugins: { allow: ["workspace-model-list"] },
-            } as OpenClawConfig,
+            } as unknown as OpenClawConfig,
           });
 
           expect(reply?.text).toContain("- anthropic");
@@ -503,7 +503,7 @@ describe("/model chat UX", () => {
             },
           },
         },
-      } as OpenClawConfig,
+      } as unknown as OpenClawConfig,
       allowedModelCatalog: [
         { provider: "anthropic", id: "claude-opus-4-6", name: "Claude Opus 4.5" },
         { provider: "openai", id: "gpt-4.1-mini", name: "GPT-4.1 mini" },
@@ -546,7 +546,7 @@ describe("/model chat UX", () => {
             },
           },
         },
-      } as OpenClawConfig,
+      } as unknown as OpenClawConfig,
       allowedModelCatalog: [{ provider: "openai", id: "gpt-5.5", name: "GPT-5.5" }],
     });
 
@@ -589,7 +589,7 @@ describe("/model chat UX", () => {
             },
           },
         },
-      } as OpenClawConfig,
+      } as unknown as OpenClawConfig,
       allowedModelCatalog: [{ provider: "openai", id: "gpt-5.5", name: "GPT-5.5" }],
     });
 
@@ -627,7 +627,7 @@ describe("/model chat UX", () => {
             },
           },
         },
-      } as OpenClawConfig,
+      } as unknown as OpenClawConfig,
       allowedModelCatalog: [{ provider: "openai", id: "gpt-5.5", name: "GPT-5.5" }],
     });
 
@@ -695,7 +695,7 @@ describe("/model chat UX", () => {
                   },
                 },
               },
-            } as OpenClawConfig,
+            } as unknown as OpenClawConfig,
             allowedModelCatalog: [
               { provider: "anthropic", id: "claude-opus-4-6", name: "Claude Opus 4.6" },
             ],
@@ -957,7 +957,7 @@ describe("/model chat UX", () => {
             },
           },
         },
-      } as OpenClawConfig,
+      } as unknown as OpenClawConfig,
     });
 
     expect(persisted.provider).toBe("openai");

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -386,14 +386,14 @@ describe("createModelSelectionState catalog loading", () => {
 
 describe("resolveContextTokens", () => {
   it("prefers provider-qualified cache keys over bare model ids", () => {
-    MODEL_CONTEXT_TOKEN_CACHE.set("claude-opus-4-6", 200_000);
-    MODEL_CONTEXT_TOKEN_CACHE.set("anthropic/claude-opus-4-6", 1_000_000);
+    MODEL_CONTEXT_TOKEN_CACHE.set("gemini-3.1-pro-preview", 200_000);
+    MODEL_CONTEXT_TOKEN_CACHE.set("google-gemini-cli/gemini-3.1-pro-preview", 1_000_000);
 
     const result = resolveContextTokens({
       cfg: {} as OpenClawConfig,
       agentCfg: undefined,
-      provider: "anthropic",
-      model: "claude-opus-4-6",
+      provider: "google-gemini-cli",
+      model: "gemini-3.1-pro-preview",
     });
 
     expect(result).toBe(1_000_000);

--- a/test/scripts/website-installer-sync-workflow.test.ts
+++ b/test/scripts/website-installer-sync-workflow.test.ts
@@ -32,6 +32,9 @@ describe("website installer sync workflow", () => {
     expect(workflow).toContain("bash /tmp/install-cli.sh --prefix /tmp/openclaw");
     expect(workflow).toContain("macos-installer:");
     expect(workflow).toContain("runs-on: macos-latest");
+    expect(workflow).toContain("node-version: 24");
+    expect(workflow).toContain("bash scripts/install.sh --no-onboard --no-prompt --version latest");
+    expect(workflow).toContain("openclaw --version");
     expect(workflow).toContain("windows-installer:");
     expect(workflow).toContain("runs-on: windows-latest");
     expect(workflow).toContain(".\\scripts\\install.ps1 -DryRun");

--- a/test/scripts/website-installer-sync-workflow.test.ts
+++ b/test/scripts/website-installer-sync-workflow.test.ts
@@ -33,6 +33,8 @@ describe("website installer sync workflow", () => {
     expect(workflow).toContain("macos-installer:");
     expect(workflow).toContain("runs-on: macos-latest");
     expect(workflow).toContain("node-version: 24");
+    expect(workflow).toContain('OPENCLAW_NO_ONBOARD: "1"');
+    expect(workflow).toContain('OPENCLAW_NO_PROMPT: "1"');
     expect(workflow).toContain("bash scripts/install.sh --no-onboard --no-prompt --version latest");
     expect(workflow).toContain("openclaw --version");
     expect(workflow).toContain("windows-installer:");


### PR DESCRIPTION
## Summary
- make the website installer sync gate run a real macOS install, not just a dry run
- verify the installed `openclaw` command resolves with `openclaw --version`
- cover the new macOS proof in the workflow unit test

## Test
- pnpm exec vitest run test/scripts/website-installer-sync-workflow.test.ts --reporter=dot
- actionlint .github/workflows/website-installer-sync.yml

## Real behavior proof
- Behavior or issue addressed: website installer sync now runs a full macOS install before it can publish installer script changes.
- Real environment tested: macOS host, Node.js v26.0.0 from `/opt/homebrew/bin/node`, npm global bin `/opt/homebrew/bin`.
- Exact steps or command run after this patch: `OPENCLAW_NO_ONBOARD=1 OPENCLAW_NO_PROMPT=1 bash scripts/install.sh --no-onboard --no-prompt --version latest`, then `/opt/homebrew/bin/openclaw --version`.
- Evidence after fix: terminal output from the macOS run:

```text
OpenClaw installed successfully (2026.5.7)!
global_bin=/opt/homebrew/bin
/opt/homebrew/bin/openclaw -> ../lib/node_modules/openclaw/openclaw.mjs
OpenClaw 2026.5.7 (eeef486)
```

- Observed result after fix: installer completed on macOS and the installed global `openclaw` binary printed `OpenClaw 2026.5.7 (eeef486)`.
- What was not tested: no known gaps.