### PR TITLE
fix(codex): deliver native image outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway: reread config from disk after the first in-process restart loop startup, preventing SIGUSR1 restarts from reusing a stale startup snapshot and dropping config written after boot. Fixes #79947. Thanks @TheLevti.
+- Codex app-server: deliver native image-generation outputs from Codex `savedPath` events as reply media, so blank-text image generation turns still attach the generated file. Thanks @keshavbotagent.
 - Media/host-read: allow buffer-verified gzip, tar, and 7z archives in the shared host-local media validator alongside ZIP and document attachments.
 - Plugins/doctor: invalidate persisted plugin registry snapshots when plugin diagnostics point at deleted source paths, so `openclaw doctor` stops repeating stale warnings after a local extension is replaced by a managed npm plugin. Fixes #80087. (#80134) Thanks @hclsys.
 - Cron: let isolated self-cleanup runs inspect their own job run history while keeping other cron jobs and mutation actions blocked. Fixes #80019. Thanks @hclsys.

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -200,6 +200,9 @@ settings such as `agents.defaults.imageGenerationModel`, `videoGenerationModel`,
 
 Text, images, video, music, TTS, approvals, and messaging-tool output continue
 through the normal OpenClaw delivery path. Media generation does not require PI.
+When Codex emits a native image-generation item with a `savedPath`, OpenClaw
+forwards that exact file through the normal reply-media path even if the Codex
+turn has no assistant text.
 
 ## Related
 

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -343,6 +343,55 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.lastAssistant?.content).toEqual([{ type: "text", text: "OK from raw" }]);
   });
 
+  it("attaches native Codex image-generation saved paths as reply media", async () => {
+    const projector = await createProjector();
+    const savedPath = "/tmp/codex-home/generated_images/session-1/ig_123.png";
+
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "imageGeneration",
+          id: "ig_123",
+          status: "completed",
+          revisedPrompt: "A tiny blue square",
+          result: "Zm9v",
+          savedPath,
+        },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.assistantTexts).toStrictEqual([]);
+    expect(result.toolMediaUrls).toEqual([savedPath]);
+  });
+
+  it("does not append native Codex image-generation media after explicit media delivery", async () => {
+    const projector = await createProjector();
+    const savedPath = "/tmp/codex-home/generated_images/session-1/ig_123.png";
+
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "imageGeneration",
+          id: "ig_123",
+          status: "completed",
+          revisedPrompt: null,
+          result: "Zm9v",
+          savedPath,
+        },
+      ]),
+    );
+
+    const result = projector.buildResult({
+      ...buildEmptyToolTelemetry(),
+      messagingToolSentMediaUrls: [savedPath],
+      toolMediaUrls: [],
+    });
+
+    expect(result.toolMediaUrls).toStrictEqual([]);
+  });
+
   it("does not fail a completed reply after a retryable app-server error notification", async () => {
     const projector = await createProjector();
 

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -115,6 +115,7 @@ export class CodexAppServerEventProjector {
   private readonly toolTranscriptMessages: AgentMessage[] = [];
   private readonly toolTranscriptCallIds = new Set<string>();
   private readonly toolTranscriptResultIds = new Set<string>();
+  private readonly nativeGeneratedMediaUrls = new Set<string>();
   private assistantStarted = false;
   private reasoningStarted = false;
   private reasoningEnded = false;
@@ -294,7 +295,7 @@ export class CodexAppServerEventProjector {
       messagingToolSentMediaUrls: toolTelemetry.messagingToolSentMediaUrls,
       messagingToolSentTargets: toolTelemetry.messagingToolSentTargets,
       heartbeatToolResponse: toolTelemetry.heartbeatToolResponse,
-      toolMediaUrls: toolTelemetry.toolMediaUrls,
+      toolMediaUrls: this.buildToolMediaUrls(toolTelemetry),
       toolAudioAsVoice: toolTelemetry.toolAudioAsVoice,
       successfulCronAdds: toolTelemetry.successfulCronAdds,
       cloudCodeAssistFormatError: false,
@@ -462,6 +463,7 @@ export class CodexAppServerEventProjector {
       this.rememberAssistantItem(item.id);
       this.assistantTextByItem.set(item.id, item.text);
     }
+    this.recordNativeGeneratedMedia(item);
     if (item?.type === "plan" && typeof item.text === "string" && item.text) {
       this.planTextByItem.set(item.id, item.text);
       this.emitPlanUpdate({ explanation: undefined, steps: splitPlanText(item.text) });
@@ -597,6 +599,7 @@ export class CodexAppServerEventProjector {
         this.rememberAssistantItem(item.id);
         this.assistantTextByItem.set(item.id, item.text);
       }
+      this.recordNativeGeneratedMedia(item);
       if (item.type === "plan" && typeof item.text === "string" && item.text) {
         this.planTextByItem.set(item.id, item.text);
         this.emitPlanUpdate({ explanation: undefined, steps: splitPlanText(item.text) });
@@ -670,6 +673,28 @@ export class CodexAppServerEventProjector {
     const itemId = readString(item, "id") ?? `raw-assistant-${this.assistantItemOrder.length + 1}`;
     this.rememberAssistantItem(itemId);
     this.assistantTextByItem.set(itemId, text);
+  }
+
+  private recordNativeGeneratedMedia(item: CodexThreadItem | undefined): void {
+    if (item?.type !== "imageGeneration") {
+      return;
+    }
+    const savedPath = readItemString(item, "savedPath")?.trim();
+    if (savedPath) {
+      this.nativeGeneratedMediaUrls.add(savedPath);
+    }
+  }
+
+  private buildToolMediaUrls(toolTelemetry: CodexAppServerToolTelemetry): string[] | undefined {
+    const mediaUrls = new Set(
+      toolTelemetry.toolMediaUrls?.map((url) => url.trim()).filter(Boolean) ?? [],
+    );
+    if ((toolTelemetry.messagingToolSentMediaUrls?.length ?? 0) === 0) {
+      for (const mediaUrl of this.nativeGeneratedMediaUrls) {
+        mediaUrls.add(mediaUrl);
+      }
+    }
+    return mediaUrls.size > 0 ? [...mediaUrls] : toolTelemetry.toolMediaUrls;
   }
 
   private async maybeEndReasoning(): Promise<void> {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2590,6 +2590,43 @@ describe("runCodexAppServerAttempt", () => {
     expect(result.timedOut).toBe(false);
   });
 
+  it("surfaces Codex-native image generation saved paths as reply media", async () => {
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          items: [
+            {
+              type: "imageGeneration",
+              id: "ig_123",
+              status: "completed",
+              revisedPrompt: "A tiny blue square",
+              result: "Zm9v",
+              savedPath: "/tmp/codex-home/generated_images/session-1/ig_123.png",
+            },
+          ],
+        },
+      },
+    });
+
+    await expect(run).resolves.toMatchObject({
+      assistantTexts: [],
+      toolMediaUrls: ["/tmp/codex-home/generated_images/session-1/ig_123.png"],
+    });
+  });
+
   it("does not complete on unscoped turn/completed notifications", async () => {
     const harness = createStartedThreadHarness();
     const run = runCodexAppServerAttempt(


### PR DESCRIPTION
## Summary
- attach Codex app-server native `imageGeneration.savedPath` outputs as reply media for the current turn
- avoid broad `generated_*` filesystem scans by using Codex's upstream saved-path contract
- skip adding native image media when a message tool already sent media, to avoid duplicate delivery
- document the Codex harness media-delivery behavior and credit the original contributor from #80122

Replaces #80122 with a narrower implementation based on the local Codex app-server protocol/source contract.

## Real behavior proof
- Behavior or issue addressed: Codex app-server image-generation turns can finish with no assistant text while the generated image is available only as a native Codex saved file; OpenClaw must still deliver that file as reply media.
- Real environment tested: Keshav's live OpenClaw Telegram gateway from #80122, plus local OpenClaw Codex app-server adapter verification against the current replacement branch.
- Exact steps or command run after this patch: Ran a Codex app-server turn-completion projection with a real `imageGeneration.savedPath` item matching the upstream Codex app-server protocol shape, then verified the OpenClaw attempt result exposes that path in `toolMediaUrls` for normal reply-media delivery.
- Evidence after fix: Live Telegram proof for the same user-visible symptom from #80122: https://raw.githubusercontent.com/keshavbotagent/openclaw/pr-80122-proof/.github/proof/pr-80122-telegram-delivery-proof.jpg ; local terminal output from this branch shows `118 passed (118)` for the Codex app-server projector/run-attempt tests and `check:changed` completed successfully.
- Observed result after fix: Blank-text Codex image-generation completion now produces `toolMediaUrls: ["/tmp/codex-home/generated_images/session-1/ig_123.png"]`, so the runner creates a media-only reply payload instead of treating the turn as empty.
- What was not tested: I did not rerun a second live Telegram gateway after rewriting the implementation; the live screenshot is from the original PR's real setup, and this replacement verifies the narrower OpenClaw adapter path against Codex's saved-path contract.

## Verification
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/plugins/codex-harness-runtime.md extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `env -u OPENCLAW_TESTBOX -u OPENCLAW_TESTBOX_ID OPENCLAW_VITEST_MAX_WORKERS=1 pnpm check:changed`
