### PR TITLE
[Fix] Wait for Pi abort settle before cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@ Docs: https://docs.openclaw.ai
 - DeepSeek: backfill V4 `reasoning_content` replay fields for unowned OpenAI-compatible proxy providers, preventing follow-up request failures outside the bundled DeepSeek and OpenRouter routes. Fixes #79608.
 - iMessage: emit a WARN log when an action is blocked because the imsg private API bridge is not attached, so operators see the silent-drop in `~/.openclaw/logs/openclaw.log` instead of having to read per-session trajectory JSONL `tool.result` payloads. Common after a gateway restart un-injects the dylib from Messages.app. (#80035) Thanks @omarshahine.
 - Codex: cross-fill missing `thread.id` and `thread.sessionId` before schema validation so live Codex app-server responses that omit `sessionId` no longer fail `thread/start` or `thread/resume`. Fixes #80124. (#80137) Thanks @kagura-agent.
+- Agents/Pi: wait for embedded abort cleanup to settle before releasing the session write lock, preventing follow-up turns from racing previous prompt teardown. (#80239) Thanks @samzong.
 
 ## 2026.5.9
 

--- a/src/agents/pi-embedded-runner/run/attempt.subscription-cleanup.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.subscription-cleanup.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { log } from "../logger.js";
+import {
+  EMBEDDED_ABORT_SETTLE_TIMEOUT_MS,
+  cleanupEmbeddedAttemptResources,
+} from "./attempt.subscription-cleanup.js";
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("cleanupEmbeddedAttemptResources", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("waits for aborted prompt settlement before flushing, disposing, and releasing the lock", async () => {
+    const order: string[] = [];
+    const settle = createDeferred<void>();
+
+    const cleanupPromise = cleanupEmbeddedAttemptResources({
+      removeToolResultContextGuard: () => {
+        order.push("guard");
+      },
+      flushPendingToolResultsAfterIdle: vi.fn(async () => {
+        order.push("flush");
+      }),
+      session: {
+        agent: {},
+        dispose: () => {
+          order.push("dispose");
+        },
+      },
+      sessionManager: {},
+      sessionLock: {
+        release: async () => {
+          order.push("release");
+        },
+      },
+      aborted: true,
+      abortSettlePromise: settle.promise,
+      runId: "run-1",
+      sessionId: "session-1",
+    });
+
+    await Promise.resolve();
+
+    expect(order).toEqual(["guard"]);
+
+    settle.resolve();
+    await cleanupPromise;
+
+    expect(order).toEqual(["guard", "flush", "dispose", "release"]);
+  });
+
+  it("releases the lock after the aborted settle timeout", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(log, "warn").mockImplementation(() => {});
+    const order: string[] = [];
+
+    const cleanupPromise = cleanupEmbeddedAttemptResources({
+      flushPendingToolResultsAfterIdle: vi.fn(async () => {
+        order.push("flush");
+      }),
+      session: {
+        agent: {},
+        dispose: () => {
+          order.push("dispose");
+        },
+      },
+      sessionManager: {},
+      sessionLock: {
+        release: async () => {
+          order.push("release");
+        },
+      },
+      aborted: true,
+      abortSettlePromise: new Promise(() => {}),
+      runId: "run-1",
+      sessionId: "session-1",
+    });
+
+    await vi.advanceTimersByTimeAsync(EMBEDDED_ABORT_SETTLE_TIMEOUT_MS - 1);
+    expect(order).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await cleanupPromise;
+
+    expect(order).toEqual(["flush", "dispose", "release"]);
+  });
+
+  it("does not wait for the settle promise on non-aborted cleanup", async () => {
+    const release = vi.fn(async () => {});
+
+    await cleanupEmbeddedAttemptResources({
+      flushPendingToolResultsAfterIdle: vi.fn(async () => {}),
+      session: {
+        agent: {},
+        dispose: vi.fn(),
+      },
+      sessionManager: {},
+      sessionLock: { release },
+      aborted: false,
+      abortSettlePromise: new Promise(() => {}),
+      runId: "run-1",
+      sessionId: "session-1",
+    });
+
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/attempt.subscription-cleanup.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.subscription-cleanup.ts
@@ -1,4 +1,8 @@
 import type { SubscribeEmbeddedPiSessionParams } from "../../pi-embedded-subscribe.types.js";
+import { log } from "../logger.js";
+
+export const EMBEDDED_ABORT_SETTLE_TIMEOUT_MS =
+  process.env.OPENCLAW_TEST_FAST === "1" ? 250 : 2_000;
 
 type IdleAwareAgent = {
   waitForIdle?: (() => Promise<void>) | undefined;
@@ -8,6 +12,40 @@ type ToolResultFlushManager = {
   flushPendingToolResults?: (() => void) | undefined;
   clearPendingToolResults?: (() => void) | undefined;
 };
+
+async function waitForEmbeddedAbortSettle(params: {
+  promise: Promise<unknown> | null | undefined;
+  runId: string;
+  sessionId: string;
+}): Promise<void> {
+  if (!params.promise) {
+    return;
+  }
+
+  let timeout: NodeJS.Timeout | undefined;
+  const outcome = await Promise.race([
+    params.promise
+      .then(() => "settled" as const)
+      .catch((err) => {
+        log.warn(
+          `embedded abort settle failed: runId=${params.runId} sessionId=${params.sessionId} err=${String(err)}`,
+        );
+        return "errored" as const;
+      }),
+    new Promise<"timed_out">((resolve) => {
+      timeout = setTimeout(() => resolve("timed_out"), EMBEDDED_ABORT_SETTLE_TIMEOUT_MS);
+    }),
+  ]);
+  if (timeout) {
+    clearTimeout(timeout);
+  }
+  if (outcome === "timed_out") {
+    log.warn(
+      `embedded abort settle timed out: runId=${params.runId} sessionId=${params.sessionId} timeoutMs=${EMBEDDED_ABORT_SETTLE_TIMEOUT_MS}`,
+    );
+  }
+}
+
 export function buildEmbeddedSubscriptionParams(
   params: SubscribeEmbeddedPiSessionParams,
 ): SubscribeEmbeddedPiSessionParams {
@@ -28,6 +66,9 @@ export async function cleanupEmbeddedAttemptResources(params: {
   bundleLspRuntime?: { dispose(): Promise<void> | void };
   sessionLock: { release(): Promise<void> | void };
   aborted?: boolean;
+  abortSettlePromise?: Promise<unknown> | null;
+  runId?: string;
+  sessionId?: string;
 }): Promise<void> {
   try {
     try {
@@ -35,9 +76,13 @@ export async function cleanupEmbeddedAttemptResources(params: {
     } catch {
       /* best-effort */
     }
-    // PERF: When the run was aborted (user stop / timeout), skip the expensive
-    // waitForIdle (up to 30 s) and just clear pending tool results synchronously
-    // so the session write-lock is released ASAP and the next message is not blocked.
+    if (params.aborted && params.abortSettlePromise) {
+      await waitForEmbeddedAbortSettle({
+        promise: params.abortSettlePromise,
+        runId: params.runId ?? "unknown",
+        sessionId: params.sessionId ?? "unknown",
+      });
+    }
     try {
       await params.flushPendingToolResultsAfterIdle({
         agent: params.session?.agent as IdleAwareAgent | null | undefined,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1602,6 +1602,7 @@ export async function runEmbeddedAttempt(
     let removeToolResultContextGuard: (() => void) | undefined;
     let trajectoryRecorder: ReturnType<typeof createTrajectoryRuntimeRecorder> | null = null;
     let trajectoryEndRecorded = false;
+    let buildAbortSettlePromise: () => Promise<void> | null = () => null;
     try {
       await repairSessionFileIfNeeded({
         sessionFile: params.sessionFile,
@@ -1905,8 +1906,38 @@ export async function runEmbeddedAttempt(
       let unwindowedContextEngineMessagesForPrecheck: AgentMessage[] | undefined;
       let contextEnginePromptAuthority: NonNullable<AssembleResult["promptAuthority"]> =
         "assembled";
+      const inFlightPromptSettlePromises = new Set<Promise<void>>();
+      const inFlightAbortSettlePromises = new Set<Promise<void>>();
+      const trackSettlePromise = (
+        promises: Set<Promise<void>>,
+        promise: Promise<void>,
+      ): Promise<void> => {
+        promises.add(promise);
+        void promise.then(
+          () => {
+            promises.delete(promise);
+          },
+          () => {
+            promises.delete(promise);
+          },
+        );
+        return promise;
+      };
+      const trackPromptSettlePromise = (promise: Promise<void>): Promise<void> =>
+        trackSettlePromise(inFlightPromptSettlePromises, promise);
+      const trackAbortSettlePromise = (promise: Promise<void>): Promise<void> =>
+        trackSettlePromise(inFlightAbortSettlePromises, promise);
+      const abortActiveSession = (): Promise<void> =>
+        trackAbortSettlePromise(Promise.resolve(activeSession.abort()));
+      buildAbortSettlePromise = (): Promise<void> | null => {
+        const promises = [...inFlightPromptSettlePromises, ...inFlightAbortSettlePromises];
+        if (promises.length === 0) {
+          return null;
+        }
+        return Promise.allSettled(promises).then(() => undefined);
+      };
       abortSessionForYield = () => {
-        yieldAbortSettled = Promise.resolve(activeSession.abort());
+        yieldAbortSettled = abortActiveSession();
       };
       queueYieldInterruptForSession = () => {
         queueSessionsYieldInterruptMessage(activeSession);
@@ -2596,7 +2627,7 @@ export async function runEmbeddedAttempt(
           runAbortController.abort(reason);
         }
         abortCompaction();
-        void activeSession.abort();
+        void abortActiveSession();
       };
       idleTimeoutTrigger = (error) => {
         idleTimedOut = true;
@@ -2604,6 +2635,11 @@ export async function runEmbeddedAttempt(
       };
       const abortable = <T>(promise: Promise<T>): Promise<T> =>
         abortableWithSignal(runAbortController.signal, promise);
+      const promptActiveSession = (
+        prompt: string,
+        options?: Parameters<typeof activeSession.prompt>[1],
+      ): Promise<void> =>
+        abortable(trackPromptSettlePromise(activeSession.prompt(prompt, options)));
 
       const subscription = subscribeEmbeddedPiSession(
         buildEmbeddedSubscriptionParams({
@@ -3488,7 +3524,7 @@ export async function runEmbeddedAttempt(
               inFlightPrompt: promptForModel,
             });
             if (promptSubmission.runtimeOnly) {
-              await abortable(activeSession.prompt(promptForModel));
+              await promptActiveSession(promptForModel);
             } else {
               await queueRuntimeContextForNextTurn({
                 session: activeSession,
@@ -3498,11 +3534,9 @@ export async function runEmbeddedAttempt(
               // Only pass images option if there are actually images to pass
               // This avoids potential issues with models that don't expect the images parameter
               if (imageResult.images.length > 0) {
-                await abortable(
-                  activeSession.prompt(promptForModel, { images: imageResult.images }),
-                );
+                await promptActiveSession(promptForModel, { images: imageResult.images });
               } else {
-                await abortable(activeSession.prompt(promptForModel));
+                await promptActiveSession(promptForModel);
               }
             }
           }
@@ -4116,6 +4150,12 @@ export async function runEmbeddedAttempt(
           runId: params.runId,
           catalogRef: toolSearchCatalogRef,
         });
+        const cleanupAborted =
+          Boolean(params.abortSignal?.aborted) ||
+          aborted ||
+          timedOut ||
+          idleTimedOut ||
+          timedOutDuringCompaction;
         await cleanupEmbeddedAttemptResources({
           removeToolResultContextGuard,
           flushPendingToolResultsAfterIdle,
@@ -4124,14 +4164,10 @@ export async function runEmbeddedAttempt(
           bundleMcpRuntime,
           bundleLspRuntime,
           sessionLock,
-          // PERF: If the run was aborted (user stop, timeout, etc.), skip the idle wait
-          // and clear pending results synchronously so we can release the session lock ASAP.
-          aborted:
-            Boolean(params.abortSignal?.aborted) ||
-            aborted ||
-            timedOut ||
-            idleTimedOut ||
-            timedOutDuringCompaction,
+          aborted: cleanupAborted,
+          abortSettlePromise: cleanupAborted ? buildAbortSettlePromise() : null,
+          runId: params.runId,
+          sessionId: params.sessionId,
         });
       } catch (err) {
         cleanupError = err;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Embedded Pi aborted cleanup could release the session write lock before the in-flight prompt or session abort had settled.
- Why it matters: A follow-up turn could write to the same transcript while the previous Pi prompt/abort path was still unwinding.
- What changed: Track in-flight prompt and abort settlement promises and wait on a bounded abort-settle barrier before aborted cleanup flush/dispose/release; add focused regression coverage for ordering, timeout fallback, and non-aborted cleanup.
- What did NOT change (scope boundary): No config surface, transcript repair, command queue, cron timeout, node invocation, provider behavior, or unrelated zombie-loop handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #74979
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: Aborted embedded Pi cleanup now waits for the tracked prompt/abort settle barrier before flushing pending tool results, disposing the session, and releasing the session write lock.
- Real environment tested: macOS/Darwin 25.4.0 arm64, Node v24.14.0, pnpm 10.33.2, local OpenClaw worktree on `fix/pi-abort-lock-settle`.
- Exact steps or command run after this patch: Ran a local non-Vitest OpenClaw runtime probe with `OPENCLAW_TEST_FAST=1 pnpm tsx --eval ...` that imports `cleanupEmbeddedAttemptResources` from the patched production source and exercises the aborted cleanup path with a manually settled abort barrier. Supporting checks also run: `pnpm test src/agents/pi-embedded-runner/run/attempt.subscription-cleanup.test.ts`; `pnpm test:changed`; `pnpm check:changed`; `pnpm check:changed --staged`; `git diff --cached --check`; `command codex review --base upstream/main`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output from the local runtime probe:

```text
timeoutMs=250
beforeSettle=guard
afterSettle=guard>flush>dispose>release
lockReleasedAfterSettle=true
```

- Observed result after fix: The production cleanup helper held the session lock while the abort-settle promise was unresolved (`beforeSettle=guard`), then flushed, disposed, and released only after settlement (`afterSettle=guard>flush>dispose>release`). The final probe assertion printed `lockReleasedAfterSettle=true`.
- What was not tested: A live provider/Pi network abort race. The closest real substitute is the non-test OpenClaw runtime probe above plus the focused regression test and changed core gates.
- Before evidence (optional but encouraged): `upstream/main` called `void activeSession.abort()`, wrapped `activeSession.prompt(...)` with `abortable(...)`, and released the lock after aborted `timeoutMs: 0` cleanup without waiting for the original prompt/abort path to settle.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `abortable()` can reject on the runner abort signal before the original Pi `activeSession.prompt()` promise has stopped writing transcript/tool state, while `abortRun()` also fired `activeSession.abort()` without retaining its settle promise.
- Missing detection / guardrail: There was no regression test asserting that aborted cleanup holds the session write lock until the prompt/abort path settles or the bounded deadline expires.
- Contributing context (if known): Aborted cleanup intentionally skips the expensive idle wait with `timeoutMs: 0`; that performance path also needed a short local settle barrier before lock release.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/run/attempt.subscription-cleanup.test.ts`
- Scenario the test should lock in: Aborted cleanup waits before flush/dispose/release, releases after the settle timeout, and does not wait for non-aborted cleanup.
- Why this is the smallest reliable guardrail: The bug is cleanup ordering around the session lock; the helper test proves that ordering directly without booting the full embedded runner harness.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
abort signal -> abortable(prompt) rejects -> cleanup timeoutMs=0 -> release session lock -> prompt/abort may still unwind

After:
abort signal -> track prompt/abort settle -> cleanup waits bounded barrier -> flush/dispose/release -> next turn can write
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Darwin 25.4.0 arm64
- Runtime/container: Node v24.14.0, pnpm 10.33.2
- Model/provider: N/A
- Integration/channel (if any): Embedded Pi runner cleanup path
- Relevant config (redacted): N/A

### Steps

1. Run the local runtime probe with `OPENCLAW_TEST_FAST=1 pnpm tsx --eval ...`.
2. Run `pnpm test src/agents/pi-embedded-runner/run/attempt.subscription-cleanup.test.ts`.
3. Run `pnpm test:changed`.
4. Run `pnpm check:changed --staged`.

### Expected

- The runtime probe shows no lock release before the abort-settle promise resolves.
- Aborted cleanup waits for the settle promise before lock release and still releases after the bounded timeout.
- Non-aborted cleanup does not wait on the settle promise.
- Changed core/coreTests gates pass.

### Actual

- Runtime probe output: `beforeSettle=guard`, `afterSettle=guard>flush>dispose>release`, `lockReleasedAfterSettle=true`.
- Focused test passed 3/3.
- `pnpm test:changed` passed 2 files / 142 tests.
- `pnpm check:changed --staged` passed core/coreTests typecheck, lint, and guards.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Non-test production cleanup helper probe, focused cleanup ordering, timeout fallback, non-aborted cleanup behavior, changed Vitest routing, core/coreTests typecheck/lint/guards, staged whitespace, CJK additions gate, and local Codex review.
- Edge cases checked: Never-settling abort settle promise, rejected settle promise path by code review, no remaining direct `activeSession.prompt(...)` call sites outside the helper, and no public contract/security/data-access expansion.
- What you did **not** verify: Live provider/Pi network abort race and full repository test suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: A broken provider or Pi runtime might never settle after abort.
  - Mitigation: The cleanup wait is bounded to 2 seconds in normal runtime and 250 ms under `OPENCLAW_TEST_FAST=1`, then best-effort cleanup continues and releases the lock.
