### PR TITLE
fix(security): consult tools.byProvider deny when auditing small-model web tool exposure

### DIFF
--- a/src/security/audit-extra.summary.ts
+++ b/src/security/audit-extra.summary.ts
@@ -6,7 +6,7 @@ import type { SandboxToolPolicy } from "../agents/sandbox/types.js";
 import { isToolAllowedByPolicies } from "../agents/tool-policy-match.js";
 import { resolveToolProfilePolicy } from "../agents/tool-policy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { AgentToolsConfig } from "../config/types.tools.js";
+import type { AgentToolsConfig, ToolPolicyConfig } from "../config/types.tools.js";
 import { hasConfiguredInternalHooks } from "../hooks/configured.js";
 import { hasConfiguredWebSearchCredential } from "../plugins/web-search-credential-presence.js";
 import { inferParamBFromIdOrName } from "../shared/model-param-b.js";
@@ -57,6 +57,28 @@ function extractAgentIdFromSource(source: string): string | null {
   return match?.[1] ?? null;
 }
 
+function lookupByProviderPolicy(
+  byProvider: Record<string, ToolPolicyConfig> | undefined,
+  modelId: string,
+): ToolPolicyConfig | undefined {
+  if (!byProvider) {
+    return undefined;
+  }
+  const lower = modelId.toLowerCase();
+  // Check full "provider/model" key first, then provider-only prefix.
+  if (Object.prototype.hasOwnProperty.call(byProvider, lower)) {
+    return byProvider[lower];
+  }
+  const slashIdx = lower.indexOf("/");
+  if (slashIdx > 0) {
+    const providerOnly = lower.slice(0, slashIdx);
+    if (Object.prototype.hasOwnProperty.call(byProvider, providerOnly)) {
+      return byProvider[providerOnly];
+    }
+  }
+  return undefined;
+}
+
 function resolveToolPolicies(params: {
   cfg: OpenClawConfig;
   agentTools?: AgentToolsConfig;
@@ -75,6 +97,15 @@ function resolveToolPolicies(params: {
   const globalPolicy = pickSandboxToolPolicy(params.cfg.tools ?? undefined);
   if (globalPolicy) {
     policies.push(globalPolicy);
+  }
+
+  if (params.modelId) {
+    const globalProviderPolicy = pickSandboxToolPolicy(
+      lookupByProviderPolicy(params.cfg.tools?.byProvider, params.modelId),
+    );
+    if (globalProviderPolicy) {
+      policies.push(globalProviderPolicy);
+    }
   }
 
   const agentPolicy = pickSandboxToolPolicy(params.agentTools);

--- a/src/security/audit-small-model-risk.test.ts
+++ b/src/security/audit-small-model-risk.test.ts
@@ -60,6 +60,50 @@ describe("security audit small-model risk findings", () => {
     }
   });
 
+  it("treats tools.byProvider deny as mitigating web tool exposure for the targeted model", () => {
+    const finding = requireFirstSmallModelFinding(
+      collectSmallModelRiskFindings({
+        cfg: {
+          agents: { defaults: { model: { primary: "ollama/mistral-8b" } } },
+          tools: {
+            web: { search: { enabled: true }, fetch: { enabled: true } },
+            byProvider: {
+              "ollama/mistral-8b": { deny: ["web_search", "web_fetch", "browser"] },
+            },
+          },
+          browser: { enabled: true },
+        },
+        env: process.env,
+      }),
+      "byProvider deny mitigates web exposure",
+    );
+    // byProvider deny removes the web tools from the model's exposure — reported as web=[off].
+    // severity stays critical because sandbox is still off; that is a separate gate.
+    expect(finding.detail).toContain("web=[off]");
+    expect(finding.detail).not.toContain("web_search");
+  });
+
+  it("does not suppress web exposure when byProvider deny targets a different model", () => {
+    const finding = requireFirstSmallModelFinding(
+      collectSmallModelRiskFindings({
+        cfg: {
+          agents: { defaults: { model: { primary: "ollama/mistral-8b" } } },
+          tools: {
+            web: { search: { enabled: true }, fetch: { enabled: true } },
+            byProvider: {
+              "openai/gpt-4o": { deny: ["web_search", "web_fetch", "browser"] },
+            },
+          },
+          browser: { enabled: true },
+        },
+        env: process.env,
+      }),
+      "byProvider deny for other model does not suppress",
+    );
+    expect(finding.severity).toBe("critical");
+    expect(finding.detail).toContain("web_search");
+  });
+
   it("resolves configured aliases before parameter-size classification", () => {
     const finding = requireFirstSmallModelFinding(
       collectSmallModelRiskFindings({


### PR DESCRIPTION
## Problem

`collectSmallModelRiskFindings()` in `src/security/audit-extra.summary.ts` checks `tools.deny` and per-agent `tools.deny` when computing web-tool exposure for small models, but **ignores `tools.byProvider`** — the per-provider/model policy gate introduced in #7284.

A user who correctly configures:
```yaml
tools:
  byProvider:
    "openai/gpt-4o-mini": { deny: ["web_search", "web_fetch", "browser"] }
```
still sees `CRITICAL` severity for that model. The audit falsely claims unmitigated web exposure even though the per-model deny is applied at runtime.

This is a sibling bug to #74455 (alias resolution missing from the same collector).

## Fix

Add `lookupByProviderPolicy()` — a minimal two-key lookup (exact `provider/model` key, then `provider` prefix) — and inject the matching `byProvider` entry into `resolveToolPolicies()` as both global and agent-scoped provider policies. This mirrors the layering in `tool-policy-pipeline.ts`.

```typescript
// Before: resolveToolPolicies only checked tools.deny, agents.*.tools.deny
// After: also checks tools.byProvider[modelId], agents.*.tools.byProvider[modelId]
```

## Tests

Added two cases to `audit-small-model-risk.test.ts`:
- `tools.byProvider` deny for the exact model → `detail` shows `web=[off]` (exposure cleared)
- `tools.byProvider` deny for a different model → exposure not suppressed (correct scoping)

Fixes #80118