### PR TITLE
[codex] Persist external CLI OAuth refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 
 - CLI/gateway: keep `gateway status --deep` plugin-aware so configured plugin manifest warnings, including missing channel config metadata, stay visible during install and update smoke checks.
 - Doctor: stop flagging the live compatibility agent directory as orphaned when the configured default agent is not `main`. Fixes #74313. (#74438) Thanks @carlos4s.
+- Auth/Claude CLI: persist fresher managed external CLI OAuth credentials back to `auth-profiles.json`, preventing stale `anthropic:claude-cli` profiles from repeatedly bootstrapping and flooding debug logs. Fixes #80129. Thanks @Caulderein.
 - Codex app-server: report Codex-native tool execution to diagnostics so long-running native `bash`, web, file, and MCP tools no longer look like stale embedded runs to the watchdog. (#80217)
 - Telegram: preserve blank lines between manually indented bullet blocks and following numbered sections in rendered replies. Fixes #76998. Thanks @evgyur.
 - Slack: pass configured agent identity through draft preview sends so partial streaming replies keep custom username/avatar on the initial Slack message. Fixes #38235. (#38237) Thanks @lacymorrow.

--- a/extensions/clickclack/src/inbound.test.ts
+++ b/extensions/clickclack/src/inbound.test.ts
@@ -7,6 +7,18 @@ import type { CoreConfig, ResolvedClickClackAccount } from "./types.js";
 
 const sendClickClackTextMock = vi.hoisted(() => vi.fn());
 
+type LlmCompleteMock = ReturnType<
+  typeof vi.fn<
+    (params: {
+      agentId?: string;
+      model?: string;
+      maxTokens?: number;
+      purpose?: string;
+      messages?: unknown[];
+    }) => Promise<unknown>
+  >
+>;
+
 vi.mock("./outbound.js", () => ({
   sendClickClackText: sendClickClackTextMock,
 }));
@@ -115,7 +127,7 @@ describe("handleClickClackInbound", () => {
 
     expect(runtime.channel.turn.runPrepared).not.toHaveBeenCalled();
     expect(runtime.agent.runEmbeddedPiAgent).not.toHaveBeenCalled();
-    const completionRequest = runtime.llm.complete.mock.calls[0]?.[0];
+    const completionRequest = (runtime.llm.complete as LlmCompleteMock).mock.calls[0]?.[0];
     expect(completionRequest?.agentId).toBe("service-bot");
     expect(completionRequest?.model).toBe("openai/gpt-5.4-mini");
     expect(completionRequest?.maxTokens).toBe(96);

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -206,7 +206,7 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-function requireFirstCallArg<T>(mock: unknown, label: string): T {
+function requireFirstCallArg<T>(mock: unknown, label: string, _type?: (value: T) => T): T {
   const call = (mock as MockCallReader).mock.calls.at(0);
   if (!call) {
     throw new Error(`expected ${label} to be called`);
@@ -238,7 +238,7 @@ function expectRequestInputTextContains(
   expect(
     input.some((entry) => {
       const item = requireRecord(entry, "turn/start input entry");
-      return item.type === "text" && String(item.text ?? "").includes(expected);
+      return item.type === "text" && typeof item.text === "string" && item.text.includes(expected);
     }),
   ).toBe(true);
 }
@@ -297,7 +297,8 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     expect(assembleParams.availableTools).toEqual(new Set());
 
     const threadStartParams = requireRequestParams(harness, "thread/start");
-    expect(String(threadStartParams.developerInstructions ?? "")).toContain(
+    const developerInstructions = threadStartParams.developerInstructions;
+    expect(typeof developerInstructions === "string" ? developerInstructions : "").toContain(
       "context-engine system",
     );
     expectRequestInputTextContains(harness, "OpenClaw assembled context for this turn:");

--- a/extensions/diffs/src/browser.test.ts
+++ b/extensions/diffs/src/browser.test.ts
@@ -624,7 +624,7 @@ function createMockBrowser(
   options?: { boundingBox?: { x: number; y: number; width: number; height: number } },
 ) {
   const browser = {
-    newPage: vi.fn(async () => {
+    newPage: vi.fn(async (_options?: unknown) => {
       const page = createMockPage(options);
       pages.push(page);
       return page;

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -105,7 +105,9 @@ function createConfigWithDiscordAccount(overrides: Record<string, unknown> = {})
 type MockCallReader = { mock: { calls: unknown[][] } };
 
 function mockMessages(mock: unknown): string[] {
-  return (mock as MockCallReader).mock.calls.map((call) => String(call[0] ?? ""));
+  return (mock as MockCallReader).mock.calls.map((call) =>
+    typeof call[0] === "string" ? call[0] : "",
+  );
 }
 
 function expectMockLogContains(mock: unknown, expected: string): void {

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -215,7 +215,12 @@ function setupRuntimeMediaMocks(params: { loadFileName: string; loadBytes: strin
   return { loadOutboundMediaFromUrl, fetchRemoteMedia };
 }
 
-function requireMockArg<T>(mock: ReturnType<typeof vi.fn>, callIndex = 0, argIndex = 0): T {
+function requireMockArg<T>(
+  mock: ReturnType<typeof vi.fn>,
+  callIndex = 0,
+  argIndex = 0,
+  _type?: (value: T) => T,
+): T {
   const call = mock.mock.calls[callIndex];
   if (!call) {
     throw new Error(`expected mock call ${callIndex}`);
@@ -223,7 +228,11 @@ function requireMockArg<T>(mock: ReturnType<typeof vi.fn>, callIndex = 0, argInd
   return call[argIndex] as T;
 }
 
-function requireMockArgs<T extends unknown[]>(mock: ReturnType<typeof vi.fn>, callIndex = 0): T {
+function requireMockArgs<T extends unknown[]>(
+  mock: ReturnType<typeof vi.fn>,
+  callIndex = 0,
+  _type?: (value: T) => T,
+): T {
   const call = mock.mock.calls[callIndex];
   if (!call) {
     throw new Error(`expected mock call ${callIndex}`);

--- a/extensions/irc/src/inbound.behavior.test.ts
+++ b/extensions/irc/src/inbound.behavior.test.ts
@@ -129,7 +129,7 @@ describe("irc inbound behavior", () => {
       expect.stringContaining("Your IRC id: alice!ident@example.com"),
       undefined,
     );
-    const replyMessages = sendReply.mock.calls.map((call) => String(call[1]));
+    const replyMessages = (sendReply.mock.calls as unknown[][]).map((call) => String(call[1]));
     expect(replyMessages.some((message) => message.includes("CODE"))).toBe(true);
   });
 
@@ -185,7 +185,9 @@ describe("irc inbound behavior", () => {
       sendReply: vi.fn(async () => {}),
     });
 
-    const assembledRequest = coreRuntime.channel.turn.runAssembled.mock.calls[0]?.[0];
+    const assembledRequest = (
+      coreRuntime.channel.turn.runAssembled as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls[0]?.[0] as { replyPipeline?: unknown } | undefined;
     expect(assembledRequest?.replyPipeline).toEqual({});
   });
 });

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -609,7 +609,7 @@ describe("handleLineWebhookEvents", () => {
     });
 
     expect(processMessage).not.toHaveBeenCalled();
-    const pairingRequest = upsertPairingRequestMock.mock.calls[0]?.[0] as
+    const pairingRequest = (upsertPairingRequestMock.mock.calls as unknown[][])[0]?.[0] as
       | { accountId?: string; channel?: string; id?: string }
       | undefined;
     expect(pairingRequest?.channel).toBe("line");
@@ -656,7 +656,7 @@ describe("handleLineWebhookEvents", () => {
 
     expect(readAllowFromStoreMock).toHaveBeenCalledWith("line", undefined, "work");
     expect(processMessage).not.toHaveBeenCalled();
-    const pairingRequest = upsertPairingRequestMock.mock.calls[0]?.[0] as
+    const pairingRequest = (upsertPairingRequestMock.mock.calls as unknown[][])[0]?.[0] as
       | { accountId?: string; channel?: string; id?: string }
       | undefined;
     expect(pairingRequest?.channel).toBe("line");

--- a/extensions/line/src/setup-surface.test.ts
+++ b/extensions/line/src/setup-surface.test.ts
@@ -466,7 +466,9 @@ describe("linePlugin gateway.startAccount", () => {
     await vi.waitFor(() => {
       expect(monitorLineProvider).toHaveBeenCalledTimes(1);
     });
-    const startupParams = monitorLineProvider.mock.calls[0]?.[0];
+    const startupParams = (monitorLineProvider.mock.calls as unknown[][])[0]?.[0] as
+      | { accountId?: string; channelAccessToken?: string; channelSecret?: string }
+      | undefined;
     expect(startupParams?.channelAccessToken).toBe("token");
     expect(startupParams?.channelSecret).toBe("secret");
     expect(startupParams?.accountId).toBe("default");

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -205,7 +205,7 @@ describe("lmstudio-models", () => {
   });
 
   it("discovers llm models and maps metadata", async () => {
-    const fetchMock = vi.fn(async (_url: string | URL) => ({
+    const fetchMock = vi.fn(async (_url: string | URL, _init?: RequestInit) => ({
       ok: true,
       json: async () => ({
         models: [

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -77,7 +77,7 @@ function requireCandidateKeyByPath(
 }
 
 function mockStringMessages(mock: { mock: { calls: unknown[][] } }): string[] {
-  return mock.mock.calls.map((call) => String(call[0] ?? ""));
+  return mock.mock.calls.map((call) => (typeof call[0] === "string" ? call[0] : ""));
 }
 
 function expectIncludesSubstring(values: readonly string[], expected: string): void {

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -149,7 +149,7 @@ function createCronHarness(
 }
 
 function mockStringMessages(mock: { mock: { calls: unknown[][] } }): string[] {
-  return mock.mock.calls.map((call) => String(call[0] ?? ""));
+  return mock.mock.calls.map((call) => (typeof call[0] === "string" ? call[0] : ""));
 }
 
 function expectLogContains(mock: { mock: { calls: unknown[][] } }, expected: string): void {

--- a/extensions/nextcloud-talk/src/inbound.behavior.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.behavior.test.ts
@@ -279,7 +279,9 @@ describe("nextcloud-talk inbound behavior", () => {
       runtime: createRuntimeEnv(),
     });
 
-    const assembledRequest = coreRuntime.channel.turn.runAssembled.mock.calls[0]?.[0];
+    const assembledRequest = (
+      coreRuntime.channel.turn.runAssembled as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls[0]?.[0] as { replyPipeline?: unknown } | undefined;
     expect(assembledRequest?.replyPipeline).toEqual({});
   });
 });

--- a/extensions/nextcloud-talk/src/send.cfg-threading.test.ts
+++ b/extensions/nextcloud-talk/src/send.cfg-threading.test.ts
@@ -221,7 +221,7 @@ describe("nextcloud-talk send cfg threading", () => {
           expect(mediaSendCall?.[0]).toBe(
             "https://nextcloud.example.com/ocs/v2.php/apps/spreed/api/v1/bot/abc123/message",
           );
-          expect((mediaSendCall?.[1] as RequestInit | undefined)?.body).toBe(
+          expect(mediaSendCall?.[1]?.body).toBe(
             JSON.stringify({
               message: "image\n\nAttachment: https://example.com/image.png",
             }),

--- a/extensions/qqbot/src/bridge/tools/remind.test.ts
+++ b/extensions/qqbot/src/bridge/tools/remind.test.ts
@@ -88,7 +88,7 @@ describe("bridge/tools/remind", () => {
   });
 
   it("supports injected cron scheduler dependencies for engine-level tests", async () => {
-    const callCron = vi.fn(async () => ({ id: "job-1" }));
+    const callCron = vi.fn(async (_params: unknown) => ({ id: "job-1" }));
     const tool = createRemindTool(
       {
         senderIsOwner: true,
@@ -118,7 +118,7 @@ describe("bridge/tools/remind", () => {
   });
 
   it("does not schedule when sender ownership is missing", async () => {
-    const callCron = vi.fn(async () => ({ id: "job-1" }));
+    const callCron = vi.fn(async (_params: unknown) => ({ id: "job-1" }));
     const tool = createRemindTool(
       {
         deliveryContext: { to: "qqbot:c2c:user-openid", accountId: "bot2" },

--- a/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
+++ b/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
@@ -5,8 +5,6 @@ import { getWrittenQQBotConfig, installCommandRuntime } from "./slash-command-te
 import { getFrameworkCommands, matchSlashCommand } from "./slash-commands-impl.js";
 import { SlashCommandRegistry, type SlashCommandContext } from "./slash-commands.js";
 
-type FrameworkCommand = ReturnType<typeof getFrameworkCommands>[number];
-
 function createStreamingContext(overrides: Partial<SlashCommandContext> = {}): SlashCommandContext {
   return {
     type: "c2c",
@@ -66,8 +64,8 @@ describe("QQBot framework slash commands", () => {
     expect(commands.map((command) => command.name)).toEqual(["private-admin", "shared-admin"]);
     const privateAdmin = commands.find((command) => command.name === "private-admin");
     const sharedAdmin = commands.find((command) => command.name === "shared-admin");
-    expect((privateAdmin as FrameworkCommand | undefined)?.c2cOnly).toBe(true);
-    expect((sharedAdmin as FrameworkCommand | undefined)?.c2cOnly).toBeUndefined();
+    expect(privateAdmin?.c2cOnly).toBe(true);
+    expect(sharedAdmin?.c2cOnly).toBeUndefined();
   });
 
   it("routes bot-streaming through the auth-gated framework registry", () => {

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -7,7 +7,7 @@ const sendVoiceMessageMock = vi.hoisted(() =>
   vi.fn(async () => ({ id: "voice-1", timestamp: "2026-04-25T00:00:00.000Z" })),
 );
 const sendMediaMock = vi.hoisted(() =>
-  vi.fn(async () => ({ id: "media-1", timestamp: "2026-04-25T00:00:00.000Z" })),
+  vi.fn(async (_params: unknown) => ({ id: "media-1", timestamp: "2026-04-25T00:00:00.000Z" })),
 );
 const sendTextMock = vi.hoisted(() =>
   vi.fn(async () => ({ id: "text-1", timestamp: "2026-04-25T00:00:00.000Z" })),

--- a/extensions/searxng/src/searxng-client.test.ts
+++ b/extensions/searxng/src/searxng-client.test.ts
@@ -101,11 +101,17 @@ describe("searxng client", () => {
     expect(result.provider).toBe("searxng");
     expect(result.query).toBe("beijing hourly weather");
     expect(result.count).toBe(1);
-    expect(result.results).toHaveLength(1);
-    expect(result.results[0]?.url).toBe("https://example.com/weather");
-    expect(result.results[0]?.siteName).toBe("example.com");
-    expect(result.results[0]?.title).toContain("Beijing hourly weather");
-    expect(result.results[0]?.snippet).toContain("Hourly forecast");
+    const results = result.results as Array<{
+      url?: string;
+      siteName?: string;
+      title?: string;
+      snippet?: string;
+    }>;
+    expect(results).toHaveLength(1);
+    expect(results[0]?.url).toBe("https://example.com/weather");
+    expect(results[0]?.siteName).toBe("example.com");
+    expect(results[0]?.title).toContain("Beijing hourly weather");
+    expect(results[0]?.snippet).toContain("Hourly forecast");
     expect(result.externalContent).toEqual({
       provider: "searxng",
       source: "web_search",

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -141,7 +141,7 @@ function expectSaveMediaBufferCall(mock: unknown, contentType: string, maxBytes:
 }
 
 function expectVerboseLogContains(expected: string): void {
-  const messages = vi.mocked(logVerbose).mock.calls.map((call) => String(call[0] ?? ""));
+  const messages = vi.mocked(logVerbose).mock.calls.map((call) => call[0]);
   expect(messages.some((message) => message.includes(expected))).toBe(true);
 }
 

--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -31,7 +31,7 @@ function expectIncludesSubstring(values: readonly string[], expected: string): v
 }
 
 function mockStringMessages(mock: { mock: { calls: unknown[][] } }): string[] {
-  return mock.mock.calls.map((call) => String(call[0] ?? ""));
+  return mock.mock.calls.map((call) => (typeof call[0] === "string" ? call[0] : ""));
 }
 
 const clientModule = await import("./client.js");

--- a/extensions/tavily/src/tavily-tools.test.ts
+++ b/extensions/tavily/src/tavily-tools.test.ts
@@ -18,6 +18,13 @@ const { runTavilySearch, runTavilyExtract } = vi.hoisted(() => ({
   runTavilyExtract: vi.fn(async (params: unknown) => ({ ok: true, params })),
 }));
 
+type TavilyExtractParams = {
+  cfg?: unknown;
+  urls?: string[];
+  query?: string;
+  chunksPerSource?: number;
+};
+
 vi.mock("./tavily-client.js", () => ({
   runTavilySearch,
   runTavilyExtract,
@@ -211,7 +218,7 @@ describe("tavily tools", () => {
     const searchParams = runTavilySearch.mock.calls[0]?.[0];
     expect(searchParams?.cfg).toBe(runtimeConfig);
     expect(searchParams?.query).toBe("openclaw");
-    const extractParams = runTavilyExtract.mock.calls[0]?.[0];
+    const extractParams = runTavilyExtract.mock.calls[0]?.[0] as TavilyExtractParams | undefined;
     expect(extractParams?.cfg).toBe(runtimeConfig);
     expect(extractParams?.urls).toEqual(["https://example.com"]);
   });
@@ -249,7 +256,7 @@ describe("tavily tools", () => {
       chunks_per_source: 2,
     });
 
-    const extractParams = runTavilyExtract.mock.calls[0]?.[0];
+    const extractParams = runTavilyExtract.mock.calls[0]?.[0] as TavilyExtractParams | undefined;
     expect(extractParams?.cfg).toEqual({});
     expect(extractParams?.urls).toEqual(["https://example.com"]);
     expect(extractParams?.query).toBe("pricing");

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -136,7 +136,9 @@ function requireMockCall(mock: unknown, index: number, label: string): unknown[]
 }
 
 function mockMessages(mock: unknown): string[] {
-  return (mock as MockCallReader).mock.calls.map((call) => String(call[0] ?? ""));
+  return (mock as MockCallReader).mock.calls.map((call) =>
+    typeof call[0] === "string" ? call[0] : "",
+  );
 }
 
 function expectMockMessageContains(mock: unknown, expected: string): void {

--- a/src/agents/auth-profiles.external-cli-sync.test.ts
+++ b/src/agents/auth-profiles.external-cli-sync.test.ts
@@ -53,6 +53,16 @@ function expectSingleProfileCredential(
   return profiles[0]?.credential as Record<string, unknown>;
 }
 
+function expectSingleProfile(
+  profiles: ReturnType<typeof resolveExternalCliAuthProfiles>,
+  profileId: string,
+) {
+  expect(profiles).toHaveLength(1);
+  expect(profiles[0]?.profileId).toBe(profileId);
+  expect(profiles[0]?.credential).toBeTruthy();
+  return profiles[0];
+}
+
 function expectCredentialFields(
   credential: Record<string, unknown> | undefined,
   expected: Record<string, unknown>,
@@ -352,7 +362,9 @@ describe("external cli oauth resolution", () => {
       providerIds: ["claude-cli"],
     });
 
-    expectCredentialFields(expectSingleProfileCredential(profiles, CLAUDE_CLI_PROFILE_ID), {
+    const profile = expectSingleProfile(profiles, CLAUDE_CLI_PROFILE_ID);
+    expect(profile?.persistence).toBe("persisted");
+    expectCredentialFields(profile?.credential as Record<string, unknown>, {
       type: "oauth",
       provider: "claude-cli",
       access: "claude-cli-access",
@@ -405,10 +417,35 @@ describe("external cli oauth resolution", () => {
       }),
     );
 
-    expectCredentialFields(expectSingleProfileCredential(profiles, CLAUDE_CLI_PROFILE_ID), {
+    const profile = expectSingleProfile(profiles, CLAUDE_CLI_PROFILE_ID);
+    expect(profile?.persistence).toBe("persisted");
+    expectCredentialFields(profile?.credential as Record<string, unknown>, {
       provider: "claude-cli",
       access: "claude-cli-fresh-access",
     });
+  });
+
+  it("does not reread external CLI credentials for a usable stored managed profile", () => {
+    mocks.readClaudeCliCredentialsCached.mockReturnValue({
+      type: "oauth",
+      provider: "anthropic",
+      access: "external-access",
+      refresh: "external-refresh",
+      expires: Date.now() + 5 * 24 * 60 * 60_000,
+    });
+
+    const profiles = resolveExternalCliAuthProfiles(
+      makeStore(CLAUDE_CLI_PROFILE_ID, {
+        type: "oauth",
+        provider: "claude-cli",
+        access: "usable-local-access",
+        refresh: "usable-local-refresh",
+        expires: Date.now() + 10 * 60_000,
+      }),
+    );
+
+    expect(profiles).toStrictEqual([]);
+    expect(mocks.readClaudeCliCredentialsCached).not.toHaveBeenCalled();
   });
 
   it("passes non-prompting keychain policy to scoped Claude CLI credential reads", () => {
@@ -425,7 +462,9 @@ describe("external cli oauth resolution", () => {
       allowKeychainPrompt: false,
     });
 
-    expectCredentialFields(expectSingleProfileCredential(profiles, CLAUDE_CLI_PROFILE_ID), {
+    const profile = expectSingleProfile(profiles, CLAUDE_CLI_PROFILE_ID);
+    expect(profile?.persistence).toBe("persisted");
+    expectCredentialFields(profile?.credential as Record<string, unknown>, {
       type: "oauth",
       provider: "claude-cli",
     });

--- a/src/agents/auth-profiles.store-cache.test.ts
+++ b/src/agents/auth-profiles.store-cache.test.ts
@@ -297,4 +297,49 @@ describe("auth profile store cache", () => {
       expect(openaiProfile?.key).toBe("sk-concurrent");
     });
   });
+
+  it("returns the reloaded store when the synced CLI profile changed concurrently", async () => {
+    await withAgentDirEnv("openclaw-auth-store-external-cli-profile-race-", (agentDir) => {
+      const profileId = "anthropic:claude-cli";
+      const authPath = writeOAuthStore(agentDir, profileId, {
+        type: "oauth",
+        provider: "claude-cli",
+        access: "stale-local-access",
+        refresh: "stale-local-refresh",
+        expires: Date.now() - 60_000,
+      });
+      mocks.resolveExternalCliAuthProfiles.mockImplementationOnce(() => {
+        writeOAuthStore(agentDir, profileId, {
+          type: "oauth",
+          provider: "claude-cli",
+          access: "manual-concurrent-access",
+          refresh: "manual-concurrent-refresh",
+          expires: Date.now() + 120_000,
+        });
+        return [
+          createPersistedOverlay(profileId, {
+            type: "oauth",
+            provider: "claude-cli",
+            access: "fresh-cli-access",
+            refresh: "fresh-cli-refresh",
+            expires: Date.now() + 60_000,
+          }),
+        ];
+      });
+
+      const first = ensureAuthProfileStore(agentDir);
+      const second = ensureAuthProfileStore(agentDir);
+      const persisted = JSON.parse(fs.readFileSync(authPath, "utf8")) as {
+        profiles: Record<string, OAuthCredential>;
+      };
+
+      expect((first.profiles[profileId] as OAuthCredential | undefined)?.access).toBe(
+        "manual-concurrent-access",
+      );
+      expect((second.profiles[profileId] as OAuthCredential | undefined)?.access).toBe(
+        "manual-concurrent-access",
+      );
+      expect(persisted.profiles[profileId]?.access).toBe("manual-concurrent-access");
+    });
+  });
 });

--- a/src/agents/auth-profiles.store-cache.test.ts
+++ b/src/agents/auth-profiles.store-cache.test.ts
@@ -9,7 +9,11 @@ import {
 } from "./auth-profiles/store.js";
 import type { OAuthCredential } from "./auth-profiles/types.js";
 
-type RuntimeOnlyOverlay = { profileId: string; credential: OAuthCredential };
+type RuntimeOnlyOverlay = {
+  profileId: string;
+  credential: OAuthCredential;
+  persistence?: "runtime-only" | "persisted";
+};
 
 const mocks = vi.hoisted(() => ({
   resolveExternalCliAuthProfiles: vi.fn<
@@ -71,6 +75,25 @@ function writeAuthStore(agentDir: string, key: string) {
   return authPath;
 }
 
+function writeOAuthStore(agentDir: string, profileId: string, credential: OAuthCredential) {
+  const authPath = path.join(agentDir, "auth-profiles.json");
+  fs.writeFileSync(
+    authPath,
+    `${JSON.stringify(
+      {
+        version: AUTH_STORE_VERSION,
+        profiles: {
+          [profileId]: credential,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  return authPath;
+}
+
 describe("auth profile store cache", () => {
   beforeEach(() => {
     clearRuntimeAuthProfileStoreSnapshots();
@@ -93,6 +116,17 @@ describe("auth profile store cache", () => {
         refresh: `refresh-${access}`,
         expires: Date.now() + 60_000,
       },
+    };
+  }
+
+  function createPersistedOverlay(
+    profileId: string,
+    credential: OAuthCredential,
+  ): RuntimeOnlyOverlay {
+    return {
+      profileId,
+      credential,
+      persistence: "persisted",
     };
   }
 
@@ -170,6 +204,41 @@ describe("auth profile store cache", () => {
         "access-1",
       );
       expect(fs.existsSync(path.join(agentDir, "auth-profiles.json"))).toBe(false);
+    });
+  });
+
+  it("persists fresher external CLI oauth over a stale local managed profile", async () => {
+    await withAgentDirEnv("openclaw-auth-store-external-cli-persist-", (agentDir) => {
+      const profileId = "anthropic:claude-cli";
+      writeOAuthStore(agentDir, profileId, {
+        type: "oauth",
+        provider: "claude-cli",
+        access: "stale-local-access",
+        refresh: "stale-local-refresh",
+        expires: Date.now() - 60_000,
+      });
+      mocks.resolveExternalCliAuthProfiles
+        .mockReturnValueOnce([
+          createPersistedOverlay(profileId, {
+            type: "oauth",
+            provider: "claude-cli",
+            access: "fresh-cli-access",
+            refresh: "fresh-cli-refresh",
+            expires: Date.now() + 60_000,
+          }),
+        ])
+        .mockReturnValue([]);
+
+      const store = ensureAuthProfileStore(agentDir);
+      const persisted = JSON.parse(
+        fs.readFileSync(path.join(agentDir, "auth-profiles.json"), "utf8"),
+      ) as { profiles: Record<string, OAuthCredential> };
+
+      expect((store.profiles[profileId] as OAuthCredential | undefined)?.access).toBe(
+        "fresh-cli-access",
+      );
+      expect(persisted.profiles[profileId]?.access).toBe("fresh-cli-access");
+      expect(persisted.profiles[profileId]?.refresh).toBe("fresh-cli-refresh");
     });
   });
 });

--- a/src/agents/auth-profiles.store-cache.test.ts
+++ b/src/agents/auth-profiles.store-cache.test.ts
@@ -6,6 +6,7 @@ import { AUTH_STORE_LOCK_OPTIONS, AUTH_STORE_VERSION } from "./auth-profiles/con
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   ensureAuthProfileStore,
+  ensureAuthProfileStoreWithoutExternalProfiles,
 } from "./auth-profiles/store.js";
 import type { OAuthCredential } from "./auth-profiles/types.js";
 
@@ -383,6 +384,57 @@ describe("auth profile store cache", () => {
       expect(fs.readFileSync(lockPath, "utf8")).toBe(lockRaw);
       expect(persisted.profiles[profileId]?.access).toBe("stale-local-access");
       expect(persisted.profiles[profileId]?.refresh).toBe("stale-local-refresh");
+    });
+  });
+
+  it("does not cache stale auth after external CLI sync lock contention", async () => {
+    await withAgentDirEnv("openclaw-auth-store-external-cli-locked-cache-", (agentDir) => {
+      const profileId = "anthropic:claude-cli";
+      const authPath = writeOAuthStore(agentDir, profileId, {
+        type: "oauth",
+        provider: "claude-cli",
+        access: "stale-local-access",
+        refresh: "stale-local-refresh",
+        expires: Date.now() - 60_000,
+      });
+      const lockPath = `${authPath}.lock`;
+      fs.writeFileSync(
+        lockPath,
+        `${JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }, null, 2)}\n`,
+        "utf8",
+      );
+      mocks.resolveExternalCliAuthProfiles
+        .mockImplementationOnce(() => {
+          writeOAuthStore(agentDir, profileId, {
+            type: "oauth",
+            provider: "claude-cli",
+            access: "fresh-disk-access",
+            refresh: "fresh-disk-refresh",
+            expires: Date.now() + 120_000,
+          });
+          const bumpedMtime = new Date(Date.now() + 2_000);
+          fs.utimesSync(authPath, bumpedMtime, bumpedMtime);
+          return [
+            createPersistedOverlay(profileId, {
+              type: "oauth",
+              provider: "claude-cli",
+              access: "fresh-cli-access",
+              refresh: "fresh-cli-refresh",
+              expires: Date.now() + 60_000,
+            }),
+          ];
+        })
+        .mockReturnValue([]);
+
+      const first = ensureAuthProfileStoreWithoutExternalProfiles(agentDir);
+      const second = ensureAuthProfileStoreWithoutExternalProfiles(agentDir);
+
+      expect((first.profiles[profileId] as OAuthCredential | undefined)?.access).toBe(
+        "stale-local-access",
+      );
+      expect((second.profiles[profileId] as OAuthCredential | undefined)?.access).toBe(
+        "fresh-disk-access",
+      );
     });
   });
 });

--- a/src/agents/auth-profiles.store-cache.test.ts
+++ b/src/agents/auth-profiles.store-cache.test.ts
@@ -241,4 +241,60 @@ describe("auth profile store cache", () => {
       expect(persisted.profiles[profileId]?.refresh).toBe("fresh-cli-refresh");
     });
   });
+
+  it("preserves concurrent auth-store updates while persisting external CLI oauth", async () => {
+    await withAgentDirEnv("openclaw-auth-store-external-cli-concurrent-", (agentDir) => {
+      const profileId = "anthropic:claude-cli";
+      const authPath = writeOAuthStore(agentDir, profileId, {
+        type: "oauth",
+        provider: "claude-cli",
+        access: "stale-local-access",
+        refresh: "stale-local-refresh",
+        expires: Date.now() - 60_000,
+      });
+      mocks.resolveExternalCliAuthProfiles.mockImplementationOnce(() => {
+        const current = JSON.parse(fs.readFileSync(authPath, "utf8")) as {
+          profiles: Record<string, unknown>;
+        };
+        fs.writeFileSync(
+          authPath,
+          `${JSON.stringify(
+            {
+              ...current,
+              profiles: {
+                ...current.profiles,
+                "openai:default": {
+                  type: "api_key",
+                  provider: "openai",
+                  key: "sk-concurrent",
+                },
+              },
+            },
+            null,
+            2,
+          )}\n`,
+          "utf8",
+        );
+        return [
+          createPersistedOverlay(profileId, {
+            type: "oauth",
+            provider: "claude-cli",
+            access: "fresh-cli-access",
+            refresh: "fresh-cli-refresh",
+            expires: Date.now() + 60_000,
+          }),
+        ];
+      });
+
+      ensureAuthProfileStore(agentDir);
+      const persisted = JSON.parse(fs.readFileSync(authPath, "utf8")) as {
+        profiles: Record<string, unknown>;
+      };
+      const cliProfile = persisted.profiles[profileId] as OAuthCredential | undefined;
+      const openaiProfile = persisted.profiles["openai:default"] as { key?: string } | undefined;
+
+      expect(cliProfile?.access).toBe("fresh-cli-access");
+      expect(openaiProfile?.key).toBe("sk-concurrent");
+    });
+  });
 });

--- a/src/agents/auth-profiles.store-cache.test.ts
+++ b/src/agents/auth-profiles.store-cache.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
+import { AUTH_STORE_LOCK_OPTIONS, AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   ensureAuthProfileStore,
@@ -340,6 +340,49 @@ describe("auth profile store cache", () => {
         "manual-concurrent-access",
       );
       expect(persisted.profiles[profileId]?.access).toBe("manual-concurrent-access");
+    });
+  });
+
+  it("does not reclaim an existing auth-store lock while syncing external CLI oauth", async () => {
+    await withAgentDirEnv("openclaw-auth-store-external-cli-live-lock-", (agentDir) => {
+      const profileId = "anthropic:claude-cli";
+      const authPath = writeOAuthStore(agentDir, profileId, {
+        type: "oauth",
+        provider: "claude-cli",
+        access: "stale-local-access",
+        refresh: "stale-local-refresh",
+        expires: Date.now() - 60_000,
+      });
+      const lockPath = `${authPath}.lock`;
+      const lockRaw = `${JSON.stringify(
+        {
+          pid: process.pid,
+          createdAt: new Date(Date.now() - AUTH_STORE_LOCK_OPTIONS.stale - 1_000).toISOString(),
+        },
+        null,
+        2,
+      )}\n`;
+      fs.writeFileSync(lockPath, lockRaw, "utf8");
+      const oldLockTime = new Date(Date.now() - AUTH_STORE_LOCK_OPTIONS.stale - 1_000);
+      fs.utimesSync(lockPath, oldLockTime, oldLockTime);
+      mocks.resolveExternalCliAuthProfiles.mockReturnValue([
+        createPersistedOverlay(profileId, {
+          type: "oauth",
+          provider: "claude-cli",
+          access: "fresh-cli-access",
+          refresh: "fresh-cli-refresh",
+          expires: Date.now() + 60_000,
+        }),
+      ]);
+
+      ensureAuthProfileStore(agentDir);
+      const persisted = JSON.parse(fs.readFileSync(authPath, "utf8")) as {
+        profiles: Record<string, OAuthCredential>;
+      };
+
+      expect(fs.readFileSync(lockPath, "utf8")).toBe(lockRaw);
+      expect(persisted.profiles[profileId]?.access).toBe("stale-local-access");
+      expect(persisted.profiles[profileId]?.refresh).toBe("stale-local-refresh");
     });
   });
 });

--- a/src/agents/auth-profiles.store.save.test.ts
+++ b/src/agents/auth-profiles.store.save.test.ts
@@ -15,6 +15,7 @@ import type { AuthProfileStore } from "./auth-profiles/types.js";
 vi.mock("./auth-profiles/external-auth.js", () => ({
   overlayExternalAuthProfiles: <T>(store: T) => store,
   shouldPersistExternalAuthProfile: () => true,
+  syncPersistedExternalCliAuthProfiles: <T>(store: T) => store,
 }));
 
 describe("saveAuthProfileStore", () => {

--- a/src/agents/auth-profiles/external-auth.ts
+++ b/src/agents/auth-profiles/external-auth.ts
@@ -1,8 +1,11 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderExternalAuthProfile } from "../../plugins/provider-external-auth.types.js";
 import { resolveExternalAuthProfilesWithPlugins } from "../../plugins/provider-runtime.js";
+import { cloneAuthProfileStore } from "./clone.js";
+import { CLAUDE_CLI_PROFILE_ID, MINIMAX_CLI_PROFILE_ID } from "./constants.js";
 import * as externalCliSync from "./external-cli-sync.js";
 import {
+  areOAuthCredentialsEquivalent,
   overlayRuntimeExternalOAuthProfiles,
   shouldPersistRuntimeExternalOAuthProfile,
   type RuntimeExternalOAuthProfile,
@@ -73,7 +76,7 @@ function resolveExternalAuthProfileMap(params: {
     resolved.set(profile.profileId, {
       profileId: profile.profileId,
       credential: profile.credential,
-      persistence: "runtime-only",
+      persistence: profile.persistence ?? "runtime-only",
     });
   }
   for (const rawProfile of profiles) {
@@ -100,6 +103,22 @@ function listRuntimeExternalAuthProfiles(params: {
       externalCli: params.externalCli,
     }).values(),
   );
+}
+
+function hasPersistableExternalCliSyncCandidate(
+  store: AuthProfileStore,
+  params?: ExternalCliOverlayOptions,
+): boolean {
+  if (params?.externalCliProviderIds || params?.externalCliProfileIds) {
+    return true;
+  }
+  for (const profileId of [CLAUDE_CLI_PROFILE_ID, MINIMAX_CLI_PROFILE_ID]) {
+    const credential = store.profiles[profileId];
+    if (credential?.type === "oauth") {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function overlayExternalAuthProfiles(
@@ -140,6 +159,37 @@ export function shouldPersistExternalAuthProfile(params: {
     credential: params.credential,
     profiles,
   });
+}
+
+export function syncPersistedExternalCliAuthProfiles(
+  store: AuthProfileStore,
+  params?: { agentDir?: string; env?: NodeJS.ProcessEnv } & ExternalCliOverlayOptions,
+): AuthProfileStore {
+  if (!hasPersistableExternalCliSyncCandidate(store, params)) {
+    return store;
+  }
+  const cliProfiles =
+    externalCliSync.resolveExternalCliAuthProfiles?.(store, {
+      allowKeychainPrompt: params?.allowKeychainPrompt,
+      providerIds: params?.externalCliProviderIds,
+      profileIds: params?.externalCliProfileIds,
+    }) ?? [];
+  const persistedProfiles = cliProfiles.filter((profile) => profile.persistence === "persisted");
+  if (persistedProfiles.length === 0) {
+    return store;
+  }
+
+  let next: AuthProfileStore | undefined;
+  for (const profile of persistedProfiles) {
+    const target = next ?? store;
+    const existing = target.profiles[profile.profileId];
+    if (existing?.type === "oauth" && areOAuthCredentialsEquivalent(existing, profile.credential)) {
+      continue;
+    }
+    next ??= cloneAuthProfileStore(store);
+    next.profiles[profile.profileId] = profile.credential;
+  }
+  return next ?? store;
 }
 
 // Compat aliases while file/function naming catches up.

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -13,6 +13,7 @@ import {
 import { log } from "./constants.js";
 import {
   areOAuthCredentialsEquivalent,
+  hasUsableOAuthCredential,
   isSafeToAdoptBootstrapOAuthIdentity,
   shouldBootstrapFromExternalCliCredential,
 } from "./oauth-shared.js";
@@ -30,6 +31,7 @@ export {
 export type ExternalCliResolvedProfile = {
   profileId: string;
   credential: OAuthCredential;
+  persistence?: "runtime-only" | "persisted";
 };
 
 export type ExternalCliAuthProfileOptions = {
@@ -232,12 +234,6 @@ export function resolveExternalCliAuthProfiles(
     if (!isExternalCliProviderInScope({ providerConfig, store, options })) {
       continue;
     }
-    const creds = providerConfig.readCredentials({
-      allowKeychainPrompt: options?.allowKeychainPrompt,
-    });
-    if (!creds) {
-      continue;
-    }
     const existing = store.profiles[providerConfig.profileId];
     const existingOAuth =
       existing?.type === "oauth" && existing.provider === providerConfig.provider
@@ -257,6 +253,19 @@ export function resolveExternalCliAuthProfiles(
         profileId: providerConfig.profileId,
         provider: providerConfig.provider,
       });
+      continue;
+    }
+    if (
+      existingOAuth &&
+      !providerConfig.bootstrapOnly &&
+      hasUsableOAuthCredential(existingOAuth, now)
+    ) {
+      continue;
+    }
+    const creds = providerConfig.readCredentials({
+      allowKeychainPrompt: options?.allowKeychainPrompt,
+    });
+    if (!creds) {
       continue;
     }
     if (existingOAuth && !isSafeToUseExternalCliCredential(existingOAuth, creds)) {
@@ -303,6 +312,7 @@ export function resolveExternalCliAuthProfiles(
     profiles.push({
       profileId: providerConfig.profileId,
       credential: creds,
+      persistence: providerConfig.bootstrapOnly ? "runtime-only" : "persisted",
     });
   }
   return profiles;

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -4,7 +4,6 @@ import { isDeepStrictEqual } from "node:util";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withFileLock } from "../../infra/file-lock.js";
 import { saveJsonFile } from "../../infra/json-file.js";
-import { isPidAlive } from "../../shared/pid-alive.js";
 import { cloneAuthProfileStore } from "./clone.js";
 import {
   AUTH_STORE_LOCK_OPTIONS,
@@ -168,19 +167,6 @@ function readAuthStoreMtimeMs(authPath: string): number | null {
   }
 }
 
-function sleepSync(ms: number): void {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function computeAuthStoreLockDelayMs(attempt: number): number {
-  const retry = AUTH_STORE_LOCK_OPTIONS.retries;
-  const base = Math.min(
-    retry.maxTimeout,
-    Math.max(retry.minTimeout, retry.minTimeout * retry.factor ** attempt),
-  );
-  return retry.randomize ? Math.round(base * (1 + Math.random())) : base;
-}
-
 function readSyncLockSnapshot(lockPath: string): SyncLockSnapshot | null {
   try {
     const stat = fs.lstatSync(lockPath);
@@ -214,64 +200,34 @@ function syncLockSnapshotMatches(lockPath: string, snapshot: SyncLockSnapshot): 
   }
 }
 
-function shouldReclaimSyncAuthStoreLock(snapshot: SyncLockSnapshot, nowMs: number): boolean {
-  const pid = snapshot.payload?.pid;
-  if (typeof pid === "number" && Number.isInteger(pid) && pid > 0 && !isPidAlive(pid)) {
-    return true;
-  }
-  const createdAt = snapshot.payload?.createdAt;
-  if (typeof createdAt === "string") {
-    const createdAtMs = Date.parse(createdAt);
-    return !Number.isFinite(createdAtMs) || nowMs - createdAtMs > AUTH_STORE_LOCK_OPTIONS.stale;
-  }
-  return nowMs - snapshot.stat.mtimeMs > AUTH_STORE_LOCK_OPTIONS.stale;
-}
-
 function acquireAuthStoreLockSync(authPath: string): (() => void) | null {
   const lockPath = `${authPath}.lock`;
   fs.mkdirSync(path.dirname(authPath), { recursive: true });
 
-  for (let attempt = 0; attempt <= AUTH_STORE_LOCK_OPTIONS.retries.retries; attempt += 1) {
+  try {
+    const fd = fs.openSync(lockPath, "wx");
+    const raw = `${JSON.stringify(
+      { pid: process.pid, createdAt: new Date().toISOString() },
+      null,
+      2,
+    )}\n`;
     try {
-      const fd = fs.openSync(lockPath, "wx");
-      const raw = `${JSON.stringify(
-        { pid: process.pid, createdAt: new Date().toISOString() },
-        null,
-        2,
-      )}\n`;
-      try {
-        fs.writeFileSync(fd, raw, "utf8");
-      } finally {
-        fs.closeSync(fd);
-      }
-      const snapshot = readSyncLockSnapshot(lockPath);
-      return () => {
-        if (snapshot && syncLockSnapshotMatches(lockPath, snapshot)) {
-          fs.rmSync(lockPath, { force: true });
-        }
-      };
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException)?.code !== "EEXIST") {
-        throw err;
-      }
-      const snapshot = readSyncLockSnapshot(lockPath);
-      if (!snapshot) {
-        continue;
-      }
-      if (shouldReclaimSyncAuthStoreLock(snapshot, Date.now())) {
-        if (syncLockSnapshotMatches(lockPath, snapshot)) {
-          fs.rmSync(lockPath, { force: true });
-        }
-        continue;
-      }
-      if (attempt >= AUTH_STORE_LOCK_OPTIONS.retries.retries) {
-        return null;
-      }
-      const delayMs = computeAuthStoreLockDelayMs(attempt);
-      sleepSync(delayMs);
+      fs.writeFileSync(fd, raw, "utf8");
+    } finally {
+      fs.closeSync(fd);
     }
+    const snapshot = readSyncLockSnapshot(lockPath);
+    return () => {
+      if (snapshot && syncLockSnapshotMatches(lockPath, snapshot)) {
+        fs.rmSync(lockPath, { force: true });
+      }
+    };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "EEXIST") {
+      return null;
+    }
+    throw err;
   }
-  return null;
 }
 
 function readCachedAuthProfileStore(params: {
@@ -385,7 +341,7 @@ function maybeSyncPersistedExternalCliAuthProfiles(params: {
     log.warn("skipped persisted external cli auth sync because auth store is locked", {
       authPath,
     });
-    return synced;
+    return params.store;
   }
   try {
     const latestStore = loadPersistedAuthProfileStore(params.agentDir) ?? {

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -10,7 +10,11 @@ import {
   EXTERNAL_CLI_SYNC_TTL_MS,
   log,
 } from "./constants.js";
-import { overlayExternalAuthProfiles, shouldPersistExternalAuthProfile } from "./external-auth.js";
+import {
+  overlayExternalAuthProfiles,
+  shouldPersistExternalAuthProfile,
+  syncPersistedExternalCliAuthProfiles,
+} from "./external-auth.js";
 import type { ExternalCliAuthDiscovery } from "./external-cli-discovery.js";
 import { isSafeToAdoptMainStoreOAuthIdentity } from "./oauth-shared.js";
 import {
@@ -234,6 +238,31 @@ function resolveExternalCliOverlayOptions(
   };
 }
 
+function maybeSyncPersistedExternalCliAuthProfiles(params: {
+  store: AuthProfileStore;
+  agentDir?: string;
+  options?: LoadAuthProfileStoreOptions;
+}): AuthProfileStore {
+  if (
+    params.options?.readOnly === true ||
+    params.options?.syncExternalCli === false ||
+    process.env.OPENCLAW_AUTH_STORE_READONLY === "1"
+  ) {
+    return params.store;
+  }
+  const synced = syncPersistedExternalCliAuthProfiles(params.store, {
+    agentDir: params.agentDir,
+    ...resolveExternalCliOverlayOptions(params.options),
+  });
+  if (synced === params.store) {
+    return params.store;
+  }
+  saveAuthProfileStore(synced, params.agentDir, {
+    filterExternalAuthProfiles: false,
+  });
+  return synced;
+}
+
 function shouldKeepProfileInLocalStore(params: {
   store: AuthProfileStore;
   profileId: string;
@@ -373,15 +402,20 @@ function loadAuthProfileStoreForAgent(
   }
   const asStore = loadPersistedAuthProfileStore(agentDir);
   if (asStore) {
+    const store = maybeSyncPersistedExternalCliAuthProfiles({
+      store: asStore,
+      agentDir,
+      options,
+    });
     if (!readOnly) {
       writeCachedAuthProfileStore({
         authPath,
         authMtimeMs: readAuthStoreMtimeMs(authPath),
         stateMtimeMs: readAuthStoreMtimeMs(statePath),
-        store: asStore,
+        store,
       });
     }
-    return asStore;
+    return store;
   }
 
   const legacy = loadLegacyAuthProfileStore(agentDir);
@@ -417,15 +451,21 @@ function loadAuthProfileStoreForAgent(
     }
   }
 
+  const syncedStore = maybeSyncPersistedExternalCliAuthProfiles({
+    store,
+    agentDir,
+    options,
+  });
+
   if (!readOnly) {
     writeCachedAuthProfileStore({
       authPath,
       authMtimeMs: readAuthStoreMtimeMs(authPath),
       stateMtimeMs: readAuthStoreMtimeMs(statePath),
-      store,
+      store: syncedStore,
     });
   }
-  return store;
+  return syncedStore;
 }
 
 export function loadAuthProfileStoreForRuntime(

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -70,6 +70,11 @@ type SyncLockSnapshot = {
   payload: Record<string, unknown> | null;
 };
 
+type ExternalCliSyncResult = {
+  store: AuthProfileStore;
+  cacheable: boolean;
+};
+
 const loadedAuthStoreCache = new Map<
   string,
   {
@@ -312,27 +317,27 @@ function maybeSyncPersistedExternalCliAuthProfiles(params: {
   store: AuthProfileStore;
   agentDir?: string;
   options?: LoadAuthProfileStoreOptions;
-}): AuthProfileStore {
+}): ExternalCliSyncResult {
   if (
     params.options?.readOnly === true ||
     params.options?.syncExternalCli === false ||
     process.env.OPENCLAW_AUTH_STORE_READONLY === "1"
   ) {
-    return params.store;
+    return { store: params.store, cacheable: true };
   }
   const synced = syncPersistedExternalCliAuthProfiles(params.store, {
     agentDir: params.agentDir,
     ...resolveExternalCliOverlayOptions(params.options),
   });
   if (synced === params.store) {
-    return params.store;
+    return { store: params.store, cacheable: true };
   }
   const changedProfiles = Object.entries(synced.profiles).filter(([profileId, credential]) => {
     const previous = params.store.profiles[profileId];
     return !isDeepStrictEqual(previous, credential);
   });
   if (changedProfiles.length === 0) {
-    return synced;
+    return { store: synced, cacheable: true };
   }
 
   const authPath = resolveAuthStorePath(params.agentDir);
@@ -341,7 +346,7 @@ function maybeSyncPersistedExternalCliAuthProfiles(params: {
     log.warn("skipped persisted external cli auth sync because auth store is locked", {
       authPath,
     });
-    return params.store;
+    return { store: params.store, cacheable: false };
   }
   try {
     const latestStore = loadPersistedAuthProfileStore(params.agentDir) ?? {
@@ -365,9 +370,9 @@ function maybeSyncPersistedExternalCliAuthProfiles(params: {
       saveAuthProfileStore(latestStore, params.agentDir, {
         filterExternalAuthProfiles: false,
       });
-      return latestStore;
+      return { store: latestStore, cacheable: true };
     }
-    return latestStore;
+    return { store: latestStore, cacheable: true };
   } finally {
     release();
   }
@@ -512,20 +517,20 @@ function loadAuthProfileStoreForAgent(
   }
   const asStore = loadPersistedAuthProfileStore(agentDir);
   if (asStore) {
-    const store = maybeSyncPersistedExternalCliAuthProfiles({
+    const synced = maybeSyncPersistedExternalCliAuthProfiles({
       store: asStore,
       agentDir,
       options,
     });
-    if (!readOnly) {
+    if (!readOnly && synced.cacheable) {
       writeCachedAuthProfileStore({
         authPath,
         authMtimeMs: readAuthStoreMtimeMs(authPath),
         stateMtimeMs: readAuthStoreMtimeMs(statePath),
-        store,
+        store: synced.store,
       });
     }
-    return store;
+    return synced.store;
   }
 
   const legacy = loadLegacyAuthProfileStore(agentDir);
@@ -561,21 +566,21 @@ function loadAuthProfileStoreForAgent(
     }
   }
 
-  const syncedStore = maybeSyncPersistedExternalCliAuthProfiles({
+  const synced = maybeSyncPersistedExternalCliAuthProfiles({
     store,
     agentDir,
     options,
   });
 
-  if (!readOnly) {
+  if (!readOnly && synced.cacheable) {
     writeCachedAuthProfileStore({
       authPath,
       authMtimeMs: readAuthStoreMtimeMs(authPath),
       stateMtimeMs: readAuthStoreMtimeMs(statePath),
-      store: syncedStore,
+      store: synced.store,
     });
   }
-  return syncedStore;
+  return synced.store;
 }
 
 export function loadAuthProfileStoreForRuntime(

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -411,10 +411,10 @@ function maybeSyncPersistedExternalCliAuthProfiles(params: {
       });
       return latestStore;
     }
+    return latestStore;
   } finally {
     release();
   }
-  return synced;
 }
 
 function shouldKeepProfileInLocalStore(params: {

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -1,8 +1,10 @@
 import fs from "node:fs";
+import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withFileLock } from "../../infra/file-lock.js";
 import { saveJsonFile } from "../../infra/json-file.js";
+import { isPidAlive } from "../../shared/pid-alive.js";
 import { cloneAuthProfileStore } from "./clone.js";
 import {
   AUTH_STORE_LOCK_OPTIONS,
@@ -61,6 +63,12 @@ type ResolvedExternalCliOverlayOptions = {
   config?: OpenClawConfig;
   externalCliProviderIds?: Iterable<string>;
   externalCliProfileIds?: Iterable<string>;
+};
+
+type SyncLockSnapshot = {
+  raw: string;
+  stat: fs.Stats;
+  payload: Record<string, unknown> | null;
 };
 
 const loadedAuthStoreCache = new Map<
@@ -160,6 +168,112 @@ function readAuthStoreMtimeMs(authPath: string): number | null {
   }
 }
 
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function computeAuthStoreLockDelayMs(attempt: number): number {
+  const retry = AUTH_STORE_LOCK_OPTIONS.retries;
+  const base = Math.min(
+    retry.maxTimeout,
+    Math.max(retry.minTimeout, retry.minTimeout * retry.factor ** attempt),
+  );
+  return retry.randomize ? Math.round(base * (1 + Math.random())) : base;
+}
+
+function readSyncLockSnapshot(lockPath: string): SyncLockSnapshot | null {
+  try {
+    const stat = fs.lstatSync(lockPath);
+    const raw = fs.readFileSync(lockPath, "utf8");
+    let payload: Record<string, unknown> | null = null;
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      payload =
+        parsed && typeof parsed === "object" && !Array.isArray(parsed)
+          ? (parsed as Record<string, unknown>)
+          : null;
+    } catch {
+      payload = null;
+    }
+    return { raw, stat, payload };
+  } catch {
+    return null;
+  }
+}
+
+function syncLockSnapshotMatches(lockPath: string, snapshot: SyncLockSnapshot): boolean {
+  try {
+    const stat = fs.lstatSync(lockPath);
+    return (
+      stat.dev === snapshot.stat.dev &&
+      stat.ino === snapshot.stat.ino &&
+      fs.readFileSync(lockPath, "utf8") === snapshot.raw
+    );
+  } catch {
+    return false;
+  }
+}
+
+function shouldReclaimSyncAuthStoreLock(snapshot: SyncLockSnapshot, nowMs: number): boolean {
+  const pid = snapshot.payload?.pid;
+  if (typeof pid === "number" && Number.isInteger(pid) && pid > 0 && !isPidAlive(pid)) {
+    return true;
+  }
+  const createdAt = snapshot.payload?.createdAt;
+  if (typeof createdAt === "string") {
+    const createdAtMs = Date.parse(createdAt);
+    return !Number.isFinite(createdAtMs) || nowMs - createdAtMs > AUTH_STORE_LOCK_OPTIONS.stale;
+  }
+  return nowMs - snapshot.stat.mtimeMs > AUTH_STORE_LOCK_OPTIONS.stale;
+}
+
+function acquireAuthStoreLockSync(authPath: string): (() => void) | null {
+  const lockPath = `${authPath}.lock`;
+  fs.mkdirSync(path.dirname(authPath), { recursive: true });
+
+  for (let attempt = 0; attempt <= AUTH_STORE_LOCK_OPTIONS.retries.retries; attempt += 1) {
+    try {
+      const fd = fs.openSync(lockPath, "wx");
+      const raw = `${JSON.stringify(
+        { pid: process.pid, createdAt: new Date().toISOString() },
+        null,
+        2,
+      )}\n`;
+      try {
+        fs.writeFileSync(fd, raw, "utf8");
+      } finally {
+        fs.closeSync(fd);
+      }
+      const snapshot = readSyncLockSnapshot(lockPath);
+      return () => {
+        if (snapshot && syncLockSnapshotMatches(lockPath, snapshot)) {
+          fs.rmSync(lockPath, { force: true });
+        }
+      };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== "EEXIST") {
+        throw err;
+      }
+      const snapshot = readSyncLockSnapshot(lockPath);
+      if (!snapshot) {
+        continue;
+      }
+      if (shouldReclaimSyncAuthStoreLock(snapshot, Date.now())) {
+        if (syncLockSnapshotMatches(lockPath, snapshot)) {
+          fs.rmSync(lockPath, { force: true });
+        }
+        continue;
+      }
+      if (attempt >= AUTH_STORE_LOCK_OPTIONS.retries.retries) {
+        return null;
+      }
+      const delayMs = computeAuthStoreLockDelayMs(attempt);
+      sleepSync(delayMs);
+    }
+  }
+  return null;
+}
+
 function readCachedAuthProfileStore(params: {
   authPath: string;
   authMtimeMs: number | null;
@@ -257,9 +371,49 @@ function maybeSyncPersistedExternalCliAuthProfiles(params: {
   if (synced === params.store) {
     return params.store;
   }
-  saveAuthProfileStore(synced, params.agentDir, {
-    filterExternalAuthProfiles: false,
+  const changedProfiles = Object.entries(synced.profiles).filter(([profileId, credential]) => {
+    const previous = params.store.profiles[profileId];
+    return !isDeepStrictEqual(previous, credential);
   });
+  if (changedProfiles.length === 0) {
+    return synced;
+  }
+
+  const authPath = resolveAuthStorePath(params.agentDir);
+  const release = acquireAuthStoreLockSync(authPath);
+  if (!release) {
+    log.warn("skipped persisted external cli auth sync because auth store is locked", {
+      authPath,
+    });
+    return synced;
+  }
+  try {
+    const latestStore = loadPersistedAuthProfileStore(params.agentDir) ?? {
+      version: AUTH_STORE_VERSION,
+      profiles: {},
+    };
+    let changed = false;
+    for (const [profileId, credential] of changedProfiles) {
+      const previous = params.store.profiles[profileId];
+      const latest = latestStore.profiles[profileId];
+      if (!isDeepStrictEqual(latest, previous)) {
+        log.debug("skipped persisted external cli auth sync for concurrently changed profile", {
+          profileId,
+        });
+        continue;
+      }
+      latestStore.profiles[profileId] = credential;
+      changed = true;
+    }
+    if (changed) {
+      saveAuthProfileStore(latestStore, params.agentDir, {
+        filterExternalAuthProfiles: false,
+      });
+      return latestStore;
+    }
+  } finally {
+    release();
+  }
   return synced;
 }
 
@@ -350,7 +504,7 @@ export async function updateAuthProfileStoreWithLock(params: {
       // Locked writers must reload from disk, not from any runtime snapshot.
       // Otherwise a live gateway can overwrite fresher CLI/config-auth writes
       // with stale in-memory auth state during usage/cooldown updates.
-      const store = loadAuthProfileStoreForAgent(params.agentDir);
+      const store = loadAuthProfileStoreForAgent(params.agentDir, { syncExternalCli: false });
       const shouldSave = params.updater(store);
       if (shouldSave) {
         saveAuthProfileStore(store, params.agentDir);

--- a/src/agents/harness/v2.test.ts
+++ b/src/agents/harness/v2.test.ts
@@ -83,10 +83,10 @@ function captureDiagnosticEvents(): {
   return { events, unsubscribe };
 }
 
-function mockCallArg<T>(mock: { mock: { calls: unknown[][] } }, index = 0): T {
+function mockCallArg(mock: { mock: { calls: unknown[][] } }, index = 0): unknown {
   const call = mock.mock.calls[index];
   expect(call).toBeDefined();
-  return call[0] as T;
+  return call[0];
 }
 
 describe("AgentHarness V2 compatibility adapter", () => {
@@ -287,11 +287,11 @@ describe("AgentHarness V2 compatibility adapter", () => {
     await expect(runAgentHarnessV2LifecycleAttempt(harness, params)).rejects.toThrow(
       "codex app-server send failed",
     );
-    const cleanupInput = mockCallArg<{
+    const cleanupInput = mockCallArg(cleanup) as {
       error?: unknown;
       prepared?: { lifecycleState?: string };
       session?: { lifecycleState?: string };
-    }>(cleanup);
+    };
     expect(cleanupInput.error).toBe(sendError);
     expect(cleanupInput.prepared?.lifecycleState).toBe("prepared");
     expect(cleanupInput.session?.lifecycleState).toBe("started");
@@ -322,11 +322,11 @@ describe("AgentHarness V2 compatibility adapter", () => {
     await expect(runAgentHarnessV2LifecycleAttempt(harness, params)).rejects.toThrow(
       "codex app-server start failed",
     );
-    const cleanupInput = mockCallArg<{
+    const cleanupInput = mockCallArg(cleanup) as {
       error?: unknown;
       prepared?: { lifecycleState?: string };
       session?: unknown;
-    }>(cleanup);
+    };
     expect(cleanupInput.error).toBe(startError);
     expect(cleanupInput.prepared?.lifecycleState).toBe("prepared");
     expect(cleanupInput.session).toBeUndefined();
@@ -358,12 +358,12 @@ describe("AgentHarness V2 compatibility adapter", () => {
     await expect(runAgentHarnessV2LifecycleAttempt(harness, params)).rejects.toThrow(
       "outcome classification failed",
     );
-    const cleanupInput = mockCallArg<{
+    const cleanupInput = mockCallArg(cleanup) as {
       error?: unknown;
       result?: unknown;
       prepared?: { lifecycleState?: string };
       session?: { lifecycleState?: string };
-    }>(cleanup);
+    };
     expect(cleanupInput.error).toBe(outcomeError);
     expect(cleanupInput.result).toBe(rawResult);
     expect(cleanupInput.prepared?.lifecycleState).toBe("prepared");

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -153,10 +153,10 @@ function resultDetails(result: { details?: unknown }): Record<string, unknown> {
   return result.details as Record<string, unknown>;
 }
 
-function firstMockCallArg<T>(mock: { mock: { calls: unknown[][] } }): T {
+function firstMockCallArg(mock: { mock: { calls: unknown[][] } }): unknown {
   const firstCall = mock.mock.calls[0];
   expect(firstCall).toBeDefined();
-  return firstCall[0] as T;
+  return firstCall[0];
 }
 
 function resetVideoGenerateMocks() {
@@ -570,21 +570,22 @@ describe("createVideoGenerateTool", () => {
     }
     await scheduledWork();
     expect(saveSpy).not.toHaveBeenCalled();
-    const progress = firstMockCallArg<{ runId: string; progressSummary: string }>(
-      taskExecutorMocks.recordTaskRunProgressByRunId,
-    );
+    const progress = firstMockCallArg(taskExecutorMocks.recordTaskRunProgressByRunId) as {
+      runId: string;
+      progressSummary: string;
+    };
     expect(progress.runId).toMatch(/^tool:video_generate:/);
     expect(progress.progressSummary).toBe("Generating video");
-    const completion = firstMockCallArg<{ runId: string }>(
-      taskExecutorMocks.completeTaskRunByRunId,
-    );
+    const completion = firstMockCallArg(taskExecutorMocks.completeTaskRunByRunId) as {
+      runId: string;
+    };
     expect(completion.runId).toMatch(/^tool:video_generate:/);
-    const wake = firstMockCallArg<{
+    const wake = firstMockCallArg(wakeSpy) as {
       handle: { taskId?: string };
       status: string;
       mediaUrls: string[];
       result: string;
-    }>(wakeSpy);
+    };
     expect(wake.handle.taskId).toBe("task-123");
     expect(wake.status).toBe("ok");
     expect(wake.mediaUrls).toEqual(["https://example.com/generated-lobster.mp4"]);
@@ -959,9 +960,10 @@ describe("createVideoGenerateTool", () => {
       providerOptions: { seed: 42, draft: true },
     });
 
-    const input = firstMockCallArg<{ autoProviderFallback?: boolean; providerOptions?: unknown }>(
-      generateSpy,
-    );
+    const input = firstMockCallArg(generateSpy) as {
+      autoProviderFallback?: boolean;
+      providerOptions?: unknown;
+    };
     expect(input.autoProviderFallback).toBe(false);
     expect(input.providerOptions).toEqual({ seed: 42, draft: true });
   });
@@ -1083,7 +1085,9 @@ describe("createVideoGenerateTool", () => {
       aspectRatio: "adaptive",
     });
 
-    expect(firstMockCallArg<{ aspectRatio?: string }>(generateSpy).aspectRatio).toBe("adaptive");
+    expect((firstMockCallArg(generateSpy) as { aspectRatio?: string }).aspectRatio).toBe(
+      "adaptive",
+    );
   });
 
   it("accepts provider-specific aspectRatio and resolution values and forwards them to the runtime", async () => {
@@ -1097,7 +1101,7 @@ describe("createVideoGenerateTool", () => {
       resolution: "draft-large",
     });
 
-    const input = firstMockCallArg<{ aspectRatio?: string; resolution?: string }>(generateSpy);
+    const input = firstMockCallArg(generateSpy) as { aspectRatio?: string; resolution?: string };
     expect(input.aspectRatio).toBe("17:9");
     expect(input.resolution).toBe("draft-large");
   });

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -54,7 +54,7 @@ function makeGatewayService(
   } as unknown as GatewayService;
 }
 
-function firstCallArg<T>(mock: { mock: { calls: unknown[][] } }): T {
+function firstCallArg<T>(mock: { mock: { calls: unknown[][] } }, _type?: (value: T) => T): T {
   const call = mock.mock.calls[0];
   expect(call).toBeDefined();
   return call?.[0] as T;

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -627,7 +627,10 @@ describe("applyAuthChoice", () => {
     expect(profile?.mode).toBe(expected.mode);
   }
   function promptMessages(mock: { mock: { calls: unknown[][] } }): string[] {
-    return mock.mock.calls.map((call) => String((call[0] as { message?: unknown })?.message ?? ""));
+    return mock.mock.calls.map((call) => {
+      const message = (call[0] as { message?: unknown }).message;
+      return typeof message === "string" ? message : "";
+    });
   }
   function expectPromptMessageContaining(mock: { mock: { calls: unknown[][] } }, expected: string) {
     expect(promptMessages(mock).some((message) => message.includes(expected))).toBe(true);
@@ -635,7 +638,7 @@ describe("applyAuthChoice", () => {
   function expectPromptMessage(mock: { mock: { calls: unknown[][] } }, expected: string) {
     expect(promptMessages(mock)).toContain(expected);
   }
-  function firstCallArg<T>(mock: { mock: { calls: unknown[][] } }): T {
+  function firstCallArg<T>(mock: { mock: { calls: unknown[][] } }, _type?: (value: T) => T): T {
     const call = mock.mock.calls[0];
     expect(call).toBeDefined();
     return call?.[0] as T;

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -78,7 +78,7 @@ function makePluginRegistry(overrides: Partial<PluginRegistry> = {}): PluginRegi
   } as unknown as PluginRegistry;
 }
 
-function callArg<T>(mock: { mock: { calls: unknown[][] } }, index = 0): T {
+function callArg<T>(mock: { mock: { calls: unknown[][] } }, index = 0, _type?: (value: T) => T): T {
   const call = mock.mock.calls[index];
   expect(call).toBeDefined();
   return call?.[0] as T;

--- a/src/gateway/server-methods/skills-upload.test.ts
+++ b/src/gateway/server-methods/skills-upload.test.ts
@@ -140,7 +140,7 @@ function expectError(result: CallResult, code: string, message: string): void {
   expect(result.error?.message).toBe(message);
 }
 
-function firstCallArg<T>(mock: { mock: { calls: unknown[][] } }): T {
+function firstCallArg<T>(mock: { mock: { calls: unknown[][] } }, _type?: (value: T) => T): T {
   const call = mock.mock.calls[0];
   expect(call).toBeDefined();
   return call?.[0] as T;

--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -61,7 +61,7 @@ function preparedSnapshot(config: OpenClawConfig): PreparedSecretsRuntimeSnapsho
   };
 }
 
-function callArg<T>(mock: { mock: { calls: unknown[][] } }, index = 0): T {
+function callArg<T>(mock: { mock: { calls: unknown[][] } }, index = 0, _type?: (value: T) => T): T {
   const call = mock.mock.calls[index];
   expect(call).toBeDefined();
   return call?.[0] as T;

--- a/src/gateway/server-startup-plugins.test.ts
+++ b/src/gateway/server-startup-plugins.test.ts
@@ -162,7 +162,7 @@ function createLog() {
   };
 }
 
-function firstCallArg<T>(mock: { mock: { calls: unknown[][] } }): T {
+function firstCallArg<T>(mock: { mock: { calls: unknown[][] } }, _type?: (value: T) => T): T {
   const call = mock.mock.calls[0];
   expect(call).toBeDefined();
   return call?.[0] as T;

--- a/src/gateway/server.sessions.reset-hooks.test.ts
+++ b/src/gateway/server.sessions.reset-hooks.test.ts
@@ -175,7 +175,7 @@ test("sessions.reset emits enriched session_end and session_start hooks", async 
   expect(endEvent.sessionKey).toBe("agent:main:main");
   expect(endEvent.reason).toBe("new");
   expect(endEvent.transcriptArchived).toBe(true);
-  expect(String(endEvent.sessionFile ?? "")).toContain(".jsonl.reset.");
+  expect(endEvent.sessionFile).toEqual(expect.stringContaining(".jsonl.reset."));
   expect(endEvent.nextSessionId).toBe(startEvent.sessionId);
   expectMainHookContext(endContext, "sess-main");
   expect(startEvent.sessionKey).toBe("agent:main:main");
@@ -371,7 +371,7 @@ test("sessions.create with emitCommandHooks=true emits reset lifecycle hooks aga
   expect(startEvent.resumedFrom).toBe("sess-parent-hooks");
   expect(startEvent.sessionId).toBeTypeOf("string");
   expect(startEvent.sessionId).not.toBe("");
-  expect(String(startEvent.sessionKey ?? "")).toMatch(/^agent:main:dashboard:/);
+  expect(startEvent.sessionKey).toEqual(expect.stringMatching(/^agent:main:dashboard:/));
 });
 
 test("sessions.create with emitCommandHooks=true resets parent in place when session.dmScope is 'main' (#77434)", async () => {

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -396,7 +396,7 @@ const expectOkInvokeResponse = async (res: Response) => {
 const firstHookCallArg = () => {
   const call = hookMocks.runBeforeToolCallHook.mock.calls[0];
   expect(call).toBeDefined();
-  return call?.[0] as RunBeforeToolCallHookArgs;
+  return call?.[0];
 };
 
 const invokeToolsRpc = async (params: Record<string, unknown>, scopes = ["operator.write"]) => {

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -22,14 +22,18 @@ vi.mock("./channel-resolution.js", () => ({
   resolveOutboundChannelMessageAdapter: resolveOutboundChannelMessageAdapterMock,
 }));
 
-function mockCallArg<T>(mock: { mock: { calls: unknown[][] } }, index = 0): T {
+function mockCallArg<T>(
+  mock: { mock: { calls: unknown[][] } },
+  index = 0,
+  _type?: (value: T) => T,
+): T {
   const call = mock.mock.calls[index];
   expect(call).toBeDefined();
   return call[0] as T;
 }
 
 function expectMockMessageContaining(mock: { mock: { calls: unknown[][] } }, expected: string) {
-  const messages = mock.mock.calls.map((call) => String(call[0] ?? ""));
+  const messages = mock.mock.calls.map((call) => (typeof call[0] === "string" ? call[0] : ""));
   expect(messages.some((message) => message.includes(expected))).toBe(true);
 }
 

--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -239,12 +239,12 @@ function createAdvancedFinalizeArgs(params: AdvancedFinalizeArgs = {}) {
   };
 }
 
-function requireMockArg<T>(mock: ReturnType<typeof vi.fn>, callIndex = 0, argIndex = 0): T {
+function requireMockArg(mock: ReturnType<typeof vi.fn>, callIndex = 0, argIndex = 0): unknown {
   const call = mock.mock.calls[callIndex];
   if (!call) {
     throw new Error(`expected mock call ${callIndex}`);
   }
-  return call[argIndex] as T;
+  return call[argIndex];
 }
 
 function expectNoteContains(
@@ -253,7 +253,7 @@ function expectNoteContains(
   title: string,
 ): void {
   const calls = vi.mocked(prompter.note).mock.calls;
-  expect(calls.some((call) => String(call[0]).includes(expected) && call[1] === title)).toBe(true);
+  expect(calls.some((call) => call[0].includes(expected) && call[1] === title)).toBe(true);
 }
 
 function expectNoteTitleNotCalled(
@@ -364,7 +364,10 @@ describe("finalizeSetupWizard", () => {
       }
     }
 
-    const probeParams = requireMockArg<{ url?: string; password?: string }>(probeGatewayReachable);
+    const probeParams = requireMockArg(probeGatewayReachable) as {
+      url?: string;
+      password?: string;
+    };
     expect(probeParams.url).toBe("ws://127.0.0.1:18789");
     expect(probeParams.password).toBe("resolved-gateway-password"); // pragma: allowlist secret
     expect(launchTuiCli).toHaveBeenCalledWith({
@@ -668,18 +671,18 @@ describe("finalizeSetupWizard", () => {
       runtime: createRuntime(),
     });
 
-    const healthArgs = requireMockArg<{
+    const healthArgs = requireMockArg(healthCommand) as {
       json?: boolean;
       timeoutMs?: number;
       token?: string;
       config?: OpenClawConfig;
-    }>(healthCommand);
+    };
     expect(healthArgs.json).toBe(false);
     expect(healthArgs.timeoutMs).toBe(10_000);
     expect(healthArgs.token).toBe("session-token");
     expect(healthArgs.config?.gateway?.auth?.mode).toBe("token");
     expect(healthArgs.config?.gateway?.auth?.token).toBe("session-token");
-    expect(requireMockArg<unknown>(healthCommand, 0, 1)).toBeTypeOf("object");
+    expect(requireMockArg(healthCommand, 0, 1)).toBeTypeOf("object");
   });
 
   it("uses the resolved setup password for health checks", async () => {
@@ -722,27 +725,27 @@ describe("finalizeSetupWizard", () => {
       runtime: createRuntime(),
     });
 
-    const waitArgs = requireMockArg<{
+    const waitArgs = requireMockArg(waitForGatewayReachable) as {
       url?: string;
       token?: string;
       password?: string;
-    }>(waitForGatewayReachable);
+    };
     expect(waitArgs.url).toBe("ws://127.0.0.1:18789");
     expect(waitArgs.token).toBeUndefined();
     expect(waitArgs.password).toBe("session-password");
-    const healthArgs = requireMockArg<{
+    const healthArgs = requireMockArg(healthCommand) as {
       json?: boolean;
       timeoutMs?: number;
       token?: string;
       password?: string;
       config?: OpenClawConfig;
-    }>(healthCommand);
+    };
     expect(healthArgs.json).toBe(false);
     expect(healthArgs.timeoutMs).toBe(10_000);
     expect(healthArgs.token).toBeUndefined();
     expect(healthArgs.password).toBe("session-password");
     expect(healthArgs.config?.gateway?.auth?.mode).toBe("password");
-    expect(requireMockArg<unknown>(healthCommand, 0, 1)).toBeTypeOf("object");
+    expect(requireMockArg(healthCommand, 0, 1)).toBeTypeOf("object");
   });
 
   it("shows actionable gateway guidance instead of a hard error in no-daemon onboarding", async () => {


### PR DESCRIPTION
## Summary

- persist fresher managed external CLI OAuth credentials, such as `anthropic:claude-cli`, back into the owning `auth-profiles.json` store
- keep bootstrap-only Codex CLI credentials runtime-only so local Codex refresh tokens remain canonical
- skip external CLI rereads when a managed local OAuth profile is already usable, preventing steady-state debug log churn

Fixes #80129.

## Verification

- `pnpm test src/agents/auth-profiles.external-cli-sync.test.ts src/agents/auth-profiles.store-cache.test.ts src/agents/auth-profiles.store.save.test.ts`
- `OPENCLAW_TESTBOX=0 pnpm check:changed`

## Real behavior proof

Behavior or issue addressed: A stale persisted `anthropic:claude-cli` OAuth profile should resync from fresher Claude CLI credentials and write the refreshed credential back to `auth-profiles.json`.

Real environment tested: Local OpenClaw checkout on macOS, isolated temporary `HOME`, isolated temporary agent directory, actual `loadAuthProfileStoreForRuntime()` path, actual Claude CLI credential-file reader, keychain disabled, no mocks. Tokens below are synthetic and redacted.

Exact steps or command run after this patch: Ran `pnpm exec tsx` with a local proof script that created a stale `auth-profiles.json`, created a fresh `.claude/.credentials.json`, then loaded the auth store through `loadAuthProfileStoreForRuntime(agentDir, { allowKeychainPrompt: false, externalCliProfileIds: ["anthropic:claude-cli"] })`.

Evidence after fix:

```text
Real OpenClaw auth-store proof for #80129
environment: isolated temp HOME plus Claude CLI credential file; no keychain; no mocks
command: pnpm exec tsx local proof script using loadAuthProfileStoreForRuntime()
before persisted profile: provider=claude-cli, access=redacted-stale-access-token, expired=true
external Claude CLI credential: access=redacted-fresh-access-token, expiresInMs=86400000
after persisted profile: provider=claude-cli, access=redacted-fresh-access-token, expiresAdvanced=true
runtime profile matches persisted refresh: true
auth-profiles.json updated on disk: true
```

Observed result after fix: The stale persisted Claude CLI profile was replaced on disk with the fresh external Claude CLI credential, and the runtime profile matched the newly persisted access and refresh tokens.

What was not tested: No live Anthropic API call and no multi-day natural OAuth rollover; the proof exercises the real local OpenClaw/Claude CLI credential sync path with synthetic redacted credentials.
