### PR TITLE
Normalize Codex dynamic tool transcript shape

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -858,6 +858,7 @@ describe("CodexAppServerEventProjector", () => {
       id: "cmd-1",
       name: "bash",
       arguments: { command: "pnpm test extensions/codex", cwd: "/workspace" },
+      input: { command: "pnpm test extensions/codex", cwd: "/workspace" },
     });
     const toolResultMessage = requireRecord(result.messagesSnapshot[2], "tool result message");
     expect(toolResultMessage.role).toBe("toolResult");
@@ -867,6 +868,9 @@ describe("CodexAppServerEventProjector", () => {
     const toolResultContent = requireArray(toolResultMessage.content, "tool result content");
     const toolResultContentItem = requireRecord(toolResultContent[0], "tool result content item");
     expect(toolResultContentItem.type).toBe("toolResult");
+    expect(toolResultContentItem.id).toBe("cmd-1");
+    expect(toolResultContentItem.name).toBe("bash");
+    expect(toolResultContentItem.toolName).toBe("bash");
     expect(toolResultContentItem.toolCallId).toBe("cmd-1");
     expect(toolResultContentItem.content).toBe("ok");
   });

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -902,6 +902,7 @@ describe("CodexAppServerEventProjector", () => {
       id: "call-browser-1",
       name: "browser",
       arguments: { action: "open", url: "http://127.0.0.1:3000" },
+      input: { action: "open", url: "http://127.0.0.1:3000" },
     });
     const toolResultMessage = requireRecord(result.messagesSnapshot[2], "tool result message");
     expect(toolResultMessage.role).toBe("toolResult");
@@ -913,6 +914,9 @@ describe("CodexAppServerEventProjector", () => {
       "tool result content item",
     );
     expect(toolResultContent.type).toBe("toolResult");
+    expect(toolResultContent.id).toBe("call-browser-1");
+    expect(toolResultContent.name).toBe("browser");
+    expect(toolResultContent.toolName).toBe("browser");
     expect(toolResultContent.toolCallId).toBe("call-browser-1");
     expect(toolResultContent.content).toBe("opened");
   });

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -1041,6 +1041,7 @@ export class CodexAppServerEventProjector {
   }
 
   private createToolCallMessage(params: ToolTranscriptCallInput): AgentMessage {
+    const args = normalizeToolTranscriptArguments(params.arguments);
     return {
       role: "assistant",
       content: [
@@ -1048,7 +1049,8 @@ export class CodexAppServerEventProjector {
           type: "toolCall",
           id: params.id,
           name: params.name,
-          arguments: normalizeToolTranscriptArguments(params.arguments),
+          arguments: args,
+          input: args,
         },
       ],
       api: this.params.model.api ?? "openai-codex-responses",
@@ -1070,6 +1072,9 @@ export class CodexAppServerEventProjector {
       content: [
         {
           type: "toolResult",
+          id: params.id,
+          name: params.name,
+          toolName: params.name,
           toolCallId: params.id,
           toolUseId: params.id,
           tool_use_id: params.id,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -734,6 +734,89 @@ describe("runCodexAppServerAttempt", () => {
     expect(heartbeat?.deferLoading).toBe(true);
   });
 
+  it("keeps searchable Codex dynamic tools canonical in mirrored transcript snapshots", async () => {
+    __testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("wiki_status"),
+    ]);
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.toolsAllow = ["wiki_status"];
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: {
+        codexDynamicToolsLoading: "searchable",
+        appServer: { mode: "yolo" },
+      },
+    });
+    await harness.waitForMethod("turn/start", 120_000);
+
+    const toolResult = (await harness.handleServerRequest({
+      id: "request-tool-wiki-status",
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-wiki-status-1",
+        namespace: CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
+        tool: "wiki_status",
+        arguments: { topic: "README.md" },
+      },
+    })) as {
+      contentItems?: Array<{ text?: string; type?: string }>;
+      success?: boolean;
+    };
+    expect(toolResult).toEqual({
+      success: true,
+      contentItems: [{ type: "inputText", text: "wiki_status done" }],
+    });
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    const result = await run;
+
+    expect(result.messagesSnapshot.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+    ]);
+    expect(result.messagesSnapshot[1]).toMatchObject({
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call-wiki-status-1",
+          name: "wiki_status",
+          arguments: { topic: "README.md" },
+          input: { topic: "README.md" },
+        },
+      ],
+    });
+    expect(result.messagesSnapshot[2]).toMatchObject({
+      role: "toolResult",
+      toolCallId: "call-wiki-status-1",
+      toolName: "wiki_status",
+      isError: false,
+      content: [
+        expect.objectContaining({
+          type: "toolResult",
+          id: "call-wiki-status-1",
+          name: "wiki_status",
+          toolName: "wiki_status",
+          toolCallId: "call-wiki-status-1",
+          toolUseId: "call-wiki-status-1",
+          tool_use_id: "call-wiki-status-1",
+          content: "wiki_status done",
+        }),
+      ],
+    });
+    expect(JSON.stringify(result.messagesSnapshot)).not.toContain("tool_search");
+    expect(JSON.stringify(result.messagesSnapshot)).not.toContain("function_call_output");
+  });
+
   it("passes the live run session key to Codex dynamic tools when sandbox policy uses another key", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);


### PR DESCRIPTION
## Summary
- Add common transcript aliases to Codex app-server mirrored tool calls/results (`input` on tool calls, `id`/`name`/`toolName` on tool result blocks) while preserving the existing canonical fields.
- Add a searchable dynamic-tool regression proving Codex tool search remains internal and mirrored snapshots expose the real OpenClaw tool call/result shape.

## Real behavior proof

- **Behavior or issue addressed:** Codex app-server mirrored transcript snapshots should expose compatibility aliases for dynamic tool calls/results without leaking `tool_search` or `function_call_output` markers.
- **Real environment tested:** macOS local OpenClaw worktree checked out at PR #80155, Node v25.2.1, pnpm 10.33.2, production `CodexAppServerEventProjector` loaded through `tsx`.
- **Exact steps or command run after this patch:** Ran `pnpm exec tsx -e '<script>'` that constructs the production Codex app-server event projector, records a dynamic `wiki_status` tool call/result pair, builds the mirrored messages snapshot, and prints the actual projected tool-call/tool-result records.
- **Evidence after fix:** Terminal output from the after-fix projector smoke:

```json
{
  "roles": [
    "user",
    "assistant",
    "toolResult"
  ],
  "toolCall": {
    "type": "toolCall",
    "id": "call-wiki-status-proof",
    "name": "wiki_status",
    "arguments": {
      "topic": "README.md"
    },
    "input": {
      "topic": "README.md"
    }
  },
  "toolResult": {
    "type": "toolResult",
    "id": "call-wiki-status-proof",
    "name": "wiki_status",
    "toolName": "wiki_status",
    "toolCallId": "call-wiki-status-proof",
    "toolUseId": "call-wiki-status-proof",
    "tool_use_id": "call-wiki-status-proof",
    "content": "wiki_status done",
    "text": "wiki_status done"
  },
  "containsToolSearch": false,
  "containsFunctionCallOutput": false
}
```

- **Observed result after fix:** The mirrored snapshot contains the new alias fields while preserving canonical `arguments`, `toolCallId`, `toolUseId`, and `tool_use_id`, and it does not contain `tool_search` or `function_call_output`.
- **What was not tested:** A live external Codex SaaS/app-server network turn was not run; this proof exercises the local production projector path for the mirrored transcript records changed by this PR.

## Verification
- `node scripts/test-extension.mjs extensions/codex -- --run` (47 files, 607 tests)
