### PR TITLE
fix: allow tweakcn theme imports in Control UI CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Network/SSRF: keep pinned automatic DNS lookups on IPv4 when dual-stack hosts also publish AAAA records, and treat `EADDRNOTAVAIL` as a transient gateway network failure instead of a fatal crash. Fixes #80078. Thanks @takamasa-aiso.
 - Control UI: show compact one-line live/idle/terminal run status badges in the Sessions table and rename the active-minute filter to its updated-within meaning. Fixes #78307. Thanks @BunsDev.
 - Control UI: scope chat session-list refreshes by agent and skip disk-only agent store discovery for configured-only lists, preventing post-first-message session switching stalls on large Windows stores. Fixes #79675. Thanks @lovelefeng-glitch, @BunsDev.
+- Control UI: allow Appearance tweakcn theme imports through the served CSP so browser-local custom theme links no longer fail with a `connect-src` violation. Fixes #78504. Thanks @BunsDev.
 - Media/host-read: allow buffer-verified gzip, tar, and 7z archives in the shared host-local media validator alongside ZIP and document attachments.
 - Plugins/doctor: invalidate persisted plugin registry snapshots when plugin diagnostics point at deleted source paths, so `openclaw doctor` stops repeating stale warnings after a local extension is replaced by a managed npm plugin. Fixes #80087. (#80134) Thanks @hclsys.
 - Cron: let isolated self-cleanup runs inspect their own job run history while keeping other cron jobs and mutation actions blocked. Fixes #80019. Thanks @hclsys.

--- a/src/gateway/control-ui-csp.test.ts
+++ b/src/gateway/control-ui-csp.test.ts
@@ -17,7 +17,7 @@ describe("buildControlUiCspHeader", () => {
     expect(csp).toContain("font-src 'self' https://fonts.gstatic.com");
   });
 
-  it("allows OpenAI realtime WebRTC offer requests without allowing all HTTPS", () => {
+  it("allows OpenAI realtime and tweakcn theme import requests without allowing all HTTPS", () => {
     const csp = buildControlUiCspHeader();
     const connectSrc = csp.split("; ").find((directive) => directive.startsWith("connect-src "));
     expect(connectSrc?.split(" ")).toEqual([
@@ -26,7 +26,10 @@ describe("buildControlUiCspHeader", () => {
       "ws:",
       "wss:",
       "https://api.openai.com",
+      "https://tweakcn.com",
     ]);
+    expect(connectSrc).not.toContain("https://*.tweakcn.com");
+    expect(connectSrc?.split(" ")).not.toContain("https:");
   });
 
   it("limits image loading to same-origin, data, and managed blob URLs", () => {

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -47,6 +47,6 @@ export function buildControlUiCspHeader(opts?: { inlineScriptHashes?: string[] }
     "img-src 'self' data: blob:",
     "font-src 'self' https://fonts.gstatic.com",
     "worker-src 'self'",
-    "connect-src 'self' ws: wss: https://api.openai.com",
+    "connect-src 'self' ws: wss: https://api.openai.com https://tweakcn.com",
   ].join("; ");
 }

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -311,6 +311,10 @@ describe("handleControlUiHttpRequest", () => {
         expect(typeof csp).toBe("string");
         expect(String(csp)).toContain("frame-ancestors 'none'");
         expect(String(csp)).toContain("script-src 'self'");
+        expect(String(csp)).toContain(
+          "connect-src 'self' ws: wss: https://api.openai.com https://tweakcn.com",
+        );
+        expect(String(csp)).not.toContain("https://*.tweakcn.com");
         expect(String(csp)).not.toContain("script-src 'self' 'unsafe-inline'");
       },
     });


### PR DESCRIPTION
## Summary

- Problem: Control UI Appearance documents tweakcn custom theme import, but the served CSP blocked the browser fetch to `https://tweakcn.com/r/themes/{id}`.
- Why it matters: users could paste a documented tweakcn share/registry link and still get a browser-side `connect-src` failure before the importer could parse the theme.
- What changed: add only `https://tweakcn.com` to Control UI `connect-src`, assert the generated CSP, assert the served HTTP header, and add the user-facing changelog entry.
- What did NOT change (scope boundary): no wildcard `https:`, no `https://*.tweakcn.com`, no gateway proxy, and no custom-theme storage/import behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #78504
- Related #78119
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: browser-side tweakcn registry fetch for Appearance custom theme import is allowed by the served Control UI CSP.
- Real environment tested: macOS local checkout, Node 22, Codex in-app Browser, temporary loopback HTTP page using `buildControlUiCspHeader()` from this branch.
- Exact steps or command run after this patch: served a local proof page with the edited CSP header, opened it in the in-app Browser, clicked `Import tweakcn theme`, and fetched `https://tweakcn.com/r/themes/cmlh0x713000104jrgmds6vcd` with the same accept/no-redirect fetch shape used by the importer.
- Evidence after fix (copied browser proof):

```text
served CSP: default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'sha256-YD6lHuB8mmZzcRM8V/mMksFH6azgtjCLhcCyZaTM5Ck='; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; worker-src 'self'; connect-src 'self' ws: wss: https://api.openai.com https://tweakcn.com
button result: Imported Deep Purple from tweakcn with light/dark tokens.
console warn/error logs: []
no CSP violation: true
```

- Observed result after fix: the tweakcn registry request succeeded, returned a payload with light and dark tokens, and no console CSP warning/error appeared.
- What was not tested: full authenticated Gateway Appearance panel import; the proof isolates the CSP/fetch boundary, and existing UI import tests cover the importer normalization/validation behavior.
- Before evidence (optional but encouraged): current `origin/main` before this branch served `connect-src 'self' ws: wss: https://api.openai.com` without tweakcn, matching #78504's reported violation.

## Root Cause (if applicable)

- Root cause: `ui/src/ui/custom-theme.ts` intentionally fetches normalized tweakcn registry URLs directly from the browser, but `src/gateway/control-ui-csp.ts` did not include the required tweakcn origin in `connect-src`.
- Missing detection / guardrail: CSP tests asserted the OpenAI realtime origin but did not cover the documented tweakcn import origin or the served Control UI header.
- Contributing context (if known): the tweakcn import feature was added as browser-local storage and direct browser fetch; the CSP allowlist was not updated with that external registry origin.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/control-ui-csp.test.ts`, `src/gateway/control-ui.http.test.ts`, `ui/src/ui/custom-theme.test.ts`
- Scenario the test should lock in: generated and served Control UI CSP allow the exact tweakcn registry origin while rejecting broad `https:` and wildcard tweakcn allowlists.
- Why this is the smallest reliable guardrail: the bug was in the CSP header, not in importer parsing or storage.
- Existing test that already covers this (if any): `ui/src/ui/custom-theme.test.ts` already covers URL normalization and no-redirect fetch behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Control UI Appearance tweakcn custom theme imports now work instead of failing in the browser with a CSP `connect-src` violation.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes.
- Secrets/tokens handling changed? (`Yes/No`) No.
- New/changed network calls? (`Yes/No`) Yes.
- Command/tool execution surface changed? (`Yes/No`) No.
- Data access scope changed? (`Yes/No`) No.
- If any `Yes`, explain risk + mitigation: the browser CSP now permits the existing documented direct fetch to `https://tweakcn.com`; mitigation is an exact origin allowlist only, with no broad HTTPS or wildcard domain permission. The importer still enforces tweakcn host/redirect checks, bounded response size, JSON schema validation, and safe CSS token validation.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22 checkout
- Model/provider: N/A
- Integration/channel (if any): Control UI / browser
- Relevant config (redacted): N/A

### Steps

1. On `origin/main` before this branch, inspect `src/gateway/control-ui-csp.ts`: `connect-src` omits `https://tweakcn.com`.
2. Apply this branch and serve a local page using `buildControlUiCspHeader()`.
3. In the in-app Browser, click the import button that fetches `https://tweakcn.com/r/themes/cmlh0x713000104jrgmds6vcd`.
4. Inspect visible result and warn/error console logs.

### Expected

- The CSP includes `https://tweakcn.com` and the browser fetch succeeds without a CSP violation.

### Actual

- The browser rendered `Imported Deep Purple from tweakcn with light/dark tokens.` and warn/error console logs were empty.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: exact CSP header generation, served Control UI CSP header, custom-theme fetch helper behavior, browser fetch proof against the tweakcn registry URL, and protocol drift with `pnpm protocol:check`.
- Edge cases checked: no `https:` blanket allowlist; no `https://*.tweakcn.com`; existing OpenAI realtime origin remains allowed.
- What you did **not** verify: full authenticated Gateway Appearance panel import.

## Local Validation

- `pnpm protocol:check`
- `pnpm test src/gateway/control-ui-csp.test.ts ui/src/ui/custom-theme.test.ts src/gateway/control-ui.http.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/gateway/control-ui-csp.ts src/gateway/control-ui-csp.test.ts src/gateway/control-ui.http.test.ts CHANGELOG.md`
- `git diff --check origin/main...HEAD`
- `pnpm check:changed`

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes.
- Config/env changes? (`Yes/No`) No.
- Migration needed? (`Yes/No`) No.
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: expanding Control UI browser egress too broadly.
  - Mitigation: allow only `https://tweakcn.com` in `connect-src`; tests assert no broad `https:` and no wildcard tweakcn origin.
