### PR TITLE
fix: reread config on in-process gateway restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway: reread config from disk after the first in-process restart loop startup, preventing SIGUSR1 restarts from reusing a stale startup snapshot and dropping config written after boot. Fixes #79947. Thanks @TheLevti.
 - Media/host-read: allow buffer-verified gzip, tar, and 7z archives in the shared host-local media validator alongside ZIP and document attachments.
 - Plugins/doctor: invalidate persisted plugin registry snapshots when plugin diagnostics point at deleted source paths, so `openclaw doctor` stops repeating stale warnings after a local extension is replaced by a managed npm plugin. Fixes #80087. (#80134) Thanks @hclsys.
 - Cron: let isolated self-cleanup runs inspect their own job run history while keeping other cron jobs and mutation actions blocked. Fixes #80019. Thanks @hclsys.

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -716,6 +716,7 @@ public struct AgentParams: Codable, Sendable {
     public let bootstrapcontextmode: AnyCodable?
     public let bootstrapcontextrunkind: AnyCodable?
     public let acpturnsource: String?
+    public let internalruntimehandoffid: String?
     public let internalevents: [[String: AnyCodable]]?
     public let inputprovenance: [String: AnyCodable]?
     public let voicewaketrigger: String?
@@ -752,6 +753,7 @@ public struct AgentParams: Codable, Sendable {
         bootstrapcontextmode: AnyCodable?,
         bootstrapcontextrunkind: AnyCodable?,
         acpturnsource: String?,
+        internalruntimehandoffid: String?,
         internalevents: [[String: AnyCodable]]?,
         inputprovenance: [String: AnyCodable]?,
         voicewaketrigger: String?,
@@ -787,6 +789,7 @@ public struct AgentParams: Codable, Sendable {
         self.bootstrapcontextmode = bootstrapcontextmode
         self.bootstrapcontextrunkind = bootstrapcontextrunkind
         self.acpturnsource = acpturnsource
+        self.internalruntimehandoffid = internalruntimehandoffid
         self.internalevents = internalevents
         self.inputprovenance = inputprovenance
         self.voicewaketrigger = voicewaketrigger
@@ -824,6 +827,7 @@ public struct AgentParams: Codable, Sendable {
         case bootstrapcontextmode = "bootstrapContextMode"
         case bootstrapcontextrunkind = "bootstrapContextRunKind"
         case acpturnsource = "acpTurnSource"
+        case internalruntimehandoffid = "internalRuntimeHandoffId"
         case internalevents = "internalEvents"
         case inputprovenance = "inputProvenance"
         case voicewaketrigger = "voiceWakeTrigger"

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -19,7 +19,8 @@ const forceFreePortAndWait = vi.fn(async (_port: number, _opts: unknown) => ({
 }));
 const waitForPortBindable = vi.fn(async (_port: number, _opts?: unknown) => 0);
 const ensureDevGatewayConfig = vi.fn(async (_opts?: unknown) => {});
-const runGatewayLoop = vi.fn(async ({ start }: { start: () => Promise<unknown> }) => {
+type GatewayLoopStart = (params?: { startupStartedAt?: number }) => Promise<unknown>;
+const runGatewayLoop = vi.fn(async ({ start }: { start: GatewayLoopStart }) => {
   await start();
 });
 const gatewayLogMessages = vi.hoisted(() => [] as string[]);
@@ -157,7 +158,7 @@ vi.mock("./dev.js", () => ({
 }));
 
 vi.mock("./run-loop.js", () => ({
-  runGatewayLoop: (params: { start: () => Promise<unknown> }) => runGatewayLoop(params),
+  runGatewayLoop: (params: { start: GatewayLoopStart }) => runGatewayLoop(params),
 }));
 
 describe("gateway run option collisions", () => {
@@ -301,6 +302,41 @@ describe("gateway run option collisions", () => {
         startupConfigSnapshotRead: {
           snapshot: configState.snapshot,
         },
+      }),
+    );
+  });
+
+  it("uses the startup snapshot only for the first in-process gateway start", async () => {
+    runGatewayLoop.mockImplementationOnce(async ({ start }: { start: GatewayLoopStart }) => {
+      await start({ startupStartedAt: 1000 });
+      await start({ startupStartedAt: 2000 });
+    });
+
+    await runGatewayCli(["gateway", "run", "--allow-unconfigured"]);
+
+    expect(startGatewayServer).toHaveBeenCalledTimes(2);
+    expect(startGatewayServer).toHaveBeenNthCalledWith(
+      1,
+      18789,
+      expect.objectContaining({
+        startupStartedAt: 1000,
+        startupConfigSnapshotRead: {
+          snapshot: configState.snapshot,
+        },
+      }),
+    );
+    expect(startGatewayServer).toHaveBeenNthCalledWith(
+      2,
+      18789,
+      expect.not.objectContaining({
+        startupConfigSnapshotRead: expect.anything(),
+      }),
+    );
+    expect(startGatewayServer).toHaveBeenNthCalledWith(
+      2,
+      18789,
+      expect.objectContaining({
+        startupStartedAt: 2000,
       }),
     );
   });

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -787,19 +787,25 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
   gatewayLog.info("starting...");
   startupTrace.mark("cli.gateway-loop");
   const healthHost = await resolveGatewayBindHost(bind, cfg.gateway?.customBindHost);
+  let startupConfigSnapshotReadForNextStart = startupConfigSnapshotRead;
   const startLoop = async () =>
     await runGatewayLoop({
       runtime: defaultRuntime,
       lockPort: port,
       healthHost,
-      start: async ({ startupStartedAt } = {}) =>
-        await startGatewayServer(port, {
+      start: async ({ startupStartedAt } = {}) => {
+        const startupConfigSnapshotReadForThisStart = startupConfigSnapshotReadForNextStart;
+        startupConfigSnapshotReadForNextStart = undefined;
+        return await startGatewayServer(port, {
           bind,
           auth: authOverride,
           tailscale: tailscaleOverride,
           startupStartedAt,
-          ...(startupConfigSnapshotRead ? { startupConfigSnapshotRead } : {}),
-        }),
+          ...(startupConfigSnapshotReadForThisStart
+            ? { startupConfigSnapshotRead: startupConfigSnapshotReadForThisStart }
+            : {}),
+        });
+      },
     });
 
   const { detectRespawnSupervisor } = await import("../../infra/supervisor-markers.js");


### PR DESCRIPTION
## Summary

- Fixes #79947.
- Consumes the `startupConfigSnapshotRead` pre-read only for the first `gateway run` start inside the in-process restart loop.
- Leaves later SIGUSR1/in-process restart iterations to reread the current on-disk config snapshot, preventing stale startup snapshots from overwriting config written after boot.
- Adds regression coverage that simulates two loop starts and asserts the second start does not receive the stale snapshot.

## Real behavior proof

- **Behavior or issue addressed:** In-process `gateway run` restarts must not reuse the first startup config snapshot after the config file changes on disk.
- **Real environment tested:** macOS local OpenClaw worktree, Node v25.2.1, pnpm 10.33.2, temp `OPENCLAW_HOME`/`OPENCLAW_STATE_DIR`/`OPENCLAW_CONFIG_PATH`, real gateway process on `127.0.0.1:19661`.
- **Exact steps or command run after this patch:** Started `pnpm --silent openclaw gateway run --port 19661` with `OPENCLAW_NO_RESPAWN=1`, temp config token `token-before`, verified `gateway health`, rewrote the temp config token to `token-after`, sent `SIGUSR1`, then verified `gateway health` with `token-after`.
- **Evidence after fix:** Terminal output from the after-fix live gateway smoke:

```text
real gateway pid=72130 port=19661
before restart with token-before: {"ok":true,"rpcOk":null,"status":null}
after SIGUSR1 restart with token-after: {"ok":true,"rpcOk":null,"status":null}
restart log lines:
1:2026-05-10T03:40:16.767-04:00 [gateway] loading configuration…
4:2026-05-10T03:40:16.827-04:00 [gateway] starting...
9:2026-05-10T03:40:20.024-04:00 [gateway] http server listening (9 plugins: acpx, bonjour, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 3.2s)
21:2026-05-10T03:40:22.715-04:00 [gateway] signal SIGUSR1 received
22:2026-05-10T03:40:22.720-04:00 [gateway] received SIGUSR1; restarting
26:2026-05-10T03:40:22.785-04:00 [gateway] restart mode: in-process restart (OPENCLAW_NO_RESPAWN)
30:2026-05-10T03:40:22.990-04:00 [gateway] http server listening (9 plugins: acpx, bonjour, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 0.2s)
```

- **Observed result after fix:** The restarted real gateway accepted the post-rewrite `token-after` config after SIGUSR1, showing the second in-process start reread disk config instead of reusing the first startup snapshot.
- **What was not tested:** No additional gaps.

## Verification

- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-cache-79947 pnpm test src/cli/gateway-cli/run.option-collisions.test.ts`
- `pnpm check:changed`
- `pnpm exec oxfmt --check --threads=1 src/cli/gateway-cli/run.ts src/cli/gateway-cli/run.option-collisions.test.ts CHANGELOG.md`
- `git diff --check`
