### PR TITLE
Detect Docker Playwright Chromium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 - Auto-reply/TUI: keep fallback timeout recovery deliverable after a primary model lifecycle error by emitting fallback progress and deferring terminal TUI errors until recovery has a chance to finish. Fixes #80000. (#80009) Thanks @TurboTheTurtle.
 - CLI/agent: let `openclaw agent --model` use the backend/admin Gateway scope without cached device-token scopes silently downscoping the request. (#78837) Thanks @VACInc.
 - CLI/help: keep help and version invocations configless while improving shared port, channel, plugin, task, session, message, pairing, and auth recovery text.
+- Browser/Docker: detect Playwright-managed Chromium from `PLAYWRIGHT_BROWSERS_PATH` and the default Playwright cache on Linux, so Docker installs that persist `/home/node/.cache/ms-playwright` no longer need `browser.executablePath`.
 - Ollama: keep DeepSeek V4 cloud models thinking-capable even when Ollama Cloud `/api/show` omits the `thinking` capability, so `/think high` no longer rejects `ollama/deepseek-v4-*:cloud`.
 - ACPX/Claude ACP: keep foreground prompts waiting for their own result when autonomous task-notification results arrive during the same session, and retarget the patch for Claude Agent ACP `0.33.1`.
 - WhatsApp: keep Baileys media uploads from passing non-Dispatcher agents to undici in `7.0.0-rc10`, and patch the bundled Baileys declaration so the latest tsdown build stays warning-clean.

--- a/Dockerfile
+++ b/Dockerfile
@@ -207,15 +207,15 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
 # Adds ~300MB but eliminates the 60-90s Playwright install on every container start.
 # Must run after node_modules COPY so playwright-core is available.
 ARG OPENCLAW_INSTALL_BROWSER=""
+ENV PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright
 RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
     if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
       apt-get update && \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends xvfb && \
-      mkdir -p /home/node/.cache/ms-playwright && \
-      PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright \
+      mkdir -p "$PLAYWRIGHT_BROWSERS_PATH" && \
       node /app/node_modules/playwright-core/cli.js install --with-deps chromium && \
-      chown -R node:node /home/node/.cache/ms-playwright; \
+      chown -R node:node "$PLAYWRIGHT_BROWSERS_PATH"; \
     fi
 
 # Optionally install Docker CLI for sandbox container management.

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -416,7 +416,8 @@ See [ClawDock](/install/clawdock) for the full helper guide.
        ```
     4. **Persist browser downloads**: set
        `PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright` and use
-       `OPENCLAW_HOME_VOLUME` or `OPENCLAW_EXTRA_MOUNTS`.
+       `OPENCLAW_HOME_VOLUME` or `OPENCLAW_EXTRA_MOUNTS`. OpenClaw auto-detects
+       the persisted Chromium on Linux.
 
   </Accordion>
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -414,10 +414,9 @@ See [ClawDock](/install/clawdock) for the full helper guide.
        docker compose run --rm openclaw-cli \
          node /app/node_modules/playwright-core/cli.js install chromium
        ```
-    4. **Persist browser downloads**: set
-       `PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright` and use
-       `OPENCLAW_HOME_VOLUME` or `OPENCLAW_EXTRA_MOUNTS`. OpenClaw auto-detects
-       the persisted Chromium on Linux.
+    4. **Persist browser downloads**: use `OPENCLAW_HOME_VOLUME` or
+       `OPENCLAW_EXTRA_MOUNTS`. OpenClaw auto-detects the Docker image's
+       Playwright-managed Chromium on Linux.
 
   </Accordion>
 

--- a/docs/tools/browser-control.md
+++ b/docs/tools/browser-control.md
@@ -113,7 +113,8 @@ docker compose run --rm openclaw-cli \
 
 To persist browser downloads, set `PLAYWRIGHT_BROWSERS_PATH` (for example,
 `/home/node/.cache/ms-playwright`) and make sure `/home/node` is persisted via
-`OPENCLAW_HOME_VOLUME` or a bind mount. See [Docker](/install/docker).
+`OPENCLAW_HOME_VOLUME` or a bind mount. OpenClaw auto-detects the persisted
+Chromium on Linux. See [Docker](/install/docker).
 
 ## How it works (internal)
 

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -677,7 +677,8 @@ Platforms:
 - macOS: checks `/Applications` and `~/Applications`.
 - Linux: checks common Chrome/Brave/Edge/Chromium locations under `/usr/bin`,
   `/snap/bin`, `/opt/google`, `/opt/brave.com`, `/usr/lib/chromium`, and
-  `/usr/lib/chromium-browser`.
+  `/usr/lib/chromium-browser`, plus Playwright-managed Chromium under
+  `PLAYWRIGHT_BROWSERS_PATH` or `~/.cache/ms-playwright`.
 - Windows: checks common install locations.
 
 ## Control API (optional)

--- a/extensions/browser/src/browser/chrome.executables.ts
+++ b/extensions/browser/src/browser/chrome.executables.ts
@@ -14,6 +14,7 @@ export type BrowserExecutable = {
 };
 
 const CHROME_VERSION_RE = /\b(\d+)(?:\.\d+){1,3}\b/g;
+const PLAYWRIGHT_BROWSERS_PATH_ENV = "PLAYWRIGHT_BROWSERS_PATH";
 
 const CHROMIUM_BUNDLE_IDS = new Set([
   "com.google.Chrome",
@@ -485,6 +486,46 @@ function findFirstChromeExecutable(candidates: string[]): BrowserExecutable | nu
   return null;
 }
 
+function findPlaywrightChromiumExecutableCandidatesLinux(): Array<BrowserExecutable> {
+  const candidates: Array<BrowserExecutable> = [];
+  for (const browserPath of getPlaywrightBrowserCachePaths()) {
+    for (const entry of readSortedDirNames(browserPath)) {
+      if (!entry.startsWith("chromium-")) {
+        continue;
+      }
+      candidates.push({
+        kind: "chromium",
+        path: path.join(browserPath, entry, "chrome-linux", "chrome"),
+      });
+    }
+  }
+  return candidates;
+}
+
+function getPlaywrightBrowserCachePaths(): string[] {
+  const configured = normalizeOptionalString(process.env[PLAYWRIGHT_BROWSERS_PATH_ENV]);
+  const candidates = [
+    configured && configured !== "0" ? configured : null,
+    path.join(os.homedir(), ".cache", "ms-playwright"),
+  ];
+  const seen = new Set<string>();
+  return candidates.filter((candidate): candidate is string => {
+    if (!candidate || seen.has(candidate)) {
+      return false;
+    }
+    seen.add(candidate);
+    return true;
+  });
+}
+
+function readSortedDirNames(dir: string): string[] {
+  try {
+    return fs.readdirSync(dir).toSorted();
+  } catch {
+    return [];
+  }
+}
+
 export function findChromeExecutableMac(): BrowserExecutable | null {
   const candidates: Array<BrowserExecutable> = [
     {
@@ -568,6 +609,7 @@ export function findChromeExecutableLinux(): BrowserExecutable | null {
     { kind: "chromium", path: "/usr/lib/chromium/chromium" },
     { kind: "chromium", path: "/usr/lib/chromium-browser/chromium-browser" },
     { kind: "chromium", path: "/snap/bin/chromium" },
+    ...findPlaywrightChromiumExecutableCandidatesLinux(),
   ];
 
   return findFirstExecutable(candidates);

--- a/extensions/browser/src/browser/chrome.executables.ts
+++ b/extensions/browser/src/browser/chrome.executables.ts
@@ -493,10 +493,12 @@ function findPlaywrightChromiumExecutableCandidatesLinux(): Array<BrowserExecuta
       if (!entry.startsWith("chromium-")) {
         continue;
       }
-      candidates.push({
-        kind: "chromium",
-        path: path.join(browserPath, entry, "chrome-linux", "chrome"),
-      });
+      for (const linuxDir of ["chrome-linux64", "chrome-linux"]) {
+        candidates.push({
+          kind: "chromium",
+          path: path.join(browserPath, entry, linuxDir, "chrome"),
+        });
+      }
     }
   }
   return candidates;

--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -25,6 +25,10 @@ vi.mock("../infra/ports.js", () => ({
   ensurePortAvailable: ensurePortAvailableMock,
 }));
 
+vi.mock("../infra/tmp-openclaw-dir.js", () => ({
+  resolvePreferredOpenClawTmpDir: () => "/tmp/openclaw-browser-test",
+}));
+
 // Shrink long launch/bootstrap timeouts so tests don't wait 15s for
 // the CHROME_LAUNCH_READY_WINDOW_MS elapse-on-failure path.
 vi.mock("./cdp-timeouts.js", async () => {
@@ -452,6 +456,10 @@ describe("chrome.ts internal", () => {
           expect(spawnOptions.env?.HTTP_PROXY).toBeUndefined();
           expect(spawnOptions.env?.HTTPS_PROXY).toBeUndefined();
           expect(spawnOptions.env?.NO_PROXY).toBeUndefined();
+          if (process.platform === "linux") {
+            expect(spawnOptions.env?.XDG_CONFIG_HOME).toBe("/tmp/openclaw-browser-test/.chromium");
+            expect(spawnOptions.env?.XDG_CACHE_HOME).toBe("/tmp/openclaw-browser-test/.chromium");
+          }
           // Cleanup.
           running.proc.kill?.("SIGTERM");
         },

--- a/extensions/browser/src/browser/chrome.test.ts
+++ b/extensions/browser/src/browser/chrome.test.ts
@@ -366,6 +366,21 @@ describe("browser chrome helpers", () => {
     }
   });
 
+  it("finds Playwright-managed Linux Chromium", () => {
+    const browserPath = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-ms-playwright-"));
+    const executablePath = path.join(browserPath, "chromium-1217", "chrome-linux", "chrome");
+    vi.stubEnv("PLAYWRIGHT_BROWSERS_PATH", browserPath);
+    fs.mkdirSync(path.dirname(executablePath), { recursive: true });
+    const exists = mockExistsSync((pathValue) => pathValue === executablePath);
+
+    try {
+      expect(findChromeExecutableLinux()).toEqual({ kind: "chromium", path: executablePath });
+    } finally {
+      exists.mockRestore();
+      fs.rmSync(browserPath, { recursive: true, force: true });
+    }
+  });
+
   it("returns null when no Chrome candidate exists on Linux", () => {
     const exists = vi.spyOn(fs, "existsSync").mockReturnValue(false);
     expect(findChromeExecutableLinux()).toBeNull();

--- a/extensions/browser/src/browser/chrome.test.ts
+++ b/extensions/browser/src/browser/chrome.test.ts
@@ -368,7 +368,7 @@ describe("browser chrome helpers", () => {
 
   it("finds Playwright-managed Linux Chromium", () => {
     const browserPath = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-ms-playwright-"));
-    const executablePath = path.join(browserPath, "chromium-1217", "chrome-linux", "chrome");
+    const executablePath = path.join(browserPath, "chromium-1217", "chrome-linux64", "chrome");
     vi.stubEnv("PLAYWRIGHT_BROWSERS_PATH", browserPath);
     fs.mkdirSync(path.dirname(executablePath), { recursive: true });
     const exists = mockExistsSync((pathValue) => pathValue === executablePath);

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -441,16 +441,21 @@ export async function launchOpenClawChrome(
       userDataDir,
       ...launchOptions,
     });
+    const env = {
+      ...omitChromeProxyEnv(process.env),
+      // Reduce accidental sharing with the user's env.
+      HOME: os.homedir(),
+    };
+    if (process.platform === "linux") {
+      env.XDG_CONFIG_HOME ??= path.join(os.tmpdir(), ".chromium");
+      env.XDG_CACHE_HOME ??= path.join(os.tmpdir(), ".chromium");
+    }
     // stdio tuple: discard stdout to prevent buffer saturation in constrained
     // environments (e.g. Docker), while keeping stderr piped for diagnostics.
     // Cast to ChildProcessWithoutNullStreams so callers can use .stderr safely;
     // the tuple overload resolution varies across @types/node versions.
     const preparedSpawn = prepareOomScoreAdjustedSpawn(exe.path, args, {
-      env: {
-        ...omitChromeProxyEnv(process.env),
-        // Reduce accidental sharing with the user's env.
-        HOME: os.homedir(),
-      },
+      env,
     });
     return spawn(preparedSpawn.command, preparedSpawn.args, {
       stdio: ["ignore", "ignore", "pipe"],

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -6,6 +6,7 @@ import { prepareOomScoreAdjustedSpawn } from "openclaw/plugin-sdk/process-runtim
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { ensurePortAvailable } from "../infra/ports.js";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { CONFIG_DIR } from "../utils.js";
 import { hasChromeProxyControlArg, omitChromeProxyEnv } from "./browser-proxy-mode.js";
@@ -441,14 +442,15 @@ export async function launchOpenClawChrome(
       userDataDir,
       ...launchOptions,
     });
-    const env = {
+    const env: NodeJS.ProcessEnv = {
       ...omitChromeProxyEnv(process.env),
       // Reduce accidental sharing with the user's env.
       HOME: os.homedir(),
     };
     if (process.platform === "linux") {
-      env.XDG_CONFIG_HOME ??= path.join(os.tmpdir(), ".chromium");
-      env.XDG_CACHE_HOME ??= path.join(os.tmpdir(), ".chromium");
+      const chromiumStateDir = path.join(resolvePreferredOpenClawTmpDir(), ".chromium");
+      env.XDG_CONFIG_HOME ??= chromiumStateDir;
+      env.XDG_CACHE_HOME ??= chromiumStateDir;
     }
     // stdio tuple: discard stdout to prevent buffer saturation in constrained
     // environments (e.g. Docker), while keeping stderr piped for diagnostics.

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -74,6 +74,16 @@ describe("test-install-sh-docker", () => {
     expect(dockerfile).toContain("NODE_OPTIONS=--max-old-space-size=8192 pnpm build:docker");
   });
 
+  it("exports the Playwright browser cache installed by the root Dockerfile", () => {
+    const dockerfile = readFileSync("Dockerfile", "utf8");
+
+    expect(dockerfile).toContain("ENV PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright");
+    expect(dockerfile).toContain('mkdir -p "$PLAYWRIGHT_BROWSERS_PATH"');
+    expect(dockerfile).toContain(
+      "node /app/node_modules/playwright-core/cli.js install --with-deps chromium",
+    );
+  });
+
   it("allows repository branch history and release tags for secret-backed Docker release checks", () => {
     const workflow = readFileSync(LIVE_E2E_WORKFLOW_PATH, "utf8");
 


### PR DESCRIPTION
Summary:
- Detect Linux Playwright-managed Chromium from Docker/Playwright cache layouts.
- Export the Docker image's Playwright browser cache path at runtime.
- Give managed Chromium writable Linux XDG config/cache dirs when the caller has not set them.

## Real behavior proof
Behavior or issue addressed: Docker browser support can launch the Playwright-managed Chromium baked into the OpenClaw image without `browser.executablePath`, without system Chromium, and without compose-level XDG overrides.
Real environment tested: WSL2 Docker host `ubuntu@100.79.136.128`, PR image `openclaw:pr-80113-browser-cache`, head `ae4998319127`.
Exact steps or command run after this patch: built the PR image with `OPENCLAW_INSTALL_BROWSER=1`, recreated the live gateway with that image, removed `browser.executablePath` and compose `XDG_*` overrides, then ran `docker exec openclaw-docker-openclaw-gateway-1 openclaw browser --json --timeout 60000 start`.
Evidence after fix:
```text
PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright
system_chromium=
"running": true
"cdpReady": true
"detectedExecutablePath": "/home/node/.cache/ms-playwright/chromium-1217/chrome-linux64/chrome"
"executablePath": null
```
Observed result after fix: OpenClaw auto-detected and launched the Playwright-managed Chromium from the Docker image cache.
What was not tested: a real inbound Telegram user probe against `@HamVerBot`; the available QA Telegram user is not in that bot's allowlisted groups.

Verification:
- Regression test covers the Playwright `chrome-linux64/chrome` cache layout.
- `pnpm exec oxfmt --check --threads=1 Dockerfile extensions/browser/src/browser/chrome.ts extensions/browser/src/browser/chrome.executables.ts extensions/browser/src/browser/chrome.test.ts test/scripts/test-install-sh-docker.test.ts docs/install/docker.md`
- `pnpm test extensions/browser/src/browser/chrome.test.ts test/scripts/test-install-sh-docker.test.ts`
- Remote Docker build and live browser start on `ubuntu@100.79.136.128` passed.
