### PR TITLE
fix(runtime): detect Fly Machines as containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - CI: add a non-blocking `plugin-inspector-advisory` artifact to Plugin Prerelease so release runs capture bundled plugin compatibility triage without changing the blocking gate.
+- Runtime/Fly: detect Fly Machines as container environments from their runtime env vars, so gateway bind and Bonjour defaults match remote container launches. (#80209) Thanks @liorb-mountapps.
 - Providers/fal: route GPT Image 2 and Nano Banana 2 reference-image edit requests to `/edit` with `image_urls` array, enforce NB2 edit geometry using `aspect_ratio` and `resolution` params, lift Fal edit mode input-image caps to 10 for GPT Image 2 and 14 for Nano Banana 2, and allow aspect-ratio hints in edit mode. (#77295) Thanks @leoge007.
 
 - Build: enable additional low-churn oxlint rules for promise, TypeScript, and runtime footgun checks.

--- a/extensions/bonjour/src/advertiser.test.ts
+++ b/extensions/bonjour/src/advertiser.test.ts
@@ -250,6 +250,22 @@ describe("gateway bonjour advertiser", () => {
     await expect(started.stop()).resolves.toBeUndefined();
   });
 
+  it("auto-disables Bonjour on Fly Machines without Docker sentinel files", async () => {
+    enableAdvertiserUnitMode();
+    process.env.FLY_MACHINE_ID = "3d8d5459a03038";
+    process.env.FLY_APP_NAME = "openclaw-clawcks-test";
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    vi.spyOn(fs, "readFileSync").mockReturnValue("10:cpuset:/\n9:perf_event:/\n8:memory:/\n0::/\n");
+
+    const started = await startAdvertiser({
+      gatewayPort: 18789,
+      sshPort: 2222,
+    });
+
+    expect(createService).not.toHaveBeenCalled();
+    await expect(started.stop()).resolves.toBeUndefined();
+  });
+
   it("honors explicit Bonjour opt-in inside detected containers", async () => {
     enableAdvertiserUnitMode();
     process.env.OPENCLAW_DISABLE_BONJOUR = "0";

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -135,6 +135,10 @@ function readBonjourDisableOverride(): boolean | null {
 }
 
 function isContainerEnvironment() {
+  if (process.env.FLY_MACHINE_ID?.trim() && process.env.FLY_APP_NAME?.trim()) {
+    return true;
+  }
+
   for (const sentinelPath of ["/.dockerenv", "/run/.containerenv", "/var/run/.containerenv"]) {
     try {
       if (fs.existsSync(sentinelPath)) {

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -515,6 +515,33 @@ describe("isContainerEnvironment", () => {
     expect(isContainerEnvironment()).toBe(true);
   });
 
+  it("returns true on Fly Machines without Docker sentinel files", () => {
+    const previousFlyMachineId = process.env.FLY_MACHINE_ID;
+    const previousFlyAppName = process.env.FLY_APP_NAME;
+    const fs = require("node:fs");
+    vi.spyOn(fs, "accessSync").mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    vi.spyOn(fs, "readFileSync").mockReturnValue("10:cpuset:/\n9:perf_event:/\n8:memory:/\n0::/\n");
+
+    try {
+      process.env.FLY_MACHINE_ID = "3d8d5459a03038";
+      process.env.FLY_APP_NAME = "openclaw-clawcks-test";
+      expect(isContainerEnvironment()).toBe(true);
+    } finally {
+      if (previousFlyMachineId === undefined) {
+        delete process.env.FLY_MACHINE_ID;
+      } else {
+        process.env.FLY_MACHINE_ID = previousFlyMachineId;
+      }
+      if (previousFlyAppName === undefined) {
+        delete process.env.FLY_APP_NAME;
+      } else {
+        process.env.FLY_APP_NAME = previousFlyAppName;
+      }
+    }
+  });
+
   it("returns true when /proc/1/cgroup contains docker marker", () => {
     const fs = require("node:fs");
     vi.spyOn(fs, "accessSync").mockImplementation(() => {

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -1,5 +1,5 @@
 import os from "node:os";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeNetworkInterfacesSnapshot } from "../test-helpers/network-interfaces.js";
 import {
   __resetContainerCacheForTest,
@@ -17,6 +17,40 @@ import {
   resolveGatewayListenHosts,
   resolveHostName,
 } from "./net.js";
+
+const flyMachineEnvKeys = ["FLY_MACHINE_ID", "FLY_APP_NAME"] as const;
+
+function clearFlyMachineEnvForTest(): () => void {
+  const previousEnv = new Map<(typeof flyMachineEnvKeys)[number], string | undefined>();
+  for (const key of flyMachineEnvKeys) {
+    previousEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+
+  return () => {
+    for (const key of flyMachineEnvKeys) {
+      const value = previousEnv.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  };
+}
+
+function useClearedFlyMachineEnv() {
+  let restoreFlyMachineEnv: (() => void) | undefined;
+
+  beforeEach(() => {
+    restoreFlyMachineEnv = clearFlyMachineEnvForTest();
+  });
+
+  afterEach(() => {
+    restoreFlyMachineEnv?.();
+    restoreFlyMachineEnv = undefined;
+  });
+}
 
 describe("resolveHostName", () => {
   it.each([
@@ -482,6 +516,8 @@ describe("isPrivateOrLoopbackHost", () => {
 });
 
 describe("isContainerEnvironment", () => {
+  useClearedFlyMachineEnv();
+
   afterEach(() => {
     __resetContainerCacheForTest();
     vi.restoreAllMocks();
@@ -516,30 +552,15 @@ describe("isContainerEnvironment", () => {
   });
 
   it("returns true on Fly Machines without Docker sentinel files", () => {
-    const previousFlyMachineId = process.env.FLY_MACHINE_ID;
-    const previousFlyAppName = process.env.FLY_APP_NAME;
     const fs = require("node:fs");
     vi.spyOn(fs, "accessSync").mockImplementation(() => {
       throw new Error("ENOENT");
     });
     vi.spyOn(fs, "readFileSync").mockReturnValue("10:cpuset:/\n9:perf_event:/\n8:memory:/\n0::/\n");
 
-    try {
-      process.env.FLY_MACHINE_ID = "3d8d5459a03038";
-      process.env.FLY_APP_NAME = "openclaw-clawcks-test";
-      expect(isContainerEnvironment()).toBe(true);
-    } finally {
-      if (previousFlyMachineId === undefined) {
-        delete process.env.FLY_MACHINE_ID;
-      } else {
-        process.env.FLY_MACHINE_ID = previousFlyMachineId;
-      }
-      if (previousFlyAppName === undefined) {
-        delete process.env.FLY_APP_NAME;
-      } else {
-        process.env.FLY_APP_NAME = previousFlyAppName;
-      }
-    }
+    process.env.FLY_MACHINE_ID = "3d8d5459a03038";
+    process.env.FLY_APP_NAME = "openclaw-test";
+    expect(isContainerEnvironment()).toBe(true);
   });
 
   it("returns true when /proc/1/cgroup contains docker marker", () => {
@@ -613,6 +634,8 @@ describe("isContainerEnvironment", () => {
 });
 
 describe("resolveGatewayBindHost", () => {
+  useClearedFlyMachineEnv();
+
   afterEach(() => {
     __resetContainerCacheForTest();
     vi.restoreAllMocks();
@@ -652,6 +675,8 @@ describe("resolveGatewayBindHost", () => {
 });
 
 describe("defaultGatewayBindMode", () => {
+  useClearedFlyMachineEnv();
+
   afterEach(() => {
     __resetContainerCacheForTest();
     vi.restoreAllMocks();

--- a/src/infra/container-environment.ts
+++ b/src/infra/container-environment.ts
@@ -22,6 +22,10 @@ export function isContainerEnvironment(): boolean {
 }
 
 function detectContainerEnvironment(): boolean {
+  if (process.env.FLY_MACHINE_ID?.trim() && process.env.FLY_APP_NAME?.trim()) {
+    return true;
+  }
+
   for (const sentinelPath of ["/.dockerenv", "/run/.containerenv", "/var/run/.containerenv"]) {
     try {
       fs.accessSync(sentinelPath, fs.constants.F_OK);


### PR DESCRIPTION
## Summary

- Problem: Fly Machines do not expose the usual Docker container markers, so OpenClaw can miss that it is running inside a container.
- Why it matters: OpenClaw can run on Fly Machines, so container-aware behavior should still apply there.
- What changed: OpenClaw now treats Fly Machines as containers when both `FLY_MACHINE_ID` and `FLY_APP_NAME` are set, and the Bonjour plugin auto-disables in the same environment.
- What did NOT change (scope boundary): No Fly deployment code, provider defaults, or runtime harness behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: OpenClaw should detect a Fly Machine as containerized and avoid Bonjour/mDNS behavior inside that container.
- Real environment tested: Fly Machines, using a locally built OpenClaw `linux/amd64` image from this branch.
- Exact steps or command run after this patch:
  - Built a local `linux/amd64` Docker image from this branch.
  - Used that local image as the base for a Fly staging image.
  - Provisioned one fresh Fly Machine from that staging image.
  - Sent an agent request.
- Evidence after fix: manual Fly staging run confirmed the agent responds from the fresh Fly Machine.
- Observed result after fix: the provisioned OpenClaw container starts and responds to agent requests.
- What was not tested: restart recovery, idle-after-15-minutes behavior, and parallel fresh container provisioning were not completed yet.
- Before evidence (optional but encouraged): Fly Machines showed plain cgroup output without `/.dockerenv`, so the existing Docker/cgroup markers were not enough.

## Root Cause (if applicable)

- Root cause: Fly Machines can run without `/.dockerenv` and without Docker-like cgroup paths.
- Missing detection / guardrail: OpenClaw did not check Fly's stable machine environment variables.
- Contributing context (if known): Fly Machines expose `FLY_MACHINE_ID` and `FLY_APP_NAME`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/net.test.ts`, `extensions/bonjour/src/advertiser.test.ts`
- Scenario the test should lock in: Fly env vars plus plain Fly cgroup output are enough to treat the runtime as a container and disable Bonjour auto-start.
- Why this is the smallest reliable guardrail: the bug is in local environment detection, so unit coverage can directly assert the inputs Fly exposes.
- Existing test that already covers this (if any): existing container detection tests covered Docker-style markers, not Fly Machines.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

OpenClaw now treats Fly Machines as containerized when `FLY_MACHINE_ID` and `FLY_APP_NAME` are set. Bonjour auto-disables in that environment.

## Diagram (if applicable)

```text
Before:
Fly Machine env + plain cgroup -> container detection false -> Bonjour may stay enabled

After:
Fly Machine env + plain cgroup -> container detection true -> Bonjour auto-disables
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows host for local tests; Fly Linux container for manual staging proof
- Runtime/container: Docker `linux/amd64`; Fly Machine staging environment
- Model/provider: OpenAI through Codex harness in the staging image
- Integration/channel (if any): Fly staging
- Relevant config (redacted): Fly container has `FLY_MACHINE_ID` and `FLY_APP_NAME`

### Steps

1. Run targeted formatting and tests.
2. Build the local OpenClaw Docker image for `linux/amd64` from this branch.
3. Use that image as the base for a Fly staging image.
4. Provision one fresh Fly Machine from that staging image.
5. Send an agent request.

### Expected

- OpenClaw treats Fly Machines as containers.
- Bonjour does not auto-start inside the Fly Machine.
- The gateway starts and the agent responds.

### Actual

- Targeted tests passed.
- Local image built and loaded.
- One fresh Fly Machine responded to an agent request.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands:

```sh
corepack pnpm exec oxfmt --check --threads=1 src/infra/container-environment.ts extensions/bonjour/src/advertiser.ts src/gateway/net.test.ts extensions/bonjour/src/advertiser.test.ts
corepack pnpm test src/gateway/net.test.ts extensions/bonjour/src/advertiser.test.ts
corepack pnpm check:changed
```


## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios:
  - Local targeted formatter passed.
  - Local targeted tests passed.
  - `corepack pnpm check:changed` passed.
  - Docker `linux/amd64` image built and loaded locally from this branch.
  - The image includes the `codex` harness plugin.
  - The image returns `true` for Fly Machine container detection.
  - One fresh Fly Machine responds to an agent request.
- Edge cases checked:
  - Plain Fly cgroup output with no Docker cgroup marker.
  - Missing one Fly env var should not trigger Fly Machine detection.
- What you did **not** verify:
  - Restart recovery.
  - 10-15 minute idle recovery.
  - Parallel container provisioning.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A non-Fly environment could set both Fly env vars by accident.
  - Mitigation: detection requires both `FLY_MACHINE_ID` and `FLY_APP_NAME`, which are Fly-specific runtime vars.

## AI-assisted disclosure

This PR was prepared with AI assistance and reviewed/tested by the contributor.





