### PR TITLE
fix(codex): mark native tools active for diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Codex app-server: report Codex-native tool execution to diagnostics so long-running native `bash`, web, file, and MCP tools no longer look like stale embedded runs to the watchdog. (#80217)
 - Telegram: preserve blank lines between manually indented bullet blocks and following numbered sections in rendered replies. Fixes #76998. Thanks @evgyur.
 - Gateway/agents: keep structured reasons when active-run queueing fails and deprecate the legacy boolean queue helper, so steering and subagent wake diagnostics distinguish completed, non-streaming, and compacting runs. Fixes #80156. Thanks @markus-lassfolk.
 - Agents/UI: compact exec and tool progress rows by hiding redundant shell tool names, replacing known workspace paths with short context markers, and preserving Discord trace scrubbing for compact command lines.

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -928,6 +928,85 @@ describe("CodexAppServerEventProjector", () => {
     expect(toolResultContentItem.content).toBe("ok");
   });
 
+  it("orders declined native tool diagnostics after their start event", async () => {
+    const projector = await createProjector();
+    const diagnosticEvents: DiagnosticEventPayload[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => diagnosticEvents.push(event));
+
+    try {
+      await projector.handleNotification(
+        forCurrentTurn("item/started", {
+          item: {
+            type: "commandExecution",
+            id: "cmd-declined",
+            command: "pnpm test extensions/codex",
+            cwd: "/workspace",
+            processId: null,
+            source: "agent",
+            status: "inProgress",
+            commandActions: [],
+            aggregatedOutput: null,
+            exitCode: null,
+            durationMs: null,
+          },
+        }),
+      );
+      await projector.handleNotification(
+        forCurrentTurn("item/completed", {
+          item: {
+            type: "commandExecution",
+            id: "cmd-declined",
+            command: "pnpm test extensions/codex",
+            cwd: "/workspace",
+            processId: null,
+            source: "agent",
+            status: "declined",
+            commandActions: [],
+            aggregatedOutput: null,
+            exitCode: null,
+            durationMs: 1,
+          },
+        }),
+      );
+      await flushDiagnosticEvents();
+    } finally {
+      unsubscribe();
+    }
+
+    const toolDiagnosticEvents = diagnosticEvents.filter(
+      (
+        event,
+      ): event is Extract<
+        DiagnosticEventPayload,
+        {
+          type:
+            | "tool.execution.started"
+            | "tool.execution.completed"
+            | "tool.execution.error"
+            | "tool.execution.blocked";
+        }
+      > => event.type.startsWith("tool.execution."),
+    );
+    expect(
+      toolDiagnosticEvents.map((event) => ({
+        type: event.type,
+        toolName: event.toolName,
+        toolCallId: event.toolCallId,
+      })),
+    ).toEqual([
+      {
+        type: "tool.execution.started",
+        toolName: "bash",
+        toolCallId: "cmd-declined",
+      },
+      {
+        type: "tool.execution.blocked",
+        toolName: "bash",
+        toolCallId: "cmd-declined",
+      },
+    ]);
+  });
+
   it("records dynamic OpenClaw tool calls in mirrored transcript snapshots", async () => {
     const projector = await createProjector();
 

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -5,6 +5,11 @@ import { SessionManager } from "@mariozechner/pi-coding-agent";
 import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness";
 import { resetAgentEventsForTest } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "openclaw/plugin-sdk/diagnostic-runtime";
+import {
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
 } from "openclaw/plugin-sdk/hook-runtime";
@@ -22,6 +27,10 @@ const TURN_ID = "turn-1";
 const tempDirs = new Set<string>();
 
 type ProjectorNotification = Parameters<CodexAppServerEventProjector["handleNotification"]>[0];
+
+function flushDiagnosticEvents() {
+  return new Promise<void>((resolve) => setImmediate(resolve));
+}
 
 function assistantMessage(text: string, timestamp: number) {
   return {
@@ -82,10 +91,12 @@ async function createProjectorWithAssistantHooks() {
 
 beforeEach(() => {
   resetAgentEventsForTest();
+  resetDiagnosticEventsForTest();
 });
 
 afterEach(async () => {
   resetAgentEventsForTest();
+  resetDiagnosticEventsForTest();
   resetGlobalHookRunner();
   resetCodexRateLimitCacheForTests();
   vi.restoreAllMocks();
@@ -780,41 +791,48 @@ describe("CodexAppServerEventProjector", () => {
   it("synthesizes normalized tool progress for Codex-native tool items", async () => {
     const onAgentEvent = vi.fn();
     const projector = await createProjector({ ...(await createParams()), onAgentEvent });
+    const diagnosticEvents: DiagnosticEventPayload[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => diagnosticEvents.push(event));
 
-    await projector.handleNotification(
-      forCurrentTurn("item/started", {
-        item: {
-          type: "commandExecution",
-          id: "cmd-1",
-          command: "pnpm test extensions/codex",
-          cwd: "/workspace",
-          processId: null,
-          source: "agent",
-          status: "inProgress",
-          commandActions: [],
-          aggregatedOutput: null,
-          exitCode: null,
-          durationMs: null,
-        },
-      }),
-    );
-    await projector.handleNotification(
-      forCurrentTurn("item/completed", {
-        item: {
-          type: "commandExecution",
-          id: "cmd-1",
-          command: "pnpm test extensions/codex",
-          cwd: "/workspace",
-          processId: null,
-          source: "agent",
-          status: "completed",
-          commandActions: [],
-          aggregatedOutput: "ok",
-          exitCode: 0,
-          durationMs: 42,
-        },
-      }),
-    );
+    try {
+      await projector.handleNotification(
+        forCurrentTurn("item/started", {
+          item: {
+            type: "commandExecution",
+            id: "cmd-1",
+            command: "pnpm test extensions/codex",
+            cwd: "/workspace",
+            processId: null,
+            source: "agent",
+            status: "inProgress",
+            commandActions: [],
+            aggregatedOutput: null,
+            exitCode: null,
+            durationMs: null,
+          },
+        }),
+      );
+      await projector.handleNotification(
+        forCurrentTurn("item/completed", {
+          item: {
+            type: "commandExecution",
+            id: "cmd-1",
+            command: "pnpm test extensions/codex",
+            cwd: "/workspace",
+            processId: null,
+            source: "agent",
+            status: "completed",
+            commandActions: [],
+            aggregatedOutput: "ok",
+            exitCode: 0,
+            durationMs: 42,
+          },
+        }),
+      );
+      await flushDiagnosticEvents();
+    } finally {
+      unsubscribe();
+    }
 
     const itemStart = findAgentEvent(onAgentEvent, {
       stream: "item",
@@ -844,6 +862,41 @@ describe("CodexAppServerEventProjector", () => {
     const toolResultPayload = requireRecord(toolResult.result, "tool result payload");
     expect(toolResultPayload.exitCode).toBe(0);
     expect(toolResultPayload.durationMs).toBe(42);
+    const toolDiagnosticEvents = diagnosticEvents.filter(
+      (
+        event,
+      ): event is Extract<
+        DiagnosticEventPayload,
+        {
+          type:
+            | "tool.execution.started"
+            | "tool.execution.completed"
+            | "tool.execution.error"
+            | "tool.execution.blocked";
+        }
+      > => event.type.startsWith("tool.execution."),
+    );
+    expect(
+      toolDiagnosticEvents.map((event) => ({
+        type: event.type,
+        toolName: event.toolName,
+        toolCallId: event.toolCallId,
+        durationMs: "durationMs" in event ? event.durationMs : undefined,
+      })),
+    ).toEqual([
+      {
+        type: "tool.execution.started",
+        toolName: "bash",
+        toolCallId: "cmd-1",
+        durationMs: undefined,
+      },
+      {
+        type: "tool.execution.completed",
+        toolName: "bash",
+        toolCallId: "cmd-1",
+        durationMs: 42,
+      },
+    ]);
     const result = projector.buildResult(buildEmptyToolTelemetry());
     expect(result.messagesSnapshot.map((message) => message.role)).toEqual([
       "user",

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -18,6 +18,7 @@ import {
   type MessagingToolSend,
   type ToolProgressDetailMode,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { readCodexTurn } from "./protocol-validators.js";
 import {
   isJsonObject,
@@ -116,6 +117,7 @@ export class CodexAppServerEventProjector {
   private readonly toolTranscriptCallIds = new Set<string>();
   private readonly toolTranscriptResultIds = new Set<string>();
   private readonly nativeGeneratedMediaUrls = new Set<string>();
+  private readonly diagnosticToolStartedAtByItem = new Map<string, number>();
   private assistantStarted = false;
   private reasoningStarted = false;
   private reasoningEnded = false;
@@ -765,6 +767,7 @@ export class CodexAppServerEventProjector {
     const meta = itemMeta(item, this.toolProgressDetailMode());
     const args = params.phase === "start" ? itemToolArgs(item) : undefined;
     const status = params.phase === "result" ? itemStatus(item) : "running";
+    this.emitDiagnosticToolExecutionEvent({ phase: params.phase, item, name, status });
     this.emitAgentEvent({
       stream: "tool",
       data: {
@@ -782,6 +785,58 @@ export class CodexAppServerEventProjector {
             }
           : {}),
       },
+    });
+  }
+
+  private emitDiagnosticToolExecutionEvent(params: {
+    phase: "start" | "result";
+    item: CodexThreadItem;
+    name: string;
+    status: ReturnType<typeof itemStatus>;
+  }): void {
+    const base = {
+      runId: this.params.runId,
+      sessionId: this.params.sessionId,
+      sessionKey: this.params.sessionKey,
+      toolName: params.name,
+      toolCallId: params.item.id,
+    };
+    if (params.phase === "start") {
+      this.diagnosticToolStartedAtByItem.set(params.item.id, Date.now());
+      emitTrustedDiagnosticEvent({
+        type: "tool.execution.started",
+        ...base,
+      });
+      return;
+    }
+
+    const startedAt = this.diagnosticToolStartedAtByItem.get(params.item.id);
+    this.diagnosticToolStartedAtByItem.delete(params.item.id);
+    const durationMs =
+      readNumber(params.item, "durationMs") ??
+      (startedAt === undefined ? 0 : Math.max(0, Date.now() - startedAt));
+    if (params.status === "blocked") {
+      emitTrustedDiagnosticEvent({
+        type: "tool.execution.blocked",
+        ...base,
+        reason: "codex_native_tool_blocked",
+        deniedReason: "codex_native_tool_blocked",
+      });
+      return;
+    }
+    if (params.status === "failed") {
+      emitTrustedDiagnosticEvent({
+        type: "tool.execution.error",
+        ...base,
+        durationMs,
+        errorCategory: "codex_native_tool_error",
+      });
+      return;
+    }
+    emitTrustedDiagnosticEvent({
+      type: "tool.execution.completed",
+      ...base,
+      durationMs,
     });
   }
 

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -816,29 +816,24 @@ export class CodexAppServerEventProjector {
       typeof params.item.durationMs === "number" ? params.item.durationMs : undefined;
     const durationMs =
       itemDurationMs ?? (startedAt === undefined ? 0 : Math.max(0, Date.now() - startedAt));
-    if (params.status === "blocked") {
-      emitTrustedDiagnosticEvent({
-        type: "tool.execution.blocked",
-        ...base,
-        reason: "codex_native_tool_blocked",
-        deniedReason: "codex_native_tool_blocked",
-      });
-      return;
-    }
-    if (params.status === "failed") {
-      emitTrustedDiagnosticEvent({
-        type: "tool.execution.error",
-        ...base,
-        durationMs,
-        errorCategory: "codex_native_tool_error",
-      });
-      return;
-    }
-    emitTrustedDiagnosticEvent({
-      type: "tool.execution.completed",
-      ...base,
-      durationMs,
-    });
+    const terminalEvent =
+      params.status === "blocked"
+        ? {
+            type: "tool.execution.blocked" as const,
+            reason: "codex_native_tool_blocked",
+            deniedReason: "codex_native_tool_blocked",
+          }
+        : params.status === "failed"
+          ? {
+              type: "tool.execution.error" as const,
+              durationMs,
+              errorCategory: "codex_native_tool_error",
+            }
+          : {
+              type: "tool.execution.completed" as const,
+              durationMs,
+            };
+    emitTrustedDiagnosticEvent({ ...base, ...terminalEvent });
   }
 
   private emitToolResultSummary(item: CodexThreadItem | undefined): void {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -812,9 +812,10 @@ export class CodexAppServerEventProjector {
 
     const startedAt = this.diagnosticToolStartedAtByItem.get(params.item.id);
     this.diagnosticToolStartedAtByItem.delete(params.item.id);
+    const itemDurationMs =
+      typeof params.item.durationMs === "number" ? params.item.durationMs : undefined;
     const durationMs =
-      readNumber(params.item, "durationMs") ??
-      (startedAt === undefined ? 0 : Math.max(0, Date.now() - startedAt));
+      itemDurationMs ?? (startedAt === undefined ? 0 : Math.max(0, Date.now() - startedAt));
     if (params.status === "blocked") {
       emitTrustedDiagnosticEvent({
         type: "tool.execution.blocked",

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -652,6 +652,7 @@ const ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["type"]>([
   "tool.execution.started",
   "tool.execution.completed",
   "tool.execution.error",
+  "tool.execution.blocked",
   "exec.process.completed",
   "message.delivery.started",
   "message.delivery.completed",

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -307,6 +307,27 @@ export function markDiagnosticRunProgressForTest(params: {
   touchSessionActivity(activity, params.reason);
 }
 
+export function markDiagnosticToolStartedForTest(params: {
+  sessionId?: string;
+  sessionKey?: string;
+  runId?: string;
+  toolName: string;
+  toolCallId?: string;
+}): void {
+  const activity = resolveSessionActivity({ ...params, create: true });
+  if (!activity) {
+    return;
+  }
+  const now = Date.now();
+  activity.activeTools.set(toolKey(params), {
+    toolName: params.toolName,
+    toolCallId: params.toolCallId,
+    startedAt: now,
+    lastProgressAt: now,
+  });
+  touchSessionActivity(activity, `tool:${params.toolName}:started`, now);
+}
+
 export function resetDiagnosticRunActivityForTest(): void {
   activityByRef.clear();
   activityByRunId.clear();

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -21,6 +21,11 @@ type ActiveTool = {
   lastProgressAt: number;
 };
 
+type DiagnosticToolStartedActivityEvent = Pick<
+  Extract<DiagnosticEventPayload, { type: "tool.execution.started" }>,
+  "runId" | "sessionId" | "sessionKey" | "toolName" | "toolCallId"
+>;
+
 export type DiagnosticSessionActivitySnapshot = {
   activeWorkKind?: DiagnosticSessionActiveWorkKind;
   activeToolName?: string;
@@ -158,9 +163,7 @@ function modelCallKey(event: { runId?: string; provider?: string; model?: string
   return `${event.runId ?? "unknown"}:${event.provider ?? "provider"}:${event.model ?? "model"}`;
 }
 
-function recordToolStarted(
-  event: Extract<DiagnosticEventPayload, { type: "tool.execution.started" }>,
-): void {
+function recordToolStarted(event: DiagnosticToolStartedActivityEvent): void {
   const activity = resolveSessionActivity({ ...event, create: true });
   if (!activity) {
     return;
@@ -314,18 +317,7 @@ export function markDiagnosticToolStartedForTest(params: {
   toolName: string;
   toolCallId?: string;
 }): void {
-  const activity = resolveSessionActivity({ ...params, create: true });
-  if (!activity) {
-    return;
-  }
-  const now = Date.now();
-  activity.activeTools.set(toolKey(params), {
-    toolName: params.toolName,
-    toolCallId: params.toolCallId,
-    startedAt: now,
-    lastProgressAt: now,
-  });
-  touchSessionActivity(activity, `tool:${params.toolName}:started`, now);
+  recordToolStarted(params);
 }
 
 export function resetDiagnosticRunActivityForTest(): void {

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -13,6 +13,7 @@ import {
   getDiagnosticSessionActivitySnapshot,
   markDiagnosticRunProgressForTest,
   markDiagnosticEmbeddedRunStarted,
+  markDiagnosticToolStartedForTest,
 } from "./diagnostic-run-activity.js";
 import {
   diagnosticSessionStates,
@@ -518,6 +519,48 @@ describe("stuck session diagnostics threshold", () => {
       { sessionId: "s1", sessionKey: "main", queueDepth: 0, allowActiveAbort: true },
       ["ageMs", "stateGeneration"],
     );
+  });
+
+  it("does not abort embedded runs while a native tool call is active", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 30_000,
+            stuckSessionAbortMs: 60_000,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+      markDiagnosticToolStartedForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        runId: "run-1",
+        toolName: "bash",
+        toolCallId: "cmd-1",
+      });
+
+      vi.advanceTimersByTime(2 * 60_000);
+    } finally {
+      unsubscribe();
+    }
+
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+    expect(events.findLast((event) => event.type === "session.stalled")).toMatchObject({
+      classification: "blocked_tool_call",
+      reason: "blocked_tool_call",
+      activeWorkKind: "tool_call",
+      activeToolName: "bash",
+      activeToolCallId: "cmd-1",
+    });
   });
 
   it("uses diagnostics.stuckSessionAbortMs for stalled active-work recovery", () => {


### PR DESCRIPTION
## Summary
- Problem: Codex-native tool items such as `commandExecution` emitted channel/tool progress but did not feed OpenClaw diagnostic `tool.execution.*` activity.
- Why it matters: the watchdog could classify a still-running native `bash`/Node scraper as a stale embedded run and abort the agent turn while the child process kept running.
- What changed: Codex app-server now emits trusted diagnostic started/completed/error/blocked events for native synthesized tool items, and active native tools classify as `blocked_tool_call` instead of abort-eligible embedded-run stalls.
- What did NOT change: no command arguments or tool output are added to diagnostics beyond existing tool name/call id/session metadata and duration/status.

## Change Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope
- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Real behavior proof
- Behavior or issue addressed: a long-running Codex-native `bash` tool should be visible to the diagnostic watchdog as active tool work, so the agent turn is not aborted as a stale embedded run while the child process is still running.
- Real environment tested: local OpenClaw checkout at `/home/clawuser/openclaw`, Node v26.1.0, real diagnostic heartbeat, real `CodexAppServerEventProjector`, and an actual long-running child `node` process. Session IDs and paths are redacted.
- Exact steps or command run after this patch: `pnpm exec tsx /tmp/openclaw-codex-native-tool-proof.mts`
- Evidence after fix (terminal capture):

```text
[diagnostic] stalled session: sessionId=proof-session-redacted sessionKey=agent:isolated:proof-redacted state=processing age=30s queueDepth=0 reason=blocked_tool_call classification=blocked_tool_call activeWorkKind=tool_call lastProgress=tool:bash:started lastProgressAge=30s activeTool=bash activeToolCallId=proof-cmd-1 activeToolAge=30s recovery=none
runtime proof: Codex-native bash diagnostic activity
{
  "toolStarted": {
    "type": "tool.execution.started",
    "toolName": "bash",
    "toolCallId": "proof-cmd-1",
    "runId": "proof-run-redacted"
  },
  "stalledClassification": {
    "classification": "blocked_tool_call",
    "reason": "blocked_tool_call",
    "activeWorkKind": "tool_call",
    "activeToolName": "bash",
    "activeToolCallId": "proof-cmd-1",
    "ageMs": 30000,
    "activeToolAgeMs": 30000
  },
  "childStillRunningAtStallCheck": true,
  "recoverStuckSessionCallCount": 0,
  "abortEmbeddedRunRequested": false
}
```

- Observed result after fix: the still-running native `bash` item emitted `tool.execution.started`; after the heartbeat crossed the abort threshold, diagnostics reported `classification=blocked_tool_call`, `activeWorkKind=tool_call`, `activeToolName=bash`, `recovery=none`, and no `abort_embedded_run` recovery request was made.
- What was not tested: I did not rerun the full 07:35 GPay cron job; the proof isolates the failed OpenClaw runtime path with a real heartbeat, projector, and child process.
- Before evidence (optional): the production GPay cron investigation showed the 07:35 IST run's agent turn was aborted at 07:49:13 while the Node scraper continued and finished at 07:49:49.

## Root Cause
- Root cause: synthesized Codex-native tool progress was only projected to agent/channel events, not to OpenClaw's trusted diagnostic tool execution event stream.
- Missing detection / guardrail: tests covered the stuck-session watchdog and Codex tool projection separately, but not the native-tool diagnostic bridge needed by long-running Codex app-server tools.
- Contributing context: the watchdog treats active tool calls ahead of embedded runs; without the native tool event, the only visible active work was the embedded run.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/event-projector.test.ts` and `src/logging/diagnostic.test.ts`
- Scenario the test should lock in: Codex-native `commandExecution` emits diagnostic `tool.execution.started/completed`; watchdog sees an active `bash` tool and does not request embedded-run abort recovery.
- Why this is the smallest reliable guardrail: it covers both owner boundaries involved in the bug without relying on a slow cron reproduction.
- Existing test that already covers this (if any): none before this PR.

## Validation
- `pnpm tsgo:prod`
- `pnpm check:test-types`
- `pnpm test extensions/codex/src/app-server/event-projector.test.ts src/logging/diagnostic.test.ts -- --run`
- `pnpm run test:extensions:package-boundary:compile`
- `pnpm exec tsx /tmp/openclaw-codex-native-tool-proof.mts`

## User-visible / Behavior Changes
- Long-running Codex-native shell/file/web/MCP tools should no longer cause the diagnostic watchdog to abort the agent turn as a stale embedded run while the tool is still active.

## Security Impact
- No new secrets, dependencies, network access, command output capture, or argument logging. Diagnostic events include tool name, call id, session/run metadata, status, and duration only.
