### PR TITLE
Expose runtime agent identity to exec commands

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -13,6 +13,7 @@ import {
 } from "../infra/exec-approvals.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
 import { sanitizeHostExecEnvWithDiagnostics } from "../infra/host-env-security.js";
+import { markOpenClawAgentExecEnv } from "../infra/openclaw-exec-env.js";
 import {
   getShellPathFromLoginShell,
   resolveShellEnvFallbackTimeoutMs,
@@ -1443,7 +1444,7 @@ export function createExecTool(
         throw new Error(`Security Violation: ${suffix}.`);
       }
 
-      const env =
+      const env = markOpenClawAgentExecEnv(
         sandbox && host === "sandbox"
           ? buildSandboxEnv({
               defaultPath: DEFAULT_PATH,
@@ -1451,7 +1452,9 @@ export function createExecTool(
               sandboxEnv: sandbox.env,
               containerWorkdir: containerWorkdir ?? sandbox.containerWorkdir,
             })
-          : (hostEnvResult?.env ?? inheritedBaseEnv);
+          : (hostEnvResult?.env ?? inheritedBaseEnv),
+        agentId,
+      );
 
       if (!sandbox && host === "gateway" && !params.env?.PATH) {
         const shellPath = getShellPathFromLoginShell({

--- a/src/infra/openclaw-exec-env.test.ts
+++ b/src/infra/openclaw-exec-env.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   ensureOpenClawExecMarkerOnProcess,
+  markOpenClawAgentExecEnv,
   markOpenClawExecEnv,
   OPENCLAW_CLI_ENV_VALUE,
   OPENCLAW_CLI_ENV_VAR,
@@ -49,5 +50,31 @@ describe("ensureOpenClawExecMarkerOnProcess", () => {
         process.env[OPENCLAW_CLI_ENV_VAR] = previous;
       }
     }
+  });
+});
+
+describe("markOpenClawAgentExecEnv", () => {
+  it("adds the runtime agent id to exec child environments", () => {
+    const env: Record<string, string | undefined> = { PATH: "/usr/bin" };
+
+    expect(markOpenClawAgentExecEnv(env, "alex")).toBe(env);
+    expect(env.OPENCLAW_AGENT_ID).toBe("alex");
+    expect(env.AGENT_NAME).toBe("alex");
+  });
+
+  it("preserves an explicit AGENT_NAME while setting OPENCLAW_AGENT_ID", () => {
+    const env: Record<string, string | undefined> = { AGENT_NAME: "custom-name" };
+
+    markOpenClawAgentExecEnv(env, "vex");
+
+    expect(env.OPENCLAW_AGENT_ID).toBe("vex");
+    expect(env.AGENT_NAME).toBe("custom-name");
+  });
+
+  it("leaves env unchanged when no agent id is available", () => {
+    const env: Record<string, string | undefined> = { PATH: "/usr/bin" };
+
+    expect(markOpenClawAgentExecEnv(env, undefined)).toBe(env);
+    expect(env).toEqual({ PATH: "/usr/bin" });
   });
 });

--- a/src/infra/openclaw-exec-env.ts
+++ b/src/infra/openclaw-exec-env.ts
@@ -1,11 +1,23 @@
 export const OPENCLAW_CLI_ENV_VAR = "OPENCLAW_CLI";
 export const OPENCLAW_CLI_ENV_VALUE = "1";
+export const OPENCLAW_AGENT_ID_ENV_VAR = "OPENCLAW_AGENT_ID";
+export const AGENT_NAME_ENV_VAR = "AGENT_NAME";
 
 export function markOpenClawExecEnv<T extends Record<string, string | undefined>>(env: T): T {
   return {
     ...env,
     [OPENCLAW_CLI_ENV_VAR]: OPENCLAW_CLI_ENV_VALUE,
   };
+}
+
+export function markOpenClawAgentExecEnv<T extends Record<string, string | undefined>>(
+  env: T,
+  agentId: string | undefined,
+): T {
+  if (!agentId) return env;
+  env[OPENCLAW_AGENT_ID_ENV_VAR] = agentId;
+  if (!env[AGENT_NAME_ENV_VAR]) env[AGENT_NAME_ENV_VAR] = agentId;
+  return env;
 }
 
 export function ensureOpenClawExecMarkerOnProcess(


### PR DESCRIPTION
## Summary
- add a helper that stamps exec child environments with `OPENCLAW_AGENT_ID`
- default `AGENT_NAME` to the runtime agent id when it is not already set
- apply the helper at the exec environment boundary so gateway/sandbox/node command execution can identify the active agent

## Why
Agent-scoped tools and skills sometimes need stable runtime identity. Without an agent id in the child process environment, local helpers can accidentally fall back to shared/generic state such as `op-agent`, mixing credentials or approval sessions across agents.

## Tests
- `pnpm install --frozen-lockfile`
- `pnpm test:fast -- src/infra/openclaw-exec-env.test.ts src/agents/bash-tools.exec-host-gateway.test.ts`
- `pnpm test:fast -- src/infra/openclaw-exec-env.test.ts`