### PR TITLE
fix(acpx): await startup probe before gateway ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- ACPX: run and await the embedded ACP backend startup probe by default so the gateway `ready` signal no longer fires before the acpx runtime has either become usable or reported a probe failure; set `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE=0` to restore lazy startup. Fixes #79596. Thanks @bzelones.
 - OpenAI-compatible models: strip prior assistant reasoning fields from replayed Chat Completions history by default, preventing oMLX/vLLM Qwen follow-up turns from rejecting or stalling on stale `reasoning` payloads. Fixes #46637. Thanks @zipzagster and @lexhoefsloot.
 - CLI/onboarding: give non-Azure custom providers a safe generated context window and heal legacy 4k wizard entries without overwriting explicit valid small model limits, preventing first-turn compaction loops. Fixes #79428. (#79911) Thanks @Jefsky.
 - OpenAI-compatible models: add `compat.strictMessageKeys` to strip Chat Completions replay messages to `role` and `content` for strict providers that reject OpenAI-style tool and metadata keys. Fixes #50374. Thanks @choutos.

--- a/docs/tools/acp-agents-setup.md
+++ b/docs/tools/acp-agents-setup.md
@@ -164,10 +164,10 @@ Then verify backend health:
 
 ### acpx command and version configuration
 
-By default, the `acpx` plugin registers the embedded ACP backend without
-spawning an ACP agent during Gateway startup. Run `/acp doctor` for an explicit
-live probe. Set `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE=1` only when you need the
-Gateway to probe the configured agent at startup.
+By default, the `acpx` plugin probes the embedded ACP backend during Gateway
+startup and waits for that probe before the gateway `ready` signal. Set
+`OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE=0` to skip the startup probe and register
+the backend lazily instead. Run `/acp doctor` for an explicit on-demand probe.
 
 Override the command or version in plugin config:
 
@@ -289,11 +289,10 @@ Restart the gateway after changing this value.
 
 ### Health probe agent configuration
 
-When `/acp doctor` or the opt-in startup probe checks the backend, the bundled
-`acpx` plugin probes one harness agent. If `acp.allowedAgents` is set, it
-defaults to the first allowed agent; otherwise it defaults to `codex`. If your
-deployment needs a different ACP agent for health checks, set the probe agent
-explicitly:
+When `/acp doctor` or the startup probe checks the backend, the bundled `acpx`
+plugin probes one harness agent. If `acp.allowedAgents` is set, it defaults to
+the first allowed agent; otherwise it defaults to `codex`. If your deployment
+needs a different ACP agent for health checks, set the probe agent explicitly:
 
 ```bash
 openclaw config set plugins.entries.acpx.config.probeAgent claude

--- a/extensions/acpx/register.runtime.ts
+++ b/extensions/acpx/register.runtime.ts
@@ -11,6 +11,7 @@ import type { OpenClawPluginService, OpenClawPluginServiceContext } from "opencl
 
 const ACPX_BACKEND_ID = "acpx";
 const ENABLE_STARTUP_PROBE_ENV = "OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE";
+const SKIP_RUNTIME_PROBE_ENV = "OPENCLAW_SKIP_ACPX_RUNTIME_PROBE";
 
 type RealAcpxServiceModule = typeof import("./src/service.js");
 type CreateAcpxRuntimeServiceParams = NonNullable<
@@ -39,7 +40,7 @@ function loadServiceModule(): Promise<RealAcpxServiceModule> {
 }
 
 function shouldRunStartupProbe(env: NodeJS.ProcessEnv = process.env): boolean {
-  return env[ENABLE_STARTUP_PROBE_ENV] === "1";
+  return env[ENABLE_STARTUP_PROBE_ENV] !== "0" && env[SKIP_RUNTIME_PROBE_ENV] !== "1";
 }
 
 async function startRealService(state: DeferredServiceState): Promise<AcpxRuntimeLike> {

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -174,7 +174,8 @@ describe("createAcpxRuntimeService", () => {
     expect(getAcpRuntimeBackend("acpx")).toBeUndefined();
   });
 
-  it("creates the embedded runtime state directory without probing at startup by default", async () => {
+  it("skips the startup probe and defers acpx backend health reporting when explicitly opted out", async () => {
+    process.env.OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE = "0";
     const workspaceDir = await makeTempDir();
     const stateDir = path.join(workspaceDir, "custom-state");
     const ctx = createServiceContext(workspaceDir);
@@ -196,6 +197,47 @@ describe("createAcpxRuntimeService", () => {
     await fs.access(stateDir);
     expect(probeAvailability).not.toHaveBeenCalled();
     expect(getAcpRuntimeBackend("acpx")?.healthy).toBeUndefined();
+
+    await service.stop?.(ctx);
+  });
+
+  it("waits for the embedded runtime startup probe before resolving", async () => {
+    const workspaceDir = await makeTempDir();
+    const ctx = createServiceContext(workspaceDir);
+    let releaseProbe!: () => void;
+    const probeStarted = vi.fn();
+    const probeAvailability = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          probeStarted();
+          releaseProbe = resolve;
+        }),
+    );
+    const runtime = createMockRuntime({
+      probeAvailability,
+      isHealthy: () => true,
+    });
+    const service = createAcpxRuntimeService({
+      runtimeFactory: () => runtime as never,
+    });
+
+    const startPromise = service.start(ctx) as Promise<void>;
+    await vi.waitFor(() => {
+      expect(probeStarted).toHaveBeenCalledOnce();
+    });
+
+    let resolved = false;
+    void startPromise.then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+
+    expect(resolved).toBe(false);
+    releaseProbe();
+    await startPromise;
+
+    expect(resolved).toBe(true);
+    expect(ctx.logger.info).toHaveBeenCalledWith("embedded acpx runtime backend ready");
 
     await service.stop?.(ctx);
   });
@@ -317,7 +359,8 @@ describe("createAcpxRuntimeService", () => {
     await service.stop?.(ctx);
   });
 
-  it("registers the default backend without importing ACPX runtime until first use", async () => {
+  it("registers the default backend lazily without importing ACPX runtime when startup probing is opted out", async () => {
+    process.env.OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE = "0";
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);
     const service = createAcpxRuntimeService();
@@ -344,8 +387,7 @@ describe("createAcpxRuntimeService", () => {
     await service.stop?.(ctx);
   });
 
-  it("can run the embedded runtime probe at startup when explicitly enabled", async () => {
-    process.env.OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE = "1";
+  it("runs the embedded runtime probe at startup by default and reports health", async () => {
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);
     const probeAvailability = vi.fn(async () => {});
@@ -361,6 +403,30 @@ describe("createAcpxRuntimeService", () => {
 
     expect(probeAvailability).toHaveBeenCalledOnce();
     expect(getAcpRuntimeBackend("acpx")?.healthy?.()).toBe(true);
+
+    await service.stop?.(ctx);
+  });
+
+  it("bounds the embedded runtime startup probe wait with the configured timeout", async () => {
+    const workspaceDir = await makeTempDir();
+    const ctx = createServiceContext(workspaceDir);
+    const probeAvailability = vi.fn(() => new Promise<void>(() => {}));
+    const runtime = createMockRuntime({
+      probeAvailability,
+      isHealthy: () => false,
+    });
+    const service = createAcpxRuntimeService({
+      pluginConfig: { timeoutSeconds: 0.001 },
+      runtimeFactory: () => runtime as never,
+    });
+
+    await service.start(ctx);
+
+    expect(probeAvailability).toHaveBeenCalledOnce();
+    expect(getAcpRuntimeBackend("acpx")?.healthy?.()).toBe(false);
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      "embedded acpx runtime setup failed: embedded acpx runtime backend startup probe timed out after 0.001s",
+    );
 
     await service.stop?.(ctx);
   });
@@ -497,7 +563,6 @@ describe("createAcpxRuntimeService", () => {
   });
 
   it("can skip the embedded runtime probe via env", async () => {
-    process.env.OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE = "1";
     process.env.OPENCLAW_SKIP_ACPX_RUNTIME_PROBE = "1";
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);
@@ -517,12 +582,12 @@ describe("createAcpxRuntimeService", () => {
     expect(getAcpRuntimeBackend("acpx")).toMatchObject({
       runtime: expect.any(Object),
     });
+    expect(getAcpRuntimeBackend("acpx")?.healthy).toBeUndefined();
 
     await service.stop?.(ctx);
   });
 
   it("formats non-string doctor details without losing object payloads", async () => {
-    process.env.OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE = "1";
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);
     const runtime = createMockRuntime({
@@ -539,11 +604,9 @@ describe("createAcpxRuntimeService", () => {
 
     await service.start(ctx);
 
-    await vi.waitFor(() => {
-      expect(ctx.logger.warn).toHaveBeenCalledWith(
-        'embedded acpx runtime backend probe failed: probe failed ({"code":"ACP_CLOSED","agent":"codex"}; stdin closed)',
-      );
-    });
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      'embedded acpx runtime backend probe failed: probe failed ({"code":"ACP_CLOSED","agent":"codex"}; stdin closed)',
+    );
 
     await service.stop?.(ctx);
   });

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -11,6 +11,7 @@ import type {
 } from "../runtime-api.js";
 import { registerAcpRuntimeBackend, unregisterAcpRuntimeBackend } from "../runtime-api.js";
 import { prepareAcpxCodexAuthConfig } from "./codex-auth-bridge.js";
+import { DEFAULT_ACPX_TIMEOUT_SECONDS } from "./config-schema.js";
 import {
   resolveAcpxPluginConfig,
   toAcpMcpServers,
@@ -34,6 +35,7 @@ type AcpxRuntimeLike = AcpRuntime & {
 };
 
 const ENABLE_STARTUP_PROBE_ENV = "OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE";
+const SKIP_RUNTIME_PROBE_ENV = "OPENCLAW_SKIP_ACPX_RUNTIME_PROBE";
 const ACPX_BACKEND_ID = "acpx";
 
 type AcpxRuntimeModule = typeof import("./runtime.js");
@@ -200,7 +202,38 @@ function resolveAllowedAgentsProbeAgent(ctx: OpenClawPluginServiceContext): stri
 }
 
 function shouldRunStartupProbe(env: NodeJS.ProcessEnv = process.env): boolean {
-  return env[ENABLE_STARTUP_PROBE_ENV] === "1";
+  return env[ENABLE_STARTUP_PROBE_ENV] !== "0";
+}
+
+function shouldProbeRuntimeAtStartup(env: NodeJS.ProcessEnv = process.env): boolean {
+  return shouldRunStartupProbe(env) && env[SKIP_RUNTIME_PROBE_ENV] !== "1";
+}
+
+async function withStartupProbeTimeout<T>(params: {
+  promise: Promise<T>;
+  timeoutSeconds: number;
+}): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutMs = Math.max(1, params.timeoutSeconds * 1_000);
+  try {
+    return await Promise.race([
+      params.promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          reject(
+            new Error(
+              `embedded acpx runtime backend startup probe timed out after ${params.timeoutSeconds}s`,
+            ),
+          );
+        }, timeoutMs);
+        (timeout as { unref?: () => void }).unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
 }
 
 async function resolveGatewayInstanceId(stateDir: string): Promise<string> {
@@ -333,43 +366,47 @@ export function createAcpxRuntimeService(
             logger: ctx.logger,
           });
 
+      const shouldProbeRuntime = shouldProbeRuntimeAtStartup();
       registerAcpRuntimeBackend({
         id: ACPX_BACKEND_ID,
         runtime,
-        ...(shouldRunStartupProbe() ? { healthy: () => runtime?.isHealthy() ?? false } : {}),
+        ...(shouldProbeRuntime ? { healthy: () => runtime?.isHealthy() ?? false } : {}),
       });
       ctx.logger.info(`embedded acpx runtime backend registered (cwd: ${pluginConfig.cwd})`);
 
-      if (!shouldRunStartupProbe() || process.env.OPENCLAW_SKIP_ACPX_RUNTIME_PROBE === "1") {
+      if (!shouldProbeRuntime) {
         return;
       }
 
       lifecycleRevision += 1;
       const currentRevision = lifecycleRevision;
-      void (async () => {
-        try {
-          await runtime?.probeAvailability();
-          if (currentRevision !== lifecycleRevision) {
-            return;
-          }
-          if (runtime?.isHealthy()) {
-            ctx.logger.info("embedded acpx runtime backend ready");
-            return;
-          }
-          const doctorReport = await runtime?.doctor?.();
-          if (currentRevision !== lifecycleRevision) {
-            return;
-          }
-          ctx.logger.warn(
-            `embedded acpx runtime backend probe failed: ${doctorReport ? formatDoctorFailureMessage(doctorReport) : "backend remained unhealthy after probe"}`,
-          );
-        } catch (err) {
-          if (currentRevision !== lifecycleRevision) {
-            return;
-          }
-          ctx.logger.warn(`embedded acpx runtime setup failed: ${formatErrorMessage(err)}`);
+      try {
+        if (runtime) {
+          await withStartupProbeTimeout({
+            promise: runtime.probeAvailability(),
+            timeoutSeconds: pluginConfig.timeoutSeconds ?? DEFAULT_ACPX_TIMEOUT_SECONDS,
+          });
         }
-      })();
+        if (currentRevision !== lifecycleRevision) {
+          return;
+        }
+        if (runtime?.isHealthy()) {
+          ctx.logger.info("embedded acpx runtime backend ready");
+          return;
+        }
+        const doctorReport = await runtime?.doctor?.();
+        if (currentRevision !== lifecycleRevision) {
+          return;
+        }
+        ctx.logger.warn(
+          `embedded acpx runtime backend probe failed: ${doctorReport ? formatDoctorFailureMessage(doctorReport) : "backend remained unhealthy after probe"}`,
+        );
+      } catch (err) {
+        if (currentRevision !== lifecycleRevision) {
+          return;
+        }
+        ctx.logger.warn(`embedded acpx runtime setup failed: ${formatErrorMessage(err)}`);
+      }
     },
     async stop(_ctx: OpenClawPluginServiceContext): Promise<void> {
       lifecycleRevision += 1;


### PR DESCRIPTION
## Summary

- Run the ACPX startup probe by default unless `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE=0` opts back into lazy startup.
- Await the ACPX probe inside `service.start()`, so Gateway sidecar readiness waits until acpx is usable or has reported a bounded probe failure.
- Preserve the existing `OPENCLAW_SKIP_ACPX_RUNTIME_PROBE=1` fast path for E2E scripts and update docs/changelog for the new default.

Closes #79596.

## Real behavior proof

- Behavior or issue addressed: Stuck ACPX ACP agents should not block Gateway readiness indefinitely during startup probing.
- Real environment tested: Local OpenClaw Gateway run from the current PR head with isolated `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH` under `/tmp/openclaw-acpx-proof.7B2Plt`.
- Exact steps or command run after this patch: Configured `plugins.entries.acpx.enabled=true`, `plugins.entries.acpx.config.timeoutSeconds=0.001`, and `plugins.entries.acpx.config.agents.codex.command="node"` with `args=["-e", "setInterval(() => {}, 1000)"]`, then ran `OPENCLAW_HOME=/tmp/openclaw-acpx-proof.7B2Plt/home OPENCLAW_STATE_DIR=/tmp/openclaw-acpx-proof.7B2Plt/state OPENCLAW_CONFIG_PATH=/tmp/openclaw-acpx-proof.7B2Plt/state/openclaw.json pnpm openclaw gateway run --auth none --bind loopback --port 19876 --verbose --allow-unconfigured`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied live output from the isolated Gateway run:

```text
10:08:43 [plugins] embedded acpx runtime backend registered (cwd: /tmp/openclaw-acpx-proof.7B2Plt/home/.openclaw/workspace)
10:08:43 [plugins] embedded acpx runtime setup failed: embedded acpx runtime backend startup probe timed out after 0.001s
10:08:43 [gateway] ready
```

- Observed result after fix: The startup probe timed out after 0.001s, the ACPX backend was reported degraded, and the gateway reached `ready` instead of hanging.
- What was not tested: No additional gaps.

## Verification

- `pnpm exec oxfmt --check --threads=1 extensions/acpx/register.runtime.ts extensions/acpx/src/service.ts extensions/acpx/src/service.test.ts docs/tools/acp-agents-setup.md CHANGELOG.md`
- `pnpm test extensions/acpx/src/service.test.ts`
- `env -u OPENCLAW_TESTBOX -u OPENCLAW_TESTBOX_ID pnpm check:changed`
- `pnpm build`
- Isolated Gateway run above for bounded ACPX startup probe behavior.

Additional suite check:

- `pnpm test extensions/acpx` still fails in `extensions/acpx/src/claude-agent-acp-completion.test.ts:178` (`resolved` becomes `true` after idle). This file is not touched by this PR and the focused ACPX startup test passes.
