### PR TITLE
fix: add actionable queue failure diagnostics

### DIFF
--- a/src/agents/pi-embedded-runner/runs.test.ts
+++ b/src/agents/pi-embedded-runner/runs.test.ts
@@ -93,6 +93,22 @@ describe("pi-embedded runner run registry", () => {
     expect(queueMessage).toHaveBeenCalledWith("continue", { steeringMode: "all" });
   });
 
+
+  it("logs actionable context when queueing into a missing run fails", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(queueEmbeddedPiMessage("session-missing", "late follow-up")).toBe(false);
+      const combined = warn.mock.calls.map((call) => call.map(String).join(" ")).join("\n");
+      expect(combined).toContain("queue message failed");
+      expect(combined).toContain("sessionId=session-missing");
+      expect(combined).toContain("reason=no_active_run");
+      expect(combined).toContain("activeRuns=0");
+      expect(combined).toContain("not a gateway outage");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("force-clears an aborted run that does not drain", async () => {
     vi.useFakeTimers();
     try {

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -63,6 +63,22 @@ function clearActiveRunSessionKeys(sessionId: string, sessionKey?: string): void
   }
 }
 
+function queueMessageFailureDetail(
+  sessionId: string,
+  reason: "no_active_run" | "not_streaming" | "compacting",
+): string {
+  const activeCount = getActiveEmbeddedRunCount();
+  const snapshot = ACTIVE_EMBEDDED_RUN_SNAPSHOTS.get(sessionId);
+  const knownSessionKey = [...ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_KEY.entries()].find(
+    ([, id]) => id === sessionId,
+  )?.[0];
+  const keyBits = knownSessionKey ? ` sessionKey=${knownSessionKey}` : "";
+  const snapshotBits = snapshot
+    ? ` snapshotStatus=${snapshot.status ?? "unknown"} snapshotRunId=${snapshot.runId ?? "unknown"}`
+    : "";
+  return `queue message failed: sessionId=${sessionId} reason=${reason} activeRuns=${activeCount} replyQueued=false${keyBits}${snapshotBits} hint=target run is not currently accepting queued messages; this is usually a stale/completed run, not a gateway outage`;
+}
+
 export function queueEmbeddedPiMessage(
   sessionId: string,
   text: string,
@@ -75,15 +91,15 @@ export function queueEmbeddedPiMessage(
       logMessageQueued({ sessionId, source: "pi-embedded-runner" });
       return true;
     }
-    diag.debug(`queue message failed: sessionId=${sessionId} reason=no_active_run`);
+    diag.warn(queueMessageFailureDetail(sessionId, "no_active_run"));
     return false;
   }
   if (!handle.isStreaming()) {
-    diag.debug(`queue message failed: sessionId=${sessionId} reason=not_streaming`);
+    diag.warn(queueMessageFailureDetail(sessionId, "not_streaming"));
     return false;
   }
   if (handle.isCompacting()) {
-    diag.debug(`queue message failed: sessionId=${sessionId} reason=compacting`);
+    diag.warn(queueMessageFailureDetail(sessionId, "compacting"));
     return false;
   }
   logMessageQueued({ sessionId, source: "pi-embedded-runner" });


### PR DESCRIPTION
## Summary

Fixes openclaw/openclaw#80156 by making failed embedded-run message queue attempts actionable in logs/diagnostics.

Instead of the low-context debug line:

```text
queue message failed: sessionId=<id> reason=no_active_run
```

this now emits a warning with:

- session id
- reason (`no_active_run`, `not_streaming`, `compacting`)
- active embedded run count
- known session key when available
- snapshot status/run id when available
- a hint clarifying that stale/completed runs are usually not gateway outages

## Why

Operators can currently receive generic alerts like:

```text
⚠️ 🔌 Gateway: agents failed
```

while the gateway itself is healthy. The useful cause is buried in journald. This patch makes the underlying queue failure diagnostic self-explanatory so notification layers and operators can distinguish stale-run follow-ups from real gateway/agent failure.

## Tests

Added a regression test for `queueEmbeddedPiMessage` when queueing into a missing run, asserting the log includes session id, reason, active count, and non-outage hint.

## Local validation

I could not run the full vitest target in the sparse checkout because dependencies were not installed and `/tmp` is space constrained. I did run:

```bash
git diff --check
```

and this PR should be validated by upstream CI.
