### PR TITLE
fix: surface node wake nudge budgets

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -1,21 +1,15 @@
-import { Type } from "typebox";
-import { isAcpRuntimeSpawnAvailable } from "../../acp/runtime/availability.js";
-import { getRuntimeConfig } from "../../config/config.js";
+import { Type } from "@sinclair/typebox";
+import { loadConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
-import { normalizeDeliveryContext } from "../../utils/delivery-context.shared.js";
+import { normalizeDeliveryContext } from "../../utils/delivery-context.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
 import { optionalStringEnum } from "../schema/typebox.js";
 import type { SpawnedToolContext } from "../spawned-context.js";
 import { registerSubagentRun } from "../subagent-registry.js";
-import {
-  SUBAGENT_SPAWN_CONTEXT_MODES,
-  SUBAGENT_SPAWN_MODES,
-  spawnSubagentDirect,
-} from "../subagent-spawn.js";
+import { SUBAGENT_SPAWN_MODES, spawnSubagentDirect } from "../subagent-spawn.js";
 import {
   describeSessionsSpawnTool,
-  SESSIONS_SPAWN_SUBAGENT_TOOL_DISPLAY_SUMMARY,
   SESSIONS_SPAWN_TOOL_DISPLAY_SUMMARY,
 } from "../tool-description-presets.js";
 import type { AnyAgentTool } from "./common.js";
@@ -100,13 +94,11 @@ async function cleanupUntrackedAcpSession(sessionKey: string): Promise<void> {
   }
 }
 
-function createSessionsSpawnToolSchema(params: { acpAvailable: boolean }) {
+function createSessionsSpawnToolSchema() {
   const schema = {
     task: Type.String(),
     label: Type.Optional(Type.String()),
-    runtime: optionalStringEnum(
-      params.acpAvailable ? SESSIONS_SPAWN_RUNTIMES : (["subagent"] as const),
-    ),
+    runtime: optionalStringEnum(SESSIONS_SPAWN_RUNTIMES),
     agentId: Type.Optional(Type.String()),
     model: Type.Optional(Type.String()),
     thinking: Type.Optional(Type.String()),
@@ -118,10 +110,6 @@ function createSessionsSpawnToolSchema(params: { acpAvailable: boolean }) {
     mode: optionalStringEnum(SUBAGENT_SPAWN_MODES),
     cleanup: optionalStringEnum(["delete", "keep"] as const),
     sandbox: optionalStringEnum(SESSIONS_SPAWN_SANDBOX_MODES),
-    context: optionalStringEnum(SUBAGENT_SPAWN_CONTEXT_MODES, {
-      description:
-        'Native subagent context mode. Omit or use "isolated" for a clean child session; use "fork" only when the child needs the requester transcript context.',
-    }),
     lightContext: Type.Optional(
       Type.Boolean({
         description:
@@ -149,32 +137,15 @@ function createSessionsSpawnToolSchema(params: { acpAvailable: boolean }) {
         mountPath: Type.Optional(Type.String()),
       }),
     ),
-    ...(params.acpAvailable
-      ? {
-          resumeSessionId: Type.Optional(
-            Type.String({
-              description:
-                'ACP-only resume target. Only meaningful with runtime="acp"; ignored for runtime="subagent". Use only an ACP/harness session ID already recorded for this requester so the ACP backend replays conversation history instead of starting fresh.',
-            }),
-          ),
-          streamTo: optionalStringEnum(SESSIONS_SPAWN_ACP_STREAM_TARGETS, {
-            description:
-              'ACP-only stream target. Only meaningful with runtime="acp"; ignored for runtime="subagent". Use "parent" to stream the ACP turn back to the requester instead of tracking it as a background sessions_spawn run.',
-          }),
-        }
-      : {}),
+    resumeSessionId: Type.Optional(
+      Type.String({
+        description:
+          'Resume an existing agent session by its ID (e.g. a Codex session UUID from ~/.codex/sessions/). Requires runtime="acp". The agent replays conversation history via session/load instead of starting fresh.',
+      }),
+    ),
+    streamTo: optionalStringEnum(SESSIONS_SPAWN_ACP_STREAM_TARGETS),
   };
   return Type.Object(schema);
-}
-
-function resolveAcpUnavailableMessage(opts?: { sandboxed?: boolean; config?: OpenClawConfig }) {
-  if (opts?.sandboxed === true) {
-    return 'runtime="acp" is unavailable from sandboxed sessions because ACP sessions run on the host. Use runtime="subagent".';
-  }
-  if (opts?.config?.acp?.enabled === false) {
-    return 'runtime="acp" is unavailable because ACP is disabled by policy (`acp.enabled=false`). Use runtime="subagent".';
-  }
-  return 'runtime="acp" is unavailable in this session because no ACP runtime backend is loaded. Enable the acpx plugin or use runtime="subagent".';
 }
 
 export function createSessionsSpawnTool(
@@ -190,18 +161,12 @@ export function createSessionsSpawnTool(
     requesterAgentIdOverride?: string;
   } & SpawnedToolContext,
 ): AnyAgentTool {
-  const acpAvailable = isAcpRuntimeSpawnAvailable({
-    config: opts?.config,
-    sandboxed: opts?.sandboxed,
-  });
   return {
     label: "Sessions",
     name: "sessions_spawn",
-    displaySummary: acpAvailable
-      ? SESSIONS_SPAWN_TOOL_DISPLAY_SUMMARY
-      : SESSIONS_SPAWN_SUBAGENT_TOOL_DISPLAY_SUMMARY,
-    description: describeSessionsSpawnTool({ acpAvailable }),
-    parameters: createSessionsSpawnToolSchema({ acpAvailable }),
+    displaySummary: SESSIONS_SPAWN_TOOL_DISPLAY_SUMMARY,
+    description: describeSessionsSpawnTool(),
+    parameters: createSessionsSpawnToolSchema(),
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
       const unsupportedParam = UNSUPPORTED_SESSIONS_SPAWN_PARAM_KEYS.find((key) =>
@@ -226,23 +191,11 @@ export function createSessionsSpawnTool(
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
       const expectsCompletionMessage = params.expectsCompletionMessage !== false;
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
-      const context =
-        params.context === "fork" || params.context === "isolated" ? params.context : undefined;
-      const streamTo = runtime === "acp" && params.streamTo === "parent" ? "parent" : undefined;
+      const streamTo = params.streamTo === "parent" ? "parent" : undefined;
       const lightContext = params.lightContext === true;
       const roleContext = requestedAgentId ? { role: requestedAgentId } : {};
-      if (runtime === "acp" && !acpAvailable) {
-        return jsonResult({
-          status: "error",
-          error: resolveAcpUnavailableMessage(opts),
-          ...roleContext,
-        });
-      }
       if (runtime === "acp" && lightContext) {
         throw new Error("lightContext is only supported for runtime='subagent'.");
-      }
-      if (runtime === "acp" && context === "fork") {
-        throw new Error('context="fork" is only supported for runtime="subagent".');
       }
       // Back-compat: older callers used timeoutSeconds for this tool.
       const timeoutSecondsCandidate =
@@ -265,6 +218,22 @@ export function createSessionsSpawnTool(
           }>)
         : undefined;
 
+      if (streamTo && runtime !== "acp") {
+        return jsonResult({
+          status: "error",
+          error: `streamTo is only supported for runtime=acp; got runtime=${runtime}`,
+          ...roleContext,
+        });
+      }
+
+      if (resumeSessionId && runtime !== "acp") {
+        return jsonResult({
+          status: "error",
+          error: `resumeSessionId is only supported for runtime=acp; got runtime=${runtime}`,
+          ...roleContext,
+        });
+      }
+
       if (runtime === "acp") {
         const { isSpawnAcpAcceptedResult, spawnAcpDirect } = await loadAcpSpawnModule();
         if (Array.isArray(attachments) && attachments.length > 0) {
@@ -281,9 +250,6 @@ export function createSessionsSpawnTool(
             label: label || undefined,
             agentId: requestedAgentId,
             resumeSessionId,
-            model: modelOverride,
-            thinking: thinkingOverrideRaw,
-            runTimeoutSeconds,
             cwd,
             mode: mode === "run" || mode === "session" ? mode : undefined,
             thread,
@@ -297,8 +263,6 @@ export function createSessionsSpawnTool(
             agentTo: opts?.agentTo,
             agentThreadId: opts?.agentThreadId,
             agentGroupId: opts?.agentGroupId ?? undefined,
-            agentGroupSpace: opts?.agentGroupSpace,
-            agentMemberRoleIds: opts?.agentMemberRoleIds,
             sandboxed: opts?.sandboxed,
           },
         );
@@ -310,7 +274,7 @@ export function createSessionsSpawnTool(
           Boolean(childRunId) &&
           streamTo !== "parent";
         if (shouldTrackViaRegistry && childSessionKey && childRunId) {
-          const cfg = getRuntimeConfig();
+          const cfg = loadConfig();
           const trackedSpawnMode = resolveTrackedSpawnMode({
             requestedMode: result.mode,
             threadRequested: thread,
@@ -377,7 +341,6 @@ export function createSessionsSpawnTool(
           mode,
           cleanup,
           sandbox,
-          context,
           lightContext,
           expectsCompletionMessage,
           attachments,
@@ -395,7 +358,6 @@ export function createSessionsSpawnTool(
           agentGroupId: opts?.agentGroupId,
           agentGroupChannel: opts?.agentGroupChannel,
           agentGroupSpace: opts?.agentGroupSpace,
-          agentMemberRoleIds: opts?.agentMemberRoleIds,
           requesterAgentIdOverride: opts?.requesterAgentIdOverride,
           workspaceDir: opts?.workspaceDir,
         },

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -1,14 +1,21 @@
-import { Type } from "@sinclair/typebox";
-import { loadConfig } from "../../config/config.js";
+import { Type } from "typebox";
+import { isAcpRuntimeSpawnAvailable } from "../../acp/runtime/availability.js";
+import { getRuntimeConfig } from "../../config/config.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
-import { normalizeDeliveryContext } from "../../utils/delivery-context.js";
+import { normalizeDeliveryContext } from "../../utils/delivery-context.shared.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
 import { optionalStringEnum } from "../schema/typebox.js";
 import type { SpawnedToolContext } from "../spawned-context.js";
 import { registerSubagentRun } from "../subagent-registry.js";
-import { SUBAGENT_SPAWN_MODES, spawnSubagentDirect } from "../subagent-spawn.js";
+import {
+  SUBAGENT_SPAWN_CONTEXT_MODES,
+  SUBAGENT_SPAWN_MODES,
+  spawnSubagentDirect,
+} from "../subagent-spawn.js";
 import {
   describeSessionsSpawnTool,
+  SESSIONS_SPAWN_SUBAGENT_TOOL_DISPLAY_SUMMARY,
   SESSIONS_SPAWN_TOOL_DISPLAY_SUMMARY,
 } from "../tool-description-presets.js";
 import type { AnyAgentTool } from "./common.js";
@@ -53,6 +60,16 @@ function summarizeError(err: unknown): string {
   return "error";
 }
 
+function addRoleToFailureResult<T extends { status: string }>(
+  result: T,
+  role: string | undefined,
+): T | (T & { role: string }) {
+  if (!role || (result.status !== "error" && result.status !== "forbidden")) {
+    return result;
+  }
+  return { ...result, role };
+}
+
 function resolveTrackedSpawnMode(params: {
   requestedMode?: "run" | "session";
   threadRequested: boolean;
@@ -83,56 +100,82 @@ async function cleanupUntrackedAcpSession(sessionKey: string): Promise<void> {
   }
 }
 
-const SessionsSpawnToolSchema = Type.Object({
-  task: Type.String(),
-  label: Type.Optional(Type.String()),
-  runtime: optionalStringEnum(SESSIONS_SPAWN_RUNTIMES),
-  agentId: Type.Optional(Type.String()),
-  resumeSessionId: Type.Optional(
-    Type.String({
-      description:
-        'Resume an existing agent session by its ID (e.g. a Codex session UUID from ~/.codex/sessions/). Requires runtime="acp". The agent replays conversation history via session/load instead of starting fresh.',
-    }),
-  ),
-  model: Type.Optional(Type.String()),
-  thinking: Type.Optional(Type.String()),
-  cwd: Type.Optional(Type.String()),
-  runTimeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
-  // Back-compat: older callers used timeoutSeconds for this tool.
-  timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
-  thread: Type.Optional(Type.Boolean()),
-  mode: optionalStringEnum(SUBAGENT_SPAWN_MODES),
-  cleanup: optionalStringEnum(["delete", "keep"] as const),
-  sandbox: optionalStringEnum(SESSIONS_SPAWN_SANDBOX_MODES),
-  streamTo: optionalStringEnum(SESSIONS_SPAWN_ACP_STREAM_TARGETS),
-  lightContext: Type.Optional(
-    Type.Boolean({
-      description:
-        "When true, spawned subagent runs use lightweight bootstrap context. Only applies to runtime='subagent'.",
-    }),
-  ),
-
-  // Inline attachments (snapshot-by-value).
-  // NOTE: Attachment contents are redacted from transcript persistence by sanitizeToolCallInputs.
-  attachments: Type.Optional(
-    Type.Array(
-      Type.Object({
-        name: Type.String(),
-        content: Type.String(),
-        encoding: Type.Optional(optionalStringEnum(["utf8", "base64"] as const)),
-        mimeType: Type.Optional(Type.String()),
-      }),
-      { maxItems: 50 },
+function createSessionsSpawnToolSchema(params: { acpAvailable: boolean }) {
+  const schema = {
+    task: Type.String(),
+    label: Type.Optional(Type.String()),
+    runtime: optionalStringEnum(
+      params.acpAvailable ? SESSIONS_SPAWN_RUNTIMES : (["subagent"] as const),
     ),
-  ),
-  attachAs: Type.Optional(
-    Type.Object({
-      // Where the spawned agent should look for attachments.
-      // Kept as a hint; implementation materializes into the child workspace.
-      mountPath: Type.Optional(Type.String()),
+    agentId: Type.Optional(Type.String()),
+    model: Type.Optional(Type.String()),
+    thinking: Type.Optional(Type.String()),
+    cwd: Type.Optional(Type.String()),
+    runTimeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
+    // Back-compat: older callers used timeoutSeconds for this tool.
+    timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
+    thread: Type.Optional(Type.Boolean()),
+    mode: optionalStringEnum(SUBAGENT_SPAWN_MODES),
+    cleanup: optionalStringEnum(["delete", "keep"] as const),
+    sandbox: optionalStringEnum(SESSIONS_SPAWN_SANDBOX_MODES),
+    context: optionalStringEnum(SUBAGENT_SPAWN_CONTEXT_MODES, {
+      description:
+        'Native subagent context mode. Omit or use "isolated" for a clean child session; use "fork" only when the child needs the requester transcript context.',
     }),
-  ),
-});
+    lightContext: Type.Optional(
+      Type.Boolean({
+        description:
+          "When true, spawned subagent runs use lightweight bootstrap context. Only applies to runtime='subagent'.",
+      }),
+    ),
+
+    // Inline attachments (snapshot-by-value).
+    // NOTE: Attachment contents are redacted from transcript persistence by sanitizeToolCallInputs.
+    attachments: Type.Optional(
+      Type.Array(
+        Type.Object({
+          name: Type.String(),
+          content: Type.String(),
+          encoding: Type.Optional(optionalStringEnum(["utf8", "base64"] as const)),
+          mimeType: Type.Optional(Type.String()),
+        }),
+        { maxItems: 50 },
+      ),
+    ),
+    attachAs: Type.Optional(
+      Type.Object({
+        // Where the spawned agent should look for attachments.
+        // Kept as a hint; implementation materializes into the child workspace.
+        mountPath: Type.Optional(Type.String()),
+      }),
+    ),
+    ...(params.acpAvailable
+      ? {
+          resumeSessionId: Type.Optional(
+            Type.String({
+              description:
+                'ACP-only resume target. Only meaningful with runtime="acp"; ignored for runtime="subagent". Use only an ACP/harness session ID already recorded for this requester so the ACP backend replays conversation history instead of starting fresh.',
+            }),
+          ),
+          streamTo: optionalStringEnum(SESSIONS_SPAWN_ACP_STREAM_TARGETS, {
+            description:
+              'ACP-only stream target. Only meaningful with runtime="acp"; ignored for runtime="subagent". Use "parent" to stream the ACP turn back to the requester instead of tracking it as a background sessions_spawn run.',
+          }),
+        }
+      : {}),
+  };
+  return Type.Object(schema);
+}
+
+function resolveAcpUnavailableMessage(opts?: { sandboxed?: boolean; config?: OpenClawConfig }) {
+  if (opts?.sandboxed === true) {
+    return 'runtime="acp" is unavailable from sandboxed sessions because ACP sessions run on the host. Use runtime="subagent".';
+  }
+  if (opts?.config?.acp?.enabled === false) {
+    return 'runtime="acp" is unavailable because ACP is disabled by policy (`acp.enabled=false`). Use runtime="subagent".';
+  }
+  return 'runtime="acp" is unavailable in this session because no ACP runtime backend is loaded. Enable the acpx plugin or use runtime="subagent".';
+}
 
 export function createSessionsSpawnTool(
   opts?: {
@@ -142,16 +185,23 @@ export function createSessionsSpawnTool(
     agentTo?: string;
     agentThreadId?: string | number;
     sandboxed?: boolean;
+    config?: OpenClawConfig;
     /** Explicit agent ID override for cron/hook sessions where session key parsing may not work. */
     requesterAgentIdOverride?: string;
   } & SpawnedToolContext,
 ): AnyAgentTool {
+  const acpAvailable = isAcpRuntimeSpawnAvailable({
+    config: opts?.config,
+    sandboxed: opts?.sandboxed,
+  });
   return {
     label: "Sessions",
     name: "sessions_spawn",
-    displaySummary: SESSIONS_SPAWN_TOOL_DISPLAY_SUMMARY,
-    description: describeSessionsSpawnTool(),
-    parameters: SessionsSpawnToolSchema,
+    displaySummary: acpAvailable
+      ? SESSIONS_SPAWN_TOOL_DISPLAY_SUMMARY
+      : SESSIONS_SPAWN_SUBAGENT_TOOL_DISPLAY_SUMMARY,
+    description: describeSessionsSpawnTool({ acpAvailable }),
+    parameters: createSessionsSpawnToolSchema({ acpAvailable }),
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
       const unsupportedParam = UNSUPPORTED_SESSIONS_SPAWN_PARAM_KEYS.find((key) =>
@@ -166,7 +216,8 @@ export function createSessionsSpawnTool(
       const label = readStringParam(params, "label") ?? "";
       const runtime = params.runtime === "acp" ? "acp" : "subagent";
       const requestedAgentId = readStringParam(params, "agentId");
-      const resumeSessionId = readStringParam(params, "resumeSessionId");
+      const requestedResumeSessionId = readStringParam(params, "resumeSessionId");
+      const resumeSessionId = runtime === "acp" ? requestedResumeSessionId : undefined;
       const modelOverride = readStringParam(params, "model");
       const thinkingOverrideRaw = readStringParam(params, "thinking");
       const cwd = readStringParam(params, "cwd");
@@ -175,10 +226,23 @@ export function createSessionsSpawnTool(
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
       const expectsCompletionMessage = params.expectsCompletionMessage !== false;
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
-      const streamTo = params.streamTo === "parent" ? "parent" : undefined;
+      const context =
+        params.context === "fork" || params.context === "isolated" ? params.context : undefined;
+      const streamTo = runtime === "acp" && params.streamTo === "parent" ? "parent" : undefined;
       const lightContext = params.lightContext === true;
+      const roleContext = requestedAgentId ? { role: requestedAgentId } : {};
+      if (runtime === "acp" && !acpAvailable) {
+        return jsonResult({
+          status: "error",
+          error: resolveAcpUnavailableMessage(opts),
+          ...roleContext,
+        });
+      }
       if (runtime === "acp" && lightContext) {
         throw new Error("lightContext is only supported for runtime='subagent'.");
+      }
+      if (runtime === "acp" && context === "fork") {
+        throw new Error('context="fork" is only supported for runtime="subagent".');
       }
       // Back-compat: older callers used timeoutSeconds for this tool.
       const timeoutSecondsCandidate =
@@ -201,20 +265,6 @@ export function createSessionsSpawnTool(
           }>)
         : undefined;
 
-      if (streamTo && runtime !== "acp") {
-        return jsonResult({
-          status: "error",
-          error: `streamTo is only supported for runtime=acp; got runtime=${runtime}`,
-        });
-      }
-
-      if (resumeSessionId && runtime !== "acp") {
-        return jsonResult({
-          status: "error",
-          error: `resumeSessionId is only supported for runtime=acp; got runtime=${runtime}`,
-        });
-      }
-
       if (runtime === "acp") {
         const { isSpawnAcpAcceptedResult, spawnAcpDirect } = await loadAcpSpawnModule();
         if (Array.isArray(attachments) && attachments.length > 0) {
@@ -222,6 +272,7 @@ export function createSessionsSpawnTool(
             status: "error",
             error:
               "attachments are currently unsupported for runtime=acp; use runtime=subagent or remove attachments",
+            ...roleContext,
           });
         }
         const result = await spawnAcpDirect(
@@ -230,6 +281,9 @@ export function createSessionsSpawnTool(
             label: label || undefined,
             agentId: requestedAgentId,
             resumeSessionId,
+            model: modelOverride,
+            thinking: thinkingOverrideRaw,
+            runTimeoutSeconds,
             cwd,
             mode: mode === "run" || mode === "session" ? mode : undefined,
             thread,
@@ -243,6 +297,8 @@ export function createSessionsSpawnTool(
             agentTo: opts?.agentTo,
             agentThreadId: opts?.agentThreadId,
             agentGroupId: opts?.agentGroupId ?? undefined,
+            agentGroupSpace: opts?.agentGroupSpace,
+            agentMemberRoleIds: opts?.agentMemberRoleIds,
             sandboxed: opts?.sandboxed,
           },
         );
@@ -254,7 +310,7 @@ export function createSessionsSpawnTool(
           Boolean(childRunId) &&
           streamTo !== "parent";
         if (shouldTrackViaRegistry && childSessionKey && childRunId) {
-          const cfg = loadConfig();
+          const cfg = getRuntimeConfig();
           const trackedSpawnMode = resolveTrackedSpawnMode({
             requestedMode: result.mode,
             threadRequested: thread,
@@ -302,10 +358,11 @@ export function createSessionsSpawnTool(
               error: `Failed to register ACP run: ${summarizeError(err)}. Cleanup was attempted, but the already-started ACP run may still finish in the background.`,
               childSessionKey,
               runId: childRunId,
+              ...roleContext,
             });
           }
         }
-        return jsonResult(result);
+        return jsonResult(addRoleToFailureResult(result, requestedAgentId));
       }
 
       const result = await spawnSubagentDirect(
@@ -320,6 +377,7 @@ export function createSessionsSpawnTool(
           mode,
           cleanup,
           sandbox,
+          context,
           lightContext,
           expectsCompletionMessage,
           attachments,
@@ -337,12 +395,13 @@ export function createSessionsSpawnTool(
           agentGroupId: opts?.agentGroupId,
           agentGroupChannel: opts?.agentGroupChannel,
           agentGroupSpace: opts?.agentGroupSpace,
+          agentMemberRoleIds: opts?.agentMemberRoleIds,
           requesterAgentIdOverride: opts?.requesterAgentIdOverride,
           workspaceDir: opts?.workspaceDir,
         },
       );
 
-      return jsonResult(result);
+      return jsonResult(addRoleToFailureResult(result, requestedAgentId));
     },
   };
 }

--- a/src/gateway/server-methods/nodes.invoke-wake.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-wake.test.ts
@@ -273,6 +273,7 @@ describe("node.invoke APNs wake path", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    delete process.env.OPENCLAW_NODE_WAKE_NUDGE_BUDGET;
   });
 
   it("keeps the existing not-connected response when wake path is unavailable", async () => {
@@ -316,6 +317,30 @@ describe("node.invoke APNs wake path", () => {
     });
     expect(mocks.resolveApnsRelayConfigFromEnv).toHaveBeenCalledTimes(2);
     expect(mocks.sendApnsBackgroundWake).not.toHaveBeenCalled();
+  });
+
+  it("treats a zero nudge budget as infinite", async () => {
+    process.env.OPENCLAW_NODE_WAKE_NUDGE_BUDGET = "0";
+    mockDirectWakeConfig("ios-node-infinite-nudge");
+    mocks.sendApnsAlert.mockResolvedValue({
+      ok: true,
+      status: 200,
+      tokenSuffix: "1234abcd",
+      topic: "ai.openclaw.ios",
+      environment: "sandbox",
+      transport: "direct",
+    });
+
+    await expect(maybeSendNodeWakeNudge("ios-node-infinite-nudge")).resolves.toMatchObject({
+      sent: true,
+      throttled: false,
+    });
+    clearNodeWakeState("ios-node-infinite-nudge");
+    await expect(maybeSendNodeWakeNudge("ios-node-infinite-nudge")).resolves.toMatchObject({
+      sent: true,
+      throttled: false,
+    });
+    expect(mocks.sendApnsAlert).toHaveBeenCalledTimes(2);
   });
 
   it("clears wake and nudge throttle state when a node disconnects", async () => {

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -61,6 +61,8 @@ export const NODE_WAKE_RECONNECT_RETRY_WAIT_MS = 12_000;
 export const NODE_WAKE_RECONNECT_POLL_MS = 150;
 const NODE_WAKE_THROTTLE_MS = 15_000;
 const NODE_WAKE_NUDGE_THROTTLE_MS = 10 * 60_000;
+const NODE_WAKE_NUDGE_DEFAULT_BUDGET = 1;
+const NODE_WAKE_NUDGE_BUDGET_ENV = "OPENCLAW_NODE_WAKE_NUDGE_BUDGET";
 const NODE_PENDING_ACTION_TTL_MS = 10 * 60_000;
 const NODE_PENDING_ACTION_MAX_PER_NODE = 64;
 
@@ -84,7 +86,14 @@ type NodeWakeAttempt = {
 type NodeWakeNudgeAttempt = {
   sent: boolean;
   throttled: boolean;
-  reason: "throttled" | "no-registration" | "no-auth" | "send-error" | "apns-not-ok" | "sent";
+  reason:
+    | "throttled"
+    | "budget-exhausted"
+    | "no-registration"
+    | "no-auth"
+    | "send-error"
+    | "apns-not-ok"
+    | "sent";
   durationMs: number;
   apnsStatus?: number;
   apnsReason?: string;
@@ -100,6 +109,44 @@ type PendingNodeAction = {
 };
 
 const pendingNodeActionsById = new Map<string, PendingNodeAction[]>();
+
+function resolveNodeWakeNudgeBudgetLimit(): number | null {
+  const raw = process.env[NODE_WAKE_NUDGE_BUDGET_ENV]?.trim();
+  if (!raw) {
+    return NODE_WAKE_NUDGE_DEFAULT_BUDGET;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    return NODE_WAKE_NUDGE_DEFAULT_BUDGET;
+  }
+  const normalized = Math.max(0, Math.floor(parsed));
+  return normalized === 0 ? null : normalized;
+}
+
+function buildNodeWakeNudgeBudget(nodeId: string, now = Date.now()) {
+  const limit = resolveNodeWakeNudgeBudgetLimit();
+  const lastNudgeAtMs = nodeWakeNudgeById.get(nodeId) ?? 0;
+  const nextNudgeAtMs = lastNudgeAtMs > 0 ? lastNudgeAtMs + NODE_WAKE_NUDGE_THROTTLE_MS : undefined;
+  const cooldownRemainingMs = nextNudgeAtMs ? Math.max(0, nextNudgeAtMs - now) : 0;
+  return {
+    mode: limit === null ? ("infinite" as const) : ("budgeted" as const),
+    limit,
+    remaining: limit === null ? null : cooldownRemainingMs > 0 ? 0 : limit,
+    throttleMs: NODE_WAKE_NUDGE_THROTTLE_MS,
+    ...(lastNudgeAtMs > 0 ? { lastNudgeAtMs } : {}),
+    ...(nextNudgeAtMs && cooldownRemainingMs > 0 ? { nextNudgeAtMs } : {}),
+    cooldownRemainingMs,
+  };
+}
+
+function attachWakeNudgeBudgetToNode<T extends { nodeId: string }>(
+  node: T,
+): T & { wakeNudgeBudget: ReturnType<typeof buildNodeWakeNudgeBudget> } {
+  return {
+    ...node,
+    wakeNudgeBudget: buildNodeWakeNudgeBudget(node.nodeId),
+  };
+}
 
 function normalizeBrowserProxyPath(value: string): string {
   const trimmed = value.trim();
@@ -424,9 +471,9 @@ export async function maybeSendNodeWakeNudge(nodeId: string): Promise<NodeWakeNu
     durationMs: Math.max(0, Date.now() - startedAtMs),
   });
 
-  const lastNudgeAtMs = nodeWakeNudgeById.get(nodeId) ?? 0;
-  if (lastNudgeAtMs > 0 && Date.now() - lastNudgeAtMs < NODE_WAKE_NUDGE_THROTTLE_MS) {
-    return withDuration({ sent: false, throttled: true, reason: "throttled" });
+  const budget = buildNodeWakeNudgeBudget(nodeId);
+  if (budget.mode === "budgeted" && budget.remaining === 0) {
+    return withDuration({ sent: false, throttled: true, reason: "budget-exhausted" });
   }
 
   const registration = await loadApnsRegistration(nodeId);
@@ -713,7 +760,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
         pairedNodes: nodePairing.paired,
         connectedNodes: context.nodeRegistry.listConnected(),
       });
-      const nodes = listKnownNodes(catalog);
+      const nodes = listKnownNodes(catalog).map((node) => attachWakeNudgeBudgetToNode(node));
       respond(true, { ts: Date.now(), nodes }, undefined);
     });
   },
@@ -747,7 +794,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown nodeId"));
         return;
       }
-      respond(true, { ts: Date.now(), ...node }, undefined);
+      respond(true, { ts: Date.now(), ...attachWakeNudgeBudgetToNode(node) }, undefined);
     });
   },
   "node.canvas.capability.refresh": async ({ params, respond, client }) => {

--- a/src/shared/node-list-types.ts
+++ b/src/shared/node-list-types.ts
@@ -18,6 +18,17 @@ export type NodeListNode = {
   connected?: boolean;
   connectedAtMs?: number;
   approvedAtMs?: number;
+  wakeNudgeBudget?: NodeWakeNudgeBudget;
+};
+
+export type NodeWakeNudgeBudget = {
+  mode: "budgeted" | "infinite";
+  limit: number | null;
+  remaining: number | null;
+  throttleMs: number;
+  lastNudgeAtMs?: number;
+  nextNudgeAtMs?: number;
+  cooldownRemainingMs: number;
 };
 
 export type PendingRequest = {


### PR DESCRIPTION
## Summary\n- expose node wake nudge budget state from node.list/node.describe\n- support OPENCLAW_NODE_WAKE_NUDGE_BUDGET=0 as infinite/basic unlimited mode\n- add gateway coverage for zero-budget infinite nudges\n- clean up stale sessions_spawn dead code surfaced by full verification\n\n## Verification\n- npm run check\n- npm test -- --run src/gateway/server-methods/nodes.invoke-wake.test.ts