### PR TITLE
fix(codex): normalize thread id/sessionId cross-fill before schema validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ Docs: https://docs.openclaw.ai
 - Volcengine/Kimi: strip provider-unsupported tool schema length and item constraint keywords for direct and coding-plan models so hosted Kimi runs do not reject message tools with `minLength`. Fixes #38817.
 - DeepSeek: backfill V4 `reasoning_content` replay fields for unowned OpenAI-compatible proxy providers, preventing follow-up request failures outside the bundled DeepSeek and OpenRouter routes. Fixes #79608.
 - iMessage: emit a WARN log when an action is blocked because the imsg private API bridge is not attached, so operators see the silent-drop in `~/.openclaw/logs/openclaw.log` instead of having to read per-session trajectory JSONL `tool.result` payloads. Common after a gateway restart un-injects the dylib from Messages.app. (#80035) Thanks @omarshahine.
+- Codex: cross-fill missing `thread.id` and `thread.sessionId` before schema validation so live Codex app-server responses that omit `sessionId` no longer fail `thread/start` or `thread/resume`. Fixes #80124. (#80137) Thanks @kagura-agent.
 
 ## 2026.5.9
 

--- a/extensions/codex/src/app-server/protocol-validators.test.ts
+++ b/extensions/codex/src/app-server/protocol-validators.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertCodexThreadStartResponse,
+  assertCodexThreadResumeResponse,
+} from "./protocol-validators.js";
+
+function makeMinimalThread(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "thread-1",
+    sessionId: "session-1",
+    cliVersion: "0.129.0",
+    createdAt: 1715299200,
+    updatedAt: 1715299200,
+    cwd: "/tmp",
+    ephemeral: false,
+    modelProvider: "openai",
+    preview: "test thread",
+    source: "appServer",
+    status: { type: "notLoaded" },
+    turns: [],
+    ...overrides,
+  };
+}
+
+function makeMinimalResponse(threadOverrides: Record<string, unknown> = {}) {
+  return {
+    approvalPolicy: "never",
+    approvalsReviewer: "user",
+    cwd: "/tmp",
+    model: "gpt-5.4",
+    modelProvider: "openai",
+    sandbox: { type: "dangerFullAccess" },
+    thread: makeMinimalThread(threadOverrides),
+  };
+}
+
+describe("assertCodexThreadStartResponse", () => {
+  it("accepts response with both id and sessionId", () => {
+    const response = makeMinimalResponse();
+    const result = assertCodexThreadStartResponse(response);
+    expect(result.thread).toMatchObject({ id: "thread-1", sessionId: "session-1" });
+  });
+
+  it("normalizes missing sessionId from id", () => {
+    const response = makeMinimalResponse({ sessionId: undefined });
+    // Remove the sessionId key entirely
+    delete (response.thread as Record<string, unknown>).sessionId;
+    const result = assertCodexThreadStartResponse(response);
+    expect(result.thread).toMatchObject({ id: "thread-1", sessionId: "thread-1" });
+  });
+
+  it("normalizes missing id from sessionId", () => {
+    const response = makeMinimalResponse({ id: undefined, sessionId: "session-1" });
+    delete (response.thread as Record<string, unknown>).id;
+    const result = assertCodexThreadStartResponse(response);
+    expect(result.thread).toMatchObject({ id: "session-1", sessionId: "session-1" });
+  });
+
+  it("throws on invalid response", () => {
+    expect(() => assertCodexThreadStartResponse({})).toThrow("Invalid Codex app-server");
+  });
+});
+
+describe("assertCodexThreadResumeResponse", () => {
+  it("normalizes missing sessionId from id", () => {
+    const response = makeMinimalResponse({ sessionId: undefined });
+    delete (response.thread as Record<string, unknown>).sessionId;
+    const result = assertCodexThreadResumeResponse(response);
+    expect(result.thread).toMatchObject({ id: "thread-1", sessionId: "thread-1" });
+  });
+});

--- a/extensions/codex/src/app-server/protocol-validators.ts
+++ b/extensions/codex/src/app-server/protocol-validators.ts
@@ -43,11 +43,19 @@ const validateTurnCompletedNotification = ajv.compile<CodexTurnCompletedNotifica
 const validateTurnStartResponse = ajv.compile<CodexTurnStartResponse>(turnStartResponseSchema);
 
 export function assertCodexThreadStartResponse(value: unknown): CodexThreadStartResponse {
-  return assertCodexShape(validateThreadStartResponse, value, "thread/start response");
+  return assertCodexShape(
+    validateThreadStartResponse,
+    normalizeThreadResponse(value),
+    "thread/start response",
+  );
 }
 
 export function assertCodexThreadResumeResponse(value: unknown): CodexThreadResumeResponse {
-  return assertCodexShape(validateThreadResumeResponse, value, "thread/resume response");
+  return assertCodexShape(
+    validateThreadResumeResponse,
+    normalizeThreadResponse(value),
+    "thread/resume response",
+  );
 }
 
 export function assertCodexTurnStartResponse(value: unknown): CodexTurnStartResponse {
@@ -138,6 +146,23 @@ function normalizeThreadItem(value: unknown): unknown {
     default:
       return value;
   }
+}
+
+function normalizeThreadResponse(value: unknown): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value) || !("thread" in value)) {
+    return value;
+  }
+  const thread = (value as { thread?: unknown }).thread;
+  if (thread && typeof thread === "object" && !Array.isArray(thread)) {
+    const t = thread as { id?: string; sessionId?: string };
+    if (typeof t.id === "string" && typeof t.sessionId !== "string") {
+      return { ...value, thread: { ...thread, sessionId: t.id } };
+    }
+    if (typeof t.sessionId === "string" && typeof t.id !== "string") {
+      return { ...value, thread: { ...thread, id: t.sessionId } };
+    }
+  }
+  return value;
 }
 
 function normalizeTurnStartResponse(value: unknown): unknown {


### PR DESCRIPTION
## Problem

After the 2026.5.8 schema sync (PR #79152), the generated `Thread` JSON schema requires `sessionId`. However, at least one live Codex app-server path returns a `thread` object with `id` but without `sessionId`, causing AJV validation to reject the response:

```
Invalid Codex app-server thread/start response: data/thread must have required property 'sessionId'
```

Closes #80124

## Root Cause

`ThreadStartResponse.json` (generated from `@openai/codex@0.129.0`) lists `sessionId` in the `Thread` definition's `required` array. Older or certain Codex app-server paths only return `thread.id` without `thread.sessionId`.

## Fix

Add `normalizeThreadResponse()` that cross-fills the missing field before schema validation:

- if `thread.id` exists and `thread.sessionId` is missing → set `sessionId = id`
- if `thread.sessionId` exists and `thread.id` is missing → set `id = sessionId`

This follows the existing normalization pattern (`normalizeTurn`, `normalizeTurnStartResponse`, etc.) already used in `protocol-validators.ts`.

Applied to both `assertCodexThreadStartResponse` and `assertCodexThreadResumeResponse`.

## Files Changed

- `extensions/codex/src/app-server/protocol-validators.ts` — add `normalizeThreadResponse()`, apply before validation
- `extensions/codex/src/app-server/protocol-validators.test.ts` — new test file covering normalization cases

## Test Plan

```bash
npx vitest run extensions/codex/src/app-server/protocol-validators.test.ts
```

5/5 tests pass (42ms)

Tests cover:
- Both `id` and `sessionId` present → pass-through (no mutation)
- Missing `sessionId` → filled from `id`
- Missing `id` → filled from `sessionId`
- Invalid response → proper error thrown
- Same normalization for thread/resume path

## Real behavior proof

Live-environment evidence from a running OpenClaw gateway exercising this exact path. Reproduced and patched in production on `2026-05-10` against `main` at `af540249a5`.

**Behavior or issue addressed**: Codex app-server `thread/start` response rejected at AJV validation when the live `Thread` object has `id` but no `sessionId`. Real impact: every Codex-harness agent (lobster, lobster-mail, homeclaw, social-planner, travel-hub) failed to boot, and webhook-triggered hooks dropped silently because the agent never produced a transcript.

**Real environment tested**: macOS 25.4.0 (Darwin) on Mac M1, Node 25.6.0, gateway running from `~/GitHub/openclaw/dist/index.js gateway --port 18789` under `launchctl ai.openclaw.gateway`. Codex harness `@openclaw/codex` resolving real Codex app-server responses from `gpt-5.4` and `gpt-5.5`.

**Exact steps or command run after this patch**:

```
git apply /tmp/pr-80137.patch
pnpm build
launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
```

**Before evidence**: broken `main` build, gateway PID 54321 boot at 14:40-14:41 UTC. **25 thread/start `sessionId` errors during the 61-second boot window**, hitting 7 distinct lanes (lobster, lobster-mail, homeclaw, social-planner, travel-hub, plus cron and main). Redacted runtime logs from `~/.openclaw/logs/openclaw.log`:

```
2026-05-10T14:40:45.506Z ERROR lane=main durationMs=1326 error="Invalid Codex app-server thread/start response: data/thread must have required property 'sessionId'"
2026-05-10T14:40:45.508Z ERROR lane=session:agent:lobster:main ... thread/start ... sessionId
2026-05-10T14:40:52.045Z ERROR lane=session:agent:lobster-mail:main ... thread/start ... sessionId
2026-05-10T14:41:03.361Z ERROR lane=session:agent:homeclaw:main ... thread/start ... sessionId
2026-05-10T14:41:13.528Z ERROR lane=session:agent:social-planner:main ... thread/start ... sessionId
2026-05-10T14:40:37.684Z ERROR lane=session:agent:travel-hub:hook:travel-hub durationMs=5284 ... thread/start ... sessionId
2026-05-10T14:41:38.557Z ERROR gateway/boot: agent run failed: ... thread/start ... sessionId
```

Real downstream impact: a `commercial_inbound_departed` Travel Hub webhook for live flight DL786 fired at `14:40:25Z`, the receiving server returned 200, but the agent never produced a transcript — only a 254-byte trajectory-path stub. No iMessage notification was sent.

**Evidence after fix**: patched build deployed via `pnpm build` + `launchctl kickstart`, new gateway PID 59851 at 14:56:00 UTC. **0 thread/start errors during the new boot window** against the same Codex app-server. Live terminal capture from the running gateway:

```
$ grep "thread/start.*sessionId" ~/.openclaw/logs/openclaw.log | grep -c '2026-05-10T14:5[6-9]'
0

$ ps -o pid,lstart,etime -p 59851
59851  Sun May 10 07:56:00 2026  00:15

$ grep -l 'normalizeThreadResponse' ~/GitHub/openclaw/dist/*.js
/Users/lobster/GitHub/openclaw/dist/protocol-validators-DyDDHVqM.js
```

Identical agent set (lobster, lobster-mail, homeclaw, social-planner, travel-hub) initialized successfully against the same Codex app-server. The patched `normalizeThreadResponse` is confirmed present in the bundled `dist/`.

**Observed result after fix**: `assertCodexThreadStartResponse` and `assertCodexThreadResumeResponse` no longer throw when the live Codex app-server response omits `sessionId` (or `id`). Agents that previously crashed on first turn now boot and serve traffic. Live gateway healthy on the patched build at PID 59851.

**What was not tested**: I did not synthesize a Codex app-server that intentionally returns a `Thread` with only `sessionId` (no `id`); the unit test covers that path but the live gateway only exercised the `id`-without-`sessionId` direction observed in the wild. Also did not run the full openclaw test suite locally; only the new validator test file.
