### PR TITLE
fix(codex): mark app-server turn startup for cron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Docs: https://docs.openclaw.ai
 - Doctor: stop flagging the live compatibility agent directory as orphaned when the configured default agent is not `main`. Fixes #74313. (#74438) Thanks @carlos4s.
 - Auth/Claude CLI: persist fresher managed external CLI OAuth credentials back to `auth-profiles.json`, preventing stale `anthropic:claude-cli` profiles from repeatedly bootstrapping and flooding debug logs. Fixes #80129. Thanks @Caulderein.
 - Context: render `/context map` only from actual run context and persist Codex app-server run reports without counting deferred tool-search schemas as prompt-loaded tool schemas.
-- Cron/Codex app-server: mark Codex `turn/start` dispatch as model-call startup progress so isolated cron watchdogs do not false-fail runs that have already entered Codex-native tool execution. Thanks @keshavbotagent.
+- Cron/agents: mark Codex `turn/start` dispatch and forwarded embedded prompt/tool execution as model-call startup progress so isolated cron watchdogs do not false-fail runs that have already entered real execution. Thanks @keshavbotagent.
 - Codex app-server: report Codex-native tool execution to diagnostics so long-running native `bash`, web, file, and MCP tools no longer look like stale embedded runs to the watchdog. (#80217)
 - Tasks: route group and channel task completions through the requester session so the parent agent can send the visible summary instead of stopping at a generic task-status line. Fixes #77251. (#77365) Thanks @funmerlin.
 - Telegram: preserve blank lines between manually indented bullet blocks and following numbered sections in rendered replies. Fixes #76998. Thanks @evgyur.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - Doctor: stop flagging the live compatibility agent directory as orphaned when the configured default agent is not `main`. Fixes #74313. (#74438) Thanks @carlos4s.
 - Auth/Claude CLI: persist fresher managed external CLI OAuth credentials back to `auth-profiles.json`, preventing stale `anthropic:claude-cli` profiles from repeatedly bootstrapping and flooding debug logs. Fixes #80129. Thanks @Caulderein.
 - Context: render `/context map` only from actual run context and persist Codex app-server run reports without counting deferred tool-search schemas as prompt-loaded tool schemas.
+- Cron/Codex app-server: mark Codex `turn/start` dispatch as model-call startup progress so isolated cron watchdogs do not false-fail runs that have already entered Codex-native tool execution.
 - Codex app-server: report Codex-native tool execution to diagnostics so long-running native `bash`, web, file, and MCP tools no longer look like stale embedded runs to the watchdog. (#80217)
 - Tasks: route group and channel task completions through the requester session so the parent agent can send the visible summary instead of stopping at a generic task-status line. Fixes #77251. (#77365) Thanks @funmerlin.
 - Telegram: preserve blank lines between manually indented bullet blocks and following numbered sections in rendered replies. Fixes #76998. Thanks @evgyur.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Docs: https://docs.openclaw.ai
 - Doctor: stop flagging the live compatibility agent directory as orphaned when the configured default agent is not `main`. Fixes #74313. (#74438) Thanks @carlos4s.
 - Auth/Claude CLI: persist fresher managed external CLI OAuth credentials back to `auth-profiles.json`, preventing stale `anthropic:claude-cli` profiles from repeatedly bootstrapping and flooding debug logs. Fixes #80129. Thanks @Caulderein.
 - Context: render `/context map` only from actual run context and persist Codex app-server run reports without counting deferred tool-search schemas as prompt-loaded tool schemas.
-- Cron/Codex app-server: mark Codex `turn/start` dispatch as model-call startup progress so isolated cron watchdogs do not false-fail runs that have already entered Codex-native tool execution.
+- Cron/Codex app-server: mark Codex `turn/start` dispatch as model-call startup progress so isolated cron watchdogs do not false-fail runs that have already entered Codex-native tool execution. Thanks @keshavbotagent.
 - Codex app-server: report Codex-native tool execution to diagnostics so long-running native `bash`, web, file, and MCP tools no longer look like stale embedded runs to the watchdog. (#80217)
 - Tasks: route group and channel task completions through the requester session so the parent agent can send the visible summary instead of stopping at a generic task-status line. Fixes #77251. (#77365) Thanks @funmerlin.
 - Telegram: preserve blank lines between manually indented bullet blocks and following numbered sections in rendered replies. Fixes #76998. Thanks @evgyur.

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -775,6 +775,39 @@ describe("runCodexAppServerAttempt", () => {
     expect(report?.tools.schemaChars).toBe(message?.schemaChars);
   });
 
+  it("reports model-call start when the app-server dispatches the turn", async () => {
+    let resolveTurnStart: ((value: unknown) => void) | undefined;
+    const turnStartResponse = new Promise<unknown>((resolve) => {
+      resolveTurnStart = resolve;
+    });
+    const harness = createStartedThreadHarness((method) => {
+      if (method === "turn/start") {
+        return turnStartResponse;
+      }
+      return undefined;
+    });
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.onExecutionPhase = vi.fn();
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start", 120_000);
+    await vi.waitFor(() => {
+      expect(params.onExecutionPhase).toHaveBeenCalledWith({
+        phase: "model_call_started",
+        provider: "codex",
+        model: "gpt-5.4-codex",
+        firstModelCallStarted: true,
+      });
+    });
+
+    resolveTurnStart?.(turnStartResult());
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+  });
+
   it("keeps searchable Codex dynamic tools canonical in mirrored transcript snapshots", async () => {
     __testing.setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("wiki_status"),

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -780,7 +780,7 @@ describe("runCodexAppServerAttempt", () => {
     const turnStartResponse = new Promise<unknown>((resolve) => {
       resolveTurnStart = resolve;
     });
-    const harness = createStartedThreadHarness((method) => {
+    const harness = createStartedThreadHarness(async (method) => {
       if (method === "turn/start") {
         return turnStartResponse;
       }

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1287,18 +1287,23 @@ export async function runCodexAppServerAttempt(
       stream: "codex_app_server.lifecycle",
       data: { phase: "turn_starting", threadId: thread.threadId },
     });
-    turn = assertCodexTurnStartResponse(
-      await client.request(
-        "turn/start",
-        buildTurnStartParams(params, {
-          threadId: thread.threadId,
-          cwd: effectiveWorkspace,
-          appServer: pluginAppServer,
-          promptText: promptBuild.prompt,
-        }),
-        { timeoutMs: params.timeoutMs, signal: runAbortController.signal },
-      ),
+    const turnStartRequest = client.request(
+      "turn/start",
+      buildTurnStartParams(params, {
+        threadId: thread.threadId,
+        cwd: effectiveWorkspace,
+        appServer: pluginAppServer,
+        promptText: promptBuild.prompt,
+      }),
+      { timeoutMs: params.timeoutMs, signal: runAbortController.signal },
     );
+    params.onExecutionPhase?.({
+      phase: "model_call_started",
+      provider: params.provider,
+      model: params.modelId,
+      firstModelCallStarted: true,
+    });
+    turn = assertCodexTurnStartResponse(await turnStartRequest);
   } catch (error) {
     const usageLimitError = formatCodexTurnStartUsageLimitError(error, pendingNotifications);
     const turnStartErrorMessage = usageLimitError ?? formatErrorMessage(error);

--- a/src/agents/pi-embedded-runner.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.e2e.test.ts
@@ -331,6 +331,53 @@ describe("runEmbeddedPiAgent", () => {
     expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
   });
 
+  it("forwards execution phase progress into embedded attempts", async () => {
+    const sessionFile = nextSessionFile();
+    const cfg = createEmbeddedPiRunnerOpenAiConfig(["mock-1"]);
+    const onExecutionPhase = vi.fn();
+    runEmbeddedAttemptMock.mockImplementationOnce(async (params) => {
+      params.onExecutionPhase?.({
+        phase: "model_call_started",
+        provider: "openai",
+        model: "mock-1",
+        firstModelCallStarted: true,
+      });
+      return makeEmbeddedRunnerAttempt({
+        assistantTexts: ["ok"],
+        lastAssistant: buildEmbeddedRunnerAssistant({
+          content: [{ type: "text", text: "ok" }],
+        }),
+      });
+    });
+
+    await runEmbeddedPiAgent({
+      sessionId: "execution-phase-forwarding",
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      prompt: "hello",
+      provider: "openai",
+      model: "mock-1",
+      timeoutMs: 5_000,
+      agentDir,
+      runId: nextRunId("execution-phase-forwarding"),
+      enqueue: immediateEnqueue,
+      onExecutionPhase,
+    });
+
+    expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(1);
+    const firstCall = runEmbeddedAttemptMock.mock.calls[0]?.[0] as {
+      onExecutionPhase?: unknown;
+    };
+    expect(firstCall.onExecutionPhase).toBe(onExecutionPhase);
+    expect(onExecutionPhase).toHaveBeenCalledWith({
+      phase: "model_call_started",
+      provider: "openai",
+      model: "mock-1",
+      firstModelCallStarted: true,
+    });
+  });
+
   it("backfills a trimmed session key from sessionId when the embedded run omits it", async () => {
     const sessionFile = nextSessionFile();
     const cfg = createEmbeddedPiRunnerOpenAiConfig(["mock-1"]);

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1278,6 +1278,7 @@ export async function runEmbeddedPiAgent(
             onReasoningEnd: params.onReasoningEnd,
             onToolResult: params.onToolResult,
             onAgentEvent: params.onAgentEvent,
+            onExecutionPhase: params.onExecutionPhase,
             extraSystemPrompt: params.extraSystemPrompt,
             sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
             inputProvenance: params.inputProvenance,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2662,6 +2662,7 @@ export async function runEmbeddedAttempt(
           blockReplyChunking: params.blockReplyChunking,
           onPartialReply: params.onPartialReply,
           onAssistantMessageStart: params.onAssistantMessageStart,
+          onExecutionPhase: params.onExecutionPhase,
           onAgentEvent: params.onAgentEvent,
           onBeforeLifecycleTerminal: () => {
             // Clear embedded-run activity before emitting terminal lifecycle events so
@@ -3522,6 +3523,12 @@ export async function runEmbeddedAttempt(
               transcriptLeafId,
               messages: btwSnapshotMessages,
               inFlightPrompt: promptForModel,
+            });
+            params.onExecutionPhase?.({
+              phase: "model_call_started",
+              provider: params.provider,
+              model: params.modelId,
+              firstModelCallStarted: true,
             });
             if (promptSubmission.runtimeOnly) {
               await promptActiveSession(promptForModel);

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -23,15 +23,18 @@ function createTestContext(): {
   warn: ReturnType<typeof vi.fn>;
   onBlockReplyFlush: ReturnType<typeof vi.fn>;
   onAgentEvent: ReturnType<typeof vi.fn>;
+  onExecutionPhase: ReturnType<typeof vi.fn>;
 } {
   const onBlockReplyFlush = vi.fn();
   const onAgentEvent = vi.fn();
+  const onExecutionPhase = vi.fn();
   const warn = vi.fn();
   const ctx: ToolHandlerContext = {
     params: {
       runId: "run-test",
       onBlockReplyFlush,
       onAgentEvent,
+      onExecutionPhase,
       onToolResult: undefined,
     },
     flushBlockReplyBuffer: vi.fn(),
@@ -70,7 +73,7 @@ function createTestContext(): {
     trimMessagingToolSent: vi.fn(),
   };
 
-  return { ctx, warn, onBlockReplyFlush, onAgentEvent };
+  return { ctx, warn, onBlockReplyFlush, onAgentEvent, onExecutionPhase };
 }
 
 type CapturedAgentEvent = { stream?: string; data?: Record<string, unknown> };
@@ -138,6 +141,29 @@ function requireSingleMessagingTarget(ctx: ToolHandlerContext) {
 }
 
 describe("handleToolExecutionStart read path checks", () => {
+  it("reports model-call startup when tool execution starts", async () => {
+    const { ctx, onExecutionPhase } = createTestContext();
+    ctx.flushBlockReplyBuffer = vi.fn(
+      () =>
+        new Promise<void>(() => {
+          /* keep pending */
+        }),
+    );
+
+    void handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "bash",
+      toolCallId: "tool-model-start",
+      args: { command: "echo hi" },
+    });
+
+    expect(onExecutionPhase).toHaveBeenCalledWith({
+      phase: "model_call_started",
+      firstModelCallStarted: true,
+    });
+    expect(ctx.state.toolMetaById.has("tool-model-start")).toBe(false);
+  });
+
   it("does not warn when read tool uses file_path alias", async () => {
     const { ctx, warn, onBlockReplyFlush } = createTestContext();
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -641,6 +641,14 @@ export function handleToolExecutionStart(
   ctx: ToolHandlerContext,
   evt: AgentEvent & { toolName: string; toolCallId: string; args: unknown },
 ): void | Promise<void> {
+  // Tool execution implies a model call already produced the tool request. Emit
+  // this before any reply-flush work so cron watchdogs are cleared immediately
+  // when a long-running tool starts.
+  ctx.params.onExecutionPhase?.({
+    phase: "model_call_started",
+    firstModelCallStarted: true,
+  });
+
   const continueAfterBlockReplyFlush = (): void | Promise<void> => {
     const onBlockReplyFlushResult = ctx.params.onBlockReplyFlush?.();
     if (isPromiseLike<void>(onBlockReplyFlushResult)) {
@@ -663,7 +671,6 @@ export function handleToolExecutionStart(
     // Track start time and args for after_tool_call hook.
     const startedAt = Date.now();
     toolStartData.set(buildToolStartKey(runId, toolCallId), { startTime: startedAt, args });
-
     if (toolName === "read") {
       const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
       const filePathValue =

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -185,6 +185,7 @@ type ToolHandlerParams = Pick<
   | "runId"
   | "onBlockReplyFlush"
   | "onAgentEvent"
+  | "onExecutionPhase"
   | "onToolResult"
   | "sessionKey"
   | "sessionId"

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -41,6 +41,10 @@ export type SubscribeEmbeddedPiSessionParams = {
   blockReplyChunking?: BlockReplyChunking;
   onPartialReply?: (payload: PartialReplyPayload) => void | Promise<void>;
   onAssistantMessageStart?: () => void | Promise<void>;
+  onExecutionPhase?: (info: {
+    phase: "model_call_started";
+    firstModelCallStarted?: boolean;
+  }) => void;
   onAgentEvent?: (evt: {
     stream: string;
     data: Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Report Codex app-server `turn/start` dispatch as `model_call_started` execution progress for cron agent turns.
- Forward embedded-run execution progress into the selected attempt backend so Codex prompt and native tool-start signals actually reach the cron watchdog.
- Add regression coverage for `turn/start` dispatch progress, embedded attempt callback forwarding, and embedded tool-start progress.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Isolated OpenClaw cron runs could enter real Codex model and native tool execution while the cron service still believed no first model call had started. That left the 60s pre-model watchdog armed and produced false failures such as `cron: isolated agent run stalled before first model call (last phase: attempt-dispatch)`.
- Real environment tested: Live OpenClaw gateway on the host, local checkout `/home/clawuser/openclaw`, rebuilt at `2026-05-10 23:23:16 +0530`, restarted as PID `457928` at `2026-05-10 23:24:14 IST`. Proof cron job `678e2bc6-86a5-4d3f-8949-5b849798a6d8` ran isolated with `openai/gpt-5.4-mini`, `lightContext: true`, and `timeoutSeconds: 180`.
- Exact steps or command run after this patch: Rebuilt the live gateway, restarted the user service, verified built `dist` contains `turnStartRequest`, `firstModelCallStarted`, and forwarded `onExecutionPhase: params.onExecutionPhase`, then forced the isolated proof cron. The proof prompt ran native bash command `sleep 70; echo cron-codex-live-proof-ok-20260510`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
Gateway proof setup:
dist timestamp: 2026-05-10 23:23:16.023322536 +0530 /home/clawuser/openclaw/dist/index.js
systemd status: active (running) since Sun 2026-05-10 23:24:14 IST
main PID: 457928 /usr/bin/node /home/clawuser/openclaw/dist/index.js gateway --port 18789
dist verification excerpts:
  run-attempt-CCGoDEew.js: const turnStartRequest = client.request("turn/start", ...)
  run-attempt-CCGoDEew.js: firstModelCallStarted: true
  selection-Dgo28jR5.js: onExecutionPhase: params.onExecutionPhase

Before final forwarding fix:
runId: manual:678e2bc6-86a5-4d3f-8949-5b849798a6d8:1778435202905:1
status: error
durationMs: 60875
error: cron: isolated agent run stalled before first model call (last phase: attempt-dispatch)
trajectory excerpt: native bash tool call emitted for /bin/bash -lc 'sleep 70; echo cron-codex-live-proof-ok-20260510'

After forwarding onExecutionPhase into runEmbeddedAttemptWithBackend:
runId: manual:678e2bc6-86a5-4d3f-8949-5b849798a6d8:1778435771042:1
status: ok
durationMs: 80436
provider/model: openai / gpt-5.4-mini
summary: cron-codex-live-proof-ok-20260510
deliveryStatus: not-requested
sessionKey: agent:main:cron:678e2bc6-86a5-4d3f-8949-5b849798a6d8:run:d1f641f1-1f1f-4e07-b847-07ab9c08d3d5
```

- Observed result after fix: The same isolated long-running native bash turn that previously false-failed at the 60s pre-model watchdog now runs beyond 70s and completes normally with `status=ok` and summary `cron-codex-live-proof-ok-20260510`. Cron no longer reports `stalled before first model call` once the embedded attempt has entered real model/tool execution.
- What was not tested: No additional provider/model matrix was run beyond live `openai/gpt-5.4-mini`; the verification focuses on the failing Codex-selected isolated cron path.
- Before evidence (optional but encouraged): The live pre-fix proof run above failed after `60875ms` while its trajectory already contained the native bash tool call, demonstrating the watchdog false-positive path.

## Verification
- `pnpm test extensions/codex/src/app-server/run-attempt.test.ts -- --run -t "reports model-call start"`
- `pnpm test src/agents/pi-embedded-subscribe.handlers.tools.test.ts -- --run -t "reports model-call startup"`
- `pnpm test src/agents/pi-embedded-runner.e2e.test.ts -- --run -t "forwards execution phase progress"`
- `pnpm tsgo:prod`
- `pnpm build` in the live checkout
- `git diff --check origin/main...HEAD`
