### PR TITLE
fix(doctor): invalidate persisted plugin registry when a diagnostic source path no longer exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Media/host-read: allow buffer-verified gzip, tar, and 7z archives in the shared host-local media validator alongside ZIP and document attachments.
+- Plugins/doctor: invalidate persisted plugin registry snapshots when plugin diagnostics point at deleted source paths, so `openclaw doctor` stops repeating stale warnings after a local extension is replaced by a managed npm plugin. Fixes #80087. (#80134) Thanks @hclsys.
 - Cron: let isolated self-cleanup runs inspect their own job run history while keeping other cron jobs and mutation actions blocked. Fixes #80019. Thanks @hclsys.
 - Cron: report isolated agent-turn setup and pre-model stalls with phase-specific timeout errors instead of waiting for the full job budget when no model call starts. Fixes #74803. Thanks @jeffsteinbok-openclaw and @dgkim311.
 - CLI/config: persist explicit `config set` and `config patch` values that equal runtime defaults instead of reporting success while dropping them. Fixes #79856. (#80106) Thanks @abodanty and @hclsys.

--- a/src/plugins/plugin-registry-snapshot.test.ts
+++ b/src/plugins/plugin-registry-snapshot.test.ts
@@ -309,12 +309,22 @@ describe("loadPluginRegistrySnapshotWithMetadata", () => {
     );
   });
 
-  it("treats persisted registry as stale when a diagnostic source path no longer exists", () => {
+  it("treats persisted registry as stale when a plugin diagnostic source path no longer exists", () => {
     const tempRoot = makeTempDir();
     const stateDir = path.join(tempRoot, "state");
-    const env = { ...createHermeticEnv(tempRoot), OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" };
+    const env = {
+      ...createHermeticEnv(tempRoot),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+    };
     const config = {};
     const ghostDir = path.join(tempRoot, "extensions", "lossless-claw");
+    const npmPluginDir = writeManagedNpmPlugin({
+      stateDir,
+      packageName: "@martian-engineering/lossless-claw",
+      pluginId: "lossless-claw",
+      version: "0.9.4",
+    });
     const staleIndex: InstalledPluginIndex = {
       ...loadInstalledPluginIndex({ config, env, stateDir, installRecords: {} }),
       diagnostics: [
@@ -335,8 +345,42 @@ describe("loadPluginRegistrySnapshotWithMetadata", () => {
     expect(result.snapshot.diagnostics).not.toContainEqual(
       expect.objectContaining({ source: ghostDir }),
     );
+    expect(result.snapshot.plugins).toContainEqual(
+      expect.objectContaining({
+        pluginId: "lossless-claw",
+        origin: "global",
+        source: fs.realpathSync(path.join(npmPluginDir, "dist", "index.js")),
+      }),
+    );
     expect(result.diagnostics).toContainEqual(
       expect.objectContaining({ code: "persisted-registry-stale-source" }),
     );
+  });
+
+  it("keeps persisted registry when a non-plugin diagnostic source path still does not exist", () => {
+    const tempRoot = makeTempDir();
+    const stateDir = path.join(tempRoot, "state");
+    const env = { ...createHermeticEnv(tempRoot), OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" };
+    const config = {};
+    const missingConfiguredPath = path.join(tempRoot, "missing-configured-plugin");
+    const index: InstalledPluginIndex = {
+      ...loadInstalledPluginIndex({ config, env, stateDir, installRecords: {} }),
+      diagnostics: [
+        {
+          level: "error",
+          message: `plugin path not found: ${missingConfiguredPath}`,
+          source: missingConfiguredPath,
+        },
+      ],
+    };
+    writePersistedInstalledPluginIndexSync(index, { stateDir });
+
+    const result = loadPluginRegistrySnapshotWithMetadata({ config, env, stateDir });
+
+    expect(result.source).toBe("persisted");
+    expect(result.snapshot.diagnostics).toContainEqual(
+      expect.objectContaining({ source: missingConfiguredPath }),
+    );
+    expect(result.diagnostics).toStrictEqual([]);
   });
 });

--- a/src/plugins/plugin-registry-snapshot.test.ts
+++ b/src/plugins/plugin-registry-snapshot.test.ts
@@ -308,4 +308,35 @@ describe("loadPluginRegistrySnapshotWithMetadata", () => {
       expect.objectContaining({ code: "persisted-registry-stale-source" }),
     );
   });
+
+  it("treats persisted registry as stale when a diagnostic source path no longer exists", () => {
+    const tempRoot = makeTempDir();
+    const stateDir = path.join(tempRoot, "state");
+    const env = { ...createHermeticEnv(tempRoot), OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" };
+    const config = {};
+    const ghostDir = path.join(tempRoot, "extensions", "lossless-claw");
+    const staleIndex: InstalledPluginIndex = {
+      ...loadInstalledPluginIndex({ config, env, stateDir, installRecords: {} }),
+      diagnostics: [
+        {
+          level: "warn",
+          message:
+            "installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js",
+          pluginId: "lossless-claw",
+          source: ghostDir,
+        },
+      ],
+    };
+    writePersistedInstalledPluginIndexSync(staleIndex, { stateDir });
+
+    const result = loadPluginRegistrySnapshotWithMetadata({ config, env, stateDir });
+
+    expect(result.source).toBe("derived");
+    expect(result.snapshot.diagnostics).not.toContainEqual(
+      expect.objectContaining({ source: ghostDir }),
+    );
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "persisted-registry-stale-source" }),
+    );
+  });
 });

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -134,7 +134,13 @@ function resolveRecordPackageJsonPath(plugin: InstalledPluginIndexRecord): strin
 function hasStalePersistedPluginDiagnostics(index: InstalledPluginIndex): boolean {
   return index.diagnostics.some((diag) => {
     const source = diag.source;
-    return typeof source === "string" && path.isAbsolute(source) && !fs.existsSync(source);
+    return (
+      typeof diag.pluginId === "string" &&
+      diag.pluginId.trim().length > 0 &&
+      typeof source === "string" &&
+      path.isAbsolute(source) &&
+      !fs.existsSync(source)
+    );
   });
 }
 

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -131,6 +131,13 @@ function resolveRecordPackageJsonPath(plugin: InstalledPluginIndexRecord): strin
   return relative.startsWith("..") || path.isAbsolute(relative) ? null : resolved;
 }
 
+function hasStalePersistedPluginDiagnostics(index: InstalledPluginIndex): boolean {
+  return index.diagnostics.some((diag) => {
+    const source = diag.source;
+    return typeof source === "string" && path.isAbsolute(source) && !fs.existsSync(source);
+  });
+}
+
 function hasStalePersistedPluginMetadata(index: InstalledPluginIndex): boolean {
   return index.plugins.some((plugin) => {
     if (!hasOptionalMissingPluginManifestFile(plugin)) {
@@ -235,6 +242,13 @@ export function loadPluginRegistrySnapshotWithMetadata(
           code: "persisted-registry-stale-source",
           message:
             "Persisted plugin registry points at a different bundled plugin tree; using derived plugin index. Run `openclaw plugins registry --refresh` to update the persisted registry.",
+        });
+      } else if (hasStalePersistedPluginDiagnostics(persistedIndex)) {
+        diagnostics.push({
+          level: "warn",
+          code: "persisted-registry-stale-source",
+          message:
+            "Persisted plugin registry contains diagnostics referencing missing paths; using derived plugin index. Run `openclaw plugins registry --refresh` to update the persisted registry.",
         });
       } else if (hasStalePersistedPluginMetadata(persistedIndex)) {
         diagnostics.push({


### PR DESCRIPTION
## Problem

`openclaw doctor` floods its output with a stale WARN diagnostic after an extensions directory is removed and replaced by an npm-installed plugin.

**Reproduction:**
1. Install a TypeScript extension at `~/.openclaw/extensions/lossless-claw/` — it emits a WARN diagnostic: _"installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js"_
2. The persisted plugin registry (`~/.openclaw/plugins/installs.json`) stores this diagnostic in its `diagnostics` array
3. Uninstall the extension and install `lossless-claw` via npm — the extensions directory no longer exists
4. Run `openclaw doctor` — the stale WARN still re-emits because the persisted registry is served from cache without re-deriving

## Root cause

`loadPluginRegistrySnapshotWithMetadata` validates plugin source paths and file metadata before trusting the persisted registry, but it did not validate plugin-owned `InstalledPluginIndex.diagnostics[].source` paths. A diagnostic whose `source` points at a now-deleted directory passed all staleness checks and was served intact.

## Fix

Add `hasStalePersistedPluginDiagnostics()` in `src/plugins/plugin-registry-snapshot.ts`: returns `true` when a plugin-scoped diagnostic carries an absolute-path `source` that no longer exists on disk. This triggers the same `persisted-registry-stale-source` fallback used by the existing plugin-source and metadata checks, causing a fresh derived index to be used instead.

The fresh derived index keeps the managed npm plugin and drops the stale diagnostic from the removed source package. Non-plugin diagnostics, such as a still-missing configured load path, stay on the persisted fast path so current configuration errors do not force pointless re-derivation every run.

## Test

Added regression tests:

- `treats persisted registry as stale when a plugin diagnostic source path no longer exists`: creates a persisted index carrying a ghost `source` path, creates a managed npm `@martian-engineering/lossless-claw` replacement, then asserts `result.source === "derived"`, the stale diagnostic is absent, and the npm plugin is loaded from `dist/index.js`.
- `keeps persisted registry when a non-plugin diagnostic source path still does not exist`: verifies current missing-path diagnostics without `pluginId` do not invalidate the persisted registry.

```bash
pnpm test src/plugins/plugin-registry-snapshot.test.ts
# Test Files  1 passed (1)
# Tests       8 passed (8)
```

## Real behavior proof

- **Behavior or issue addressed:** `openclaw doctor` no longer repeats a stale `lossless-claw` warning from a deleted `~/.openclaw/extensions/lossless-claw` source path after the plugin is available as a managed npm install.
- **Real environment tested:** Local OpenClaw source checkout on macOS with a hermetic `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH`, using the actual `pnpm --silent openclaw` CLI commands from this PR branch.
- **Exact steps or command run after this patch:** Seeded a temporary OpenClaw state with a persisted plugin registry containing a stale plugin diagnostic for `/tmp/openclaw-pr80134-proof.GMPG1b/extensions/lossless-claw`, installed a managed npm replacement under `state/npm/node_modules/@martian-engineering/lossless-claw`, then ran `openclaw plugins list --json` and `openclaw doctor --non-interactive`.
- **Evidence after fix:** Terminal capture:

```text
--- openclaw plugins list --json excerpt ---
"registry": {
  "source": "derived",
  "diagnostics": [
    {
      "level": "warn",
      "code": "persisted-registry-stale-source",
      "message": "Persisted plugin registry contains diagnostics referencing missing paths; using derived plugin index. Run `openclaw plugins registry --refresh` to update the persisted registry."
    }
  ]
},
"plugins": [
  {
    "id": "lossless-claw",
    "name": "@martian-engineering/lossless-claw",
    "version": "0.9.4",
    "source": "/private/tmp/openclaw-pr80134-proof.GMPG1b/state/npm/node_modules/@martian-engineering/lossless-claw/dist/index.js",
    "origin": "global",
    "enabled": true,
    "status": "loaded"
  }
]

--- openclaw doctor --non-interactive | grep lossless-claw ---
no lossless-claw doctor warnings
```

- **Observed result after fix:** The persisted registry is treated as stale, the managed npm `lossless-claw` plugin is loaded from `dist/index.js`, and `openclaw doctor` emits no `lossless-claw` warning for the deleted extension path.
- **What was not tested:** No production DGX host rerun in this maintainer fixup; the CLI proof uses the same persisted registry and managed npm state shape in an isolated local OpenClaw state.

## Files changed

- `src/plugins/plugin-registry-snapshot.ts` — plugin-scoped stale diagnostic source check
- `src/plugins/plugin-registry-snapshot.test.ts` — regression coverage for npm replacement and non-plugin missing-path diagnostics
- `CHANGELOG.md` — user-facing fix note
