### PR TITLE
Add Telegram real-user Crabbox proof

### DIFF
--- a/.agents/skills/telegram-crabbox-e2e-proof/SKILL.md
+++ b/.agents/skills/telegram-crabbox-e2e-proof/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: telegram-crabbox-e2e-proof
+description: Use when reviewing, reproducing, or proving OpenClaw Telegram behavior with a real Telegram user on Crabbox, including PR review workflows that need an agent-controlled Telegram Desktop recording, TDLib user-driver commands, Convex-leased credentials, WebVNC observation, and motion-trimmed artifacts.
+---
+
+# Telegram Crabbox E2E Proof
+
+Use this for Telegram PR review or bug reproduction when bot-to-bot proof is
+not enough. The goal is to let the agent keep a real Telegram user session open
+until it is satisfied, then attach visual proof.
+
+Do not use personal accounts. Do not add credentials to the repo, prompt, or
+artifact bundle. The runner leases the shared burner account from Convex.
+
+## Start
+
+Run from the OpenClaw repo and branch under test:
+
+```bash
+pnpm qa:telegram-user:crabbox -- start \
+  --tdlib-url http://artifacts.openclaw.ai/tdlib-v1.8.0-linux-x64.tgz \
+  --output-dir .artifacts/qa-e2e/telegram-user-crabbox/pr-review
+```
+
+This starts one held session:
+
+- leases the exclusive `telegram-user` Convex credential
+- restores TDLib and Telegram Desktop with the same user account
+- starts a mock OpenClaw Telegram SUT from the current checkout
+- selects the configured Telegram chat in the visible Linux desktop
+- starts desktop recording
+- writes `.artifacts/qa-e2e/telegram-user-crabbox/pr-review/session.json`
+
+Keep the session alive while investigating. It is valid for the agent to test
+for minutes, run several commands, use WebVNC, inspect transcripts, and only
+finish once the behavior is understood.
+
+## While Testing
+
+Send as the real Telegram user:
+
+```bash
+pnpm qa:telegram-user:crabbox -- send \
+  --session .artifacts/qa-e2e/telegram-user-crabbox/pr-review/session.json \
+  --text /status
+```
+
+For slash commands, omit the bot username; the runner targets the SUT bot.
+
+Run arbitrary commands on the Crabbox:
+
+```bash
+pnpm qa:telegram-user:crabbox -- run \
+  --session .artifacts/qa-e2e/telegram-user-crabbox/pr-review/session.json \
+  -- bash -lc 'source /tmp/openclaw-telegram-user-crabbox/env.sh && python3 /tmp/openclaw-telegram-user-crabbox/user-driver.py transcript --limit 20 --json'
+```
+
+Useful remote user-driver commands:
+
+```bash
+source /tmp/openclaw-telegram-user-crabbox/env.sh
+python3 /tmp/openclaw-telegram-user-crabbox/user-driver.py status --json
+python3 /tmp/openclaw-telegram-user-crabbox/user-driver.py chats --json
+python3 /tmp/openclaw-telegram-user-crabbox/user-driver.py transcript --limit 20 --json
+python3 /tmp/openclaw-telegram-user-crabbox/user-driver.py send --text '/status@{sut}'
+python3 /tmp/openclaw-telegram-user-crabbox/user-driver.py probe --text '@{sut} Reply exactly: USER-E2E-{run}' --expect USER-E2E-
+```
+
+Capture the current desktop without ending the session:
+
+```bash
+pnpm qa:telegram-user:crabbox -- screenshot \
+  --session .artifacts/qa-e2e/telegram-user-crabbox/pr-review/session.json
+```
+
+Check lease state and get the WebVNC command:
+
+```bash
+pnpm qa:telegram-user:crabbox -- status \
+  --session .artifacts/qa-e2e/telegram-user-crabbox/pr-review/session.json
+```
+
+## Finish
+
+Always finish or explicitly keep the box:
+
+```bash
+pnpm qa:telegram-user:crabbox -- finish \
+  --session .artifacts/qa-e2e/telegram-user-crabbox/pr-review/session.json
+```
+
+`finish` stops recording, creates motion-trimmed MP4/GIF artifacts, captures a
+final screenshot and logs, releases the Convex credential, stops the local SUT,
+and stops the Crabbox lease. Pass `--keep-box` only when a human needs to
+continue VNC debugging after the credential is released.
+
+After any failure or interruption, verify cleanup:
+
+```bash
+crabbox list --provider aws
+```
+
+If a session file exists and the credential may still be leased, run `finish`
+with that session file before retrying.
+
+## Attach Proof
+
+Attach only the useful visual artifact to the PR unless logs are needed:
+
+```bash
+rm -rf .artifacts/qa-e2e/telegram-user-crabbox/pr-gif-only
+mkdir -p .artifacts/qa-e2e/telegram-user-crabbox/pr-gif-only
+cp .artifacts/qa-e2e/telegram-user-crabbox/pr-review/telegram-user-crabbox-session-motion.gif \
+  .artifacts/qa-e2e/telegram-user-crabbox/pr-gif-only/telegram-user-crabbox-session-motion.gif
+crabbox artifacts publish \
+  --pr <pr-number> \
+  --repo openclaw/openclaw \
+  --dir .artifacts/qa-e2e/telegram-user-crabbox/pr-gif-only \
+  --summary 'Telegram real-user Crabbox session motion GIF' \
+  --template openclaw
+```
+
+Use full artifact publishing only when the PR needs logs or JSON output. Never
+publish credential payloads, local env files, TDLib databases, Telegram Desktop
+profiles, or raw session archives.
+
+## Quick Smoke
+
+For a fast one-shot check, use:
+
+```bash
+pnpm qa:telegram-user:crabbox -- --text /status
+```
+
+This is a start/send/finish shortcut. Prefer the held session for PR review,
+issue reproduction, or any task where the agent may need several attempts.

--- a/.agents/skills/telegram-crabbox-e2e-proof/SKILL.md
+++ b/.agents/skills/telegram-crabbox-e2e-proof/SKILL.md
@@ -105,24 +105,20 @@ with that session file before retrying.
 
 ## Attach Proof
 
-Attach only the useful visual artifact to the PR unless logs are needed:
+Attach only the useful visual artifact to the PR unless logs are needed. The
+runner is GIF-only by default:
 
 ```bash
-rm -rf .artifacts/qa-e2e/telegram-user-crabbox/pr-gif-only
-mkdir -p .artifacts/qa-e2e/telegram-user-crabbox/pr-gif-only
-cp .artifacts/qa-e2e/telegram-user-crabbox/pr-review/telegram-user-crabbox-session-motion.gif \
-  .artifacts/qa-e2e/telegram-user-crabbox/pr-gif-only/telegram-user-crabbox-session-motion.gif
-crabbox artifacts publish \
+pnpm qa:telegram-user:crabbox -- publish \
+  --session .artifacts/qa-e2e/telegram-user-crabbox/pr-review/session.json \
   --pr <pr-number> \
-  --repo openclaw/openclaw \
-  --dir .artifacts/qa-e2e/telegram-user-crabbox/pr-gif-only \
-  --summary 'Telegram real-user Crabbox session motion GIF' \
-  --template openclaw
+  --summary 'Telegram real-user Crabbox session motion GIF'
 ```
 
-Use full artifact publishing only when the PR needs logs or JSON output. Never
-publish credential payloads, local env files, TDLib databases, Telegram Desktop
-profiles, or raw session archives.
+This copies only `telegram-user-crabbox-session-motion.gif` into a temporary
+publish bundle and comments that GIF. Use `--full-artifacts` only when the PR
+needs logs or JSON output. Never publish credential payloads, local env files,
+TDLib databases, Telegram Desktop profiles, or raw session archives.
 
 ## Quick Smoke
 

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -576,10 +576,21 @@ Payload shapes the broker validates on `admin/add`:
 - Discord (`kind: "discord"`): `{ guildId: string, channelId: string, driverBotToken: string, sutBotToken: string, sutApplicationId: string }`.
 - WhatsApp (`kind: "whatsapp"`): `{ driverPhoneE164: string, sutPhoneE164: string, driverAuthArchiveBase64: string, sutAuthArchiveBase64: string, groupJid?: string }` - phone numbers must be distinct E.164 strings.
 
-For visual real-user Telegram proof, prefer `pnpm qa:telegram-user:crabbox -- --text /status`.
-It uses one Convex `telegram-user` lease for both the TDLib CLI driver and the
-Telegram Desktop witness, captures a Crabbox recording plus motion-trimmed
-video/GIF artifacts, and releases the lease on shutdown.
+For visual real-user Telegram proof, prefer a held Crabbox session:
+
+```bash
+pnpm qa:telegram-user:crabbox -- start --tdlib-url http://artifacts.openclaw.ai/tdlib-v1.8.0-linux-x64.tgz --output-dir .artifacts/qa-e2e/telegram-user-crabbox/pr-review
+pnpm qa:telegram-user:crabbox -- send --session .artifacts/qa-e2e/telegram-user-crabbox/pr-review/session.json --text /status
+pnpm qa:telegram-user:crabbox -- finish --session .artifacts/qa-e2e/telegram-user-crabbox/pr-review/session.json
+```
+
+`start` holds one exclusive Convex `telegram-user` lease for both the TDLib CLI
+driver and Telegram Desktop witness, starts desktop recording, and leaves the
+Crabbox alive for arbitrary agent-driven repro steps. Agents can use `send`,
+`run`, `screenshot`, and `status` until they are satisfied, then `finish`
+collects the screenshot, video, motion-trimmed video/GIF, TDLib probe outputs,
+and logs before releasing the credential. The default `probe` command remains a
+one-command shorthand for quick `/status` smoke checks.
 
 Slack lanes can also use the pool. Slack payload shape checks currently live in the Slack QA runner rather than the broker; use `{ channelId: string, driverBotToken: string, sutBotToken: string, sutAppToken: string }`, with a Slack channel id like `Cxxxxxxxxxx`. See [Setting up the Slack workspace](#setting-up-the-slack-workspace) for app and scope provisioning.
 

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -572,8 +572,14 @@ Telegram, Discord, Slack, and WhatsApp lanes can lease credentials from a shared
 Payload shapes the broker validates on `admin/add`:
 
 - Telegram (`kind: "telegram"`): `{ groupId: string, driverToken: string, sutToken: string }` - `groupId` must be a numeric chat-id string.
+- Telegram real user (`kind: "telegram-user"`): `{ groupId: string, sutToken: string, testerUserId: string, testerUsername: string, telegramApiId: string, telegramApiHash: string, tdlibDatabaseEncryptionKey: string, tdlibArchiveBase64: string, tdlibArchiveSha256: string, desktopTdataArchiveBase64: string, desktopTdataArchiveSha256: string }` - one exclusive burner-account lease used by both the TDLib CLI driver and Telegram Desktop visual witness.
 - Discord (`kind: "discord"`): `{ guildId: string, channelId: string, driverBotToken: string, sutBotToken: string, sutApplicationId: string }`.
 - WhatsApp (`kind: "whatsapp"`): `{ driverPhoneE164: string, sutPhoneE164: string, driverAuthArchiveBase64: string, sutAuthArchiveBase64: string, groupJid?: string }` - phone numbers must be distinct E.164 strings.
+
+For visual real-user Telegram proof, prefer `pnpm qa:telegram-user:crabbox -- --text /status`.
+It uses one Convex `telegram-user` lease for both the TDLib CLI driver and the
+Telegram Desktop witness, captures a Crabbox recording plus motion-trimmed
+video/GIF artifacts, and releases the lease on shutdown.
 
 Slack lanes can also use the pool. Slack payload shape checks currently live in the Slack QA runner rather than the broker; use `{ channelId: string, driverBotToken: string, sutBotToken: string, sutAppToken: string }`, with a Slack channel id like `Cxxxxxxxxxx`. See [Setting up the Slack workspace](#setting-up-the-slack-workspace) for app and scope provisioning.
 

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -589,7 +589,9 @@ driver and Telegram Desktop witness, starts desktop recording, and leaves the
 Crabbox alive for arbitrary agent-driven repro steps. Agents can use `send`,
 `run`, `screenshot`, and `status` until they are satisfied, then `finish`
 collects the screenshot, video, motion-trimmed video/GIF, TDLib probe outputs,
-and logs before releasing the credential. The default `probe` command remains a
+and logs before releasing the credential. `publish --session <file> --pr
+<number>` comments only the motion GIF by default; `--full-artifacts` is the
+explicit opt-in for logs and JSON output. The default `probe` command remains a
 one-command shorthand for quick `/status` smoke checks.
 
 Slack lanes can also use the pool. Slack payload shape checks currently live in the Slack QA runner rather than the broker; use `{ channelId: string, driverBotToken: string, sutBotToken: string, sutAppToken: string }`, with a Slack channel id like `Cxxxxxxxxxx`. See [Setting up the Slack workspace](#setting-up-the-slack-workspace) for app and scope provisioning.

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -452,19 +452,42 @@ node --import tsx scripts/e2e/telegram-user-credential.ts release --lease-file "
 
 Use the restored Desktop profile with `Telegram -workdir "$tmp/desktop"` when a visual recording is needed. In local operator environments, `scripts/e2e/telegram-user-credential.ts` reads `~/.codex/skills/custom/telegram-e2e-bot-to-bot/convex.local.env` by default if process env vars are absent.
 
+Agent-driven Crabbox session:
+
+```bash
+pnpm qa:telegram-user:crabbox -- start \
+  --tdlib-url http://artifacts.openclaw.ai/tdlib-v1.8.0-linux-x64.tgz \
+  --output-dir .artifacts/qa-e2e/telegram-user-crabbox/pr-review
+pnpm qa:telegram-user:crabbox -- send \
+  --session .artifacts/qa-e2e/telegram-user-crabbox/pr-review/session.json \
+  --text /status
+pnpm qa:telegram-user:crabbox -- finish \
+  --session .artifacts/qa-e2e/telegram-user-crabbox/pr-review/session.json
+```
+
+`start` leases the `telegram-user` credential, restores the same account into
+TDLib and Telegram Desktop on a Crabbox Linux desktop, starts a local mock SUT
+gateway from the current checkout, opens the visible Telegram chat, starts
+desktop recording, and writes a private `session.json`. While the session is
+alive, an agent can keep testing until satisfied:
+
+- `send --session <file> --text <message>` sends through the real TDLib user and waits for the SUT reply.
+- `run --session <file> -- <remote command>` runs an arbitrary command on the Crabbox and saves its output, for example `bash -lc 'source /tmp/openclaw-telegram-user-crabbox/env.sh && python3 /tmp/openclaw-telegram-user-crabbox/user-driver.py transcript --limit 20 --json'`.
+- `screenshot --session <file>` captures the current visible desktop.
+- `status --session <file>` prints the lease and WebVNC command.
+- `finish --session <file>` stops the recorder, captures screenshot/video/motion-trim artifacts, releases the Convex credential, stops local SUT processes, and stops the Crabbox lease unless `--keep-box` is passed.
+
 One-command Crabbox proof:
 
 ```bash
 pnpm qa:telegram-user:crabbox -- --text /status
 ```
 
-That command leases the `telegram-user` credential, restores the same account
-into TDLib and Telegram Desktop on a Crabbox Linux desktop, starts a local mock
-SUT gateway from the current checkout, sends the command as the real QA user,
-records the visible Telegram Desktop session, trims the recording to the motion
-window, writes artifacts under `.artifacts/qa-e2e/telegram-user-crabbox/`, then
-releases the credential and stops the box. Use `--id <cbx_...>` to reuse a warm
-desktop lease, `--keep-box` to keep VNC open after failure,
+The default `probe` command is shorthand for one start/send/finish cycle. Use
+it for a quick `/status` smoke. Use the session commands for PR review,
+bug-reproduction work, or any case where the agent needs minutes of arbitrary
+experimentation before deciding the proof is complete. Use `--id <cbx_...>` to
+reuse a warm desktop lease, `--keep-box` to keep VNC open after finish,
 `--desktop-chat-title <name>` to pick the visible chat, and `--tdlib-url <tgz>`
 when using a prebaked Linux `libtdjson.so` archive instead of building TDLib on
 a fresh box. The runner verifies `--tdlib-url` with `--tdlib-sha256 <hex>` or,

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -476,6 +476,7 @@ alive, an agent can keep testing until satisfied:
 - `screenshot --session <file>` captures the current visible desktop.
 - `status --session <file>` prints the lease and WebVNC command.
 - `finish --session <file>` stops the recorder, captures screenshot/video/motion-trim artifacts, releases the Convex credential, stops local SUT processes, and stops the Crabbox lease unless `--keep-box` is passed.
+- `publish --session <file> --pr <number>` publishes a GIF-only PR comment by default. Pass `--full-artifacts` only when logs or JSON artifacts are intentionally needed.
 
 One-command Crabbox proof:
 

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -404,6 +404,9 @@ Default endpoint contract (`OPENCLAW_QA_CONVEX_SITE_URL` + `/qa-credentials/v1`)
   - Request: `{ kind, ownerId, actorRole, leaseTtlMs, heartbeatIntervalMs }`
   - Success: `{ status: "ok", credentialId, leaseToken, payload, leaseTtlMs?, heartbeatIntervalMs? }`
   - Exhausted/retryable: `{ status: "error", code: "POOL_EXHAUSTED" | "NO_CREDENTIAL_AVAILABLE", ... }`
+- `POST /payload-chunk`
+  - Request: `{ kind, ownerId, actorRole, credentialId, leaseToken, index }`
+  - Success: `{ status: "ok", index, data }`
 - `POST /heartbeat`
   - Request: `{ kind, ownerId, actorRole, credentialId, leaseToken, leaseTtlMs }`
   - Success: `{ status: "ok" }` (or empty `2xx`)
@@ -426,6 +429,46 @@ Payload shape for Telegram kind:
 - `{ groupId: string, driverToken: string, sutToken: string }`
 - `groupId` must be a numeric Telegram chat id string.
 - `admin/add` validates this shape for `kind: "telegram"` and rejects malformed payloads.
+
+Payload shape for Telegram real-user kind:
+
+- `{ groupId: string, sutToken: string, testerUserId: string, testerUsername: string, telegramApiId: string, telegramApiHash: string, tdlibDatabaseEncryptionKey: string, tdlibArchiveBase64: string, tdlibArchiveSha256: string, desktopTdataArchiveBase64: string, desktopTdataArchiveSha256: string }`
+- `groupId`, `testerUserId`, and `telegramApiId` must be numeric strings.
+- `tdlibArchiveSha256` and `desktopTdataArchiveSha256` must be SHA-256 hex strings.
+- `kind: "telegram-user"` represents one Telegram burner account. Treat the lease as account-wide: the TDLib CLI driver and Telegram Desktop visual witness restore from the same payload, and only one job should hold the lease at a time.
+
+Telegram real-user lease restore:
+
+```bash
+tmp=$(mktemp -d /tmp/openclaw-telegram-user.XXXXXX)
+node --import tsx scripts/e2e/telegram-user-credential.ts lease-restore \
+  --user-driver-dir "$tmp/user-driver" \
+  --desktop-workdir "$tmp/desktop" \
+  --lease-file "$tmp/lease.json"
+TELEGRAM_USER_DRIVER_STATE_DIR="$tmp/user-driver" \
+  uv run ~/.codex/skills/custom/telegram-e2e-bot-to-bot/scripts/user-driver.py status --json
+node --import tsx scripts/e2e/telegram-user-credential.ts release --lease-file "$tmp/lease.json"
+```
+
+Use the restored Desktop profile with `Telegram -workdir "$tmp/desktop"` when a visual recording is needed. In local operator environments, `scripts/e2e/telegram-user-credential.ts` reads `~/.codex/skills/custom/telegram-e2e-bot-to-bot/convex.local.env` by default if process env vars are absent.
+
+One-command Crabbox proof:
+
+```bash
+pnpm qa:telegram-user:crabbox -- --text /status
+```
+
+That command leases the `telegram-user` credential, restores the same account
+into TDLib and Telegram Desktop on a Crabbox Linux desktop, starts a local mock
+SUT gateway from the current checkout, sends the command as the real QA user,
+records the visible Telegram Desktop session, trims the recording to the motion
+window, writes artifacts under `.artifacts/qa-e2e/telegram-user-crabbox/`, then
+releases the credential and stops the box. Use `--id <cbx_...>` to reuse a warm
+desktop lease, `--keep-box` to keep VNC open after failure,
+`--desktop-chat-title <name>` to pick the visible chat, and `--tdlib-url <tgz>`
+when using a prebaked Linux `libtdjson.so` archive instead of building TDLib on
+a fresh box. The runner verifies `--tdlib-url` with `--tdlib-sha256 <hex>` or,
+by default, a sibling `<url>.sha256` file.
 
 Broker-validated multi-channel payloads:
 

--- a/extensions/qa-lab/src/live-transports/shared/credential-lease.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/shared/credential-lease.runtime.test.ts
@@ -80,6 +80,59 @@ describe("credential lease runtime", () => {
     expect(headers.authorization).toBe("Bearer maintainer-secret");
   });
 
+  it("hydrates chunked convex credential payloads after acquire", async () => {
+    const serialized = JSON.stringify({
+      groupId: "-100123",
+      driverToken: "driver",
+      sutToken: "sut",
+    });
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          status: "ok",
+          credentialId: "cred-chunked",
+          leaseToken: "lease-chunked",
+          payload: {
+            __openclawQaCredentialPayloadChunksV1: true,
+            byteLength: serialized.length,
+            chunkCount: 2,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ status: "ok", data: serialized.slice(0, 20) }))
+      .mockResolvedValueOnce(jsonResponse({ status: "ok", data: serialized.slice(20) }));
+
+    const lease = await acquireQaCredentialLease({
+      kind: "telegram",
+      source: "convex",
+      role: "ci",
+      env: {
+        OPENCLAW_QA_CONVEX_SITE_URL: "https://qa-cred.example.convex.site",
+        OPENCLAW_QA_CONVEX_SECRET_CI: "ci-secret",
+      },
+      fetchImpl,
+      resolveEnvPayload: () => ({ groupId: "-1", driverToken: "unused", sutToken: "unused" }),
+      parsePayload: (payload) =>
+        payload as { groupId: string; driverToken: string; sutToken: string },
+    });
+
+    expect(lease.payload).toEqual({
+      groupId: "-100123",
+      driverToken: "driver",
+      sutToken: "sut",
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(fetchImpl.mock.calls[1]?.[0]).toBe(
+      "https://qa-cred.example.convex.site/qa-credentials/v1/payload-chunk",
+    );
+    expect(JSON.parse(String(fetchImpl.mock.calls[1]?.[1]?.body))).toMatchObject({
+      credentialId: "cred-chunked",
+      index: 0,
+      leaseToken: "lease-chunked",
+    });
+  });
+
   it("defaults convex credential role to maintainer outside CI", async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValueOnce(
       jsonResponse({

--- a/extensions/qa-lab/src/live-transports/shared/credential-lease.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/shared/credential-lease.runtime.ts
@@ -17,6 +17,7 @@ const DEFAULT_HTTP_TIMEOUT_MS = 15_000;
 const DEFAULT_LEASE_TTL_MS = 20 * 60 * 1_000;
 const RETRY_BACKOFF_MS = [500, 1_000, 2_000, 4_000, 5_000] as const;
 const RETRYABLE_ACQUIRE_CODES = new Set(["POOL_EXHAUSTED", "NO_CREDENTIAL_AVAILABLE"]);
+const CHUNKED_PAYLOAD_MARKER = "__openclawQaCredentialPayloadChunksV1";
 
 const convexAcquireSuccessSchema = z.object({
   status: z.literal("ok"),
@@ -38,6 +39,11 @@ const convexOkSchema = z.object({
   status: z.literal("ok"),
 });
 
+const convexPayloadChunkSuccessSchema = z.object({
+  status: z.literal("ok"),
+  data: z.string(),
+});
+
 type ConvexCredentialBrokerConfig = {
   acquireTimeoutMs: number;
   acquireUrl: string;
@@ -47,6 +53,7 @@ type ConvexCredentialBrokerConfig = {
   httpTimeoutMs: number;
   leaseTtlMs: number;
   ownerId: string;
+  payloadChunkUrl: string;
   releaseUrl: string;
   role: QaCredentialRole;
 };
@@ -196,7 +203,36 @@ function resolveConvexCredentialBrokerConfig(params: {
     ),
     acquireUrl: joinQaCredentialEndpoint(baseUrl, endpointPrefix, "acquire"),
     heartbeatUrl: joinQaCredentialEndpoint(baseUrl, endpointPrefix, "heartbeat"),
+    payloadChunkUrl: joinQaCredentialEndpoint(baseUrl, endpointPrefix, "payload-chunk"),
     releaseUrl: joinQaCredentialEndpoint(baseUrl, endpointPrefix, "release"),
+  };
+}
+
+function parseChunkedPayloadMarker(payload: unknown) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+  const record = payload as Record<string, unknown>;
+  if (record[CHUNKED_PAYLOAD_MARKER] !== true) {
+    return null;
+  }
+  if (
+    typeof record.chunkCount !== "number" ||
+    !Number.isInteger(record.chunkCount) ||
+    record.chunkCount < 1
+  ) {
+    throw new Error("Chunked credential payload marker has an invalid chunkCount.");
+  }
+  if (
+    typeof record.byteLength !== "number" ||
+    !Number.isInteger(record.byteLength) ||
+    record.byteLength < 0
+  ) {
+    throw new Error("Chunked credential payload marker has an invalid byteLength.");
+  }
+  return {
+    chunkCount: record.chunkCount,
+    byteLength: record.byteLength,
   };
 }
 
@@ -257,6 +293,42 @@ async function postConvexBroker(params: {
     );
   }
   return payload;
+}
+
+async function resolveConvexCredentialPayload(params: {
+  acquired: z.infer<typeof convexAcquireSuccessSchema>;
+  config: ConvexCredentialBrokerConfig;
+  fetchImpl: typeof fetch;
+  kind: string;
+}) {
+  const marker = parseChunkedPayloadMarker(params.acquired.payload);
+  if (!marker) {
+    return params.acquired.payload;
+  }
+  const chunks: string[] = [];
+  for (let index = 0; index < marker.chunkCount; index += 1) {
+    const payload = await postConvexBroker({
+      fetchImpl: params.fetchImpl,
+      timeoutMs: params.config.httpTimeoutMs,
+      authToken: params.config.authToken,
+      url: params.config.payloadChunkUrl,
+      body: {
+        kind: params.kind,
+        ownerId: params.config.ownerId,
+        actorRole: params.config.role,
+        credentialId: params.acquired.credentialId,
+        leaseToken: params.acquired.leaseToken,
+        index,
+      },
+    });
+    const parsed = convexPayloadChunkSuccessSchema.parse(payload);
+    chunks.push(parsed.data);
+  }
+  const serialized = chunks.join("");
+  if (serialized.length !== marker.byteLength) {
+    throw new Error("Chunked credential payload length mismatch.");
+  }
+  return JSON.parse(serialized) as unknown;
 }
 
 function computeAcquireBackoffMs(params: {
@@ -355,7 +427,13 @@ export async function acquireQaCredentialLease<TPayload>(
       };
       let parsedPayload: TPayload;
       try {
-        parsedPayload = opts.parsePayload(acquired.payload);
+        const resolvedPayload = await resolveConvexCredentialPayload({
+          acquired,
+          config,
+          fetchImpl,
+          kind: opts.kind,
+        });
+        parsedPayload = opts.parsePayload(resolvedPayload);
       } catch (error) {
         try {
           await releaseLease();

--- a/extensions/qa-lab/src/live-transports/telegram/telegram-user-credential.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-user-credential.runtime.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  TELEGRAM_USER_QA_CREDENTIAL_KIND,
+  parseTelegramUserQaCredentialPayload,
+} from "./telegram-user-credential.runtime.js";
+
+describe("Telegram user QA credential payload", () => {
+  it("parses the account-wide CLI and Desktop credential shape", () => {
+    const sha256 = "a".repeat(64);
+
+    expect(
+      parseTelegramUserQaCredentialPayload({
+        groupId: " -100123 ",
+        sutToken: " sut-token ",
+        testerUserId: " 8709353529 ",
+        testerUsername: " OpenClawTestUser ",
+        telegramApiId: " 123456 ",
+        telegramApiHash: " api-hash ",
+        tdlibDatabaseEncryptionKey: " db-key ",
+        tdlibArchiveBase64: " tdlib-archive ",
+        tdlibArchiveSha256: sha256.toUpperCase(),
+        desktopTdataArchiveBase64: " desktop-archive ",
+        desktopTdataArchiveSha256: sha256,
+      }),
+    ).toEqual({
+      groupId: "-100123",
+      sutToken: "sut-token",
+      testerUserId: "8709353529",
+      testerUsername: "OpenClawTestUser",
+      telegramApiId: "123456",
+      telegramApiHash: "api-hash",
+      tdlibDatabaseEncryptionKey: "db-key",
+      tdlibArchiveBase64: "tdlib-archive",
+      tdlibArchiveSha256: sha256,
+      desktopTdataArchiveBase64: "desktop-archive",
+      desktopTdataArchiveSha256: sha256,
+    });
+    expect(TELEGRAM_USER_QA_CREDENTIAL_KIND).toBe("telegram-user");
+  });
+
+  it("rejects malformed payloads", () => {
+    expect(() =>
+      parseTelegramUserQaCredentialPayload({
+        groupId: "-100123",
+        sutToken: "sut-token",
+        testerUserId: "not-a-user-id",
+        testerUsername: "OpenClawTestUser",
+        telegramApiId: "123456",
+        telegramApiHash: "api-hash",
+        tdlibDatabaseEncryptionKey: "db-key",
+        tdlibArchiveBase64: "tdlib-archive",
+        tdlibArchiveSha256: "a".repeat(64),
+        desktopTdataArchiveBase64: "desktop-archive",
+        desktopTdataArchiveSha256: "b".repeat(64),
+      }),
+    ).toThrow(/numeric string/u);
+  });
+});

--- a/extensions/qa-lab/src/live-transports/telegram/telegram-user-credential.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-user-credential.runtime.ts
@@ -1,0 +1,36 @@
+import { z } from "openclaw/plugin-sdk/zod";
+
+export const TELEGRAM_USER_QA_CREDENTIAL_KIND = "telegram-user";
+
+const sha256HexSchema = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .regex(/^[a-f0-9]{64}$/u, "must be a SHA-256 hex string");
+
+const numericStringSchema = z.string().trim().regex(/^\d+$/u, "must be a numeric string");
+
+const telegramUserQaCredentialPayloadSchema = z.object({
+  groupId: z
+    .string()
+    .trim()
+    .regex(/^-?\d+$/u, "must be a numeric Telegram chat id"),
+  sutToken: z.string().trim().min(1),
+  testerUserId: numericStringSchema,
+  testerUsername: z.string().trim().min(1),
+  telegramApiId: numericStringSchema,
+  telegramApiHash: z.string().trim().min(1),
+  tdlibDatabaseEncryptionKey: z.string().trim().min(1),
+  tdlibArchiveBase64: z.string().trim().min(1),
+  tdlibArchiveSha256: sha256HexSchema,
+  desktopTdataArchiveBase64: z.string().trim().min(1),
+  desktopTdataArchiveSha256: sha256HexSchema,
+});
+
+export type TelegramUserQaCredentialPayload = z.infer<typeof telegramUserQaCredentialPayloadSchema>;
+
+export function parseTelegramUserQaCredentialPayload(
+  payload: unknown,
+): TelegramUserQaCredentialPayload {
+  return telegramUserQaCredentialPayloadSchema.parse(payload);
+}

--- a/package.json
+++ b/package.json
@@ -1506,6 +1506,7 @@
     "qa:lab:up:fast": "node --import tsx scripts/qa-lab-up.ts --use-prebuilt-image --bind-ui-dist --skip-ui-build",
     "qa:lab:watch": "vite build --watch --config extensions/qa-lab/web/vite.config.ts",
     "qa:otel:smoke": "node --import tsx scripts/qa-otel-smoke.ts",
+    "qa:telegram-user:crabbox": "node --import tsx scripts/e2e/telegram-user-crabbox-proof.ts",
     "release-metadata:check": "node scripts/check-release-metadata-only.mjs",
     "release:beta-smoke": "node --import tsx scripts/release-beta-smoke.ts",
     "release:check": "pnpm release:generated:check && node --import tsx scripts/release-check.ts",

--- a/qa/convex-credential-broker/README.md
+++ b/qa/convex-credential-broker/README.md
@@ -161,6 +161,10 @@ credential for both the TDLib CLI driver and the Telegram Desktop visual witness
 - non-empty `desktopTdataArchiveBase64`
 - `desktopTdataArchiveSha256` as a SHA-256 hex string
 
+Long-running agent sessions should acquire this lease once, keep it for the
+whole Crabbox review/repro session, then release it from the same session file.
+Do not run parallel `telegram-user` jobs against the burner account.
+
 For `kind: "discord"`, broker `admin/add` validates that payload includes:
 
 - `guildId` as a Discord snowflake string

--- a/qa/convex-credential-broker/README.md
+++ b/qa/convex-credential-broker/README.md
@@ -6,6 +6,7 @@ Keep private operator notes in `~/Projects/manager/docs/`, not in public docs.
 This broker exposes:
 
 - `POST /qa-credentials/v1/acquire`
+- `POST /qa-credentials/v1/payload-chunk`
 - `POST /qa-credentials/v1/heartbeat`
 - `POST /qa-credentials/v1/release`
 - `POST /qa-credentials/v1/admin/add`
@@ -144,6 +145,21 @@ For `kind: "telegram"`, broker `admin/add` validates that payload includes:
 - `groupId` as a numeric chat id string
 - non-empty `driverToken`
 - non-empty `sutToken`
+
+For `kind: "telegram-user"`, broker `admin/add` validates one exclusive real-user
+credential for both the TDLib CLI driver and the Telegram Desktop visual witness:
+
+- `groupId` as a numeric chat id string
+- non-empty `sutToken`
+- `testerUserId` as a numeric Telegram user id string
+- non-empty `testerUsername`
+- `telegramApiId` as a numeric string
+- non-empty `telegramApiHash`
+- non-empty `tdlibDatabaseEncryptionKey`
+- non-empty `tdlibArchiveBase64`
+- `tdlibArchiveSha256` as a SHA-256 hex string
+- non-empty `desktopTdataArchiveBase64`
+- `desktopTdataArchiveSha256` as a SHA-256 hex string
 
 For `kind: "discord"`, broker `admin/add` validates that payload includes:
 

--- a/qa/convex-credential-broker/convex/credentials.ts
+++ b/qa/convex-credential-broker/convex/credentials.ts
@@ -11,7 +11,9 @@ const MAX_LEASE_TTL_MS = 2 * 60 * 60 * 1_000;
 const MIN_HEARTBEAT_INTERVAL_MS = 5_000;
 const MIN_LEASE_TTL_MS = 30_000;
 const MAX_LIST_LIMIT = 500;
+const PAYLOAD_CHUNK_SIZE = 256_000;
 const MIN_LIST_LIMIT = 1;
+const CHUNKED_PAYLOAD_MARKER = "__openclawQaCredentialPayloadChunksV1";
 
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 const DEFAULT_LEASE_TTL_MS = 20 * 60 * 1_000;
@@ -58,6 +60,25 @@ type CredentialSetRecord = {
   lastLeasedAtMs: number;
   note?: string;
   lease?: CredentialLease;
+};
+
+type ChunkedCredentialPayloadMarker = {
+  [CHUNKED_PAYLOAD_MARKER]: true;
+  byteLength: number;
+  chunkCount: number;
+};
+
+type CredentialPayloadChunkRecord = {
+  _id: unknown;
+  credentialId: Id<"credential_sets">;
+  index: number;
+  data: string;
+  createdAtMs: number;
+};
+
+type CredentialPayloadStorage = {
+  chunks: string[];
+  payload: unknown;
 };
 
 type EventInsertCtx = {
@@ -111,7 +132,88 @@ function leaseIsActive(lease: CredentialLease | undefined, nowMs: number) {
   return Boolean(lease && lease.expiresAtMs > nowMs);
 }
 
-function toCredentialSummary(row: CredentialSetRecord, includePayload: boolean) {
+function isChunkedCredentialPayloadMarker(
+  payload: unknown,
+): payload is ChunkedCredentialPayloadMarker {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return false;
+  }
+  const record = payload as Record<string, unknown>;
+  return (
+    record[CHUNKED_PAYLOAD_MARKER] === true &&
+    typeof record.byteLength === "number" &&
+    typeof record.chunkCount === "number"
+  );
+}
+
+async function readCredentialPayload(
+  ctx: {
+    db: {
+      query: (table: "credential_payload_chunks") => {
+        withIndex: (
+          indexName: "by_credential_index",
+          range: (q: {
+            eq: (
+              field: "credentialId",
+              value: Id<"credential_sets">,
+            ) => {
+              eq: (field: "index", value: number) => unknown;
+            };
+          }) => unknown,
+        ) => {
+          collect: () => Promise<CredentialPayloadChunkRecord[]>;
+        };
+      };
+    };
+  },
+  row: CredentialSetRecord,
+) {
+  if (!isChunkedCredentialPayloadMarker(row.payload)) {
+    return row.payload;
+  }
+  const chunks: string[] = [];
+  for (let index = 0; index < row.payload.chunkCount; index += 1) {
+    const rows = await ctx.db
+      .query("credential_payload_chunks")
+      .withIndex("by_credential_index", (q) => q.eq("credentialId", row._id).eq("index", index))
+      .collect();
+    const chunk = rows[0];
+    if (!chunk) {
+      throw new Error(`Credential payload chunk ${index} is missing.`);
+    }
+    chunks.push(chunk.data);
+  }
+  const serialized = chunks.join("");
+  if (serialized.length !== row.payload.byteLength) {
+    throw new Error("Credential payload chunk length mismatch.");
+  }
+  return JSON.parse(serialized) as unknown;
+}
+
+function createCredentialPayloadStorage(payload: unknown): CredentialPayloadStorage {
+  const serializedPayload = JSON.stringify(payload);
+  const chunks: string[] = [];
+  for (let offset = 0; offset < serializedPayload.length; offset += PAYLOAD_CHUNK_SIZE) {
+    chunks.push(serializedPayload.slice(offset, offset + PAYLOAD_CHUNK_SIZE));
+  }
+  if (chunks.length <= 1) {
+    return { payload, chunks: [] };
+  }
+  return {
+    payload: {
+      [CHUNKED_PAYLOAD_MARKER]: true,
+      byteLength: serializedPayload.length,
+      chunkCount: chunks.length,
+    },
+    chunks,
+  };
+}
+
+function toCredentialSummary(
+  row: CredentialSetRecord,
+  includePayload: boolean,
+  resolvedPayload?: unknown,
+) {
   return {
     credentialId: row._id,
     kind: row.kind,
@@ -131,7 +233,7 @@ function toCredentialSummary(row: CredentialSetRecord, includePayload: boolean) 
           },
         }
       : {}),
-    ...(includePayload ? { payload: row.payload } : {}),
+    ...(includePayload ? { payload: resolvedPayload ?? row.payload } : {}),
   };
 }
 
@@ -317,6 +419,59 @@ export const acquireLease = internalMutation({
   },
 });
 
+export const getPayloadChunk = internalQuery({
+  args: {
+    kind: v.string(),
+    ownerId: v.string(),
+    actorRole,
+    credentialId: v.id("credential_sets"),
+    leaseToken: v.string(),
+    index: v.number(),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<BrokerErrorResult | { status: "ok"; data: string; index: number }> => {
+    const nowMs = Date.now();
+    const row = (await ctx.db.get(args.credentialId)) as CredentialSetRecord | null;
+    if (!row) {
+      return brokerError("CREDENTIAL_NOT_FOUND", "Credential record does not exist.");
+    }
+    if (row.kind !== args.kind) {
+      return brokerError("KIND_MISMATCH", "Credential kind did not match this payload request.");
+    }
+    if (row.status !== "active") {
+      return brokerError("CREDENTIAL_DISABLED", "Credential is disabled.");
+    }
+    if (!row.lease || row.lease.expiresAtMs < nowMs) {
+      return brokerError("LEASE_NOT_FOUND", "Credential is not currently leased.");
+    }
+    if (row.lease.ownerId !== args.ownerId || row.lease.leaseToken !== args.leaseToken) {
+      return brokerError("LEASE_NOT_OWNER", "Credential lease owner/token mismatch.");
+    }
+    if (row.lease.actorRole !== args.actorRole) {
+      return brokerError("AUTH_ROLE_MISMATCH", "Credential lease actor role mismatch.");
+    }
+    if (!isChunkedCredentialPayloadMarker(row.payload)) {
+      return brokerError("PAYLOAD_NOT_CHUNKED", "Credential payload is not chunked.");
+    }
+    if (!Number.isInteger(args.index) || args.index < 0 || args.index >= row.payload.chunkCount) {
+      return brokerError("INVALID_CHUNK_INDEX", "Credential payload chunk index is out of range.");
+    }
+    const chunks = (await ctx.db
+      .query("credential_payload_chunks")
+      .withIndex("by_credential_index", (q) =>
+        q.eq("credentialId", args.credentialId).eq("index", args.index),
+      )
+      .collect()) as CredentialPayloadChunkRecord[];
+    const chunk = chunks[0];
+    if (!chunk) {
+      return brokerError("PAYLOAD_CHUNK_MISSING", "Credential payload chunk is missing.");
+    }
+    return { status: "ok", data: chunk.data, index: args.index };
+  },
+});
+
 export const heartbeatLease = internalMutation({
   args: {
     kind: v.string(),
@@ -431,15 +586,25 @@ export const addCredentialSet = internalMutation({
     const actorId = normalizeActorId(args.actorId);
     const status = args.status ?? "active";
     const note = args.note?.trim();
+    const storage = createCredentialPayloadStorage(args.payload);
     const credentialId = await ctx.db.insert("credential_sets", {
       kind: args.kind,
       status,
-      payload: args.payload,
+      payload: storage.payload,
       createdAtMs: nowMs,
       updatedAtMs: nowMs,
       lastLeasedAtMs: 0,
       ...(note ? { note } : {}),
     });
+
+    for (const [index, data] of storage.chunks.entries()) {
+      await ctx.db.insert("credential_payload_chunks", {
+        credentialId,
+        index,
+        data,
+        createdAtMs: nowMs,
+      });
+    }
 
     await insertAdminEvent({
       ctx,
@@ -455,7 +620,7 @@ export const addCredentialSet = internalMutation({
       _id: credentialId,
       kind: args.kind,
       status,
-      payload: args.payload,
+      payload: storage.payload,
       createdAtMs: nowMs,
       updatedAtMs: nowMs,
       lastLeasedAtMs: 0,
@@ -583,9 +748,18 @@ export const listCredentialSets = internalQuery({
 
     sortCredentialRowsForList(rows);
     const selected = rows.slice(0, limit);
+    const summaries = await Promise.all(
+      selected.map(async (row) =>
+        toCredentialSummary(
+          row,
+          includePayload,
+          includePayload ? await readCredentialPayload(ctx, row) : undefined,
+        ),
+      ),
+    );
     return {
       status: "ok",
-      credentials: selected.map((row) => toCredentialSummary(row, includePayload)),
+      credentials: summaries,
       count: selected.length,
     };
   },

--- a/qa/convex-credential-broker/convex/http.ts
+++ b/qa/convex-credential-broker/convex/http.ts
@@ -162,6 +162,21 @@ function optionalPositiveInteger(body: Record<string, unknown>, key: string) {
   return raw;
 }
 
+function optionalNonnegativeInteger(body: Record<string, unknown>, key: string) {
+  if (!(key in body) || body[key] === undefined || body[key] === null) {
+    return undefined;
+  }
+  const raw = body[key];
+  if (typeof raw !== "number" || !Number.isFinite(raw) || !Number.isInteger(raw) || raw < 0) {
+    throw new BrokerHttpError(
+      400,
+      "INVALID_BODY",
+      `Expected "${key}" to be a non-negative integer.`,
+    );
+  }
+  return raw;
+}
+
 function optionalBoolean(body: Record<string, unknown>, key: string) {
   if (!(key in body) || body[key] === undefined || body[key] === null) {
     return undefined;
@@ -307,6 +322,35 @@ http.route({
         ) as Id<"credential_sets">,
         leaseToken: requireString(body, "leaseToken"),
         leaseTtlMs: optionalPositiveInteger(body, "leaseTtlMs"),
+      });
+
+      return jsonResponse(200, result);
+    } catch (error) {
+      const normalized = normalizeError(error);
+      return jsonResponse(normalized.httpStatus, normalized.payload);
+    }
+  }),
+});
+
+http.route({
+  path: "/qa-credentials/v1/payload-chunk",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    try {
+      const tokenRole = resolveAuthRole(parseBearerToken(request));
+      const body = await parseJsonObject(request);
+      const actorRole = parseActorRole(body);
+      assertRoleAllowed(tokenRole, actorRole);
+
+      const result = await ctx.runQuery(internal.credentials.getPayloadChunk, {
+        kind: requireString(body, "kind"),
+        ownerId: requireString(body, "ownerId"),
+        actorRole,
+        credentialId: normalizeCredentialId(
+          requireString(body, "credentialId"),
+        ) as Id<"credential_sets">,
+        leaseToken: requireString(body, "leaseToken"),
+        index: optionalNonnegativeInteger(body, "index") ?? 0,
       });
 
       return jsonResponse(200, result);

--- a/qa/convex-credential-broker/convex/payload-validation.ts
+++ b/qa/convex-credential-broker/convex/payload-validation.ts
@@ -14,7 +14,9 @@ type PayloadValidationFailureFactory = (httpStatus: number, code: string, messag
 
 const DISCORD_SNOWFLAKE_RE = /^\d{17,20}$/u;
 const E164_RE = /^\+[1-9]\d{6,14}$/u;
+const SHA256_HEX_RE = /^[a-f0-9]{64}$/u;
 const TELEGRAM_CHAT_ID_RE = /^-?\d+$/u;
+const TELEGRAM_USER_ID_RE = /^\d+$/u;
 
 function createCredentialPayloadValidationError(httpStatus: number, code: string, message: string) {
   return new CredentialPayloadValidationError(httpStatus, code, message);
@@ -81,6 +83,82 @@ function normalizeTelegramCredentialPayload(
     groupId,
     driverToken,
     sutToken,
+  } satisfies Record<string, unknown>;
+}
+
+function normalizeTelegramUserCredentialPayload(
+  payload: Record<string, unknown>,
+  createFailure: PayloadValidationFailureFactory,
+) {
+  const kind = "telegram-user";
+  const groupId = requirePayloadString(payload, "groupId", kind, createFailure);
+  if (!TELEGRAM_CHAT_ID_RE.test(groupId)) {
+    throwPayloadError(
+      createFailure,
+      'Credential payload for kind "telegram-user" must include a numeric "groupId" string.',
+    );
+  }
+  const testerUserId = requirePayloadString(payload, "testerUserId", kind, createFailure);
+  if (!TELEGRAM_USER_ID_RE.test(testerUserId)) {
+    throwPayloadError(
+      createFailure,
+      'Credential payload for kind "telegram-user" must include a numeric "testerUserId" string.',
+    );
+  }
+  const telegramApiId = requirePayloadString(payload, "telegramApiId", kind, createFailure);
+  if (!TELEGRAM_USER_ID_RE.test(telegramApiId)) {
+    throwPayloadError(
+      createFailure,
+      'Credential payload for kind "telegram-user" must include a numeric "telegramApiId" string.',
+    );
+  }
+  const tdlibArchiveSha256 = requirePayloadString(
+    payload,
+    "tdlibArchiveSha256",
+    kind,
+    createFailure,
+  ).toLowerCase();
+  const desktopTdataArchiveSha256 = requirePayloadString(
+    payload,
+    "desktopTdataArchiveSha256",
+    kind,
+    createFailure,
+  ).toLowerCase();
+  if (!SHA256_HEX_RE.test(tdlibArchiveSha256)) {
+    throwPayloadError(
+      createFailure,
+      'Credential payload for kind "telegram-user" must include "tdlibArchiveSha256" as a SHA-256 hex string.',
+    );
+  }
+  if (!SHA256_HEX_RE.test(desktopTdataArchiveSha256)) {
+    throwPayloadError(
+      createFailure,
+      'Credential payload for kind "telegram-user" must include "desktopTdataArchiveSha256" as a SHA-256 hex string.',
+    );
+  }
+
+  return {
+    groupId,
+    sutToken: requirePayloadString(payload, "sutToken", kind, createFailure),
+    testerUserId,
+    testerUsername: requirePayloadString(payload, "testerUsername", kind, createFailure),
+    telegramApiId,
+    telegramApiHash: requirePayloadString(payload, "telegramApiHash", kind, createFailure),
+    tdlibDatabaseEncryptionKey: requirePayloadString(
+      payload,
+      "tdlibDatabaseEncryptionKey",
+      kind,
+      createFailure,
+    ),
+    tdlibArchiveBase64: requirePayloadString(payload, "tdlibArchiveBase64", kind, createFailure),
+    tdlibArchiveSha256,
+    desktopTdataArchiveBase64: requirePayloadString(
+      payload,
+      "desktopTdataArchiveBase64",
+      kind,
+      createFailure,
+    ),
+    desktopTdataArchiveSha256,
   } satisfies Record<string, unknown>;
 }
 
@@ -177,19 +255,23 @@ function normalizeWhatsAppCredentialPayload(
   } satisfies Record<string, unknown>;
 }
 
+const credentialPayloadNormalizers: Record<
+  string,
+  (
+    payload: Record<string, unknown>,
+    createFailure: PayloadValidationFailureFactory,
+  ) => Record<string, unknown>
+> = {
+  discord: normalizeDiscordCredentialPayload,
+  telegram: normalizeTelegramCredentialPayload,
+  "telegram-user": normalizeTelegramUserCredentialPayload,
+  whatsapp: normalizeWhatsAppCredentialPayload,
+};
+
 export function normalizeCredentialPayloadForKind(
   kind: string,
   payload: Record<string, unknown>,
   createFailure: PayloadValidationFailureFactory = createCredentialPayloadValidationError,
 ) {
-  if (kind === "telegram") {
-    return normalizeTelegramCredentialPayload(payload, createFailure);
-  }
-  if (kind === "discord") {
-    return normalizeDiscordCredentialPayload(payload, createFailure);
-  }
-  if (kind === "whatsapp") {
-    return normalizeWhatsAppCredentialPayload(payload, createFailure);
-  }
-  return payload;
+  return credentialPayloadNormalizers[kind]?.(payload, createFailure) ?? payload;
 }

--- a/qa/convex-credential-broker/convex/schema.ts
+++ b/qa/convex-credential-broker/convex/schema.ts
@@ -33,6 +33,13 @@ export default defineSchema({
     .index("by_kind_status", ["kind", "status"])
     .index("by_kind_lastLeasedAtMs", ["kind", "lastLeasedAtMs"]),
 
+  credential_payload_chunks: defineTable({
+    credentialId: v.id("credential_sets"),
+    index: v.number(),
+    data: v.string(),
+    createdAtMs: v.number(),
+  }).index("by_credential_index", ["credentialId", "index"]),
+
   lease_events: defineTable({
     kind: v.string(),
     eventType: leaseEventType,

--- a/scripts/e2e/telegram-user-crabbox-proof.ts
+++ b/scripts/e2e/telegram-user-crabbox-proof.ts
@@ -23,6 +23,7 @@ type CrabboxInspect = {
 };
 
 type Options = {
+  command: "finish" | "probe" | "run" | "screenshot" | "send" | "start" | "status";
   crabboxBin: string;
   desktopChatTitle: string;
   dryRun: boolean;
@@ -36,6 +37,8 @@ type Options = {
   outputDir: string;
   provider: string;
   recordSeconds: number;
+  remoteCommand: string[];
+  sessionFile?: string;
   sutUsername?: string;
   target: string;
   tdlibSha256?: string;
@@ -64,6 +67,43 @@ type LocalSut = {
   gatewayLog: string;
 };
 
+type SessionFile = {
+  command: "telegram-user-crabbox-session";
+  createdAt: string;
+  crabbox: {
+    createdLease: boolean;
+    id: string;
+    inspect: CrabboxInspect;
+    provider: string;
+    target: string;
+  };
+  credential: {
+    groupId: string;
+    leaseFile: string;
+    sutUsername: string;
+    testerUserId: string;
+    testerUsername: string;
+  };
+  localRoot: string;
+  localSut: {
+    gatewayLog: string;
+    gatewayPid: number;
+    mockLog: string;
+    mockPid: number;
+    requestLog: string;
+    stateDir: string;
+    tempRoot: string;
+    workspace: string;
+  };
+  outputDir: string;
+  recorder: {
+    log: string;
+    pidFile: string;
+    remoteVideo: string;
+  };
+  remoteRoot: string;
+};
+
 const DEFAULT_SKILL_DIR = "~/.codex/skills/custom/telegram-e2e-bot-to-bot";
 const DEFAULT_CONVEX_ENV_FILE = `${DEFAULT_SKILL_DIR}/convex.local.env`;
 const DEFAULT_USER_DRIVER = `${DEFAULT_SKILL_DIR}/scripts/user-driver.py`;
@@ -73,7 +113,13 @@ const REMOTE_ROOT = "/tmp/openclaw-telegram-user-crabbox";
 function usageText() {
   return [
     "Usage:",
-    "  node --import tsx scripts/e2e/telegram-user-crabbox-proof.ts [--text /status] [--expect OpenClaw]",
+    "  node --import tsx scripts/e2e/telegram-user-crabbox-proof.ts [probe] [--text /status] [--expect OpenClaw]",
+    "  node --import tsx scripts/e2e/telegram-user-crabbox-proof.ts start [--tdlib-url <url>]",
+    "  node --import tsx scripts/e2e/telegram-user-crabbox-proof.ts send --session <session.json> --text <text>",
+    "  node --import tsx scripts/e2e/telegram-user-crabbox-proof.ts run --session <session.json> -- <remote command>",
+    "  node --import tsx scripts/e2e/telegram-user-crabbox-proof.ts screenshot --session <session.json>",
+    "  node --import tsx scripts/e2e/telegram-user-crabbox-proof.ts status --session <session.json>",
+    "  node --import tsx scripts/e2e/telegram-user-crabbox-proof.ts finish --session <session.json>",
     "",
     "Useful options:",
     "  --desktop-chat-title <name>   Telegram Desktop chat to select before recording.",
@@ -81,6 +127,7 @@ function usageText() {
     "  --keep-box                    Leave the Crabbox lease running for VNC debugging.",
     "  --output-dir <path>           Artifact directory under the repo.",
     "  --record-seconds <seconds>    Desktop video duration. Default: 35.",
+    "  --session <path>              Session file from start. Default: <output-dir>/session.json.",
     "  --tdlib-sha256 <hex>         Expected SHA-256 for --tdlib-url. Defaults to <url>.sha256.",
     "  --tdlib-url <url>             Linux tdlib archive containing libtdjson.so.",
     "  --dry-run                     Validate local inputs and print the plan.",
@@ -116,8 +163,11 @@ function parsePositiveInteger(value: string, label: string) {
 
 function parseArgs(argv: string[]): Options {
   argv = argv[0] === "--" ? argv.slice(1) : argv;
+  const commands = new Set(["finish", "probe", "run", "screenshot", "send", "start", "status"]);
+  const command = commands.has(argv[0] ?? "") ? (argv.shift() as Options["command"]) : "probe";
   const stamp = new Date().toISOString().replace(/[:.]/gu, "-");
   const opts: Options = {
+    command,
     crabboxBin: trimToValue(process.env.OPENCLAW_TELEGRAM_USER_CRABBOX_BIN) ?? "crabbox",
     desktopChatTitle:
       trimToValue(process.env.OPENCLAW_TELEGRAM_USER_DESKTOP_CHAT_TITLE) ?? "OpenClaw Testing",
@@ -130,12 +180,18 @@ function parseArgs(argv: string[]): Options {
     outputDir: path.join(DEFAULT_OUTPUT_ROOT, stamp),
     provider: process.env.OPENCLAW_TELEGRAM_USER_CRABBOX_PROVIDER?.trim() || "aws",
     recordSeconds: 35,
+    remoteCommand: [],
     target: "linux",
     text: "/status",
     timeoutMs: 90_000,
     ttl: "120m",
     userDriverScript: DEFAULT_USER_DRIVER,
   };
+  const commandSeparator = argv.indexOf("--");
+  if (command === "run" && commandSeparator >= 0) {
+    opts.remoteCommand = argv.slice(commandSeparator + 1);
+    argv = argv.slice(0, commandSeparator);
+  }
   let expectWasPassed = false;
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -177,6 +233,8 @@ function parseArgs(argv: string[]): Options {
       opts.provider = readValue();
     } else if (arg === "--record-seconds") {
       opts.recordSeconds = parsePositiveInteger(readValue(), "--record-seconds");
+    } else if (arg === "--session") {
+      opts.sessionFile = readValue();
     } else if (arg === "--sut-username") {
       opts.sutUsername = readValue().replace(/^@/u, "");
     } else if (arg === "--target") {
@@ -199,6 +257,12 @@ function parseArgs(argv: string[]): Options {
     } else {
       throw new Error(`Unknown argument: ${arg}`);
     }
+  }
+  if (command === "run" && opts.remoteCommand.length === 0) {
+    throw new Error("run requires a remote command after --.");
+  }
+  if (["finish", "run", "screenshot", "send", "status"].includes(command) && !opts.sessionFile) {
+    throw new Error(`${command} requires --session.`);
   }
   return opts;
 }
@@ -248,6 +312,10 @@ function requireString(source: JsonObject, key: string) {
 function optionalString(source: JsonObject, key: string) {
   const value = source[key];
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function shellQuote(value: string) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 function runCommand(params: {
@@ -375,6 +443,53 @@ function killTree(child: ChildProcess | undefined) {
   } catch {
     child.kill("SIGTERM");
   }
+}
+
+function killPidTree(pid: number | undefined) {
+  if (!pid) {
+    return;
+  }
+  try {
+    process.kill(-pid, "SIGTERM");
+  } catch {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      return;
+    }
+  }
+}
+
+function spawnDaemon(params: {
+  args: string[];
+  command: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  logPath: string;
+}) {
+  const log = fs.openSync(params.logPath, "a");
+  const child = spawn(params.command, params.args, {
+    cwd: params.cwd,
+    detached: true,
+    env: params.env,
+    stdio: ["ignore", log, log],
+  });
+  child.unref();
+  fs.closeSync(log);
+  return child.pid;
+}
+
+async function waitForLog(logPath: string, pattern: RegExp, label: string, timeoutMs: number) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const text = fs.existsSync(logPath) ? fs.readFileSync(logPath, "utf8") : "";
+    if (pattern.test(text)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  const text = fs.existsSync(logPath) ? fs.readFileSync(logPath, "utf8") : "";
+  throw new Error(`${label} did not become ready within ${timeoutMs}ms\n${text.slice(-4000)}`);
 }
 
 async function telegram(token: string, method: string, body: JsonObject = {}) {
@@ -568,6 +683,65 @@ async function startLocalSut(params: {
   };
 }
 
+async function startLocalSutDaemon(params: {
+  gatewayPort: number;
+  groupId: string;
+  mockPort: number;
+  outputDir: string;
+  sutToken: string;
+  testerId: string;
+  repoRoot: string;
+}) {
+  const drained = await drainSutUpdates(params.sutToken);
+  const config = writeSutConfig(params);
+  const requestLog = path.join(params.outputDir, "mock-openai-requests.ndjson");
+  const mockLog = path.join(params.outputDir, "mock-openai.log");
+  const gatewayLog = path.join(params.outputDir, "gateway.log");
+  const mockPid = spawnDaemon({
+    command: "node",
+    args: ["scripts/e2e/mock-openai-server.mjs"],
+    cwd: params.repoRoot,
+    env: {
+      ...process.env,
+      MOCK_PORT: String(params.mockPort),
+      MOCK_REQUEST_LOG: requestLog,
+      SUCCESS_MARKER: "OPENCLAW_E2E_OK",
+    },
+    logPath: mockLog,
+  });
+  if (!mockPid) {
+    throw new Error("mock-openai did not start.");
+  }
+  await waitForLog(mockLog, /mock-openai listening/u, "mock-openai", 10_000);
+
+  const gatewayPid = spawnDaemon({
+    command: "pnpm",
+    args: ["openclaw", "gateway", "--port", String(params.gatewayPort)],
+    cwd: params.repoRoot,
+    env: {
+      ...process.env,
+      OPENAI_API_KEY: "sk-openclaw-e2e-mock",
+      OPENCLAW_CONFIG_PATH: config.configPath,
+      OPENCLAW_STATE_DIR: config.stateDir,
+      TELEGRAM_BOT_TOKEN: params.sutToken,
+    },
+    logPath: gatewayLog,
+  });
+  if (!gatewayPid) {
+    throw new Error("gateway did not start.");
+  }
+  await waitForLog(gatewayLog, /\[gateway\] ready/u, "gateway", 60_000);
+  return {
+    ...config,
+    drained,
+    gatewayLog,
+    gatewayPid,
+    mockLog,
+    mockPid,
+    requestLog,
+  };
+}
+
 function extractLeaseId(output: string) {
   return output.match(/\b(?:cbx_[a-f0-9]+|tbx_[A-Za-z0-9_-]+)\b/u)?.[0];
 }
@@ -694,7 +868,7 @@ tdlib_url=${tdlibUrl}
 mkdir -p "$root"
 tar -xzf "$root/state.tgz" -C "$root"
 sudo apt-get update -y
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y curl git cmake g++ make zlib1g-dev libssl-dev python3 ffmpeg scrot xz-utils tar wmctrl xdotool libopengl0 libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 libxkbcommon-x11-0 >/tmp/openclaw-telegram-apt.log
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y curl git cmake g++ make zlib1g-dev libssl-dev python3 ffmpeg scrot xz-utils tar wmctrl xdotool x11-utils libopengl0 libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 libxkbcommon-x11-0 >/tmp/openclaw-telegram-apt.log
 if ! command -v python3 >/dev/null 2>&1; then
   echo "python3 is required" >&2
   exit 127
@@ -773,6 +947,7 @@ sleep 1
 
 function renderRemoteProbe(params: {
   expect: string[];
+  outputPath?: string;
   sutUsername: string;
   text: string;
   timeoutMs: number;
@@ -784,7 +959,7 @@ function renderRemoteProbe(params: {
     "--timeout-ms",
     String(params.timeoutMs),
     "--output",
-    `${REMOTE_ROOT}/probe.json`,
+    params.outputPath ?? `${REMOTE_ROOT}/probe.json`,
     "--json",
   ];
   for (const expected of params.expect) {
@@ -913,10 +1088,22 @@ function summarizeProbe(probePath: string) {
   const probe = readJsonFile(probePath);
   const reply = probe.reply;
   const sent = probe.sent;
+  const messageId = (value: unknown) => {
+    if (!value || typeof value !== "object") {
+      return undefined;
+    }
+    if ("messageId" in value) {
+      return value.messageId;
+    }
+    if ("id" in value) {
+      return value.id;
+    }
+    return undefined;
+  };
   return {
     ok: probe.ok === true,
-    replyMessageId: reply && typeof reply === "object" && "id" in reply ? reply.id : undefined,
-    sentMessageId: sent && typeof sent === "object" && "id" in sent ? sent.id : undefined,
+    replyMessageId: messageId(reply),
+    sentMessageId: messageId(sent),
   };
 }
 
@@ -953,12 +1140,447 @@ function writeReport(params: {
   return reportPath;
 }
 
+function sessionPath(root: string, opts: Options, outputDir: string) {
+  return opts.sessionFile
+    ? resolveRepoPath(root, opts.sessionFile)
+    : path.join(outputDir, "session.json");
+}
+
+function writeSession(pathname: string, session: SessionFile) {
+  fs.mkdirSync(path.dirname(pathname), { recursive: true });
+  fs.writeFileSync(pathname, `${JSON.stringify(session, null, 2)}\n`, { mode: 0o600 });
+  fs.chmodSync(pathname, 0o600);
+}
+
+function readSession(root: string, opts: Options, outputDir: string) {
+  const pathname = sessionPath(root, opts, outputDir);
+  if (!fs.existsSync(pathname)) {
+    throw new Error(`Missing session file: ${path.relative(root, pathname)}`);
+  }
+  const session = readJsonFile(pathname) as SessionFile;
+  if (session.command !== "telegram-user-crabbox-session") {
+    throw new Error(`Invalid Telegram Crabbox session file: ${path.relative(root, pathname)}`);
+  }
+  return {
+    path: pathname,
+    session,
+  };
+}
+
+async function writeRemoteSessionScripts(params: {
+  inspect: CrabboxInspect;
+  localRoot: string;
+  opts: Options;
+  root: string;
+  stateArchive: string;
+  sutUsername: string;
+}) {
+  const setupScript = path.join(params.localRoot, "remote-setup.sh");
+  const launchScript = path.join(params.localRoot, "launch-desktop.sh");
+  const selectChatScript = path.join(params.localRoot, "select-desktop-chat.sh");
+  await writeExecutable(
+    setupScript,
+    renderRemoteSetup({ tdlibSha256: params.opts.tdlibSha256, tdlibUrl: params.opts.tdlibUrl }),
+  );
+  await writeExecutable(launchScript, renderLaunchDesktop());
+  await writeExecutable(
+    selectChatScript,
+    renderSelectDesktopChat({ chatTitle: params.opts.desktopChatTitle }),
+  );
+
+  await sshRun(params.root, params.inspect, `rm -rf ${REMOTE_ROOT} && mkdir -p ${REMOTE_ROOT}`);
+  await scpToRemote(params.root, params.inspect, params.stateArchive, `${REMOTE_ROOT}/state.tgz`);
+  await scpToRemote(params.root, params.inspect, setupScript, `${REMOTE_ROOT}/remote-setup.sh`);
+  await scpToRemote(params.root, params.inspect, launchScript, `${REMOTE_ROOT}/launch-desktop.sh`);
+  await scpToRemote(
+    params.root,
+    params.inspect,
+    selectChatScript,
+    `${REMOTE_ROOT}/select-desktop-chat.sh`,
+  );
+  await sshRun(params.root, params.inspect, `bash ${REMOTE_ROOT}/remote-setup.sh`);
+  await sshRun(params.root, params.inspect, `bash ${REMOTE_ROOT}/launch-desktop.sh`);
+  await sshRun(params.root, params.inspect, `bash ${REMOTE_ROOT}/select-desktop-chat.sh`);
+  await sshRun(
+    params.root,
+    params.inspect,
+    `cat >${REMOTE_ROOT}/env.sh <<'EOF'
+export TELEGRAM_USER_DRIVER_STATE_DIR=${REMOTE_ROOT}/user-driver
+export TELEGRAM_USER_DRIVER_SUT_USERNAME=${params.sutUsername}
+EOF
+`,
+  );
+}
+
+async function startRemoteRecording(root: string, inspect: CrabboxInspect) {
+  const command = `set -euo pipefail
+export DISPLAY="\${DISPLAY:-:99}"
+root=${REMOTE_ROOT}
+video="$root/session.mp4"
+log="$root/ffmpeg.log"
+pid_file="$root/ffmpeg.pid"
+rm -f "$video" "$log" "$pid_file"
+size="$(xdpyinfo | awk '/dimensions:/ {print $2; exit}')"
+nohup ffmpeg -y -hide_banner -loglevel warning -f x11grab -framerate 15 -video_size "$size" -i "$DISPLAY" -pix_fmt yuv420p "$video" >"$log" 2>&1 &
+echo $! >"$pid_file"`;
+  await sshRun(root, inspect, command);
+  return {
+    log: `${REMOTE_ROOT}/ffmpeg.log`,
+    pidFile: `${REMOTE_ROOT}/ffmpeg.pid`,
+    remoteVideo: `${REMOTE_ROOT}/session.mp4`,
+  };
+}
+
+async function stopRemoteRecording(root: string, inspect: CrabboxInspect, session: SessionFile) {
+  await sshRun(
+    root,
+    inspect,
+    `set -euo pipefail
+pid_file=${JSON.stringify(session.recorder.pidFile)}
+if [ -s "$pid_file" ]; then
+  pid="$(cat "$pid_file")"
+  kill -INT "$pid" >/dev/null 2>&1 || true
+  for _ in $(seq 1 20); do
+    kill -0 "$pid" >/dev/null 2>&1 || exit 0
+    sleep 0.5
+  done
+  kill -TERM "$pid" >/dev/null 2>&1 || true
+fi`,
+  );
+}
+
+async function startSession(root: string, opts: Options, outputDir: string) {
+  const localRoot = path.join(outputDir, ".session");
+  fs.rmSync(localRoot, { force: true, recursive: true });
+  fs.mkdirSync(localRoot, { mode: 0o700, recursive: true });
+
+  const convexEnvFile = expandHome(opts.envFile ?? DEFAULT_CONVEX_ENV_FILE);
+  const hasConvexEnv =
+    trimToValue(process.env.OPENCLAW_QA_CONVEX_SITE_URL) &&
+    trimToValue(process.env.OPENCLAW_QA_CONVEX_SECRET_CI);
+  if (!hasConvexEnv && !fs.existsSync(convexEnvFile)) {
+    throw new Error(`Missing Convex env file: ${opts.envFile ?? DEFAULT_CONVEX_ENV_FILE}`);
+  }
+  await runCommand({ command: opts.crabboxBin, args: ["--version"], cwd: root });
+  if (opts.dryRun) {
+    return {
+      command: "telegram-user-crabbox-session",
+      outputDir,
+      provider: opts.provider,
+      target: opts.target,
+      tdlibSha256: opts.tdlibSha256,
+      tdlibUrl: opts.tdlibUrl,
+    };
+  }
+
+  const credential = await leaseCredential({ localRoot, opts, root });
+  const sut = opts.sutUsername
+    ? { id: "", username: opts.sutUsername }
+    : await sutIdentity(credential.sutToken);
+  const stateArchive = await prepareRemoteState({ localRoot, opts, root });
+  let leaseId = opts.leaseId;
+  let createdLease = false;
+  if (!leaseId) {
+    leaseId = await warmupCrabbox(opts, root);
+    createdLease = true;
+  }
+  const inspect = await inspectCrabbox(opts, root, leaseId);
+  let localSut: Awaited<ReturnType<typeof startLocalSutDaemon>> | undefined;
+  try {
+    await writeRemoteSessionScripts({
+      inspect,
+      localRoot,
+      opts,
+      root,
+      stateArchive,
+      sutUsername: sut.username,
+    });
+    localSut = await startLocalSutDaemon({
+      gatewayPort: opts.gatewayPort,
+      groupId: credential.groupId,
+      mockPort: opts.mockPort,
+      outputDir,
+      repoRoot: root,
+      sutToken: credential.sutToken,
+      testerId: credential.testerUserId,
+    });
+    const recorder = await startRemoteRecording(root, inspect);
+    const session: SessionFile = {
+      command: "telegram-user-crabbox-session",
+      createdAt: new Date().toISOString(),
+      crabbox: {
+        createdLease,
+        id: leaseId,
+        inspect,
+        provider: opts.provider,
+        target: opts.target,
+      },
+      credential: {
+        groupId: credential.groupId,
+        leaseFile: credential.leaseFile,
+        sutUsername: sut.username,
+        testerUserId: credential.testerUserId,
+        testerUsername: credential.testerUsername,
+      },
+      localRoot,
+      localSut,
+      outputDir,
+      recorder,
+      remoteRoot: REMOTE_ROOT,
+    };
+    const pathname = sessionPath(root, opts, outputDir);
+    writeSession(pathname, session);
+    return {
+      session: path.relative(root, pathname),
+      status: "pass",
+      telegram: {
+        groupId: credential.groupId,
+        sutUsername: sut.username,
+        testerUserId: credential.testerUserId,
+        testerUsername: credential.testerUsername,
+      },
+      webvnc: `${opts.crabboxBin} webvnc --provider ${opts.provider} --target ${opts.target} --id ${leaseId} --open`,
+      commands: {
+        send: `pnpm qa:telegram-user:crabbox -- send --session ${path.relative(root, pathname)} --text '/status'`,
+        run: `pnpm qa:telegram-user:crabbox -- run --session ${path.relative(root, pathname)} -- bash -lc 'source ${REMOTE_ROOT}/env.sh && python3 ${REMOTE_ROOT}/user-driver.py transcript --limit 20 --json'`,
+        finish: `pnpm qa:telegram-user:crabbox -- finish --session ${path.relative(root, pathname)}`,
+      },
+    };
+  } catch (error) {
+    killPidTree(localSut?.gatewayPid);
+    killPidTree(localSut?.mockPid);
+    await releaseCredential(root, opts, credential.leaseFile).catch(() => {});
+    if (leaseId && createdLease) {
+      await stopCrabbox(root, opts, leaseId).catch(() => {});
+    }
+    throw error;
+  }
+}
+
+async function sendSessionProbe(root: string, opts: Options, outputDir: string) {
+  const { session } = readSession(root, opts, outputDir);
+  const stamp = new Date().toISOString().replace(/[:.]/gu, "-");
+  const targetText = buildTargetText(opts.text, session.credential.sutUsername);
+  const remoteProbe = `${REMOTE_ROOT}/probe-${stamp}.json`;
+  const probeScript = path.join(session.localRoot, `remote-probe-${stamp}.sh`);
+  await writeExecutable(
+    probeScript,
+    renderRemoteProbe({
+      expect: opts.expect,
+      outputPath: remoteProbe,
+      sutUsername: session.credential.sutUsername,
+      text: targetText,
+      timeoutMs: opts.timeoutMs,
+    }),
+  );
+  await scpToRemote(root, session.crabbox.inspect, probeScript, `${REMOTE_ROOT}/remote-probe.sh`);
+  await sshRun(root, session.crabbox.inspect, `bash ${REMOTE_ROOT}/remote-probe.sh`);
+  const localProbe = path.join(session.outputDir, `probe-${stamp}.json`);
+  await scpFromRemote(root, session.crabbox.inspect, remoteProbe, localProbe);
+  return {
+    probe: path.relative(root, localProbe),
+    status: "pass",
+    summary: summarizeProbe(localProbe),
+    text: targetText,
+  };
+}
+
+async function runSessionCommand(root: string, opts: Options, outputDir: string) {
+  const { session } = readSession(root, opts, outputDir);
+  const command = opts.remoteCommand.map(shellQuote).join(" ");
+  const result = await sshRun(root, session.crabbox.inspect, command);
+  const logPath = path.join(
+    session.outputDir,
+    `remote-command-${new Date().toISOString().replace(/[:.]/gu, "-")}.log`,
+  );
+  fs.writeFileSync(logPath, `${result.stdout}${result.stderr}`);
+  return { command: opts.remoteCommand, log: path.relative(root, logPath), status: "pass" };
+}
+
+async function screenshotSession(root: string, opts: Options, outputDir: string) {
+  const { session } = readSession(root, opts, outputDir);
+  const screenshotPath = path.join(
+    session.outputDir,
+    `telegram-user-crabbox-${new Date().toISOString().replace(/[:.]/gu, "-")}.png`,
+  );
+  await runCommand({
+    command: opts.crabboxBin,
+    args: [
+      "screenshot",
+      "--provider",
+      session.crabbox.provider,
+      "--target",
+      session.crabbox.target,
+      "--id",
+      session.crabbox.id,
+      "--output",
+      screenshotPath,
+    ],
+    cwd: root,
+    stdio: "inherit",
+  });
+  return { screenshot: path.relative(root, screenshotPath), status: "pass" };
+}
+
+async function statusSession(root: string, opts: Options, outputDir: string) {
+  const { path: pathname, session } = readSession(root, opts, outputDir);
+  const inspect = await inspectCrabbox(opts, root, session.crabbox.id);
+  return {
+    crabbox: {
+      id: session.crabbox.id,
+      slug: inspect.slug,
+      state: inspect.state,
+    },
+    session: path.relative(root, pathname),
+    status: "pass",
+    webvnc: `${opts.crabboxBin} webvnc --provider ${session.crabbox.provider} --target ${session.crabbox.target} --id ${session.crabbox.id} --open`,
+  };
+}
+
+async function finishSession(root: string, opts: Options, outputDir: string) {
+  const { path: pathname, session } = readSession(root, opts, outputDir);
+  const summary: JsonObject = {
+    artifacts: {},
+    finishedAt: new Date().toISOString(),
+    session: path.relative(root, pathname),
+    startedAt: session.createdAt,
+    status: "fail",
+  };
+  const videoPath = path.join(session.outputDir, "telegram-user-crabbox-session.mp4");
+  const motionVideoPath = path.join(session.outputDir, "telegram-user-crabbox-session-motion.mp4");
+  const motionGifPath = path.join(session.outputDir, "telegram-user-crabbox-session-motion.gif");
+  const screenshotPath = path.join(session.outputDir, "telegram-user-crabbox-session.png");
+  const desktopLogPath = path.join(session.outputDir, "telegram-desktop.log");
+  const statusPath = path.join(session.outputDir, "status.json");
+  const ffmpegLogPath = path.join(session.outputDir, "ffmpeg.log");
+  try {
+    await stopRemoteRecording(root, session.crabbox.inspect, session);
+    await scpFromRemote(root, session.crabbox.inspect, session.recorder.remoteVideo, videoPath);
+    await scpFromRemote(
+      root,
+      session.crabbox.inspect,
+      `${REMOTE_ROOT}/telegram-desktop.log`,
+      desktopLogPath,
+    ).catch(() => {});
+    await scpFromRemote(
+      root,
+      session.crabbox.inspect,
+      `${REMOTE_ROOT}/status.json`,
+      statusPath,
+    ).catch(() => {});
+    await scpFromRemote(root, session.crabbox.inspect, session.recorder.log, ffmpegLogPath).catch(
+      () => {},
+    );
+    const preview = await runCommand({
+      command: opts.crabboxBin,
+      args: [
+        "media",
+        "preview",
+        "--input",
+        videoPath,
+        "--output",
+        motionGifPath,
+        "--trimmed-video-output",
+        motionVideoPath,
+        "--json",
+      ],
+      cwd: root,
+      stdio: "inherit",
+    });
+    summary.mediaPreview = JSON.parse(preview.stdout) as JsonObject;
+    await runCommand({
+      command: opts.crabboxBin,
+      args: [
+        "screenshot",
+        "--provider",
+        session.crabbox.provider,
+        "--target",
+        session.crabbox.target,
+        "--id",
+        session.crabbox.id,
+        "--output",
+        screenshotPath,
+      ],
+      cwd: root,
+      stdio: "inherit",
+    });
+    summary.artifacts = {
+      desktopLog: path.relative(root, desktopLogPath),
+      ffmpegLog: path.relative(root, ffmpegLogPath),
+      previewGif: path.relative(root, motionGifPath),
+      screenshot: path.relative(root, screenshotPath),
+      status: path.relative(root, statusPath),
+      trimmedVideo: path.relative(root, motionVideoPath),
+      video: path.relative(root, videoPath),
+    };
+    summary.status = "pass";
+  } finally {
+    killPidTree(session.localSut.gatewayPid);
+    killPidTree(session.localSut.mockPid);
+    await releaseCredential(root, opts, session.credential.leaseFile).catch((error: unknown) => {
+      summary.credentialReleaseError = error instanceof Error ? error.message : String(error);
+    });
+    if (session.crabbox.createdLease && !opts.keepBox) {
+      await stopCrabbox(root, opts, session.crabbox.id).catch((error: unknown) => {
+        summary.crabboxStopError = error instanceof Error ? error.message : String(error);
+      });
+    }
+    if (opts.keepBox) {
+      summary.keepBox = true;
+      summary.webvnc = `${opts.crabboxBin} webvnc --provider ${session.crabbox.provider} --target ${session.crabbox.target} --id ${session.crabbox.id} --open`;
+    }
+    fs.rmSync(session.localRoot, { force: true, recursive: true });
+    const summaryPath = path.join(session.outputDir, "telegram-user-crabbox-session-summary.json");
+    fs.writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+    const reportPath = writeReport({
+      motionGifPath,
+      motionVideoPath,
+      outputDir: session.outputDir,
+      screenshotPath,
+      status: summary.status === "pass" ? "pass" : "fail",
+      summaryPath,
+      videoPath,
+    });
+    summary.report = path.relative(root, reportPath);
+    fs.writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+    console.log(JSON.stringify({ reportPath, status: summary.status, summaryPath }, null, 2));
+  }
+  if (summary.status !== "pass") {
+    process.exitCode = 1;
+  }
+}
+
 async function main() {
   const opts = parseArgs(process.argv.slice(2));
   const root = repoRoot();
   const outputDir = resolveRepoPath(root, opts.outputDir);
   fs.mkdirSync(outputDir, { recursive: true });
   opts.outputDir = outputDir;
+
+  if (opts.command === "start") {
+    console.log(JSON.stringify(await startSession(root, opts, outputDir), null, 2));
+    return;
+  }
+  if (opts.command === "send") {
+    console.log(JSON.stringify(await sendSessionProbe(root, opts, outputDir), null, 2));
+    return;
+  }
+  if (opts.command === "run") {
+    console.log(JSON.stringify(await runSessionCommand(root, opts, outputDir), null, 2));
+    return;
+  }
+  if (opts.command === "screenshot") {
+    console.log(JSON.stringify(await screenshotSession(root, opts, outputDir), null, 2));
+    return;
+  }
+  if (opts.command === "status") {
+    console.log(JSON.stringify(await statusSession(root, opts, outputDir), null, 2));
+    return;
+  }
+  if (opts.command === "finish") {
+    await finishSession(root, opts, outputDir);
+    return;
+  }
 
   const localRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-telegram-crabbox-"));
   const summary: JsonObject = {

--- a/scripts/e2e/telegram-user-crabbox-proof.ts
+++ b/scripts/e2e/telegram-user-crabbox-proof.ts
@@ -23,7 +23,7 @@ type CrabboxInspect = {
 };
 
 type Options = {
-  command: "finish" | "probe" | "run" | "screenshot" | "send" | "start" | "status";
+  command: "finish" | "probe" | "publish" | "run" | "screenshot" | "send" | "start" | "status";
   crabboxBin: string;
   desktopChatTitle: string;
   dryRun: boolean;
@@ -36,6 +36,10 @@ type Options = {
   mockPort: number;
   outputDir: string;
   provider: string;
+  publishFullArtifacts: boolean;
+  publishPr?: number;
+  publishRepo: string;
+  publishSummary?: string;
   recordSeconds: number;
   remoteCommand: string[];
   sessionFile?: string;
@@ -120,14 +124,19 @@ function usageText() {
     "  node --import tsx scripts/e2e/telegram-user-crabbox-proof.ts screenshot --session <session.json>",
     "  node --import tsx scripts/e2e/telegram-user-crabbox-proof.ts status --session <session.json>",
     "  node --import tsx scripts/e2e/telegram-user-crabbox-proof.ts finish --session <session.json>",
+    "  node --import tsx scripts/e2e/telegram-user-crabbox-proof.ts publish --session <session.json> --pr <number>",
     "",
     "Useful options:",
     "  --desktop-chat-title <name>   Telegram Desktop chat to select before recording.",
     "  --id <cbx_id>                 Reuse an existing Crabbox desktop lease.",
     "  --keep-box                    Leave the Crabbox lease running for VNC debugging.",
     "  --output-dir <path>           Artifact directory under the repo.",
+    "  --pr <number>                 Pull request number for publish.",
     "  --record-seconds <seconds>    Desktop video duration. Default: 35.",
+    "  --repo <owner/name>           GitHub repo for publish. Default: openclaw/openclaw.",
     "  --session <path>              Session file from start. Default: <output-dir>/session.json.",
+    "  --summary <text>              Artifact publish summary.",
+    "  --full-artifacts              Publish all session artifacts. Default publishes only the motion GIF.",
     "  --tdlib-sha256 <hex>         Expected SHA-256 for --tdlib-url. Defaults to <url>.sha256.",
     "  --tdlib-url <url>             Linux tdlib archive containing libtdjson.so.",
     "  --dry-run                     Validate local inputs and print the plan.",
@@ -163,7 +172,16 @@ function parsePositiveInteger(value: string, label: string) {
 
 function parseArgs(argv: string[]): Options {
   argv = argv[0] === "--" ? argv.slice(1) : argv;
-  const commands = new Set(["finish", "probe", "run", "screenshot", "send", "start", "status"]);
+  const commands = new Set([
+    "finish",
+    "probe",
+    "publish",
+    "run",
+    "screenshot",
+    "send",
+    "start",
+    "status",
+  ]);
   const command = commands.has(argv[0] ?? "") ? (argv.shift() as Options["command"]) : "probe";
   const stamp = new Date().toISOString().replace(/[:.]/gu, "-");
   const opts: Options = {
@@ -179,6 +197,8 @@ function parseArgs(argv: string[]): Options {
     mockPort: 19_882,
     outputDir: path.join(DEFAULT_OUTPUT_ROOT, stamp),
     provider: process.env.OPENCLAW_TELEGRAM_USER_CRABBOX_PROVIDER?.trim() || "aws",
+    publishFullArtifacts: false,
+    publishRepo: "openclaw/openclaw",
     recordSeconds: 35,
     remoteCommand: [],
     target: "linux",
@@ -231,10 +251,18 @@ function parseArgs(argv: string[]): Options {
       opts.outputDir = readValue();
     } else if (arg === "--provider") {
       opts.provider = readValue();
+    } else if (arg === "--pr") {
+      opts.publishPr = parsePositiveInteger(readValue(), "--pr");
+    } else if (arg === "--repo") {
+      opts.publishRepo = readValue();
     } else if (arg === "--record-seconds") {
       opts.recordSeconds = parsePositiveInteger(readValue(), "--record-seconds");
     } else if (arg === "--session") {
       opts.sessionFile = readValue();
+    } else if (arg === "--summary") {
+      opts.publishSummary = readValue();
+    } else if (arg === "--full-artifacts") {
+      opts.publishFullArtifacts = true;
     } else if (arg === "--sut-username") {
       opts.sutUsername = readValue().replace(/^@/u, "");
     } else if (arg === "--target") {
@@ -261,8 +289,14 @@ function parseArgs(argv: string[]): Options {
   if (command === "run" && opts.remoteCommand.length === 0) {
     throw new Error("run requires a remote command after --.");
   }
-  if (["finish", "run", "screenshot", "send", "status"].includes(command) && !opts.sessionFile) {
+  if (
+    ["finish", "publish", "run", "screenshot", "send", "status"].includes(command) &&
+    !opts.sessionFile
+  ) {
     throw new Error(`${command} requires --session.`);
+  }
+  if (command === "publish" && !opts.publishPr) {
+    throw new Error("publish requires --pr.");
   }
   return opts;
 }
@@ -1550,6 +1584,55 @@ async function finishSession(root: string, opts: Options, outputDir: string) {
   }
 }
 
+async function publishSessionArtifacts(root: string, opts: Options, outputDir: string) {
+  const { session } = readSession(root, opts, outputDir);
+  const motionGifPath = path.join(session.outputDir, "telegram-user-crabbox-session-motion.gif");
+  const publishDir = opts.publishFullArtifacts
+    ? session.outputDir
+    : path.join(session.outputDir, "publish-gif-only");
+  if (!opts.publishFullArtifacts) {
+    if (!fs.existsSync(motionGifPath)) {
+      throw new Error(
+        `Missing motion GIF. Run finish first: ${path.relative(root, motionGifPath)}`,
+      );
+    }
+    fs.rmSync(publishDir, { force: true, recursive: true });
+    fs.mkdirSync(publishDir, { recursive: true });
+    fs.copyFileSync(
+      motionGifPath,
+      path.join(publishDir, "telegram-user-crabbox-session-motion.gif"),
+    );
+  }
+  await runCommand({
+    command: opts.crabboxBin,
+    args: [
+      "artifacts",
+      "publish",
+      "--pr",
+      String(opts.publishPr),
+      "--repo",
+      opts.publishRepo,
+      "--dir",
+      publishDir,
+      "--summary",
+      opts.publishSummary ??
+        (opts.publishFullArtifacts
+          ? "Telegram real-user Crabbox session artifacts"
+          : "Telegram real-user Crabbox session motion GIF"),
+      "--template",
+      "openclaw",
+      ...(opts.dryRun ? ["--dry-run"] : []),
+    ],
+    cwd: root,
+    stdio: "inherit",
+  });
+  return {
+    artifactMode: opts.publishFullArtifacts ? "full" : "gif-only",
+    publishDir: path.relative(root, publishDir),
+    status: "pass",
+  };
+}
+
 async function main() {
   const opts = parseArgs(process.argv.slice(2));
   const root = repoRoot();
@@ -1579,6 +1662,10 @@ async function main() {
   }
   if (opts.command === "finish") {
     await finishSession(root, opts, outputDir);
+    return;
+  }
+  if (opts.command === "publish") {
+    console.log(JSON.stringify(await publishSessionArtifacts(root, opts, outputDir), null, 2));
     return;
   }
 

--- a/scripts/e2e/telegram-user-crabbox-proof.ts
+++ b/scripts/e2e/telegram-user-crabbox-proof.ts
@@ -1,0 +1,1239 @@
+#!/usr/bin/env -S node --import tsx
+
+import { type ChildProcess, spawn, type SpawnOptionsWithoutStdio } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+type CommandResult = {
+  stderr: string;
+  stdout: string;
+};
+
+type JsonObject = Record<string, unknown>;
+
+type CrabboxInspect = {
+  host?: string;
+  id?: string;
+  slug?: string;
+  sshKey?: string;
+  sshPort?: string;
+  sshUser?: string;
+  state?: string;
+};
+
+type Options = {
+  crabboxBin: string;
+  desktopChatTitle: string;
+  dryRun: boolean;
+  envFile?: string;
+  expect: string[];
+  gatewayPort: number;
+  idleTimeout: string;
+  keepBox: boolean;
+  leaseId?: string;
+  mockPort: number;
+  outputDir: string;
+  provider: string;
+  recordSeconds: number;
+  sutUsername?: string;
+  target: string;
+  tdlibSha256?: string;
+  tdlibUrl?: string;
+  text: string;
+  timeoutMs: number;
+  ttl: string;
+  userDriverScript: string;
+};
+
+type LocalSut = {
+  configPath: string;
+  drained: {
+    drained: number;
+    pendingAfter?: number;
+    pendingBefore?: number;
+    webhookUrlSet: boolean;
+  };
+  mock: ChildProcess;
+  mockLog: string;
+  requestLog: string;
+  stateDir: string;
+  tempRoot: string;
+  workspace: string;
+  gateway: ChildProcess;
+  gatewayLog: string;
+};
+
+const DEFAULT_SKILL_DIR = "~/.codex/skills/custom/telegram-e2e-bot-to-bot";
+const DEFAULT_CONVEX_ENV_FILE = `${DEFAULT_SKILL_DIR}/convex.local.env`;
+const DEFAULT_USER_DRIVER = `${DEFAULT_SKILL_DIR}/scripts/user-driver.py`;
+const DEFAULT_OUTPUT_ROOT = ".artifacts/qa-e2e/telegram-user-crabbox";
+const REMOTE_ROOT = "/tmp/openclaw-telegram-user-crabbox";
+
+function usageText() {
+  return [
+    "Usage:",
+    "  node --import tsx scripts/e2e/telegram-user-crabbox-proof.ts [--text /status] [--expect OpenClaw]",
+    "",
+    "Useful options:",
+    "  --desktop-chat-title <name>   Telegram Desktop chat to select before recording.",
+    "  --id <cbx_id>                 Reuse an existing Crabbox desktop lease.",
+    "  --keep-box                    Leave the Crabbox lease running for VNC debugging.",
+    "  --output-dir <path>           Artifact directory under the repo.",
+    "  --record-seconds <seconds>    Desktop video duration. Default: 35.",
+    "  --tdlib-sha256 <hex>         Expected SHA-256 for --tdlib-url. Defaults to <url>.sha256.",
+    "  --tdlib-url <url>             Linux tdlib archive containing libtdjson.so.",
+    "  --dry-run                     Validate local inputs and print the plan.",
+  ].join("\n");
+}
+
+function usage(): never {
+  throw new Error(usageText());
+}
+
+function expandHome(value: string) {
+  if (value === "~") {
+    return os.homedir();
+  }
+  if (value.startsWith("~/")) {
+    return path.join(os.homedir(), value.slice(2));
+  }
+  return value;
+}
+
+function trimToValue(value: string | undefined) {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parsePositiveInteger(value: string, label: string) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${label} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function parseArgs(argv: string[]): Options {
+  argv = argv[0] === "--" ? argv.slice(1) : argv;
+  const stamp = new Date().toISOString().replace(/[:.]/gu, "-");
+  const opts: Options = {
+    crabboxBin: trimToValue(process.env.OPENCLAW_TELEGRAM_USER_CRABBOX_BIN) ?? "crabbox",
+    desktopChatTitle:
+      trimToValue(process.env.OPENCLAW_TELEGRAM_USER_DESKTOP_CHAT_TITLE) ?? "OpenClaw Testing",
+    dryRun: false,
+    expect: ["OpenClaw"],
+    gatewayPort: 19_879,
+    idleTimeout: "60m",
+    keepBox: false,
+    mockPort: 19_882,
+    outputDir: path.join(DEFAULT_OUTPUT_ROOT, stamp),
+    provider: process.env.OPENCLAW_TELEGRAM_USER_CRABBOX_PROVIDER?.trim() || "aws",
+    recordSeconds: 35,
+    target: "linux",
+    text: "/status",
+    timeoutMs: 90_000,
+    ttl: "120m",
+    userDriverScript: DEFAULT_USER_DRIVER,
+  };
+  let expectWasPassed = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const readValue = () => {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        usage();
+      }
+      index += 1;
+      return value;
+    };
+    if (arg === "--crabbox-bin") {
+      opts.crabboxBin = readValue();
+    } else if (arg === "--desktop-chat-title") {
+      opts.desktopChatTitle = readValue();
+    } else if (arg === "--dry-run") {
+      opts.dryRun = true;
+    } else if (arg === "--env-file") {
+      opts.envFile = readValue();
+    } else if (arg === "--expect") {
+      if (!expectWasPassed) {
+        opts.expect = [];
+        expectWasPassed = true;
+      }
+      opts.expect.push(readValue());
+    } else if (arg === "--gateway-port") {
+      opts.gatewayPort = parsePositiveInteger(readValue(), "--gateway-port");
+    } else if (arg === "--id") {
+      opts.leaseId = readValue();
+    } else if (arg === "--idle-timeout") {
+      opts.idleTimeout = readValue();
+    } else if (arg === "--keep-box") {
+      opts.keepBox = true;
+    } else if (arg === "--mock-port") {
+      opts.mockPort = parsePositiveInteger(readValue(), "--mock-port");
+    } else if (arg === "--output-dir") {
+      opts.outputDir = readValue();
+    } else if (arg === "--provider") {
+      opts.provider = readValue();
+    } else if (arg === "--record-seconds") {
+      opts.recordSeconds = parsePositiveInteger(readValue(), "--record-seconds");
+    } else if (arg === "--sut-username") {
+      opts.sutUsername = readValue().replace(/^@/u, "");
+    } else if (arg === "--target") {
+      opts.target = readValue();
+    } else if (arg === "--tdlib-sha256") {
+      opts.tdlibSha256 = readValue().toLowerCase();
+    } else if (arg === "--tdlib-url") {
+      opts.tdlibUrl = readValue();
+    } else if (arg === "--text") {
+      opts.text = readValue();
+    } else if (arg === "--timeout-ms") {
+      opts.timeoutMs = parsePositiveInteger(readValue(), "--timeout-ms");
+    } else if (arg === "--ttl") {
+      opts.ttl = readValue();
+    } else if (arg === "--user-driver-script") {
+      opts.userDriverScript = readValue();
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(usageText());
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+function repoRoot() {
+  const cwd = process.cwd();
+  if (
+    !fs.existsSync(path.join(cwd, "package.json")) ||
+    !fs.existsSync(path.join(cwd, "scripts/e2e/mock-openai-server.mjs"))
+  ) {
+    throw new Error("Run from the OpenClaw repo root.");
+  }
+  return cwd;
+}
+
+function resolveRepoPath(root: string, value: string) {
+  const resolved = path.isAbsolute(value) ? value : path.resolve(root, value);
+  const relative = path.relative(root, resolved);
+  if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Output path must stay inside the repo: ${value}`);
+  }
+  return resolved;
+}
+
+function readJsonFile(filePath: string): JsonObject {
+  try {
+    return JSON.parse(fs.readFileSync(expandHome(filePath), "utf8")) as JsonObject;
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return {};
+    }
+    throw error;
+  }
+}
+
+function requireString(source: JsonObject, key: string) {
+  const value = source[key];
+  if (typeof value === "number") {
+    return String(value);
+  }
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  throw new Error(`Missing ${key}.`);
+}
+
+function optionalString(source: JsonObject, key: string) {
+  const value = source[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function runCommand(params: {
+  args: string[];
+  command: string;
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  stdio?: "inherit" | "pipe";
+  stdin?: string;
+}) {
+  return new Promise<CommandResult>((resolve, reject) => {
+    const child = spawn(params.command, params.args, {
+      cwd: params.cwd,
+      env: params.env ?? process.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      stdout += text;
+      if (params.stdio === "inherit") {
+        process.stdout.write(text);
+      }
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      stderr += text;
+      if (params.stdio === "inherit") {
+        process.stderr.write(text);
+      }
+    });
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      const detail = signal ? `signal ${signal}` : `exit code ${code ?? "unknown"}`;
+      reject(
+        new Error(
+          `${params.command} ${params.args.join(" ")} failed with ${detail}\n${stdout}${stderr}`,
+        ),
+      );
+    });
+    if (params.stdin) {
+      child.stdin.end(params.stdin);
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+function spawnLogged(command: string, args: string[], options: SpawnOptionsWithoutStdio) {
+  const child = spawn(command, args, {
+    ...options,
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  let output = "";
+  const capture = (chunk: string) => {
+    output = `${output}${chunk}`.slice(-12000);
+  };
+  child.stdout.on("data", capture);
+  child.stderr.on("data", capture);
+  return {
+    child,
+    get output() {
+      return output;
+    },
+  };
+}
+
+function waitForOutput(
+  child: ChildProcess,
+  pattern: RegExp,
+  output: () => string,
+  label: string,
+  timeoutMs: number,
+) {
+  return new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(
+        new Error(`${label} did not become ready within ${timeoutMs}ms\n${output().slice(-4000)}`),
+      );
+    }, timeoutMs);
+    const onData = () => {
+      if (pattern.test(output())) {
+        cleanup();
+        resolve();
+      }
+    };
+    const onExit = (code: number | null) => {
+      cleanup();
+      reject(
+        new Error(
+          `${label} exited before ready with code ${code ?? "unknown"}\n${output().slice(-4000)}`,
+        ),
+      );
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.stdout?.off("data", onData);
+      child.stderr?.off("data", onData);
+      child.off("exit", onExit);
+    };
+    child.stdout?.on("data", onData);
+    child.stderr?.on("data", onData);
+    child.on("exit", onExit);
+    onData();
+  });
+}
+
+function killTree(child: ChildProcess | undefined) {
+  if (!child || child.killed || child.exitCode !== null) {
+    return;
+  }
+  if (!child.pid) {
+    return;
+  }
+  try {
+    process.kill(-child.pid, "SIGTERM");
+  } catch {
+    child.kill("SIGTERM");
+  }
+}
+
+async function telegram(token: string, method: string, body: JsonObject = {}) {
+  const response = await fetch(`https://api.telegram.org/bot${token}/${method}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const payload = (await response.json()) as JsonObject;
+  if (!response.ok || payload.ok !== true) {
+    throw new Error(
+      optionalString(payload, "description") ?? `${method} failed with HTTP ${response.status}`,
+    );
+  }
+  return payload.result;
+}
+
+async function drainSutUpdates(sutToken: string) {
+  const before = telegramResultObject(await telegram(sutToken, "getWebhookInfo"), "getWebhookInfo");
+  const rawUpdates = await telegram(sutToken, "getUpdates", {
+    allowed_updates: ["message", "edited_message"],
+    timeout: 0,
+  });
+  if (!Array.isArray(rawUpdates)) {
+    throw new Error("getUpdates returned an invalid payload.");
+  }
+  const updates = rawUpdates;
+  if (updates.length) {
+    const last = updates.at(-1);
+    if (
+      last &&
+      typeof last === "object" &&
+      "update_id" in last &&
+      typeof last.update_id === "number"
+    ) {
+      await telegram(sutToken, "getUpdates", { offset: last.update_id + 1, timeout: 0 });
+    }
+  }
+  const after = telegramResultObject(await telegram(sutToken, "getWebhookInfo"), "getWebhookInfo");
+  return {
+    drained: updates.length,
+    pendingAfter:
+      typeof after.pending_update_count === "number" ? after.pending_update_count : undefined,
+    pendingBefore:
+      typeof before.pending_update_count === "number" ? before.pending_update_count : undefined,
+    webhookUrlSet: typeof before.url === "string" && before.url.length > 0,
+  };
+}
+
+async function sutIdentity(sutToken: string) {
+  const result = telegramResultObject(await telegram(sutToken, "getMe"), "getMe");
+  const username = requireString(result, "username").replace(/^@/u, "");
+  return { id: requireString(result, "id"), username };
+}
+
+function telegramResultObject(value: unknown, label: string): JsonObject {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} returned an invalid payload.`);
+  }
+  return value as JsonObject;
+}
+
+function writeSutConfig(params: {
+  gatewayPort: number;
+  groupId: string;
+  mockPort: number;
+  outputDir: string;
+  testerId: string;
+}) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-tg-crabbox-sut-"));
+  const stateDir = path.join(tempRoot, "state");
+  const workspace = path.join(tempRoot, "workspace");
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.mkdirSync(workspace, { recursive: true });
+  const configPath = path.join(tempRoot, "openclaw.json");
+  const config = {
+    agents: {
+      defaults: {
+        model: { primary: "openai/gpt-5.5" },
+        models: { "openai/gpt-5.5": { params: { openaiWsWarmup: false, transport: "sse" } } },
+      },
+      list: [
+        {
+          default: true,
+          id: "main",
+          model: { primary: "openai/gpt-5.5" },
+          name: "Main",
+          workspace,
+        },
+      ],
+    },
+    channels: {
+      telegram: {
+        allowFrom: [params.testerId],
+        botToken: { id: "TELEGRAM_BOT_TOKEN", provider: "default", source: "env" },
+        commands: { native: true, nativeSkills: false },
+        dmPolicy: "allowlist",
+        enabled: true,
+        groupAllowFrom: [params.testerId],
+        groupPolicy: "allowlist",
+        groups: {
+          [params.groupId]: {
+            allowFrom: [params.testerId],
+            groupPolicy: "allowlist",
+            requireMention: false,
+          },
+        },
+        replyToMode: "first",
+      },
+    },
+    gateway: { auth: { mode: "none" }, bind: "loopback", mode: "local", port: params.gatewayPort },
+    messages: { groupChat: { visibleReplies: "automatic" } },
+    models: {
+      providers: {
+        openai: {
+          api: "openai-responses",
+          apiKey: { id: "OPENAI_API_KEY", provider: "default", source: "env" },
+          baseUrl: `http://127.0.0.1:${params.mockPort}/v1`,
+          models: [
+            { api: "openai-responses", contextWindow: 128000, id: "gpt-5.5", name: "gpt-5.5" },
+          ],
+          request: { allowPrivateNetwork: true },
+        },
+      },
+    },
+    plugins: {
+      allow: ["telegram", "openai"],
+      enabled: true,
+      entries: { openai: { enabled: true }, telegram: { enabled: true } },
+    },
+  };
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  return { configPath, stateDir, tempRoot, workspace };
+}
+
+async function startLocalSut(params: {
+  gatewayPort: number;
+  groupId: string;
+  mockPort: number;
+  outputDir: string;
+  sutToken: string;
+  testerId: string;
+  repoRoot: string;
+}) {
+  const drained = await drainSutUpdates(params.sutToken);
+  const config = writeSutConfig(params);
+  const requestLog = path.join(params.outputDir, "mock-openai-requests.ndjson");
+  const mock = spawnLogged("node", ["scripts/e2e/mock-openai-server.mjs"], {
+    cwd: params.repoRoot,
+    env: {
+      ...process.env,
+      MOCK_PORT: String(params.mockPort),
+      MOCK_REQUEST_LOG: requestLog,
+      SUCCESS_MARKER: "OPENCLAW_E2E_OK",
+    },
+  });
+  await waitForOutput(
+    mock.child,
+    /mock-openai listening/u,
+    () => mock.output,
+    "mock-openai",
+    10_000,
+  );
+  const gateway = spawnLogged(
+    "pnpm",
+    ["openclaw", "gateway", "--port", String(params.gatewayPort)],
+    {
+      cwd: params.repoRoot,
+      env: {
+        ...process.env,
+        OPENAI_API_KEY: "sk-openclaw-e2e-mock",
+        OPENCLAW_CONFIG_PATH: config.configPath,
+        OPENCLAW_STATE_DIR: config.stateDir,
+        TELEGRAM_BOT_TOKEN: params.sutToken,
+      },
+    },
+  );
+  await waitForOutput(gateway.child, /\[gateway\] ready/u, () => gateway.output, "gateway", 60_000);
+  return {
+    ...config,
+    drained,
+    gateway: gateway.child,
+    get gatewayLog() {
+      return gateway.output;
+    },
+    mock: mock.child,
+    get mockLog() {
+      return mock.output;
+    },
+    requestLog,
+  };
+}
+
+function extractLeaseId(output: string) {
+  return output.match(/\b(?:cbx_[a-f0-9]+|tbx_[A-Za-z0-9_-]+)\b/u)?.[0];
+}
+
+async function warmupCrabbox(opts: Options, root: string) {
+  const result = await runCommand({
+    command: opts.crabboxBin,
+    args: [
+      "warmup",
+      "--provider",
+      opts.provider,
+      "--target",
+      opts.target,
+      "--desktop",
+      "--browser",
+      "--idle-timeout",
+      opts.idleTimeout,
+      "--ttl",
+      opts.ttl,
+    ],
+    cwd: root,
+    stdio: "inherit",
+  });
+  const leaseId = extractLeaseId(`${result.stdout}\n${result.stderr}`);
+  if (!leaseId) {
+    throw new Error("Crabbox warmup did not print a lease id.");
+  }
+  return leaseId;
+}
+
+async function inspectCrabbox(opts: Options, root: string, leaseId: string) {
+  const result = await runCommand({
+    command: opts.crabboxBin,
+    args: [
+      "inspect",
+      "--provider",
+      opts.provider,
+      "--target",
+      opts.target,
+      "--id",
+      leaseId,
+      "--json",
+    ],
+    cwd: root,
+  });
+  return JSON.parse(result.stdout) as CrabboxInspect;
+}
+
+function sshArgs(inspect: CrabboxInspect) {
+  if (!inspect.host || !inspect.sshKey || !inspect.sshUser) {
+    throw new Error("Crabbox inspect output is missing SSH details.");
+  }
+  return {
+    base: [
+      "-i",
+      inspect.sshKey,
+      "-p",
+      inspect.sshPort ?? "22",
+      "-o",
+      "IdentitiesOnly=yes",
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "StrictHostKeyChecking=accept-new",
+      "-o",
+      "ConnectTimeout=15",
+    ],
+    scpBase: [
+      "-i",
+      inspect.sshKey,
+      "-P",
+      inspect.sshPort ?? "22",
+      "-o",
+      "IdentitiesOnly=yes",
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "StrictHostKeyChecking=accept-new",
+      "-o",
+      "ConnectTimeout=15",
+    ],
+    target: `${inspect.sshUser}@${inspect.host}`,
+  };
+}
+
+async function scpToRemote(root: string, inspect: CrabboxInspect, local: string, remote: string) {
+  const ssh = sshArgs(inspect);
+  await runCommand({
+    command: "scp",
+    args: [...ssh.scpBase, local, `${ssh.target}:${remote}`],
+    cwd: root,
+    stdio: "inherit",
+  });
+}
+
+async function scpFromRemote(root: string, inspect: CrabboxInspect, remote: string, local: string) {
+  const ssh = sshArgs(inspect);
+  await runCommand({
+    command: "scp",
+    args: [...ssh.scpBase, `${ssh.target}:${remote}`, local],
+    cwd: root,
+    stdio: "inherit",
+  });
+}
+
+async function sshRun(root: string, inspect: CrabboxInspect, remoteCommand: string) {
+  const ssh = sshArgs(inspect);
+  return await runCommand({
+    command: "ssh",
+    args: [...ssh.base, ssh.target, remoteCommand],
+    cwd: root,
+    stdio: "inherit",
+  });
+}
+
+function renderRemoteSetup(params: { tdlibSha256?: string; tdlibUrl?: string }) {
+  const tdlibSha256 = JSON.stringify(params.tdlibSha256 ?? "");
+  const tdlibUrl = JSON.stringify(params.tdlibUrl ?? "");
+  return `#!/usr/bin/env bash
+set -euo pipefail
+root=${REMOTE_ROOT}
+tdlib_sha256=${tdlibSha256}
+tdlib_url=${tdlibUrl}
+mkdir -p "$root"
+tar -xzf "$root/state.tgz" -C "$root"
+sudo apt-get update -y
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y curl git cmake g++ make zlib1g-dev libssl-dev python3 ffmpeg scrot xz-utils tar wmctrl xdotool libopengl0 libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 libxkbcommon-x11-0 >/tmp/openclaw-telegram-apt.log
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required" >&2
+  exit 127
+fi
+if [ ! -x "$root/Telegram/Telegram" ]; then
+  curl -fL https://telegram.org/dl/desktop/linux -o "$root/telegram.tar.xz"
+  tar -xJf "$root/telegram.tar.xz" -C "$root"
+fi
+if ! ldconfig -p | grep -q libtdjson.so; then
+  if [ -n "$tdlib_url" ]; then
+    curl -fL "$tdlib_url" -o "$root/tdlib-linux.tgz"
+    if [ -z "$tdlib_sha256" ]; then
+      curl -fL "$tdlib_url.sha256" -o "$root/tdlib-linux.tgz.sha256"
+      tdlib_sha256="$(awk '{print $1; exit}' "$root/tdlib-linux.tgz.sha256")"
+    fi
+    printf '%s  %s\\n' "$tdlib_sha256" "$root/tdlib-linux.tgz" | sha256sum -c -
+    mkdir -p "$root/tdlib-linux"
+    tar -xzf "$root/tdlib-linux.tgz" -C "$root/tdlib-linux"
+    lib="$(find "$root/tdlib-linux" -name libtdjson.so -type f | head -n 1)"
+    test -n "$lib"
+    sudo install -m 0755 "$lib" /usr/local/lib/libtdjson.so
+  else
+    rm -rf "$root/td" "$root/td-build"
+    git clone --depth 1 --branch v1.8.0 https://github.com/tdlib/td.git "$root/td"
+    cmake -S "$root/td" -B "$root/td-build" -DCMAKE_BUILD_TYPE=Release -DTD_ENABLE_JNI=OFF
+    cmake --build "$root/td-build" --target tdjson -j "$(nproc)"
+    sudo cmake --install "$root/td-build"
+  fi
+  sudo ldconfig
+fi
+TELEGRAM_USER_DRIVER_STATE_DIR="$root/user-driver" python3 "$root/user-driver.py" status --json --timeout-ms 60000 >"$root/status.json"
+`;
+}
+
+function renderLaunchDesktop() {
+  return `#!/usr/bin/env bash
+set -euo pipefail
+root=${REMOTE_ROOT}
+export DISPLAY="\${DISPLAY:-:99}"
+pkill -f "$root/Telegram/Telegram" >/dev/null 2>&1 || true
+nohup "$root/Telegram/Telegram" -workdir "$root/desktop" >"$root/telegram-desktop.log" 2>&1 &
+pid=$!
+sleep 8
+if ! kill -0 "$pid" >/dev/null 2>&1; then
+  cat "$root/telegram-desktop.log" >&2
+  exit 1
+fi
+if ! wmctrl -l | grep -i telegram >/dev/null 2>&1; then
+  cat "$root/telegram-desktop.log" >&2
+  exit 1
+fi
+`;
+}
+
+function renderSelectDesktopChat(params: { chatTitle: string }) {
+  return `#!/usr/bin/env bash
+set -euo pipefail
+chat_title=${JSON.stringify(params.chatTitle)}
+export DISPLAY="\${DISPLAY:-:99}"
+win="$(wmctrl -l | awk 'tolower($0) ~ /telegram/ {print $1; exit}')"
+test -n "$win"
+left=520
+top=170
+xdotool windowactivate --sync "$win"
+xdotool windowsize "$win" 980 720
+xdotool windowmove "$win" "$left" "$top"
+sleep 1
+xdotool mousemove "$((left + 180))" "$((top + 50))" click 1
+xdotool key ctrl+a BackSpace
+xdotool type --delay 5 -- "$chat_title"
+sleep 2
+xdotool mousemove "$((left + 150))" "$((top + 120))" click 1
+sleep 1
+`;
+}
+
+function renderRemoteProbe(params: {
+  expect: string[];
+  sutUsername: string;
+  text: string;
+  timeoutMs: number;
+}) {
+  const args = [
+    "probe",
+    "--text",
+    params.text,
+    "--timeout-ms",
+    String(params.timeoutMs),
+    "--output",
+    `${REMOTE_ROOT}/probe.json`,
+    "--json",
+  ];
+  for (const expected of params.expect) {
+    args.push("--expect", expected);
+  }
+  const escapedArgs = args.map((arg) => JSON.stringify(arg)).join(" ");
+  return `#!/usr/bin/env bash
+set -euo pipefail
+root=${REMOTE_ROOT}
+export TELEGRAM_USER_DRIVER_STATE_DIR="$root/user-driver"
+export TELEGRAM_USER_DRIVER_SUT_USERNAME=${JSON.stringify(params.sutUsername)}
+python3 "$root/user-driver.py" ${escapedArgs}
+`;
+}
+
+async function writeExecutable(filePath: string, content: string) {
+  fs.writeFileSync(filePath, content);
+  fs.chmodSync(filePath, 0o700);
+}
+
+async function prepareRemoteState(params: { localRoot: string; opts: Options; root: string }) {
+  const stateArchive = path.join(params.localRoot, "remote-state.tgz");
+  const userDriverScript = expandHome(params.opts.userDriverScript);
+  if (!fs.existsSync(userDriverScript)) {
+    throw new Error(`Missing user driver script: ${params.opts.userDriverScript}`);
+  }
+  await runCommand({
+    command: "cp",
+    args: [userDriverScript, path.join(params.localRoot, "user-driver.py")],
+    cwd: params.root,
+  });
+  await runCommand({
+    command: "tar",
+    args: [
+      "-C",
+      params.localRoot,
+      "-czf",
+      stateArchive,
+      "user-driver",
+      "desktop",
+      "user-driver.py",
+    ],
+    cwd: params.root,
+  });
+  return stateArchive;
+}
+
+async function leaseCredential(params: { localRoot: string; opts: Options; root: string }) {
+  const userDriverDir = path.join(params.localRoot, "user-driver");
+  const desktopWorkdir = path.join(params.localRoot, "desktop");
+  const leaseFile = path.join(params.localRoot, "lease.json");
+  const payloadFile = path.join(params.localRoot, "payload.json");
+  const args = [
+    "scripts/e2e/telegram-user-credential.ts",
+    "lease-restore",
+    "--user-driver-dir",
+    userDriverDir,
+    "--desktop-workdir",
+    desktopWorkdir,
+    "--lease-file",
+    leaseFile,
+    "--payload-output",
+    payloadFile,
+  ];
+  if (params.opts.envFile) {
+    args.push("--env-file", params.opts.envFile);
+  }
+  const result = await runCommand({
+    command: "node",
+    args: ["--import", "tsx", ...args],
+    cwd: params.root,
+    stdio: "inherit",
+  });
+  const acquired = JSON.parse(result.stdout || "{}") as JsonObject;
+  const payload = readJsonFile(payloadFile);
+  return {
+    acquired,
+    desktopWorkdir,
+    groupId: requireString(payload, "groupId"),
+    leaseFile,
+    payloadFile,
+    sutToken: requireString(payload, "sutToken"),
+    testerUserId: requireString(payload, "testerUserId"),
+    testerUsername: requireString(payload, "testerUsername"),
+    userDriverDir,
+  };
+}
+
+async function releaseCredential(root: string, opts: Options, leaseFile: string) {
+  if (!fs.existsSync(leaseFile)) {
+    return;
+  }
+  const args = ["scripts/e2e/telegram-user-credential.ts", "release", "--lease-file", leaseFile];
+  if (opts.envFile) {
+    args.push("--env-file", opts.envFile);
+  }
+  await runCommand({
+    command: "node",
+    args: ["--import", "tsx", ...args],
+    cwd: root,
+    stdio: "inherit",
+  });
+}
+
+async function stopCrabbox(root: string, opts: Options, leaseId: string) {
+  await runCommand({
+    command: opts.crabboxBin,
+    args: ["stop", "--provider", opts.provider, leaseId],
+    cwd: root,
+    stdio: "inherit",
+  });
+}
+
+function buildTargetText(text: string, sutUsername: string) {
+  if (!text.startsWith("/")) {
+    return text.replaceAll("{sut}", sutUsername);
+  }
+  if (/^\/\S+@\w+/u.test(text)) {
+    return text;
+  }
+  const [command, ...rest] = text.split(/\s+/u);
+  return [`${command}@${sutUsername}`, ...rest].join(" ").trim();
+}
+
+function summarizeProbe(probePath: string) {
+  const probe = readJsonFile(probePath);
+  const reply = probe.reply;
+  const sent = probe.sent;
+  return {
+    ok: probe.ok === true,
+    replyMessageId: reply && typeof reply === "object" && "id" in reply ? reply.id : undefined,
+    sentMessageId: sent && typeof sent === "object" && "id" in sent ? sent.id : undefined,
+  };
+}
+
+function writeReport(params: {
+  motionGifPath?: string;
+  motionVideoPath?: string;
+  outputDir: string;
+  screenshotPath?: string;
+  status: "pass" | "fail";
+  summaryPath: string;
+  videoPath?: string;
+}) {
+  const reportPath = path.join(params.outputDir, "telegram-user-crabbox-proof.md");
+  fs.writeFileSync(
+    reportPath,
+    [
+      "# Telegram User Crabbox Proof",
+      "",
+      `Status: ${params.status}`,
+      `Summary: ${path.basename(params.summaryPath)}`,
+      params.videoPath ? `Video: ${path.basename(params.videoPath)}` : "Video: missing",
+      params.motionVideoPath
+        ? `Motion video: ${path.basename(params.motionVideoPath)}`
+        : "Motion video: missing",
+      params.motionGifPath
+        ? `Motion GIF: ${path.basename(params.motionGifPath)}`
+        : "Motion GIF: missing",
+      params.screenshotPath
+        ? `Screenshot: ${path.basename(params.screenshotPath)}`
+        : "Screenshot: missing",
+      "",
+    ].join("\n"),
+  );
+  return reportPath;
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const root = repoRoot();
+  const outputDir = resolveRepoPath(root, opts.outputDir);
+  fs.mkdirSync(outputDir, { recursive: true });
+  opts.outputDir = outputDir;
+
+  const localRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-telegram-crabbox-"));
+  const summary: JsonObject = {
+    artifacts: {},
+    crabbox: { provider: opts.provider, target: opts.target },
+    outputDir,
+    startedAt: new Date().toISOString(),
+    status: "fail",
+  };
+
+  let credential: Awaited<ReturnType<typeof leaseCredential>> | undefined;
+  let leaseId = opts.leaseId;
+  let createdLease = false;
+  let localSut: LocalSut | undefined;
+
+  try {
+    const convexEnvFile = expandHome(opts.envFile ?? DEFAULT_CONVEX_ENV_FILE);
+    const hasConvexEnv =
+      trimToValue(process.env.OPENCLAW_QA_CONVEX_SITE_URL) &&
+      trimToValue(process.env.OPENCLAW_QA_CONVEX_SECRET_CI);
+    if (!hasConvexEnv && !fs.existsSync(convexEnvFile)) {
+      throw new Error(`Missing Convex env file: ${opts.envFile ?? DEFAULT_CONVEX_ENV_FILE}`);
+    }
+    await runCommand({ command: opts.crabboxBin, args: ["--version"], cwd: root });
+    if (opts.dryRun) {
+      summary.status = "pass";
+      summary.plan = {
+        command: "telegram-user-crabbox-proof",
+        outputDir,
+        provider: opts.provider,
+        target: opts.target,
+        tdlibSha256: opts.tdlibSha256,
+        tdlibUrl: opts.tdlibUrl,
+        text: opts.text,
+      };
+      return;
+    }
+
+    credential = await leaseCredential({ localRoot, opts, root });
+    const sut = opts.sutUsername
+      ? { id: "", username: opts.sutUsername }
+      : await sutIdentity(credential.sutToken);
+    const targetText = buildTargetText(opts.text, sut.username);
+    summary.telegram = {
+      groupId: credential.groupId,
+      sutUsername: sut.username,
+      testerUserId: credential.testerUserId,
+      testerUsername: credential.testerUsername,
+      text: targetText,
+    };
+
+    const stateArchive = await prepareRemoteState({
+      localRoot,
+      opts,
+      root,
+    });
+    if (!leaseId) {
+      leaseId = await warmupCrabbox(opts, root);
+      createdLease = true;
+    }
+    summary.crabbox = {
+      createdLease,
+      id: leaseId,
+      provider: opts.provider,
+      target: opts.target,
+    };
+    const inspect = await inspectCrabbox(opts, root, leaseId);
+    summary.crabbox = {
+      createdLease,
+      id: leaseId,
+      provider: opts.provider,
+      slug: inspect.slug,
+      state: inspect.state,
+      target: opts.target,
+    };
+
+    const setupScript = path.join(localRoot, "remote-setup.sh");
+    const launchScript = path.join(localRoot, "launch-desktop.sh");
+    const selectChatScript = path.join(localRoot, "select-desktop-chat.sh");
+    const probeScript = path.join(localRoot, "remote-probe.sh");
+    await writeExecutable(
+      setupScript,
+      renderRemoteSetup({ tdlibSha256: opts.tdlibSha256, tdlibUrl: opts.tdlibUrl }),
+    );
+    await writeExecutable(launchScript, renderLaunchDesktop());
+    await writeExecutable(
+      selectChatScript,
+      renderSelectDesktopChat({ chatTitle: opts.desktopChatTitle }),
+    );
+    await writeExecutable(
+      probeScript,
+      renderRemoteProbe({
+        expect: opts.expect,
+        sutUsername: sut.username,
+        text: targetText,
+        timeoutMs: opts.timeoutMs,
+      }),
+    );
+
+    await sshRun(root, inspect, `rm -rf ${REMOTE_ROOT} && mkdir -p ${REMOTE_ROOT}`);
+    await scpToRemote(root, inspect, stateArchive, `${REMOTE_ROOT}/state.tgz`);
+    await scpToRemote(root, inspect, setupScript, `${REMOTE_ROOT}/remote-setup.sh`);
+    await scpToRemote(root, inspect, launchScript, `${REMOTE_ROOT}/launch-desktop.sh`);
+    await scpToRemote(root, inspect, selectChatScript, `${REMOTE_ROOT}/select-desktop-chat.sh`);
+    await scpToRemote(root, inspect, probeScript, `${REMOTE_ROOT}/remote-probe.sh`);
+    await sshRun(root, inspect, `bash ${REMOTE_ROOT}/remote-setup.sh`);
+
+    const sutRuntime = await startLocalSut({
+      gatewayPort: opts.gatewayPort,
+      groupId: credential.groupId,
+      mockPort: opts.mockPort,
+      outputDir,
+      repoRoot: root,
+      sutToken: credential.sutToken,
+      testerId: credential.testerUserId,
+    });
+    localSut = sutRuntime;
+    summary.localSut = {
+      drained: sutRuntime.drained,
+      gatewayPort: opts.gatewayPort,
+      mockPort: opts.mockPort,
+      requestLog: path.relative(root, sutRuntime.requestLog),
+    };
+
+    await sshRun(root, inspect, `bash ${REMOTE_ROOT}/launch-desktop.sh`);
+    await sshRun(root, inspect, `bash ${REMOTE_ROOT}/select-desktop-chat.sh`);
+    const videoPath = path.join(outputDir, "telegram-user-crabbox-proof.mp4");
+    const recording = spawn(
+      opts.crabboxBin,
+      [
+        "artifacts",
+        "video",
+        "--provider",
+        opts.provider,
+        "--target",
+        opts.target,
+        "--id",
+        leaseId,
+        "--duration",
+        `${opts.recordSeconds}s`,
+        "--output",
+        videoPath,
+      ],
+      { cwd: root, stdio: "inherit" },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 3_000));
+    await sshRun(root, inspect, `bash ${REMOTE_ROOT}/remote-probe.sh`);
+    const recordCode = await new Promise<number | null>((resolve) => recording.on("exit", resolve));
+    if (recordCode !== 0) {
+      throw new Error(`Crabbox recording failed with exit code ${recordCode ?? "unknown"}.`);
+    }
+    const motionVideoPath = path.join(outputDir, "telegram-user-crabbox-proof-motion.mp4");
+    const motionGifPath = path.join(outputDir, "telegram-user-crabbox-proof-motion.gif");
+    const preview = await runCommand({
+      command: opts.crabboxBin,
+      args: [
+        "media",
+        "preview",
+        "--input",
+        videoPath,
+        "--output",
+        motionGifPath,
+        "--trimmed-video-output",
+        motionVideoPath,
+        "--json",
+      ],
+      cwd: root,
+      stdio: "inherit",
+    });
+    summary.mediaPreview = JSON.parse(preview.stdout) as JsonObject;
+
+    const screenshotPath = path.join(outputDir, "telegram-user-crabbox-proof.png");
+    await runCommand({
+      command: opts.crabboxBin,
+      args: [
+        "screenshot",
+        "--provider",
+        opts.provider,
+        "--target",
+        opts.target,
+        "--id",
+        leaseId,
+        "--output",
+        screenshotPath,
+      ],
+      cwd: root,
+      stdio: "inherit",
+    });
+    const probePath = path.join(outputDir, "probe.json");
+    const statusPath = path.join(outputDir, "status.json");
+    const desktopLogPath = path.join(outputDir, "telegram-desktop.log");
+    await scpFromRemote(root, inspect, `${REMOTE_ROOT}/probe.json`, probePath);
+    await scpFromRemote(root, inspect, `${REMOTE_ROOT}/status.json`, statusPath);
+    await scpFromRemote(root, inspect, `${REMOTE_ROOT}/telegram-desktop.log`, desktopLogPath);
+    summary.artifacts = {
+      desktopLog: path.relative(root, desktopLogPath),
+      probe: path.relative(root, probePath),
+      previewGif: path.relative(root, motionGifPath),
+      screenshot: path.relative(root, screenshotPath),
+      status: path.relative(root, statusPath),
+      trimmedVideo: path.relative(root, motionVideoPath),
+      video: path.relative(root, videoPath),
+    };
+    summary.probe = summarizeProbe(probePath);
+    summary.status = "pass";
+  } finally {
+    killTree(localSut?.gateway);
+    killTree(localSut?.mock);
+    if (credential) {
+      await releaseCredential(root, opts, credential.leaseFile).catch((error: unknown) => {
+        summary.credentialReleaseError = error instanceof Error ? error.message : String(error);
+      });
+    }
+    if (leaseId && createdLease && !opts.keepBox) {
+      await stopCrabbox(root, opts, leaseId).catch((error: unknown) => {
+        summary.crabboxStopError = error instanceof Error ? error.message : String(error);
+      });
+    }
+    if (opts.keepBox && leaseId) {
+      summary.keepBox = true;
+      summary.webvnc = `${opts.crabboxBin} webvnc --provider ${opts.provider} --target ${opts.target} --id ${leaseId} --open`;
+    }
+    summary.finishedAt = new Date().toISOString();
+    const summaryPath = path.join(outputDir, "telegram-user-crabbox-proof-summary.json");
+    fs.writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+    const artifacts = summary.artifacts;
+    const screenshotPath =
+      artifacts &&
+      typeof artifacts === "object" &&
+      "screenshot" in artifacts &&
+      typeof artifacts.screenshot === "string"
+        ? path.join(root, artifacts.screenshot)
+        : undefined;
+    const motionGifPath =
+      artifacts &&
+      typeof artifacts === "object" &&
+      "previewGif" in artifacts &&
+      typeof artifacts.previewGif === "string"
+        ? path.join(root, artifacts.previewGif)
+        : undefined;
+    const motionVideoPath =
+      artifacts &&
+      typeof artifacts === "object" &&
+      "trimmedVideo" in artifacts &&
+      typeof artifacts.trimmedVideo === "string"
+        ? path.join(root, artifacts.trimmedVideo)
+        : undefined;
+    const videoPath =
+      artifacts &&
+      typeof artifacts === "object" &&
+      "video" in artifacts &&
+      typeof artifacts.video === "string"
+        ? path.join(root, artifacts.video)
+        : undefined;
+    const reportPath = writeReport({
+      motionGifPath,
+      motionVideoPath,
+      outputDir,
+      screenshotPath,
+      status: summary.status === "pass" ? "pass" : "fail",
+      summaryPath,
+      videoPath,
+    });
+    summary.report = path.relative(root, reportPath);
+    fs.writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+    fs.rmSync(localRoot, { force: true, recursive: true });
+    console.log(JSON.stringify({ outputDir, reportPath, status: summary.status }, null, 2));
+  }
+
+  if (summary.status !== "pass") {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/e2e/telegram-user-credential.ts
+++ b/scripts/e2e/telegram-user-credential.ts
@@ -1,0 +1,618 @@
+#!/usr/bin/env -S node --import tsx
+
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { chmod, copyFile, mkdir, readFile, rm, unlink, writeFile } from "node:fs/promises";
+
+type JsonObject = Record<string, unknown>;
+
+const DEFAULT_USER_DRIVER_DIR = "~/.codex/skills/custom/telegram-e2e-bot-to-bot/user-driver";
+const DEFAULT_BOT_CREDENTIALS_FILE =
+  "~/.codex/skills/custom/telegram-e2e-bot-to-bot/credentials.local.json";
+const DEFAULT_CONVEX_ENV_FILE = "~/.codex/skills/custom/telegram-e2e-bot-to-bot/convex.local.env";
+const TELEGRAM_USER_KIND = "telegram-user";
+const CHUNKED_PAYLOAD_MARKER = "__openclawQaCredentialPayloadChunksV1";
+
+function usage(): never {
+  throw new Error(
+    [
+      "Usage:",
+      "  node --import tsx scripts/e2e/telegram-user-credential.ts export (--desktop-tdata-dir <path> | --desktop-tdata-archive <tdata.tgz>) --output <payload.json>",
+      "  node --import tsx scripts/e2e/telegram-user-credential.ts restore --payload-file <payload.json> --user-driver-dir <path> --desktop-workdir <path>",
+      "  node --import tsx scripts/e2e/telegram-user-credential.ts lease-restore --user-driver-dir <path> --desktop-workdir <path> --lease-file <lease.json> [--payload-output <payload.json>] [--env-file <path>]",
+      "  node --import tsx scripts/e2e/telegram-user-credential.ts release --lease-file <lease.json> [--env-file <path>]",
+    ].join("\n"),
+  );
+}
+
+function printUsage() {
+  console.log(
+    [
+      "Usage:",
+      "  node --import tsx scripts/e2e/telegram-user-credential.ts export (--desktop-tdata-dir <path> | --desktop-tdata-archive <tdata.tgz>) --output <payload.json>",
+      "  node --import tsx scripts/e2e/telegram-user-credential.ts restore --payload-file <payload.json> --user-driver-dir <path> --desktop-workdir <path>",
+      "  node --import tsx scripts/e2e/telegram-user-credential.ts lease-restore --user-driver-dir <path> --desktop-workdir <path> --lease-file <lease.json> [--payload-output <payload.json>] [--env-file <path>]",
+      "  node --import tsx scripts/e2e/telegram-user-credential.ts release --lease-file <lease.json> [--env-file <path>]",
+    ].join("\n"),
+  );
+}
+
+function expandHome(path: string) {
+  if (path === "~") {
+    return process.env.HOME || path;
+  }
+  if (path.startsWith("~/")) {
+    return `${process.env.HOME || "~"}${path.slice(1)}`;
+  }
+  return path;
+}
+
+function parseArgs(argv: string[]) {
+  const args = argv.slice(2);
+  const command = args[0] || usage();
+  if (command === "--help" || command === "-h") {
+    printUsage();
+    process.exit(0);
+  }
+  const opts = new Map<string, string>();
+  for (let index = 1; index < args.length; index += 1) {
+    if (args[index] === "--") {
+      continue;
+    }
+    const key = args[index];
+    if (!key.startsWith("--")) {
+      usage();
+    }
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) {
+      usage();
+    }
+    opts.set(key.slice(2), value);
+    index += 1;
+  }
+  return { command, opts };
+}
+
+async function readJson(path: string): Promise<JsonObject> {
+  try {
+    return JSON.parse(await readFile(expandHome(path), "utf8")) as JsonObject;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return {};
+    }
+    throw error;
+  }
+}
+
+function fileExists(path: string) {
+  return readFile(expandHome(path))
+    .then(() => true)
+    .catch((error: unknown) => {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+        return false;
+      }
+      throw error;
+    });
+}
+
+async function readEnvFile(path: string) {
+  if (!(await fileExists(path))) {
+    return {};
+  }
+  const env: Record<string, string> = {};
+  const text = await readFile(expandHome(path), "utf8");
+  for (const line of text.split(/\r?\n/u)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    const separator = trimmed.indexOf("=");
+    if (separator < 1) {
+      throw new Error(`Invalid env line in ${path}.`);
+    }
+    const key = trimmed.slice(0, separator).trim();
+    const value = trimmed
+      .slice(separator + 1)
+      .trim()
+      .replace(/^['"]|['"]$/gu, "");
+    env[key] = value;
+  }
+  return env;
+}
+
+function requireString(source: JsonObject, key: string) {
+  const value = source[key];
+  if (typeof value === "number") {
+    return String(value);
+  }
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  throw new Error(`Missing ${key}.`);
+}
+
+function optionalString(source: JsonObject, key: string) {
+  const value = source[key];
+  if (typeof value === "number") {
+    return String(value);
+  }
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  return undefined;
+}
+
+function optionalPositiveInteger(value: string | undefined, fallback: number) {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`Expected positive integer, got ${value}.`);
+  }
+  return parsed;
+}
+
+async function fileSha256(path: string) {
+  return createHash("sha256")
+    .update(await readFile(path))
+    .digest("hex");
+}
+
+async function tgzBase64(path: string) {
+  return (await readFile(path)).toString("base64");
+}
+
+async function writePrivateJson(path: string, payload: JsonObject) {
+  const expanded = expandHome(path);
+  await mkdir(expanded.substring(0, expanded.lastIndexOf("/")), { recursive: true });
+  await writeFile(expanded, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 });
+  await chmodPrivate(expanded);
+}
+
+async function chmodPrivate(path: string) {
+  await chmod(path, 0o600);
+}
+
+function runCommand(command: string, args: string[], cwd?: string) {
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      const detail = signal ? `signal ${signal}` : `exit code ${code ?? "unknown"}`;
+      reject(new Error(`${command} ${args.join(" ")} failed with ${detail}\n${stdout}${stderr}`));
+    });
+  });
+}
+
+function joinBrokerEndpoint(siteUrl: string, endpoint: string) {
+  const normalized = siteUrl.replace(/\/+$/u, "");
+  return `${normalized}/qa-credentials/v1/${endpoint}`;
+}
+
+function assertBrokerSuccess(payload: JsonObject, action: string) {
+  if (payload.status === "error") {
+    throw new Error(
+      `${action} failed: ${requireString(payload, "code")} ${optionalString(payload, "message") || ""}`.trim(),
+    );
+  }
+  if (payload.status !== "ok") {
+    throw new Error(`${action} returned an invalid response.`);
+  }
+}
+
+async function postBroker(params: {
+  action: string;
+  body: JsonObject;
+  siteUrl: string;
+  token: string;
+}) {
+  const response = await fetch(joinBrokerEndpoint(params.siteUrl, params.action), {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${params.token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(params.body),
+  });
+  const payload = (await response.json()) as JsonObject;
+  if (!response.ok) {
+    assertBrokerSuccess(payload, params.action);
+    throw new Error(`${params.action} failed with HTTP ${response.status}.`);
+  }
+  assertBrokerSuccess(payload, params.action);
+  return payload;
+}
+
+async function resolveConvexLeaseConfig(opts: Map<string, string>) {
+  const envFile = opts.get("env-file") || DEFAULT_CONVEX_ENV_FILE;
+  const fileEnv = await readEnvFile(envFile);
+  const siteUrl =
+    opts.get("site-url") ||
+    process.env.OPENCLAW_QA_CONVEX_SITE_URL?.trim() ||
+    fileEnv.OPENCLAW_QA_CONVEX_SITE_URL;
+  const token =
+    opts.get("ci-secret") ||
+    process.env.OPENCLAW_QA_CONVEX_SECRET_CI?.trim() ||
+    fileEnv.OPENCLAW_QA_CONVEX_SECRET_CI;
+  if (!siteUrl) {
+    throw new Error("Missing OPENCLAW_QA_CONVEX_SITE_URL.");
+  }
+  if (!token) {
+    throw new Error("Missing OPENCLAW_QA_CONVEX_SECRET_CI.");
+  }
+  return {
+    siteUrl,
+    token,
+    leaseTtlMs: optionalPositiveInteger(
+      opts.get("lease-ttl-ms") ||
+        process.env.OPENCLAW_QA_CREDENTIAL_LEASE_TTL_MS?.trim() ||
+        fileEnv.OPENCLAW_QA_CREDENTIAL_LEASE_TTL_MS,
+      20 * 60 * 1_000,
+    ),
+    heartbeatIntervalMs: optionalPositiveInteger(
+      opts.get("heartbeat-interval-ms") ||
+        process.env.OPENCLAW_QA_CREDENTIAL_HEARTBEAT_INTERVAL_MS?.trim() ||
+        fileEnv.OPENCLAW_QA_CREDENTIAL_HEARTBEAT_INTERVAL_MS,
+      30_000,
+    ),
+    ownerId:
+      opts.get("owner-id") ||
+      process.env.OPENCLAW_QA_CREDENTIAL_OWNER_ID?.trim() ||
+      `telegram-user-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`,
+  };
+}
+
+function parseChunkedPayloadMarker(payload: unknown) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+  const record = payload as Record<string, unknown>;
+  if (record[CHUNKED_PAYLOAD_MARKER] !== true) {
+    return null;
+  }
+  if (
+    typeof record.chunkCount !== "number" ||
+    !Number.isInteger(record.chunkCount) ||
+    record.chunkCount < 1
+  ) {
+    throw new Error("Chunked payload marker has invalid chunkCount.");
+  }
+  if (
+    typeof record.byteLength !== "number" ||
+    !Number.isInteger(record.byteLength) ||
+    record.byteLength < 0
+  ) {
+    throw new Error("Chunked payload marker has invalid byteLength.");
+  }
+  return {
+    chunkCount: record.chunkCount,
+    byteLength: record.byteLength,
+  };
+}
+
+async function hydratePayloadFromLease(params: {
+  acquired: JsonObject;
+  ownerId: string;
+  siteUrl: string;
+  token: string;
+}) {
+  const marker = parseChunkedPayloadMarker(params.acquired.payload);
+  if (!marker) {
+    return params.acquired.payload as JsonObject;
+  }
+  const credentialId = requireString(params.acquired, "credentialId");
+  const leaseToken = requireString(params.acquired, "leaseToken");
+  const chunks: string[] = [];
+  for (let index = 0; index < marker.chunkCount; index += 1) {
+    const chunk = await postBroker({
+      action: "payload-chunk",
+      siteUrl: params.siteUrl,
+      token: params.token,
+      body: {
+        kind: TELEGRAM_USER_KIND,
+        ownerId: params.ownerId,
+        actorRole: "ci",
+        credentialId,
+        leaseToken,
+        index,
+      },
+    });
+    chunks.push(requireString(chunk, "data"));
+  }
+  const serialized = chunks.join("");
+  if (serialized.length !== marker.byteLength) {
+    throw new Error("Chunked payload length mismatch.");
+  }
+  return JSON.parse(serialized) as JsonObject;
+}
+
+async function createTelegramUserPayload(opts: Map<string, string>) {
+  const userDriverDir = expandHome(opts.get("user-driver-dir") || DEFAULT_USER_DRIVER_DIR);
+  const botCredentialsFile = expandHome(
+    opts.get("bot-credentials-file") || DEFAULT_BOT_CREDENTIALS_FILE,
+  );
+  const desktopTdataDir = opts.get("desktop-tdata-dir");
+  const desktopTdataArchiveInput = opts.get("desktop-tdata-archive");
+  const output = opts.get("output");
+  if (
+    (!desktopTdataDir && !desktopTdataArchiveInput) ||
+    (desktopTdataDir && desktopTdataArchiveInput) ||
+    !output
+  ) {
+    usage();
+  }
+
+  const config = await readJson(`${userDriverDir}/config.local.json`);
+  const botCredentials = await readJson(botCredentialsFile);
+  const sutToken =
+    process.env.OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN?.trim() ||
+    process.env.TELEGRAM_E2E_SUT_BOT_TOKEN?.trim() ||
+    (typeof botCredentials.sutBotToken === "string" ? botCredentials.sutBotToken.trim() : "") ||
+    (typeof botCredentials.botAToken === "string" ? botCredentials.botAToken.trim() : "") ||
+    (typeof botCredentials.BOTA === "string" ? botCredentials.BOTA.trim() : "");
+  if (!sutToken) {
+    throw new Error("Missing SUT token in env or bot credentials file.");
+  }
+
+  const groupId =
+    process.env.OPENCLAW_QA_TELEGRAM_GROUP_ID?.trim() ||
+    process.env.TELEGRAM_E2E_GROUP_ID?.trim() ||
+    (typeof config.defaultChatId === "string" ? config.defaultChatId.trim() : "") ||
+    (typeof botCredentials.groupId === "string" ? botCredentials.groupId.trim() : "");
+  if (!groupId) {
+    throw new Error("Missing group id in env, user-driver config, or bot credentials file.");
+  }
+
+  const tempRoot = `/tmp/openclaw-telegram-user-credential-${Date.now()}-${Math.random()
+    .toString(16)
+    .slice(2)}`;
+  const tdlibArchive = `${tempRoot}/tdlib.tgz`;
+  const desktopArchive = `${tempRoot}/desktop-tdata.tgz`;
+  await mkdir(tempRoot, { recursive: true });
+  try {
+    await runCommand("tar", ["-C", userDriverDir, "-czf", tdlibArchive, "db", "files"]);
+    if (desktopTdataArchiveInput) {
+      await copyFile(expandHome(desktopTdataArchiveInput), desktopArchive);
+    } else {
+      await runCommand("tar", [
+        "-C",
+        `${expandHome(desktopTdataDir!)}/..`,
+        "--exclude",
+        "tdata/countries",
+        "--exclude",
+        "tdata/dictionaries",
+        "--exclude",
+        "tdata/dumps",
+        "--exclude",
+        "tdata/emoji",
+        "--exclude",
+        "tdata/user_data",
+        "--exclude",
+        "tdata/working",
+        "-czf",
+        desktopArchive,
+        "tdata",
+      ]);
+    }
+
+    await writePrivateJson(output, {
+      groupId,
+      sutToken,
+      testerUserId: requireString(config, "testerUserId"),
+      testerUsername: requireString(config, "testerUsername"),
+      telegramApiId: requireString(config, "apiId"),
+      telegramApiHash: requireString(config, "apiHash"),
+      tdlibDatabaseEncryptionKey: requireString(config, "databaseEncryptionKey"),
+      tdlibArchiveBase64: await tgzBase64(tdlibArchive),
+      tdlibArchiveSha256: await fileSha256(tdlibArchive),
+      desktopTdataArchiveBase64: await tgzBase64(desktopArchive),
+      desktopTdataArchiveSha256: await fileSha256(desktopArchive),
+    });
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+}
+
+async function restoreTelegramUserPayloadFromFile(opts: Map<string, string>) {
+  const payloadFile = opts.get("payload-file");
+  if (!payloadFile) {
+    usage();
+  }
+  await restoreTelegramUserPayload({
+    payload: await readJson(payloadFile),
+    userDriverDir: opts.get("user-driver-dir"),
+    desktopWorkdir: opts.get("desktop-workdir"),
+  });
+}
+
+async function restoreTelegramUserPayload(params: {
+  payload: JsonObject;
+  userDriverDir: string | undefined;
+  desktopWorkdir: string | undefined;
+}) {
+  const userDriverDir = params.userDriverDir;
+  const desktopWorkdir = params.desktopWorkdir;
+  if (!userDriverDir || !desktopWorkdir) {
+    usage();
+  }
+  const payload = params.payload;
+  const tempRoot = `/tmp/openclaw-telegram-user-restore-${Date.now()}-${Math.random()
+    .toString(16)
+    .slice(2)}`;
+  const tdlibArchive = `${tempRoot}/tdlib.tgz`;
+  const desktopArchive = `${tempRoot}/desktop-tdata.tgz`;
+  await mkdir(tempRoot, { recursive: true });
+  await mkdir(expandHome(userDriverDir), { recursive: true });
+  await mkdir(expandHome(desktopWorkdir), { recursive: true });
+  try {
+    await writeFile(
+      tdlibArchive,
+      Buffer.from(requireString(payload, "tdlibArchiveBase64"), "base64"),
+    );
+    await writeFile(
+      desktopArchive,
+      Buffer.from(requireString(payload, "desktopTdataArchiveBase64"), "base64"),
+    );
+    if ((await fileSha256(tdlibArchive)) !== requireString(payload, "tdlibArchiveSha256")) {
+      throw new Error("TDLib archive SHA-256 mismatch.");
+    }
+    if (
+      (await fileSha256(desktopArchive)) !== requireString(payload, "desktopTdataArchiveSha256")
+    ) {
+      throw new Error("Telegram Desktop archive SHA-256 mismatch.");
+    }
+
+    await runCommand("tar", ["-C", expandHome(userDriverDir), "-xzf", tdlibArchive]);
+    await runCommand("tar", ["-C", expandHome(desktopWorkdir), "-xzf", desktopArchive]);
+    await writePrivateJson(`${expandHome(userDriverDir)}/config.local.json`, {
+      apiId: Number(requireString(payload, "telegramApiId")),
+      apiHash: requireString(payload, "telegramApiHash"),
+      databaseEncryptionKey: requireString(payload, "tdlibDatabaseEncryptionKey"),
+      defaultChatId: requireString(payload, "groupId"),
+      testerUserId: Number(requireString(payload, "testerUserId")),
+      testerUsername: requireString(payload, "testerUsername"),
+    });
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+}
+
+async function leaseAndRestoreTelegramUser(opts: Map<string, string>) {
+  const userDriverDir = opts.get("user-driver-dir");
+  const desktopWorkdir = opts.get("desktop-workdir");
+  const leaseFile = opts.get("lease-file");
+  const payloadOutput = opts.get("payload-output");
+  if (!userDriverDir || !desktopWorkdir || !leaseFile) {
+    usage();
+  }
+  const config = await resolveConvexLeaseConfig(opts);
+  const acquired = await postBroker({
+    action: "acquire",
+    siteUrl: config.siteUrl,
+    token: config.token,
+    body: {
+      kind: TELEGRAM_USER_KIND,
+      ownerId: config.ownerId,
+      actorRole: "ci",
+      leaseTtlMs: config.leaseTtlMs,
+      heartbeatIntervalMs: config.heartbeatIntervalMs,
+    },
+  });
+  const lease = {
+    siteUrl: config.siteUrl,
+    kind: TELEGRAM_USER_KIND,
+    ownerId: config.ownerId,
+    actorRole: "ci",
+    credentialId: requireString(acquired, "credentialId"),
+    leaseToken: requireString(acquired, "leaseToken"),
+  };
+
+  try {
+    const payload = await hydratePayloadFromLease({
+      acquired,
+      siteUrl: config.siteUrl,
+      token: config.token,
+      ownerId: config.ownerId,
+    });
+    await restoreTelegramUserPayload({ payload, userDriverDir, desktopWorkdir });
+    await writePrivateJson(leaseFile, lease);
+    if (payloadOutput) {
+      await writePrivateJson(payloadOutput, payload);
+    }
+    console.log(
+      JSON.stringify(
+        {
+          status: "ok",
+          credentialId: lease.credentialId,
+          ownerId: lease.ownerId,
+          leaseFile,
+          userDriverDir,
+          desktopWorkdir,
+          testerUserId: requireString(payload, "testerUserId"),
+          testerUsername: requireString(payload, "testerUsername"),
+          groupId: requireString(payload, "groupId"),
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    await releaseTelegramUserLeaseBody({
+      siteUrl: lease.siteUrl,
+      token: config.token,
+      lease,
+    });
+    throw error;
+  }
+}
+
+async function releaseTelegramUserLeaseBody(params: {
+  siteUrl: string;
+  token: string;
+  lease: JsonObject;
+}) {
+  return postBroker({
+    action: "release",
+    siteUrl: params.siteUrl,
+    token: params.token,
+    body: {
+      kind: requireString(params.lease, "kind"),
+      ownerId: requireString(params.lease, "ownerId"),
+      actorRole: requireString(params.lease, "actorRole"),
+      credentialId: requireString(params.lease, "credentialId"),
+      leaseToken: requireString(params.lease, "leaseToken"),
+    },
+  });
+}
+
+async function releaseTelegramUserLease(opts: Map<string, string>) {
+  const leaseFile = opts.get("lease-file");
+  if (!leaseFile) {
+    usage();
+  }
+  const config = await resolveConvexLeaseConfig(opts);
+  const lease = await readJson(leaseFile);
+  await releaseTelegramUserLeaseBody({
+    siteUrl: config.siteUrl,
+    token: config.token,
+    lease,
+  });
+  await unlink(expandHome(leaseFile)).catch((error: unknown) => {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  });
+  console.log(
+    JSON.stringify({ status: "ok", credentialId: requireString(lease, "credentialId") }, null, 2),
+  );
+}
+
+const { command, opts } = parseArgs(process.argv);
+if (command === "export") {
+  await createTelegramUserPayload(opts);
+} else if (command === "restore") {
+  await restoreTelegramUserPayloadFromFile(opts);
+} else if (command === "lease-restore") {
+  await leaseAndRestoreTelegramUser(opts);
+} else if (command === "release") {
+  await releaseTelegramUserLease(opts);
+} else {
+  usage();
+}

--- a/test/qa-convex-credential-payload-validation.test.ts
+++ b/test/qa-convex-credential-payload-validation.test.ts
@@ -69,6 +69,68 @@ describe("QA Convex credential payload validation", () => {
     expect(normalizeCredentialPayloadForKind("future-kind", payload)).toBe(payload);
   });
 
+  it("normalizes Telegram user credential payloads", () => {
+    const sha256 = "a".repeat(64);
+
+    expect(
+      normalizeCredentialPayloadForKind("telegram-user", {
+        groupId: " -100123 ",
+        sutToken: " sut-token ",
+        testerUserId: " 8709353529 ",
+        testerUsername: " OpenClawTestUser ",
+        telegramApiId: " 123456 ",
+        telegramApiHash: " api-hash ",
+        tdlibDatabaseEncryptionKey: " db-key ",
+        tdlibArchiveBase64: " tdlib-archive ",
+        tdlibArchiveSha256: sha256.toUpperCase(),
+        desktopTdataArchiveBase64: " desktop-archive ",
+        desktopTdataArchiveSha256: sha256,
+        ignored: true,
+      }),
+    ).toEqual({
+      groupId: "-100123",
+      sutToken: "sut-token",
+      testerUserId: "8709353529",
+      testerUsername: "OpenClawTestUser",
+      telegramApiId: "123456",
+      telegramApiHash: "api-hash",
+      tdlibDatabaseEncryptionKey: "db-key",
+      tdlibArchiveBase64: "tdlib-archive",
+      tdlibArchiveSha256: sha256,
+      desktopTdataArchiveBase64: "desktop-archive",
+      desktopTdataArchiveSha256: sha256,
+    });
+  });
+
+  it("rejects malformed Telegram user credential payloads", () => {
+    const validPayload = {
+      groupId: "-100123",
+      sutToken: "sut-token",
+      testerUserId: "8709353529",
+      testerUsername: "OpenClawTestUser",
+      telegramApiId: "123456",
+      telegramApiHash: "api-hash",
+      tdlibDatabaseEncryptionKey: "db-key",
+      tdlibArchiveBase64: "tdlib-archive",
+      tdlibArchiveSha256: "a".repeat(64),
+      desktopTdataArchiveBase64: "desktop-archive",
+      desktopTdataArchiveSha256: "b".repeat(64),
+    };
+
+    expect(() =>
+      normalizeCredentialPayloadForKind("telegram-user", {
+        ...validPayload,
+        testerUserId: "tester",
+      }),
+    ).toThrow(/testerUserId/u);
+    expect(() =>
+      normalizeCredentialPayloadForKind("telegram-user", {
+        ...validPayload,
+        tdlibArchiveSha256: "not-sha",
+      }),
+    ).toThrow(/tdlibArchiveSha256/u);
+  });
+
   it("normalizes WhatsApp credential payloads", () => {
     expect(
       normalizeCredentialPayloadForKind("whatsapp", {


### PR DESCRIPTION
## Summary
- add a Convex `telegram-user` credential shape with chunked payload leasing for TDLib and Telegram Desktop session archives
- add a Node/tsx Crabbox proof runner that can either run a quick one-shot probe or hold an exclusive agent-driven session across multiple commands
- document the real-user Telegram proof path, shared broker contract, and repo skill for PR-review agents

## Real behavior proof
Behavior or issue addressed: real Telegram user can lease the shared `telegram-user` credential, restore both TDLib and Telegram Desktop on Linux Crabbox, keep that lease alive across multiple agent-driven test actions, send `/status@foremanclawbot`, and observe the SUT reply before one final cleanup.

Real environment tested: OpenClaw checkout `69716b0` on Crabbox AWS Linux desktop `cbx_5625e45d8efb`; QA tester account `OpenClawTestUser`; SUT bot `foremanclawbot`; R2 TDLib archive `http://artifacts.openclaw.ai/tdlib-v1.8.0-linux-x64.tgz`.

Exact steps or command run after this patch:
1. `pnpm qa:telegram-user:crabbox -- start --tdlib-url http://artifacts.openclaw.ai/tdlib-v1.8.0-linux-x64.tgz --output-dir .artifacts/qa-e2e/telegram-user-crabbox/session-proof`
2. `pnpm qa:telegram-user:crabbox -- send --session .artifacts/qa-e2e/telegram-user-crabbox/session-proof/session.json --text /status`
3. `pnpm qa:telegram-user:crabbox -- run --session .artifacts/qa-e2e/telegram-user-crabbox/session-proof/session.json -- bash -lc 'source /tmp/openclaw-telegram-user-crabbox/env.sh && python3 /tmp/openclaw-telegram-user-crabbox/user-driver.py transcript --limit 5 --json'`
4. `pnpm qa:telegram-user:crabbox -- screenshot --session .artifacts/qa-e2e/telegram-user-crabbox/session-proof/session.json`
5. `pnpm qa:telegram-user:crabbox -- finish --session .artifacts/qa-e2e/telegram-user-crabbox/session-proof/session.json`

Evidence after fix: terminal output excerpt from the held Crabbox session showed `/tmp/openclaw-telegram-user-crabbox/tdlib-linux.tgz: OK`, `session: .artifacts/qa-e2e/telegram-user-crabbox/session-proof/session.json`, WebVNC command for `cbx_5625e45d8efb`, sent `/status@foremanclawbot` as Telegram user id `8709353529`, observed reply message id `6491734016` from SUT bot id `8098866274`, saved remote transcript output to `.artifacts/qa-e2e/telegram-user-crabbox/session-proof/remote-command-2026-05-10T09-18-47-939Z.log`, captured screenshot `.artifacts/qa-e2e/telegram-user-crabbox/session-proof/telegram-user-crabbox-2026-05-10T09-18-53-051Z.png`, then wrote final video artifacts under `.artifacts/qa-e2e/telegram-user-crabbox/session-proof/telegram-user-crabbox-session.{mp4,png}` and motion artifacts under `telegram-user-crabbox-session-motion.{mp4,gif}`.

Observed result after fix: The SUT replied with `OpenClaw 2026.5.10-beta.1 (69716b0)` status text. The session stayed alive across `start`, `send`, arbitrary remote `run`, and `screenshot`; `finish` produced a `45.467s` source recording, a `1.633s` motion-trim preview, released Convex credential `jd73nkdt73snbtwcfhy32tegdx86e8av`, and Crabbox printed `released lease=cbx_5625e45d8efb`.

Not tested: This PR does not yet upload the recording to a GitHub comment or add a scenario DSL for arbitrary Telegram bug reproduction.

## Additional checks
- `pnpm test test/qa-convex-credential-payload-validation.test.ts extensions/qa-lab/src/live-transports/shared/credential-lease.runtime.test.ts extensions/qa-lab/src/live-transports/telegram/telegram-user-credential.runtime.test.ts`
- `pnpm exec tsgo --ignoreConfig --noEmit --skipLibCheck --target ES2022 --module NodeNext --moduleResolution NodeNext --types node scripts/e2e/telegram-user-crabbox-proof.ts scripts/e2e/telegram-user-credential.ts`
- `pnpm qa:telegram-user:crabbox -- start --dry-run --tdlib-url http://artifacts.openclaw.ai/tdlib-v1.8.0-linux-x64.tgz --output-dir .artifacts/qa-e2e/telegram-user-crabbox/session-dry-run-2`
- `git diff --check`

