### PR TITLE
[codex] Expose active model plugin context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK: deprecate public subpaths currently used by only one or two bundled plugin owners, keeping them importable while steering new plugin code to focused shared SDK seams or plugin-owned APIs.
 - Plugin SDK: remove the owner-specific `provider-auth-login` public subpath after moving Chutes, GitHub Copilot, and OpenAI Codex auth flows back to provider-owned modules.
 - Plugin SDK: remove provider-specific model, stream, and xAI compatibility helpers from public exports after moving bundled callers to provider-owned modules.
+- Plugin SDK: expose runtime-supplied active model metadata to native plugin tool factories for diagnostics and plugin-owned policy decisions. Fixes #77857. Thanks @jamiezigelbaum.
 - QA/Mantis: add Telegram live PR evidence automation with Convex-leased credentials, Crabbox transcript capture, motion GIF previews, and inline PR comments.
 - QA/Mantis: add a Telegram desktop scenario builder that leases Crabbox, installs native Telegram Desktop, configures an OpenClaw Telegram gateway with leased bot credentials, and records VNC screenshot/video artifacts.
 - Discord/voice: add realtime voice diagnostics for speaker turns, playback resets, barge-in detection, and audio cutoff analysis.

--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -248,6 +248,14 @@ register(api) {
 }
 ```
 
+Tool factories receive a runtime-supplied context object. Use
+`ctx.activeModel` when a tool needs to log, display, or adapt to the active
+model for the current turn. The object can include `provider`, `modelId`, and
+`modelRef`. Treat it as informational runtime metadata, not as a security
+boundary against the local operator, installed plugin code, or a modified
+OpenClaw runtime. For sensitive local tools, keep an explicit plugin or operator
+opt-in and fail closed when the active model metadata is missing or unsuitable.
+
 Every tool registered with `api.registerTool(...)` must also be declared in the
 plugin manifest:
 

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -8,7 +8,8 @@
     "@slack/bolt": "^4.7.2",
     "@slack/types": "^2.21.1",
     "@slack/web-api": "^7.15.2",
-    "https-proxy-agent": "^9.0.0"
+    "https-proxy-agent": "^9.0.0",
+    "typebox": "1.1.38"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1424,6 +1424,9 @@ importers:
       https-proxy-agent:
         specifier: ^9.0.0
         version: 9.0.0
+      typebox:
+        specifier: 1.1.38
+        version: 1.1.38
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*

--- a/src/agents/openclaw-plugin-tools.ts
+++ b/src/agents/openclaw-plugin-tools.ts
@@ -24,6 +24,7 @@ type ResolveOpenClawPluginToolsOptions = OpenClawPluginToolOptions & {
   sandboxRoot?: string;
   modelHasVision?: boolean;
   modelProvider?: string;
+  modelId?: string;
   allowMediaInvokeCommands?: boolean;
   requesterAgentIdOverride?: string;
   requireExplicitMessageTarget?: boolean;

--- a/src/agents/openclaw-tools.plugin-context.test.ts
+++ b/src/agents/openclaw-tools.plugin-context.test.ts
@@ -42,6 +42,22 @@ describe("openclaw plugin tool context", () => {
     expect(result.context.sessionId).toBe("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
   });
 
+  it("forwards runtime-owned active model metadata", () => {
+    const result = resolveOpenClawPluginToolInputs({
+      options: {
+        config: {} as never,
+        modelProvider: " local-provider ",
+        modelId: " local-model ",
+      },
+    });
+
+    expect(result.context.activeModel).toStrictEqual({
+      provider: "local-provider",
+      modelId: "local-model",
+      modelRef: "local-provider/local-model",
+    });
+  });
+
   it("infers the default agent workspace when workspaceDir is omitted", () => {
     const workspaceDir = path.join(process.cwd(), "tmp-main-workspace");
     const result = resolveOpenClawPluginToolInputs({

--- a/src/agents/openclaw-tools.plugin-context.test.ts
+++ b/src/agents/openclaw-tools.plugin-context.test.ts
@@ -58,6 +58,22 @@ describe("openclaw plugin tool context", () => {
     });
   });
 
+  it("does not duplicate provider-qualified active model refs", () => {
+    const result = resolveOpenClawPluginToolInputs({
+      options: {
+        config: {} as never,
+        modelProvider: "openrouter",
+        modelId: "openrouter/auto",
+      },
+    });
+
+    expect(result.context.activeModel).toStrictEqual({
+      provider: "openrouter",
+      modelId: "openrouter/auto",
+      modelRef: "openrouter/auto",
+    });
+  });
+
   it("infers the default agent workspace when workspaceDir is omitted", () => {
     const workspaceDir = path.join(process.cwd(), "tmp-main-workspace");
     const result = resolveOpenClawPluginToolInputs({

--- a/src/agents/openclaw-tools.plugin-context.ts
+++ b/src/agents/openclaw-tools.plugin-context.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import type { GatewayMessageChannel } from "../utils/message-channel.js";
 import { resolveAgentWorkspaceDir, resolveSessionAgentIds } from "./agent-scope.js";
+import { modelKey } from "./model-ref-shared.js";
 import type { ToolFsPolicy } from "./tool-fs-policy.js";
 import { resolveWorkspaceRoot } from "./workspace-dir.js";
 
@@ -51,7 +52,7 @@ export function resolveOpenClawPluginToolInputs(params: {
       ? {
           ...(modelProvider ? { provider: modelProvider } : {}),
           ...(modelId ? { modelId } : {}),
-          ...(modelProvider && modelId ? { modelRef: `${modelProvider}/${modelId}` } : {}),
+          ...(modelProvider && modelId ? { modelRef: modelKey(modelProvider, modelId) } : {}),
         }
       : undefined;
   const deliveryContext = normalizeDeliveryContext({

--- a/src/agents/openclaw-tools.plugin-context.ts
+++ b/src/agents/openclaw-tools.plugin-context.ts
@@ -15,6 +15,8 @@ export type OpenClawPluginToolOptions = {
   workspaceDir?: string;
   config?: OpenClawConfig;
   fsPolicy?: ToolFsPolicy;
+  modelProvider?: string;
+  modelId?: string;
   requesterSenderId?: string | null;
   requesterAgentIdOverride?: string;
   senderIsOwner?: boolean;
@@ -42,6 +44,16 @@ export function resolveOpenClawPluginToolInputs(params: {
       ? undefined
       : resolveAgentWorkspaceDir(resolvedConfig, sessionAgentId);
   const workspaceDir = resolveWorkspaceRoot(options?.workspaceDir ?? inferredWorkspaceDir);
+  const modelProvider = options?.modelProvider?.trim();
+  const modelId = options?.modelId?.trim();
+  const activeModel =
+    modelProvider || modelId
+      ? {
+          ...(modelProvider ? { provider: modelProvider } : {}),
+          ...(modelId ? { modelId } : {}),
+          ...(modelProvider && modelId ? { modelRef: `${modelProvider}/${modelId}` } : {}),
+        }
+      : undefined;
   const deliveryContext = normalizeDeliveryContext({
     channel: options?.agentChannel,
     to: options?.agentTo,
@@ -60,6 +72,7 @@ export function resolveOpenClawPluginToolInputs(params: {
       agentId: sessionAgentId,
       sessionKey: options?.agentSessionKey,
       sessionId: options?.sessionId,
+      activeModel,
       browser: {
         sandboxBridgeUrl: options?.sandboxBrowserBridgeUrl,
         allowHostControl: options?.allowHostBrowserControl,

--- a/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
@@ -10,6 +10,7 @@ import {
 import "./test-helpers/fast-bash-tools.js";
 import "./test-helpers/fast-coding-tools.js";
 import "./test-helpers/fast-openclaw-tools.js";
+import * as openClawPluginTools from "./openclaw-plugin-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
 import { createOpenClawCodingTools } from "./pi-tools.js";
 import { createHostSandboxFsBridge } from "./test-helpers/host-sandbox-fs-bridge.js";
@@ -417,6 +418,40 @@ describe("createOpenClawCodingTools", () => {
     });
 
     expect(createOpenClawToolsMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards active model metadata to plugin-only tool construction", () => {
+    const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
+    createOpenClawToolsMock.mockClear();
+    const resolvePluginToolsSpy = vi
+      .spyOn(openClawPluginTools, "resolveOpenClawPluginToolsForOptions")
+      .mockReturnValue([]);
+
+    try {
+      createOpenClawCodingTools({
+        config: testConfig,
+        includeCoreTools: false,
+        runtimeToolAllowlist: ["memory_search"],
+        modelProvider: "openrouter",
+        modelId: "openrouter/auto",
+        toolConstructionPlan: {
+          includeBaseCodingTools: false,
+          includeShellTools: false,
+          includeChannelTools: false,
+          includeOpenClawTools: false,
+          includePluginTools: true,
+        },
+      });
+
+      expect(createOpenClawToolsMock).not.toHaveBeenCalled();
+      expect(resolvePluginToolsSpy).toHaveBeenCalledTimes(1);
+      expect(resolvePluginToolsSpy.mock.calls[0]?.[0].options).toMatchObject({
+        modelProvider: "openrouter",
+        modelId: "openrouter/auto",
+      });
+    } finally {
+      resolvePluginToolsSpy.mockRestore();
+    }
   });
 
   it("uses tools.alsoAllow for optional plugin discovery without widening to all plugins", () => {

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -738,6 +738,7 @@ export function createOpenClawCodingTools(options?: {
             currentThreadTs: options?.currentThreadTs,
             currentMessageId: options?.currentMessageId,
             modelProvider: options?.modelProvider,
+            modelId: options?.modelId,
             modelHasVision: options?.modelHasVision,
             requireExplicitMessageTarget: options?.requireExplicitMessageTarget,
             disableMessageTool: options?.disableMessageTool,

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -121,7 +121,11 @@ export type {
   UnifiedModelCatalogSource,
 } from "../model-catalog/types.js";
 export type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
-export type { OpenClawPluginToolContext, OpenClawPluginToolFactory } from "../plugins/types.js";
+export type {
+  OpenClawPluginActiveModelContext,
+  OpenClawPluginToolContext,
+  OpenClawPluginToolFactory,
+} from "../plugins/types.js";
 export type {
   MemoryPluginCapability,
   MemoryPluginPublicArtifact,

--- a/src/plugins/tool-descriptor-cache.test.ts
+++ b/src/plugins/tool-descriptor-cache.test.ts
@@ -91,6 +91,38 @@ describe("plugin tool descriptor cache keys", () => {
     expect(firstKey).not.toBe(secondKey);
   });
 
+  it("varies descriptor keys by active model metadata", () => {
+    const base = {
+      pluginId: "demo",
+      source: "/tmp/demo.js",
+      contractToolNames: ["demo"],
+      ctx: {
+        workspaceDir: "/tmp/workspace",
+        agentId: "main",
+        activeModel: {
+          provider: "openai",
+          modelId: "gpt-5.4",
+          modelRef: "openai/gpt-5.4",
+        },
+      },
+    };
+
+    const firstKey = buildPluginToolDescriptorCacheKey(base);
+    const secondKey = buildPluginToolDescriptorCacheKey({
+      ...base,
+      ctx: {
+        ...base.ctx,
+        activeModel: {
+          provider: "openrouter",
+          modelId: "openrouter/auto",
+          modelRef: "openrouter/auto",
+        },
+      },
+    });
+
+    expect(firstKey).not.toBe(secondKey);
+  });
+
   it("keeps descriptor keys stable across config bookkeeping writes", () => {
     const firstConfig = {
       id: "runtime",

--- a/src/plugins/tool-descriptor-cache.ts
+++ b/src/plugins/tool-descriptor-cache.ts
@@ -104,6 +104,7 @@ function buildDescriptorContextCacheKey(params: {
     workspaceDir: ctx.workspaceDir ?? null,
     agentDir: ctx.agentDir ?? null,
     agentId: ctx.agentId ?? null,
+    activeModel: ctx.activeModel ?? null,
     browser: ctx.browser ?? null,
     messageChannel: ctx.messageChannel ?? null,
     agentAccountId: ctx.agentAccountId ?? null,

--- a/src/plugins/tool-types.ts
+++ b/src/plugins/tool-types.ts
@@ -4,6 +4,12 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HookEntry } from "../hooks/types.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 
+export type OpenClawPluginActiveModelContext = {
+  provider?: string;
+  modelId?: string;
+  modelRef?: string;
+};
+
 /** Trusted execution context passed to plugin-owned agent tool factories. */
 export type OpenClawPluginToolContext = {
   config?: OpenClawConfig;
@@ -19,6 +25,12 @@ export type OpenClawPluginToolContext = {
   sessionKey?: string;
   /** Ephemeral session UUID - regenerated on /new and /reset. Use for per-conversation isolation. */
   sessionId?: string;
+  /**
+   * Runtime-supplied active model metadata for informational use, diagnostics,
+   * and plugin-owned policy decisions. This is not a security boundary against
+   * the local operator, installed plugin code, or a modified OpenClaw runtime.
+   */
+  activeModel?: OpenClawPluginActiveModelContext;
   browser?: {
     sandboxBridgeUrl?: string;
     allowHostControl?: boolean;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -151,6 +151,7 @@ export type {
   PluginFormat,
 } from "./manifest-types.js";
 export type {
+  OpenClawPluginActiveModelContext,
   OpenClawPluginHookOptions,
   OpenClawPluginToolContext,
   OpenClawPluginToolFactory,


### PR DESCRIPTION
## Summary

- add `ctx.activeModel` to native plugin tool factory context with runtime-supplied `provider`, `modelId`, and `modelRef`
- thread existing active model values from OpenClaw tool construction into plugin tool resolution
- document the field as informational metadata, not a security boundary, and add changelog coverage

Fixes #77857.

## Verification

- `pnpm test src/agents/openclaw-tools.plugin-context.test.ts -- --reporter=verbose`
- `env -u OPENCLAW_TESTBOX -u OPENCLAW_TESTBOX_ID -u OPENCLAW_TESTBOX_REMOTE_RUN pnpm check:changed`
- `git diff --check`
- `env -u OPENCLAW_TESTBOX -u OPENCLAW_TESTBOX_ID -u OPENCLAW_TESTBOX_REMOTE_RUN pnpm test:changed` failed on existing `origin/main` models-config mock failures unrelated to this PR:
  - `src/agents/models-config.skips-writing-models-json-no-env-token.test.ts`
  - `src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts`
- verified the same two models-config failures reproduce on `origin/main` (`115049753d`) in a detached worktree
