### PR TITLE
Telegram: keep verbose tool results separate from final answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,7 @@ Docs: https://docs.openclaw.ai
 - ACPX/Windows: hide the MCP proxy target child process window on Windows so ACP-backed agents do not flash or fail because of terminal window handling. Fixes #60672. (#60678) Thanks @KChow-ctrl.
 - Agents: abort generic repeated no-progress tool loops at the critical threshold when identical calls keep returning identical outcomes. (#80668) Thanks @frankekn.
 - Exec approvals: omit generated command highlights for non-POSIX Windows and shell-wrapper approval commands until those command languages have native highlighting support. (#80566) Thanks @jesse-merhi.
+- Telegram: keep verbose tool progress and result drafts separate from the final assistant answer so tool output no longer blends into the final Telegram message. (#80294) Thanks @jalehman.
 
 ## 2026.5.9
 

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1140,6 +1140,25 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(rotationOrder).toBeLessThan(finalUpdateOrder);
   });
 
+  it("rotates a verbose tool result draft before streaming the final answer", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "🛠️ Exec: pnpm test" }, { kind: "tool" });
+      await dispatcherOptions.deliver({ text: "Tests passed" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "🛠️ Exec: pnpm test");
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Tests passed");
+    expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+    const rotationOrder = answerDraftStream.forceNewMessage.mock.invocationCallOrder[0];
+    const finalUpdateOrder = answerDraftStream.update.mock.invocationCallOrder[1];
+    expect(rotationOrder).toBeLessThan(finalUpdateOrder);
+  });
+
   it("keeps progress updates in a draft and sends the final answer normally", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1116,6 +1116,30 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("rotates a tool-progress-only answer draft before streaming the final answer", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver({ text: "Branch is up to date" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(/`🛠️ Exec`$/),
+    );
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Branch is up to date");
+    expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+    const rotationOrder = answerDraftStream.forceNewMessage.mock.invocationCallOrder[0];
+    const finalUpdateOrder = answerDraftStream.update.mock.invocationCallOrder[1];
+    expect(rotationOrder).toBeLessThan(finalUpdateOrder);
+  });
+
   it("keeps progress updates in a draft and sends the final answer normally", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
@@ -1141,7 +1165,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
       "Cracking...\n`🛠️ Exec`\n`🛠️ git rev-parse --abbrev-ref HEAD`",
     );
     expect(answerDraftStream.update).not.toHaveBeenCalledWith("Branch is up to date");
-    expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
     expectDeliveredReply(0, { text: "Branch is up to date" });
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });
@@ -1262,9 +1287,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.update).toHaveBeenCalledWith(
       "Shelling\n`🔎 Web Search: docs lookup`\n• `tests passed`",
     );
-    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(draftStream.materialize).not.toHaveBeenCalled();
-    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).not.toHaveBeenCalled();
     expectDeliveredReply(0, { text: "Final after tool" });
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -588,6 +588,14 @@ export const dispatchTelegramMessage = async ({
   let streamToolProgressSuppressed = false;
   let streamToolProgressLines: string[] = [];
   let lastAnswerPartialText = "";
+  let activeAnswerDraftIsToolProgressOnly = false;
+  const noteAnswerToolProgressDraft = () => {
+    activeAnswerDraftIsToolProgressOnly =
+      !answerLane.hasStreamedMessage || activeAnswerDraftIsToolProgressOnly;
+  };
+  const resetAnswerToolProgressDraft = () => {
+    activeAnswerDraftIsToolProgressOnly = false;
+  };
   const renderProgressDraft = async (options?: { flush?: boolean }) => {
     if (!answerLane.stream || streamMode !== "progress") {
       return;
@@ -601,6 +609,7 @@ export const dispatchTelegramMessage = async ({
     if (!streamText || streamText === answerLane.lastPartialText) {
       return;
     }
+    noteAnswerToolProgressDraft();
     answerLane.lastPartialText = streamText;
     answerLane.hasStreamedMessage = true;
     answerLane.finalized = false;
@@ -640,6 +649,7 @@ export const dispatchTelegramMessage = async ({
         seed: progressSeed,
         formatLine: formatProgressAsMarkdownCode,
       });
+      noteAnswerToolProgressDraft();
       answerLane.lastPartialText = streamText;
       answerLane.hasStreamedMessage = true;
       answerLane.finalized = false;
@@ -732,6 +742,9 @@ export const dispatchTelegramMessage = async ({
     }
     lane.hasStreamedMessage = false;
     lane.finalized = false;
+    if (lane === answerLane) {
+      resetAnswerToolProgressDraft();
+    }
   };
   const rotateLaneForNewMessage = async (lane: DraftLaneState) => {
     if (!lane.hasStreamedMessage && typeof lane.stream?.messageId() !== "number") {
@@ -742,7 +755,21 @@ export const dispatchTelegramMessage = async ({
     lane.stream?.forceNewMessage();
     resetDraftLaneState(lane);
   };
+  const rotateAnswerLaneAfterToolProgress = async () => {
+    if (!activeAnswerDraftIsToolProgressOnly) {
+      return false;
+    }
+    await answerLane.stream?.stop();
+    answerLane.stream?.forceNewMessage();
+    resetDraftLaneState(answerLane);
+    streamToolProgressSuppressed = true;
+    streamToolProgressLines = [];
+    return true;
+  };
   const prepareAnswerLaneForText = async () => {
+    if (await rotateAnswerLaneAfterToolProgress()) {
+      return;
+    }
     if (!answerLane.finalized) {
       return;
     }
@@ -762,6 +789,7 @@ export const dispatchTelegramMessage = async ({
       if (streamMode === "progress") {
         return;
       }
+      resetAnswerToolProgressDraft();
       streamToolProgressSuppressed = true;
       streamToolProgressLines = [];
     }
@@ -1092,8 +1120,12 @@ export const dispatchTelegramMessage = async ({
       payload: ReplyPayload,
       text: string,
     ): Promise<LaneDeliveryResult> => {
-      await answerLane.stream?.clear();
-      resetDraftLaneState(answerLane);
+      if (activeAnswerDraftIsToolProgressOnly) {
+        await rotateAnswerLaneAfterToolProgress();
+      } else {
+        await answerLane.stream?.clear();
+        resetDraftLaneState(answerLane);
+      }
       const delivered = await sendPayload(applyTextToPayload(payload, text), { durable: true });
       answerLane.finalized = true;
       return delivered ? { kind: "sent" } : { kind: "skipped" };
@@ -1216,6 +1248,24 @@ export const dispatchTelegramMessage = async ({
                     const segments = split.segments;
                     const reply = resolveSendableOutboundReplyParts(effectivePayload);
 
+                    const deliverFinalAnswerText = async (
+                      answerPayload: ReplyPayload,
+                      text: string,
+                      buttons?: TelegramInlineButtons,
+                    ) => {
+                      if (streamMode === "progress") {
+                        return deliverProgressModeFinalAnswer(answerPayload, text);
+                      }
+                      await rotateAnswerLaneAfterToolProgress();
+                      return deliverLaneText({
+                        laneName: "answer",
+                        text,
+                        payload: answerPayload,
+                        infoKind: "final",
+                        buttons,
+                      });
+                    };
+
                     const flushBufferedFinalAnswer = async () => {
                       const buffered =
                         reasoningStepState.takeBufferedFinalAnswer(replyFenceGeneration);
@@ -1227,13 +1277,11 @@ export const dispatchTelegramMessage = async ({
                           | { buttons?: TelegramInlineButtons }
                           | undefined
                       )?.buttons;
-                      await deliverLaneText({
-                        laneName: "answer",
-                        text: buffered.text,
-                        payload: buffered.payload,
-                        infoKind: "final",
-                        buttons: bufferedButtons,
-                      });
+                      await deliverFinalAnswerText(
+                        buffered.payload,
+                        buffered.text,
+                        bufferedButtons,
+                      );
                       reasoningStepState.resetForNextStep();
                     };
 
@@ -1255,12 +1303,11 @@ export const dispatchTelegramMessage = async ({
                         reasoningStepState.noteReasoningHint();
                       }
                       const result =
-                        streamMode === "progress" &&
-                        segment.lane === "answer" &&
-                        info.kind === "final"
-                          ? await deliverProgressModeFinalAnswer(
+                        segment.lane === "answer" && info.kind === "final"
+                          ? await deliverFinalAnswerText(
                               effectivePayload,
                               segment.update.text,
+                              telegramButtons,
                             )
                           : await deliverLaneText({
                               laneName: segment.lane,
@@ -1315,6 +1362,7 @@ export const dispatchTelegramMessage = async ({
                     }
 
                     if (info.kind === "final") {
+                      await rotateAnswerLaneAfterToolProgress();
                       await answerLane.stream?.stop();
                       await reasoningLane.stream?.stop();
                       reasoningStepState.resetForNextStep();

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -589,13 +589,18 @@ export const dispatchTelegramMessage = async ({
   let streamToolProgressLines: string[] = [];
   let lastAnswerPartialText = "";
   let activeAnswerDraftIsToolProgressOnly = false;
-  const noteAnswerToolProgressDraft = () => {
-    activeAnswerDraftIsToolProgressOnly =
-      !answerLane.hasStreamedMessage || activeAnswerDraftIsToolProgressOnly;
-  };
-  const resetAnswerToolProgressDraft = () => {
+  function resetAnswerToolProgressDraft() {
     activeAnswerDraftIsToolProgressOnly = false;
-  };
+  }
+  async function prepareAnswerLaneForToolProgress() {
+    if (activeAnswerDraftIsToolProgressOnly) {
+      return;
+    }
+    if (answerLane.hasStreamedMessage) {
+      await rotateLaneForNewMessage(answerLane);
+    }
+    activeAnswerDraftIsToolProgressOnly = true;
+  }
   const renderProgressDraft = async (options?: { flush?: boolean }) => {
     if (!answerLane.stream || streamMode !== "progress") {
       return;
@@ -609,7 +614,7 @@ export const dispatchTelegramMessage = async ({
     if (!streamText || streamText === answerLane.lastPartialText) {
       return;
     }
-    noteAnswerToolProgressDraft();
+    await prepareAnswerLaneForToolProgress();
     answerLane.lastPartialText = streamText;
     answerLane.hasStreamedMessage = true;
     answerLane.finalized = false;
@@ -649,7 +654,7 @@ export const dispatchTelegramMessage = async ({
         seed: progressSeed,
         formatLine: formatProgressAsMarkdownCode,
       });
-      noteAnswerToolProgressDraft();
+      await prepareAnswerLaneForToolProgress();
       answerLane.lastPartialText = streamText;
       answerLane.hasStreamedMessage = true;
       answerLane.finalized = false;
@@ -1301,6 +1306,9 @@ export const dispatchTelegramMessage = async ({
                       }
                       if (segment.lane === "reasoning") {
                         reasoningStepState.noteReasoningHint();
+                      }
+                      if (segment.lane === "answer" && info.kind === "tool") {
+                        await prepareAnswerLaneForToolProgress();
                       }
                       const result =
                         segment.lane === "answer" && info.kind === "final"


### PR DESCRIPTION
## Summary

Fix Telegram verbose delivery so tool progress/results stay separate from the final assistant answer.

This addresses the live Telegram behavior where the final assistant response could edit/reuse the last verbose tool message, visually blending the tool output and final answer into one Telegram message.

## What changed

- Track answer-lane drafts that contain only tool progress text.
- Rotate the Telegram answer draft before real final answer text is delivered.
- Treat verbose tool-result deliveries (`info.kind === "tool"`) the same way as progress-only drafts.
- Add regressions for both progress callbacks and live verbose tool-result delivery.

## Real behavior proof

- Behavior or issue addressed: Telegram verbose tool progress/results were being reused as the final assistant answer message, making the final answer visually blend with tool output in Telegram.
- Real environment tested: Josh's live OpenClaw Telegram setup on macOS, running the gateway from `test/telegram-verbose-progress-lane` with redacted live Telegram credentials.
- Exact steps or command run after the patch: Cherry-picked both fix commits onto the live checkout, ran `pnpm build`, restarted the live gateway with `launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway`, then sent live Telegram turns that produced verbose tool progress/results followed by final assistant answers.
- Evidence after fix: Copied live output from the OpenClaw setup showed `openclaw gateway status --deep` / gateway logs running from `test/telegram-verbose-progress-lane` at `c3a3dfdd3a` after the second restart, and the Telegram conversation showed the verbose tool-result message remaining separate while the final assistant answer was delivered as a fresh Telegram message.
- Observed result after fix: The final assistant response no longer edited or reused the last verbose tool/progress message; tool output and final answer appeared as separate Telegram messages.
- What was not tested: No known remaining gaps for the Telegram verbose progress/result separation; broad unrelated CI/test failures are tracked separately from this Telegram behavior proof.

## Validation

```text
pnpm test extensions/telegram/src/bot-message-dispatch.test.ts -t "verbose tool result|tool-progress-only|keeps progress updates"
# passed 3

pnpm test extensions/telegram/src/bot-message-dispatch.test.ts
# passed 41

git diff --check
# passed

pnpm exec oxfmt --check --threads=1 extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts
# passed

pnpm tsgo:extensions:test
# passed

pnpm build
# passed on the live checkout after cherry-picking both commits
```

## Notes

The live checkout has a pre-existing dirty generated Canvas bundle hash (`extensions/canvas/src/host/a2ui/.bundle.hash`). This PR intentionally does not include it.
