### PR TITLE
[codex] Project Tool Search target calls in transcripts

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -180,6 +180,7 @@ import {
   applyToolSearchCatalog,
   clearToolSearchCatalog,
   createToolSearchCatalogRef,
+  projectToolSearchTargetTranscriptMessages,
   resolveToolSearchConfig,
   TOOL_CALL_RAW_TOOL_NAME,
   TOOL_DESCRIBE_RAW_TOOL_NAME,
@@ -187,6 +188,7 @@ import {
   TOOL_SEARCH_RAW_TOOL_NAME,
   type ToolSearchCatalogRef,
   type ToolSearchCatalogToolExecutor,
+  type ToolSearchTargetTranscriptProjection,
 } from "../../tool-search.js";
 import { shouldAllowProviderOwnedThinkingReplay } from "../../transcript-policy.js";
 import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
@@ -977,6 +979,7 @@ export async function runEmbeddedAttempt(
     const toolSearchCatalogRef: ToolSearchCatalogRef | undefined = toolSearchControlsEnabledForRun
       ? createToolSearchCatalogRef()
       : undefined;
+    const toolSearchTargetTranscriptProjections: ToolSearchTargetTranscriptProjection[] = [];
     const toolsRaw = !shouldConstructTools
       ? []
       : (() => {
@@ -2662,20 +2665,47 @@ export async function runEmbeddedAttempt(
         getCompactionCount,
         getLastCompactionTokensAfter,
       } = subscription;
-      toolSearchCatalogExecutor = async (toolParams) =>
-        await runToolLifecycle({
-          toolName: toolParams.toolName,
-          toolCallId: toolParams.toolCallId,
-          args: toolParams.input,
-          execute: async () =>
-            await toolParams.tool.execute(
-              toolParams.toolCallId,
-              toolParams.input,
-              toolParams.signal ?? runAbortController.signal,
-              toolParams.onUpdate,
-              undefined as never,
-            ),
-        });
+      toolSearchCatalogExecutor = async (toolParams) => {
+        try {
+          const result = await runToolLifecycle({
+            toolName: toolParams.toolName,
+            toolCallId: toolParams.toolCallId,
+            args: toolParams.input,
+            execute: async () =>
+              await toolParams.tool.execute(
+                toolParams.toolCallId,
+                toolParams.input,
+                toolParams.signal ?? runAbortController.signal,
+                toolParams.onUpdate,
+                undefined as never,
+              ),
+          });
+          toolSearchTargetTranscriptProjections.push({
+            parentToolCallId: toolParams.parentToolCallId,
+            toolCallId: toolParams.toolCallId,
+            toolName: toolParams.toolName,
+            input: toolParams.input,
+            result,
+            timestamp: Date.now(),
+          });
+          return result;
+        } catch (error) {
+          const message = formatErrorMessage(error);
+          toolSearchTargetTranscriptProjections.push({
+            parentToolCallId: toolParams.parentToolCallId,
+            toolCallId: toolParams.toolCallId,
+            toolName: toolParams.toolName,
+            input: toolParams.input,
+            result: {
+              content: [{ type: "text", text: message }],
+              details: { status: "error", error: message },
+            },
+            isError: true,
+            timestamp: Date.now(),
+          });
+          throw error;
+        }
+      };
 
       const queueHandle: EmbeddedPiQueueHandle & {
         kind: "embedded";
@@ -3230,11 +3260,17 @@ export async function runEmbeddedAttempt(
               messages: activeSession.messages,
               note: `images: prompt=${imageResult.images.length}`,
             });
+            const trajectoryProviderVisibleTools = toTrajectoryToolDefinitions(effectiveTools);
             trajectoryRecorder?.recordEvent("context.compiled", {
               systemPrompt: systemPromptForHook,
               prompt: promptForModel,
               messages: activeSession.messages,
-              tools: toTrajectoryToolDefinitions(effectiveTools),
+              tools: toTrajectoryToolDefinitions(
+                toolSearch.compacted ? uncompactedEffectiveTools : effectiveTools,
+              ),
+              ...(toolSearch.compacted
+                ? { providerVisibleTools: trajectoryProviderVisibleTools }
+                : {}),
               imagesCount: imageResult.images.length,
               streamStrategy,
               transport: effectiveAgentTransport,
@@ -3608,7 +3644,10 @@ export async function runEmbeddedAttempt(
             );
           }
         }
-        messagesSnapshot = snapshotSelection.messagesSnapshot;
+        messagesSnapshot = projectToolSearchTargetTranscriptMessages(
+          snapshotSelection.messagesSnapshot,
+          toolSearchTargetTranscriptProjections,
+        );
         sessionIdUsed = snapshotSelection.sessionIdUsed;
 
         lastAssistant = messagesSnapshot

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -12,6 +12,7 @@ import {
   clearToolSearchCatalog,
   createToolSearchCatalogRef,
   createToolSearchTools,
+  projectToolSearchTargetTranscriptMessages,
   TOOL_CALL_RAW_TOOL_NAME,
   TOOL_DESCRIBE_RAW_TOOL_NAME,
   TOOL_SEARCH_CODE_MODE_TOOL_NAME,
@@ -473,6 +474,7 @@ describe("Tool Search", () => {
         tool: expect.objectContaining({ name: "fake_lifecycle" }),
         toolName: "fake_lifecycle",
         toolCallId: "tool_search_code:call-lifecycle:fake_lifecycle:1",
+        parentToolCallId: "call-lifecycle",
         input: { value: "ok" },
         signal: expect.any(AbortSignal),
         onUpdate,
@@ -496,11 +498,71 @@ describe("Tool Search", () => {
         tool: expect.objectContaining({ name: "fake_lifecycle" }),
         toolName: "fake_lifecycle",
         toolCallId: "tool_search_code:call-lifecycle-structured:fake_lifecycle:1",
+        parentToolCallId: "call-lifecycle-structured",
         input: { value: "structured" },
         signal: abortController.signal,
         onUpdate,
       }),
     );
+  });
+
+  it("projects target tool calls after their Tool Search wrapper result", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "wrapper-call",
+            name: TOOL_CALL_RAW_TOOL_NAME,
+            arguments: { id: "fake_target", args: { value: "ok" } },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "wrapper-call",
+        toolName: TOOL_CALL_RAW_TOOL_NAME,
+        content: [{ type: "text", text: "wrapped" }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "done" }],
+      },
+    ];
+
+    const projected = projectToolSearchTargetTranscriptMessages(messages as never, [
+      {
+        parentToolCallId: "wrapper-call",
+        toolCallId: "tool_search_code:wrapper-call:fake_target:1",
+        toolName: "fake_target",
+        input: { value: "ok" },
+        result: jsonResult({ ok: true }),
+        timestamp: 123,
+      },
+    ]);
+
+    expect(projected).toHaveLength(5);
+    expect(projected[2]).toMatchObject({
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "tool_search_code:wrapper-call:fake_target:1",
+          name: "fake_target",
+          arguments: { value: "ok" },
+          input: { value: "ok" },
+        },
+      ],
+    });
+    expect(projected[3]).toMatchObject({
+      role: "toolResult",
+      toolCallId: "tool_search_code:wrapper-call:fake_target:1",
+      toolName: "fake_target",
+      isError: false,
+      content: [{ type: "text", text: JSON.stringify({ ok: true }, null, 2) }],
+    });
+    expect(projected[4]).toBe(messages[2]);
   });
 
   it("does not execute fire-and-forget bridged calls after code returns", async () => {

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -1,6 +1,10 @@
 import { spawn } from "node:child_process";
 import os from "node:os";
-import type { AgentToolResult, AgentToolUpdateCallback } from "@mariozechner/pi-agent-core";
+import type {
+  AgentMessage,
+  AgentToolResult,
+  AgentToolUpdateCallback,
+} from "@mariozechner/pi-agent-core";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -37,10 +41,21 @@ export type ToolSearchCatalogToolExecutor = (params: {
   tool: CatalogTool;
   toolName: string;
   toolCallId: string;
+  parentToolCallId?: string;
   input: unknown;
   signal?: AbortSignal;
   onUpdate?: AgentToolUpdateCallback<unknown>;
 }) => Promise<AgentToolResult<unknown>>;
+
+export type ToolSearchTargetTranscriptProjection = {
+  parentToolCallId?: string;
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+  result?: unknown;
+  isError?: boolean;
+  timestamp?: number;
+};
 
 export type ToolSearchConfig = {
   enabled: boolean;
@@ -518,6 +533,149 @@ function dropToolSearchControlTools(tools: AnyAgentTool[]): AnyAgentTool[] {
   return tools.filter((tool) => !TOOL_SEARCH_CONTROL_TOOL_NAMES.has(tool.name));
 }
 
+function readMessageToolResultId(message: AgentMessage): string | undefined {
+  const record = message as unknown as Record<string, unknown>;
+  const role = typeof record.role === "string" ? record.role : "";
+  const canUseDirectId = role === "toolResult" || role === "tool";
+  const direct = record.toolCallId ?? record.toolUseId ?? record.tool_use_id;
+  if (canUseDirectId && typeof direct === "string" && direct.trim()) {
+    return direct;
+  }
+  const content = record.content;
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  for (const block of content) {
+    if (!isRecord(block)) {
+      continue;
+    }
+    if (block.type !== "toolResult") {
+      continue;
+    }
+    const nested = block.toolCallId ?? block.toolUseId ?? block.tool_use_id ?? block.id;
+    if (typeof nested === "string" && nested.trim()) {
+      return nested;
+    }
+  }
+  return undefined;
+}
+
+function textFromToolSearchProjectionResult(result: unknown, isError: boolean): string {
+  if (isRecord(result)) {
+    const details = isRecord(result.details) ? result.details : undefined;
+    const detailError = details?.error;
+    if (typeof detailError === "string" && detailError.trim()) {
+      return detailError;
+    }
+    const content = result.content;
+    if (Array.isArray(content)) {
+      const text = content
+        .map((item) => (isRecord(item) && typeof item.text === "string" ? item.text : ""))
+        .filter(Boolean)
+        .join("\n");
+      if (text.trim()) {
+        return text;
+      }
+    }
+  }
+  const safe = toJsonSafe(result);
+  if (typeof safe === "string") {
+    return safe;
+  }
+  const encoded = JSON.stringify(safe);
+  if (typeof encoded === "string") {
+    return encoded;
+  }
+  return isError ? "Tool Search target tool failed." : "Tool Search target tool completed.";
+}
+
+function buildToolSearchTargetTranscriptMessages(
+  projection: ToolSearchTargetTranscriptProjection,
+): AgentMessage[] {
+  const input = toJsonSafe(projection.input);
+  const timestamp = projection.timestamp ?? Date.now();
+  const resultRecord = isRecord(projection.result) ? projection.result : undefined;
+  const resultContent =
+    Array.isArray(resultRecord?.content) && resultRecord.content.length > 0
+      ? toJsonSafe(resultRecord.content)
+      : [
+          {
+            type: "text",
+            text: textFromToolSearchProjectionResult(
+              projection.result,
+              projection.isError === true,
+            ),
+          },
+        ];
+  return [
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: projection.toolCallId,
+          name: projection.toolName,
+          arguments: input,
+          input,
+        },
+      ],
+      stopReason: "toolUse",
+      timestamp,
+    } as unknown as AgentMessage,
+    {
+      role: "toolResult",
+      toolCallId: projection.toolCallId,
+      toolName: projection.toolName,
+      isError: projection.isError === true,
+      content: resultContent,
+      timestamp,
+    } as unknown as AgentMessage,
+  ];
+}
+
+export function projectToolSearchTargetTranscriptMessages(
+  messages: AgentMessage[],
+  projections: readonly ToolSearchTargetTranscriptProjection[],
+): AgentMessage[] {
+  if (projections.length === 0) {
+    return messages;
+  }
+  const byParent = new Map<string, ToolSearchTargetTranscriptProjection[]>();
+  const unmatched: ToolSearchTargetTranscriptProjection[] = [];
+  for (const projection of projections) {
+    const parent = projection.parentToolCallId?.trim();
+    if (!parent) {
+      unmatched.push(projection);
+      continue;
+    }
+    const group = byParent.get(parent) ?? [];
+    group.push(projection);
+    byParent.set(parent, group);
+  }
+  const inserted = new Set<ToolSearchTargetTranscriptProjection>();
+  const projected: AgentMessage[] = [];
+  for (const message of messages) {
+    projected.push(message);
+    const toolResultId = readMessageToolResultId(message);
+    const group = toolResultId ? byParent.get(toolResultId) : undefined;
+    if (!group) {
+      continue;
+    }
+    for (const projection of group) {
+      projected.push(...buildToolSearchTargetTranscriptMessages(projection));
+      inserted.add(projection);
+    }
+  }
+  for (const projection of [...unmatched, ...projections]) {
+    if (inserted.has(projection)) {
+      continue;
+    }
+    projected.push(...buildToolSearchTargetTranscriptMessages(projection));
+    inserted.add(projection);
+  }
+  return projected;
+}
+
 export function createToolSearchCatalogRef(): ToolSearchCatalogRef {
   return {};
 }
@@ -888,6 +1046,7 @@ class ToolSearchRuntime {
       tool: entry.tool,
       toolName: entry.name,
       toolCallId,
+      parentToolCallId: options?.parentToolCallId,
       input: input ?? {},
       signal: options?.signal ?? this.ctx.abortSignal,
       onUpdate: options?.onUpdate,


### PR DESCRIPTION
## Summary
- Project hidden Tool Search target executions into canonical `messagesSnapshot` output as target `toolCall`/`toolResult` pairs.
- Keep provider-facing Tool Search controls compact, but expose logical target tools in trajectory context, with compact controls retained as `providerVisibleTools`.
- Cover bridge parent-call propagation and transcript projection in Tool Search tests.

## Why
Core Tool Search currently lets non-Codex models call wrapper tools such as `tool_search_code` or `tool_call`, then runs the selected target tool behind the bridge. The target lifecycle events use the right tool name, but verifier-facing transcript and trajectory surfaces can still show only the wrapper call. Benchmarks that score actual tool calls can then miss the logical target execution and return zeroes.

This is the core/native counterpart to #80155, which handles the Codex app-server dynamic tool transcript shape.

## Real behavior proof
- Behavior or issue addressed: Core/native PI Tool Search target calls were executed behind `tool_search_code`, but verifier-facing `messagesSnapshot`/trajectory output could show only the wrapper call instead of the logical target tool call/result.
- Real environment tested: Local OpenClaw source worktree on Darwin 24.1.0 arm64 with Node v25.2.1.
- Exact steps or command run after this patch: Ran `node --import tsx --input-type=module` with an inline script that registered a real Tool Search catalog, executed the `tool_search_code` bridge, captured the hidden target execution, and printed the projected transcript/trajectory shape.
- Evidence after fix: terminal output excerpt:

```json
{
  "visibleProviderTools": ["tool_search_code"],
  "hiddenCatalogToolCount": 1,
  "bridgeResultOk": true,
  "bridgeTelemetry": {
    "catalogSize": 1,
    "sources": { "openclaw": 1, "mcp": 0, "client": 0 },
    "searchCount": 0,
    "describeCount": 1,
    "callCount": 1
  },
  "capturedTargetExecutions": [
    {
      "parentToolCallId": "wrapper-call-proof",
      "toolCallId": "tool_search_code:wrapper-call-proof:proof_lookup_record:1",
      "toolName": "proof_lookup_record",
      "input": { "value": "invoice-42" }
    }
  ],
  "projectedMessagesSnapshot": [
    { "role": "assistant", "toolCall": "tool_search_code", "id": "wrapper-call-proof" },
    { "role": "toolResult", "toolName": "tool_search_code", "id": "wrapper-call-proof" },
    {
      "role": "assistant",
      "toolCall": "proof_lookup_record",
      "id": "tool_search_code:wrapper-call-proof:proof_lookup_record:1",
      "arguments": { "value": "invoice-42" }
    },
    {
      "role": "toolResult",
      "toolName": "proof_lookup_record",
      "id": "tool_search_code:wrapper-call-proof:proof_lookup_record:1",
      "text": "target-result invoice-42 via tool_search_code:wrapper-call-proof:proof_lookup_record:1"
    },
    { "role": "assistant", "text": "done" }
  ],
  "trajectoryCompiledShape": {
    "tools": ["proof_lookup_record"],
    "providerVisibleTools": ["tool_search_code"]
  }
}
```

- Observed result after fix: The target execution keeps `tool_search_code` as the only provider-visible tool, records the parent wrapper id, and projects the logical `proof_lookup_record` `toolCall`/`toolResult` pair into `messagesSnapshot`; trajectory context exposes logical target tools while preserving compact `providerVisibleTools`.
- What was not tested: Full external-model network run; the proof uses the local OpenClaw Tool Search bridge/runtime with an in-process catalog target so no provider credentials or network calls are required.

## Validation
- `node scripts/test-projects.mjs src/agents/tool-search.test.ts`
- `node scripts/test-projects.mjs src/agents/pi-embedded-runner/run/attempt.test.ts`
- `pnpm check:changed`
