### PR TITLE
fix: strip message/text param when card is present in message tool send

### DIFF
--- a/src/infra/outbound/message-action-normalization.test.ts
+++ b/src/infra/outbound/message-action-normalization.test.ts
@@ -181,4 +181,84 @@ describe("normalizeMessageActionInput", () => {
       }),
     ).toThrow(/requires a target/);
   });
+
+  describe("card-aware text sanitization", () => {
+    it("clears message param when card is present on send action", () => {
+      const result = normalizeMessageActionInput({
+        action: "send",
+        args: {
+          target: "user:ou_123",
+          message: "Daily Report",
+          card: { header: { title: { tag: "plain_text", content: "Daily Report" } } },
+        },
+      });
+      expect(result.message).toBeUndefined();
+      expect(result._cardNotificationHint).toBe("Daily Report");
+      expect(result.card).toBeDefined();
+    });
+
+    it("clears text param when card is present on send action", () => {
+      const result = normalizeMessageActionInput({
+        action: "send",
+        args: {
+          target: "user:ou_123",
+          text: "Alert Title",
+          card: { elements: [] },
+        },
+      });
+      expect(result.text).toBeUndefined();
+      expect(result._cardNotificationHint).toBe("Alert Title");
+    });
+
+    it("preserves message param when no card is present", () => {
+      const result = normalizeMessageActionInput({
+        action: "send",
+        args: {
+          target: "user:ou_123",
+          message: "Hello world",
+        },
+      });
+      expect(result.message).toBe("Hello world");
+      expect(result._cardNotificationHint).toBeUndefined();
+    });
+
+    it("does not sanitize for non-send actions", () => {
+      const result = normalizeMessageActionInput({
+        action: "edit",
+        args: {
+          messageId: "msg_123",
+          message: "Updated text",
+          card: { elements: [] },
+        },
+      });
+      expect(result.message).toBe("Updated text");
+    });
+
+    it("handles empty message with card gracefully", () => {
+      const result = normalizeMessageActionInput({
+        action: "send",
+        args: {
+          target: "user:ou_123",
+          message: "",
+          card: { elements: [] },
+        },
+      });
+      expect(result._cardNotificationHint).toBeUndefined();
+    });
+
+    it("prefers message over text for notification hint", () => {
+      const result = normalizeMessageActionInput({
+        action: "send",
+        args: {
+          target: "user:ou_123",
+          message: "Primary",
+          text: "Secondary",
+          card: { elements: [] },
+        },
+      });
+      expect(result._cardNotificationHint).toBe("Primary");
+      expect(result.message).toBeUndefined();
+      expect(result.text).toBeUndefined();
+    });
+  });
 });

--- a/src/infra/outbound/message-action-normalization.ts
+++ b/src/infra/outbound/message-action-normalization.ts
@@ -70,5 +70,23 @@ export function normalizeMessageActionInput(params: {
     throw new Error(`Action ${action} requires a target.`);
   }
 
+  // Card-aware text sanitization: when a card payload is present, the
+  // `message`/`text` parameter is typically a notification preview or card
+  // title rather than a standalone message body. Channel plugins that support
+  // cards (Feishu, Teams, Slack, etc.) would otherwise send both a text
+  // message and the card, resulting in duplicates. Move the text to a hint
+  // field so plugins can use it for push-notification previews without
+  // sending a visible text message.
+  if (action === "send" && normalizedArgs.card != null && typeof normalizedArgs.card === "object") {
+    const msgText = normalizeOptionalString(normalizedArgs.message as string) ?? "";
+    const altText = normalizeOptionalString(normalizedArgs.text as string) ?? "";
+    const hintText = msgText || altText;
+    if (hintText) {
+      normalizedArgs._cardNotificationHint = hintText;
+    }
+    if (msgText) delete normalizedArgs.message;
+    if (altText) delete normalizedArgs.text;
+  }
+
   return normalizedArgs;
 }


### PR DESCRIPTION
## Summary

When an agent calls `message(action="send", message="Title", card={...})`, channel plugins receive both `text` and `card` and send them as separate messages — the user sees a duplicate text message before the card.

## Changes

**`src/infra/outbound/message-action-normalization.ts`**
- Added card-aware text sanitization in `normalizeMessageActionInput()`
- When `action === "send"` and `card` is a non-null object:
  - Moves `message`/`text` to `_cardNotificationHint` (for push notification previews)
  - Deletes `message`/`text` from args so plugins do not send standalone text
- Only applies to `send` action; other actions (edit, etc.) are unaffected

**`src/infra/outbound/message-action-normalization.test.ts`**
- 6 new test cases covering:
  - `message` cleared when card present
  - `text` cleared when card present  
  - `message` preserved when no card
  - Non-send actions unaffected
  - Empty message handled gracefully
  - `message` preferred over `text` for hint

## Motivation

- All card-capable channels (Feishu, Teams, Slack, Discord) benefit from a single core fix
- LLM behavior is unpredictable — prompt-level fixes ("pass empty message") are unreliable
- Plugin contract is cleaner: when `card` is present, plugins can trust there is no separate text to send

## Backward Compatibility

- `_cardNotificationHint` is an optional metadata field — plugins can read it for push notification previews
- Existing plugins that do not reference `_cardNotificationHint` are unaffected
- Plugin-level workarounds (skipping text when card present) remain compatible

Fixes #80244