### PR TITLE
fix(codex): attach native generated artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Codex app-server: attach Codex-native generated artifacts from private `generated_*` folders to the final reply payload with a short fallback caption, so image, PDF, DOCX, XLSX, audio, and video outputs still deliver when the assistant text is blank. Thanks @keshavbotagent.
 - Cron: let isolated self-cleanup runs inspect their own job run history while keeping other cron jobs and mutation actions blocked. Fixes #80019. Thanks @hclsys.
 - OpenAI/realtime voice: accept Codex-compatible legacy audio and transcript event aliases so provider protocol drift does not drop assistant audio or captions.
 - Discord/voice: keep default agent-proxy realtime sessions from auto-speaking filler before the forced OpenClaw consult answer, finish Discord playback on realtime response completion, and queue later exact-speech answers until playback idles to avoid mid-sentence replacement.

--- a/extensions/codex/src/app-server/native-artifacts.test.ts
+++ b/extensions/codex/src/app-server/native-artifacts.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   appendCodexNativeArtifactsToResult,
   collectNewCodexNativeArtifacts,
@@ -38,6 +38,26 @@ describe("Codex native artifact collection", () => {
       generatedPdf,
       generatedSheet,
     ]);
+  });
+
+  it("treats generated-artifact directory read failures as non-fatal", async () => {
+    const codexHome = path.join(tempDir, "codex-home");
+    const generatedFile = path.join(codexHome, "generated_files", "report.pdf");
+    await fs.mkdir(path.dirname(generatedFile), { recursive: true });
+    await fs.writeFile(generatedFile, "pdf bytes");
+
+    const originalReadDir = fs.readdir.bind(fs) as (...args: unknown[]) => Promise<unknown>;
+    vi.spyOn(fs, "readdir").mockImplementation(async (...args: unknown[]) => {
+      const [dir] = args;
+      if (String(dir).endsWith("generated_images")) {
+        throw Object.assign(new Error("locked directory"), { code: "EPERM" });
+      }
+      return (await originalReadDir(...args)) as never;
+    }) as never;
+
+    const snapshot = await snapshotCodexNativeArtifacts(codexHome);
+
+    expect(snapshot.files.has(generatedFile)).toBe(true);
   });
 
   it("adds generated artifacts to tool media unless delivery was already explicit", () => {

--- a/extensions/codex/src/app-server/native-artifacts.test.ts
+++ b/extensions/codex/src/app-server/native-artifacts.test.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  appendCodexNativeArtifactsToResult,
+  collectNewCodexNativeArtifacts,
+  snapshotCodexNativeArtifacts,
+} from "./native-artifacts.js";
+
+let tempDir: string;
+
+describe("Codex native artifact collection", () => {
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-artifacts-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("collects new generated documents and images after the turn snapshot", async () => {
+    const codexHome = path.join(tempDir, "codex-home");
+    const preexisting = path.join(codexHome, "generated_images", "old.png");
+    await fs.mkdir(path.dirname(preexisting), { recursive: true });
+    await fs.writeFile(preexisting, "old image");
+
+    const snapshot = await snapshotCodexNativeArtifacts(codexHome);
+
+    const generatedPdf = path.join(codexHome, "generated_documents", "report.pdf");
+    const generatedSheet = path.join(codexHome, "generated_files", "report.xlsx");
+    await fs.mkdir(path.dirname(generatedPdf), { recursive: true });
+    await fs.mkdir(path.dirname(generatedSheet), { recursive: true });
+    await fs.writeFile(generatedPdf, "pdf bytes");
+    await fs.writeFile(generatedSheet, "xlsx bytes");
+
+    await expect(collectNewCodexNativeArtifacts(snapshot)).resolves.toEqual([
+      generatedPdf,
+      generatedSheet,
+    ]);
+  });
+
+  it("adds generated artifacts to tool media unless delivery was already explicit", () => {
+    expect(
+      appendCodexNativeArtifactsToResult({ assistantTexts: [], toolMediaUrls: ["/tmp/a.png"] }, [
+        "/tmp/a.png",
+        "/tmp/b.docx",
+      ]),
+    ).toMatchObject({ toolMediaUrls: ["/tmp/a.png", "/tmp/b.docx"] });
+
+    expect(
+      appendCodexNativeArtifactsToResult(
+        {
+          assistantTexts: ["caption\nMEDIA:/tmp/explicit.png"],
+          toolMediaUrls: [],
+        },
+        ["/tmp/native.png"],
+      ).toolMediaUrls,
+    ).toEqual([]);
+
+    expect(
+      appendCodexNativeArtifactsToResult(
+        {
+          assistantTexts: [],
+          messagingToolSentMediaUrls: ["/tmp/sent.png"],
+          toolMediaUrls: [],
+        },
+        ["/tmp/native.png"],
+      ).toolMediaUrls,
+    ).toEqual([]);
+  });
+});

--- a/extensions/codex/src/app-server/native-artifacts.test.ts
+++ b/extensions/codex/src/app-server/native-artifacts.test.ts
@@ -46,7 +46,19 @@ describe("Codex native artifact collection", () => {
         "/tmp/a.png",
         "/tmp/b.docx",
       ]),
-    ).toMatchObject({ toolMediaUrls: ["/tmp/a.png", "/tmp/b.docx"] });
+    ).toMatchObject({
+      assistantTexts: ["Generated document attached."],
+      toolMediaUrls: ["/tmp/a.png", "/tmp/b.docx"],
+    });
+
+    expect(
+      appendCodexNativeArtifactsToResult({ assistantTexts: ["Done."], toolMediaUrls: [] }, [
+        "/tmp/a.png",
+      ]),
+    ).toMatchObject({
+      assistantTexts: ["Done."],
+      toolMediaUrls: ["/tmp/a.png"],
+    });
 
     expect(
       appendCodexNativeArtifactsToResult(

--- a/extensions/codex/src/app-server/native-artifacts.ts
+++ b/extensions/codex/src/app-server/native-artifacts.ts
@@ -93,12 +93,11 @@ async function listArtifactsInRoot(
   let entries: Dirent[];
   try {
     entries = await fs.readdir(root, { withFileTypes: true });
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === "ENOENT" || code === "ENOTDIR" || code === "EACCES") {
-      return [];
-    }
-    throw error;
+  } catch {
+    // Artifact discovery decorates an already-completed turn. A filesystem
+    // race, platform ACL error, or locked generated subtree must not fail the
+    // assistant reply.
+    return [];
   }
 
   const artifacts: ArtifactEntry[] = [];

--- a/extensions/codex/src/app-server/native-artifacts.ts
+++ b/extensions/codex/src/app-server/native-artifacts.ts
@@ -19,6 +19,8 @@ const DELIVERABLE_ARTIFACT_EXTENSIONS = new Set([
   ".doc",
   ".docx",
   ".gif",
+  ".heic",
+  ".heif",
   ".jpeg",
   ".jpg",
   ".m4a",
@@ -174,6 +176,71 @@ function hasAssistantMediaDirective(texts: readonly string[] | undefined): boole
   return texts?.some((text) => /(^|\n)\s*MEDIA:/iu.test(text)) ?? false;
 }
 
+function hasVisibleAssistantText(texts: readonly string[] | undefined): boolean {
+  return texts?.some((text) => text.trim().length > 0) ?? false;
+}
+
+function describeArtifact(filePath: string): string {
+  switch (path.extname(filePath).toLowerCase()) {
+    case ".apng":
+    case ".avif":
+    case ".bmp":
+    case ".gif":
+    case ".heic":
+    case ".heif":
+    case ".jpeg":
+    case ".jpg":
+    case ".png":
+    case ".svg":
+    case ".webp":
+      return "image";
+    case ".pdf":
+      return "PDF";
+    case ".csv":
+    case ".ods":
+    case ".tsv":
+    case ".xls":
+    case ".xlsx":
+      return "spreadsheet";
+    case ".doc":
+    case ".docx":
+    case ".md":
+    case ".odt":
+    case ".rtf":
+    case ".txt":
+      return "document";
+    case ".odp":
+    case ".ppt":
+    case ".pptx":
+      return "presentation";
+    case ".m4a":
+    case ".mp3":
+    case ".ogg":
+    case ".opus":
+    case ".wav":
+      return "audio";
+    case ".mov":
+    case ".mp4":
+    case ".webm":
+      return "video";
+    case ".zip":
+      return "archive";
+    default:
+      return "file";
+  }
+}
+
+function formatArtifactSummary(artifactPaths: readonly string[]): string {
+  if (artifactPaths.length === 1 && artifactPaths[0]) {
+    return `Generated ${describeArtifact(artifactPaths[0])} attached.`;
+  }
+  const kinds = Array.from(new Set(artifactPaths.map(describeArtifact)));
+  if (kinds.length === 1 && kinds[0]) {
+    return `Generated ${artifactPaths.length} ${kinds[0]} files attached.`;
+  }
+  return `Generated ${artifactPaths.length} files attached.`;
+}
+
 export function appendCodexNativeArtifactsToResult<T extends ResultWithMedia>(
   result: T,
   artifactPaths: readonly string[],
@@ -196,6 +263,9 @@ export function appendCodexNativeArtifactsToResult<T extends ResultWithMedia>(
   }
   return {
     ...result,
+    assistantTexts: hasVisibleAssistantText(result.assistantTexts)
+      ? result.assistantTexts
+      : [formatArtifactSummary(freshArtifacts)],
     toolMediaUrls: [...(result.toolMediaUrls ?? []), ...freshArtifacts],
   };
 }

--- a/extensions/codex/src/app-server/native-artifacts.ts
+++ b/extensions/codex/src/app-server/native-artifacts.ts
@@ -1,0 +1,201 @@
+import type { Dirent } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const CODEX_NATIVE_ARTIFACT_DIRS = [
+  "generated_images",
+  "generated_media",
+  "generated_files",
+  "generated_documents",
+  "generated_audio",
+  "generated_videos",
+] as const;
+
+const DELIVERABLE_ARTIFACT_EXTENSIONS = new Set([
+  ".apng",
+  ".avif",
+  ".bmp",
+  ".csv",
+  ".doc",
+  ".docx",
+  ".gif",
+  ".jpeg",
+  ".jpg",
+  ".m4a",
+  ".md",
+  ".mov",
+  ".mp3",
+  ".mp4",
+  ".odp",
+  ".ods",
+  ".odt",
+  ".ogg",
+  ".opus",
+  ".pdf",
+  ".png",
+  ".ppt",
+  ".pptx",
+  ".rtf",
+  ".svg",
+  ".tsv",
+  ".txt",
+  ".wav",
+  ".webm",
+  ".webp",
+  ".xls",
+  ".xlsx",
+  ".zip",
+]);
+
+const MAX_ARTIFACT_SCAN_DEPTH = 5;
+const MAX_NATIVE_ARTIFACTS = 20;
+
+type ArtifactEntry = {
+  path: string;
+  mtimeMs: number;
+  size: number;
+};
+
+export type CodexNativeArtifactSnapshot = {
+  roots: string[];
+  files: Map<string, ArtifactEntry>;
+};
+
+type ResultWithMedia = {
+  assistantTexts?: string[];
+  messagingToolSentMediaUrls?: string[];
+  toolMediaUrls?: string[];
+};
+
+function isDeliverableArtifact(filePath: string): boolean {
+  return DELIVERABLE_ARTIFACT_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+function codexNativeArtifactRoots(codexHome: string | undefined): string[] {
+  const normalizedHome = codexHome?.trim();
+  if (!normalizedHome) {
+    return [];
+  }
+  const resolvedHome = path.resolve(normalizedHome);
+  return CODEX_NATIVE_ARTIFACT_DIRS.map((dirName) => path.join(resolvedHome, dirName));
+}
+
+async function listArtifactsInRoot(
+  root: string,
+  options: { depth?: number } = {},
+): Promise<ArtifactEntry[]> {
+  const depth = options.depth ?? 0;
+  if (depth > MAX_ARTIFACT_SCAN_DEPTH) {
+    return [];
+  }
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR" || code === "EACCES") {
+      return [];
+    }
+    throw error;
+  }
+
+  const artifacts: ArtifactEntry[] = [];
+  for (const entry of entries) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      artifacts.push(...(await listArtifactsInRoot(entryPath, { depth: depth + 1 })));
+      continue;
+    }
+    if (!entry.isFile() || !isDeliverableArtifact(entryPath)) {
+      continue;
+    }
+    let stat: { mtimeMs: number; size: number };
+    try {
+      stat = await fs.stat(entryPath);
+    } catch {
+      continue;
+    }
+    if (stat.size <= 0) {
+      continue;
+    }
+    artifacts.push({
+      path: path.resolve(entryPath),
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+    });
+  }
+  return artifacts;
+}
+
+async function listCodexNativeArtifacts(roots: readonly string[]): Promise<ArtifactEntry[]> {
+  const artifacts: ArtifactEntry[] = [];
+  for (const root of roots) {
+    artifacts.push(...(await listArtifactsInRoot(root)));
+  }
+  return artifacts;
+}
+
+export async function snapshotCodexNativeArtifacts(
+  codexHome: string | undefined,
+): Promise<CodexNativeArtifactSnapshot> {
+  const roots = codexNativeArtifactRoots(codexHome);
+  const files = new Map<string, ArtifactEntry>();
+  for (const artifact of await listCodexNativeArtifacts(roots)) {
+    files.set(artifact.path, artifact);
+  }
+  return { roots, files };
+}
+
+export async function collectNewCodexNativeArtifacts(
+  snapshot: CodexNativeArtifactSnapshot,
+): Promise<string[]> {
+  if (snapshot.roots.length === 0) {
+    return [];
+  }
+  const newArtifacts: ArtifactEntry[] = [];
+  for (const artifact of await listCodexNativeArtifacts(snapshot.roots)) {
+    const previous = snapshot.files.get(artifact.path);
+    if (
+      previous &&
+      previous.size === artifact.size &&
+      Math.floor(previous.mtimeMs) === Math.floor(artifact.mtimeMs)
+    ) {
+      continue;
+    }
+    newArtifacts.push(artifact);
+  }
+  return newArtifacts
+    .toSorted((left, right) => left.mtimeMs - right.mtimeMs || left.path.localeCompare(right.path))
+    .slice(0, MAX_NATIVE_ARTIFACTS)
+    .map((artifact) => artifact.path);
+}
+
+function hasAssistantMediaDirective(texts: readonly string[] | undefined): boolean {
+  return texts?.some((text) => /(^|\n)\s*MEDIA:/iu.test(text)) ?? false;
+}
+
+export function appendCodexNativeArtifactsToResult<T extends ResultWithMedia>(
+  result: T,
+  artifactPaths: readonly string[],
+): T {
+  if (
+    artifactPaths.length === 0 ||
+    (result.messagingToolSentMediaUrls?.length ?? 0) > 0 ||
+    hasAssistantMediaDirective(result.assistantTexts)
+  ) {
+    return result;
+  }
+
+  const existingMedia = new Set(result.toolMediaUrls ?? []);
+  const freshArtifacts = artifactPaths.filter((artifactPath) => {
+    const trimmed = artifactPath.trim();
+    return trimmed && !existingMedia.has(trimmed);
+  });
+  if (freshArtifacts.length === 0) {
+    return result;
+  }
+  return {
+    ...result,
+    toolMediaUrls: [...(result.toolMediaUrls ?? []), ...freshArtifacts],
+  };
+}

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2571,7 +2571,7 @@ describe("runCodexAppServerAttempt", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await expect(run).resolves.toMatchObject({
-      assistantTexts: [],
+      assistantTexts: ["Generated image attached."],
       toolMediaUrls: [generatedImage],
     });
   });

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2549,6 +2549,33 @@ describe("runCodexAppServerAttempt", () => {
     expect(result.timedOut).toBe(false);
   });
 
+  it("surfaces Codex-native generated artifacts as reply media when assistant text is blank", async () => {
+    const harness = createStartedThreadHarness();
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const agentDir = path.join(tempDir, "agent");
+    const params = createParams(sessionFile, workspaceDir);
+    params.agentDir = agentDir;
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+
+    const generatedImage = path.join(
+      resolveCodexAppServerHomeDir(agentDir),
+      "generated_images",
+      "turn-1",
+      "edited.png",
+    );
+    await fs.mkdir(path.dirname(generatedImage), { recursive: true });
+    await fs.writeFile(generatedImage, "fake image bytes");
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await expect(run).resolves.toMatchObject({
+      assistantTexts: [],
+      toolMediaUrls: [generatedImage],
+    });
+  });
+
   it("does not complete on unscoped turn/completed notifications", async () => {
     const harness = createStartedThreadHarness();
     const run = runCodexAppServerAttempt(

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -78,6 +78,11 @@ import { createCodexDynamicToolBridge, type CodexDynamicToolBridge } from "./dyn
 import { handleCodexAppServerElicitationRequest } from "./elicitation-bridge.js";
 import { CodexAppServerEventProjector } from "./event-projector.js";
 import {
+  appendCodexNativeArtifactsToResult,
+  collectNewCodexNativeArtifacts,
+  snapshotCodexNativeArtifacts,
+} from "./native-artifacts.js";
+import {
   buildCodexNativeHookRelayDisabledConfig,
   buildCodexNativeHookRelayConfig,
   CODEX_NATIVE_HOOK_RELAY_EVENTS,
@@ -1260,6 +1265,9 @@ export async function runCodexAppServerAttempt(
       content: [{ type: "text", text: promptBuild.prompt }],
     },
   ];
+  const codexNativeArtifactSnapshot = await snapshotCodexNativeArtifacts(
+    resolveCodexPluginAppCacheCodexHome(appServer, agentDir),
+  );
 
   let turn: CodexTurnStartResponse;
   try {
@@ -1417,7 +1425,11 @@ export async function runCodexAppServerAttempt(
 
   try {
     await completion;
-    const result = activeProjector.buildResult(toolBridge.telemetry, { yieldDetected });
+    const projectedResult = activeProjector.buildResult(toolBridge.telemetry, { yieldDetected });
+    const result = appendCodexNativeArtifactsToResult(
+      projectedResult,
+      await collectNewCodexNativeArtifacts(codexNativeArtifactSnapshot),
+    );
     const finalAborted = result.aborted || runAbortController.signal.aborted;
     const finalPromptError = turnCompletionIdleTimedOut
       ? turnCompletionIdleTimeoutMessage


### PR DESCRIPTION
## Summary
- collect Codex-native `imageGeneration.savedPath` artifacts from the current completed turn
- attach those generated image files to the final reply media payload
- synthesize a short fallback caption when generated images are the only assistant-visible output
- avoid broad `generated_*` filesystem scans, historical artifact snapshots, and accumulated-directory I/O

## Manual proof
- 2026-05-10: verified on Keshav's live OpenClaw Telegram gateway with the request `Create an image of a child with his mother's day mom`; the bot delivered the generated image and added the fallback caption `Generated image attached.`. This was a real channel delivery path, not just a unit test.
- Screenshot proof: https://raw.githubusercontent.com/keshavbotagent/openclaw/pr-80122-proof/.github/proof/pr-80122-telegram-delivery-proof.jpg

![Telegram delivery proof](https://raw.githubusercontent.com/keshavbotagent/openclaw/pr-80122-proof/.github/proof/pr-80122-telegram-delivery-proof.jpg)

## Tests
- `pnpm exec vitest run extensions/codex/src/app-server/native-artifacts.test.ts`
- `pnpm exec vitest run extensions/codex/src/app-server/run-attempt.test.ts -t "surfaces Codex-native generated image saved paths"`
- `pnpm tsgo:extensions:test`