### PR TITLE
[Fix] Share streaming event envelopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway: scope `sessions.resolve` sessionId and label store loads to the requested agent so large unrelated agent stores are not parsed for scoped lookups. Fixes #51264. (#79474) Thanks @samzong.
+- Gateway: share serialized streaming event envelopes across eligible WebSocket and node subscribers while preserving per-client sequence numbers. (#80299) Thanks @samzong.
 - Browser: report Chrome MCP existing-session page readiness in browser status without letting status probes exceed the client timeout. Fixes #80268. (#80280) Thanks @ai-hpc.
 - Memory: reject symlinked directory components in configured extra memory paths before reading Markdown files. (#80331) Thanks @samzong.
 - Sessions/transcripts: replace whole-file `readFile` scans with shared streaming helpers (`streamSessionTranscriptLines` and `streamSessionTranscriptLinesReverse`) for idempotency lookup, latest/tail assistant text reads, delivery-mirror dedupe, and compaction fork loading, so long-running sessions no longer materialize the full transcript in memory. Forward scans use `readline` over a bounded `createReadStream`; reverse scans read bounded chunks from the file end and decode complete JSONL lines newest-first without a fixed tail cap. Synthetic 200 MiB transcript: peak RSS delta drops from +252 MiB to +27 MiB while preserving malformed-line tolerance and idempotency-key return semantics. Fixes #54296. Thanks @jack-stormentswe.

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_DANGEROUS_NODE_COMMANDS,
   resolveNodeCommandAllowlist,
 } from "./node-command-policy.js";
+import type { SerializedEventPayload } from "./node-registry.js";
 import type { RequestFrame } from "./protocol/index.js";
 import { createGatewayBroadcaster } from "./server-broadcast.js";
 import { createChatRunRegistry } from "./server-chat.js";
@@ -26,6 +27,7 @@ import { MAX_BUFFERED_BYTES } from "./server-constants.js";
 import { handleNodeInvokeResult } from "./server-methods/nodes.handlers.invoke-result.js";
 import type { GatewayClient as GatewayMethodClient } from "./server-methods/types.js";
 import type { GatewayRequestContext, RespondFn } from "./server-methods/types.js";
+import { createGatewayNodeSessionRuntime } from "./server-node-session-runtime.js";
 import { createNodeSubscriptionManager } from "./server-node-subscriptions.js";
 import { formatError, normalizeVoiceWakeTriggers } from "./server-utils.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
@@ -571,6 +573,47 @@ describe("gateway broadcaster", () => {
     ]);
   });
 
+  it("reuses the same payload shape while assigning per-client seq values", () => {
+    const firstSocket = makeRecordingSocket();
+    const secondSocket = makeRecordingSocket();
+    const thirdSocket = makeRecordingSocket();
+    const clients = new Set<GatewayWsClient>([
+      makeGatewayWsClient("c-1", firstSocket, {
+        role: "operator",
+        scopes: ["operator.read"],
+      } as GatewayWsClient["connect"]),
+      makeGatewayWsClient("c-2", secondSocket, {
+        role: "operator",
+        scopes: ["operator.write"],
+      } as GatewayWsClient["connect"]),
+      makeGatewayWsClient("c-3", thirdSocket, {
+        role: "operator",
+        scopes: ["operator.admin"],
+      } as GatewayWsClient["connect"]),
+    ]);
+    const payloadKeys: string[] = [];
+    const payload = {
+      toJSON(key: string) {
+        payloadKeys.push(key);
+        return { foo: key };
+      },
+    };
+
+    const { broadcast } = createGatewayBroadcaster({ clients });
+    broadcast("talk.mode", { enabled: true });
+    broadcast("chat", payload);
+
+    expect(payloadKeys).toEqual(["payload"]);
+    expect(firstSocket.sent.at(-1)?.payload).toEqual({ foo: "payload" });
+    expect(secondSocket.sent.at(-1)?.payload).toEqual({ foo: "payload" });
+    expect(thirdSocket.sent.at(-1)?.payload).toEqual({ foo: "payload" });
+    expect([
+      firstSocket.sent.at(-1)?.seq,
+      secondSocket.sent.at(-1)?.seq,
+      thirdSocket.sent.at(-1)?.seq,
+    ]).toEqual([1, 2, 2]);
+  });
+
   it("preserves seq gaps when dropIfSlow skips an eligible broadcast", () => {
     const slowReadSocket = makeRecordingSocket();
     slowReadSocket.bufferedAmount = Number.MAX_SAFE_INTEGER;
@@ -710,10 +753,13 @@ describe("node subscription manager", () => {
     const sent: Array<{
       nodeId: string;
       event: string;
-      payloadJSON?: string | null;
+      payloadJSON?: SerializedEventPayload | null;
     }> = [];
-    const sendEvent = (evt: { nodeId: string; event: string; payloadJSON?: string | null }) =>
-      sent.push(evt);
+    const sendEvent = (evt: {
+      nodeId: string;
+      event: string;
+      payloadJSON?: SerializedEventPayload | null;
+    }) => sent.push(evt);
 
     manager.subscribe("node-a", "main");
     manager.subscribe("node-b", "main");
@@ -722,6 +768,45 @@ describe("node subscription manager", () => {
     expect(sent).toHaveLength(2);
     expect(sent.map((s) => s.nodeId).toSorted()).toEqual(["node-a", "node-b"]);
     expect(sent[0].event).toBe("chat");
+  });
+
+  test("runtime forwards subscribed node payload json without parsing it again", () => {
+    const frames: string[] = [];
+    const socket: TestSocket = {
+      bufferedAmount: 0,
+      send: vi.fn((payload: string) => frames.push(payload)),
+      close: vi.fn(),
+    };
+    const parseSpy = vi.spyOn(JSON, "parse");
+    try {
+      const runtime = createGatewayNodeSessionRuntime({ broadcast: vi.fn() });
+      runtime.nodeRegistry.register(
+        makeGatewayWsClient("conn-node-a", socket, {
+          role: "node",
+          scopes: [],
+          client: {
+            id: "node-client",
+            version: "1.0.0",
+            platform: "darwin",
+            mode: "node",
+          },
+          device: { id: "node-a" },
+        } as unknown as GatewayWsClient["connect"]),
+        {},
+      );
+      runtime.nodeSubscribe("node-a", "main");
+
+      runtime.nodeSendToSession("main", "chat", { ok: true });
+
+      expect(parseSpy).not.toHaveBeenCalled();
+    } finally {
+      parseSpy.mockRestore();
+    }
+    expect(JSON.parse(frames[0] ?? "{}")).toEqual({
+      type: "event",
+      event: "chat",
+      payload: { ok: true },
+    });
   });
 
   test("unsubscribeAll clears session mappings", () => {

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { NodeRegistry } from "./node-registry.js";
+import { NodeRegistry, serializeEventPayload } from "./node-registry.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 
 function makeClient(connId: string, nodeId: string, sent: string[] = []): GatewayWsClient {
@@ -53,5 +53,35 @@ describe("gateway/node-registry", () => {
     expect(registry.unregister("conn-old")).toBeNull();
     expect(registry.get("node-1")).toBe(newSession);
     await expect(oldDisconnected).resolves.toBeInstanceOf(Error);
+  });
+
+  it("sends raw event payload JSON without changing the envelope shape", () => {
+    const registry = new NodeRegistry();
+    const frames: string[] = [];
+    registry.register(makeClient("conn-1", "node-1", frames), {});
+    const payload = serializeEventPayload({ foo: "bar" });
+
+    expect(registry.sendEventRaw("node-1", "chat", payload)).toBe(true);
+    expect(registry.sendEventRaw("missing-node", "chat", payload)).toBe(false);
+    expect(registry.sendEventRaw("node-1", "heartbeat", null)).toBe(true);
+    expect(
+      registry.sendEventRaw(
+        "node-1",
+        "chat",
+        "not-json" as unknown as Parameters<NodeRegistry["sendEventRaw"]>[2],
+      ),
+    ).toBe(false);
+    expect(
+      registry.sendEventRaw(
+        "node-1",
+        "chat",
+        '{"x":1},"seq":999' as unknown as Parameters<NodeRegistry["sendEventRaw"]>[2],
+      ),
+    ).toBe(false);
+
+    expect(frames).toEqual([
+      '{"type":"event","event":"chat","payload":{"foo":"bar"}}',
+      '{"type":"event","event":"heartbeat"}',
+    ]);
   });
 });

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -38,6 +38,30 @@ type NodeInvokeResult = {
   error?: { code?: string; message?: string } | null;
 };
 
+const SERIALIZED_EVENT_PAYLOAD = Symbol("openclaw.serializedEventPayload");
+
+export type SerializedEventPayload = {
+  readonly json: string;
+  readonly [SERIALIZED_EVENT_PAYLOAD]: true;
+};
+
+export function serializeEventPayload(payload: unknown): SerializedEventPayload | null {
+  if (!payload) {
+    return null;
+  }
+  const json = JSON.stringify(payload);
+  return typeof json === "string" ? { json, [SERIALIZED_EVENT_PAYLOAD]: true } : null;
+}
+
+function isSerializedEventPayload(value: unknown): value is SerializedEventPayload {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { [SERIALIZED_EVENT_PAYLOAD]?: unknown })[SERIALIZED_EVENT_PAYLOAD] === true &&
+    typeof (value as { json?: unknown }).json === "string"
+  );
+}
+
 export class NodeRegistry {
   private nodesById = new Map<string, NodeSession>();
   private nodesByConn = new Map<string, string>();
@@ -198,6 +222,18 @@ export class NodeRegistry {
     return this.sendEventToSession(node, event, payload);
   }
 
+  sendEventRaw(
+    nodeId: string,
+    event: string,
+    payloadJSON?: SerializedEventPayload | null,
+  ): boolean {
+    const node = this.nodesById.get(nodeId);
+    if (!node) {
+      return false;
+    }
+    return this.sendEventRawInternal(node, event, payloadJSON);
+  }
+
   private sendEventInternal(node: NodeSession, event: string, payload: unknown): boolean {
     try {
       node.client.socket.send(
@@ -206,6 +242,29 @@ export class NodeRegistry {
           event,
           payload,
         }),
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private sendEventRawInternal(
+    node: NodeSession,
+    event: string,
+    payloadJSON?: SerializedEventPayload | null,
+  ): boolean {
+    if (
+      payloadJSON !== null &&
+      payloadJSON !== undefined &&
+      !isSerializedEventPayload(payloadJSON)
+    ) {
+      return false;
+    }
+    try {
+      const payloadFragment = payloadJSON ? `,"payload":${payloadJSON.json}` : "";
+      node.client.socket.send(
+        `{"type":"event","event":${JSON.stringify(event)}${payloadFragment}}`,
       );
       return true;
     } catch {

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -51,6 +51,13 @@ const EVENT_SCOPE_GUARDS: Record<string, string[]> = {
 // (e.g. reconfiguring wake-word triggers).
 const NODE_ALLOWED_EVENTS = new Set<string>(["voicewake.changed", "voicewake.routing.changed"]);
 
+function serializeFrameField(name: "payload" | "stateVersion", value: unknown): string {
+  const fieldJSON = JSON.stringify({ [name]: value });
+  const keyJSON = JSON.stringify(name);
+  const prefix = `{${keyJSON}:`;
+  return fieldJSON.startsWith(prefix) ? `,${keyJSON}:${fieldJSON.slice(prefix.length, -1)}` : "";
+}
+
 function hasEventScope(client: GatewayWsClient, event: string): boolean {
   const required = EVENT_SCOPE_GUARDS[event];
   // Plugin-defined gateway broadcast events (plugin.* namespace) are allowed
@@ -113,6 +120,26 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
       }
       logWs("out", "event", logMeta);
     }
+    let frameBase:
+      | {
+          eventJSON: string;
+          payloadFragment: string;
+          stateVersionFragment: string;
+        }
+      | undefined;
+    const getFrameBase = () => {
+      if (!frameBase) {
+        frameBase = {
+          eventJSON: JSON.stringify(event),
+          payloadFragment: serializeFrameField("payload", payload),
+          stateVersionFragment:
+            opts?.stateVersion === undefined
+              ? ""
+              : serializeFrameField("stateVersion", opts.stateVersion),
+        };
+      }
+      return frameBase;
+    };
     for (const c of params.clients) {
       if (targetConnIds && !targetConnIds.has(c.connId)) {
         continue;
@@ -152,13 +179,9 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
         if (!isTargeted) {
           clientSeq.set(c, nextSeq);
         }
-        const frame = JSON.stringify({
-          type: "event",
-          event,
-          payload,
-          seq: eventSeq,
-          stateVersion: opts?.stateVersion,
-        });
+        const base = getFrameBase();
+        const seqFragment = eventSeq === undefined ? "" : `,"seq":${eventSeq}`;
+        const frame = `{"type":"event","event":${base.eventJSON}${base.payloadFragment}${seqFragment}${base.stateVersionFragment}}`;
         c.socket.send(frame);
       } catch {
         /* ignore */

--- a/src/gateway/server-node-session-runtime.ts
+++ b/src/gateway/server-node-session-runtime.ts
@@ -1,9 +1,8 @@
-import { NodeRegistry } from "./node-registry.js";
+import { NodeRegistry, type SerializedEventPayload } from "./node-registry.js";
 import {
   createSessionEventSubscriberRegistry,
   createSessionMessageSubscriberRegistry,
 } from "./server-chat-state.js";
-import { safeParseJson } from "./server-json.js";
 import { createNodeSubscriptionManager } from "./server-node-subscriptions.js";
 import { hasConnectedTalkNode } from "./server-talk-nodes.js";
 
@@ -15,9 +14,12 @@ export function createGatewayNodeSessionRuntime(params: {
   const nodeSubscriptions = createNodeSubscriptionManager();
   const sessionEventSubscribers = createSessionEventSubscriberRegistry();
   const sessionMessageSubscribers = createSessionMessageSubscriberRegistry();
-  const nodeSendEvent = (opts: { nodeId: string; event: string; payloadJSON?: string | null }) => {
-    const payload = safeParseJson(opts.payloadJSON ?? null);
-    nodeRegistry.sendEvent(opts.nodeId, opts.event, payload);
+  const nodeSendEvent = (opts: {
+    nodeId: string;
+    event: string;
+    payloadJSON?: SerializedEventPayload | null;
+  }) => {
+    nodeRegistry.sendEventRaw(opts.nodeId, opts.event, opts.payloadJSON ?? null);
   };
   const nodeSendToSession = (sessionKey: string, event: string, payload: unknown) =>
     nodeSubscriptions.sendToSession(sessionKey, event, payload, nodeSendEvent);

--- a/src/gateway/server-node-subscriptions.ts
+++ b/src/gateway/server-node-subscriptions.ts
@@ -1,7 +1,9 @@
+import { serializeEventPayload, type SerializedEventPayload } from "./node-registry.js";
+
 type NodeSendEventFn = (opts: {
   nodeId: string;
   event: string;
-  payloadJSON?: string | null;
+  payloadJSON?: SerializedEventPayload | null;
 }) => void;
 
 type NodeListConnectedFn = () => Array<{ nodeId: string }>;
@@ -34,7 +36,7 @@ export function createNodeSubscriptionManager(): NodeSubscriptionManager {
   const nodeSubscriptions = new Map<string, Set<string>>();
   const sessionSubscribers = new Map<string, Set<string>>();
 
-  const toPayloadJSON = (payload: unknown) => (payload ? JSON.stringify(payload) : null);
+  const toPayloadJSON = (payload: unknown) => serializeEventPayload(payload);
 
   const subscribe = (nodeId: string, sessionKey: string) => {
     const normalizedNodeId = nodeId.trim();


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Gateway streaming fan-out reserialized the same event payload for each WebSocket recipient, and node subscription fan-out parsed pre-serialized payload JSON before reserializing it.
- Why it matters: Chat delta events are on the streaming hot path, so redundant JSON work scales with recipient count and stream length.
- What changed: Cache broadcast frame fragments per broadcast call, add a branded serialized event payload path for node fan-out, and keep malformed raw payload strings out of outbound frames.
- What did NOT change (scope boundary): No public protocol fields changed; `payload`, `seq`, and `stateVersion` omission semantics remain compatible with the old `JSON.stringify` envelope behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: Repeated serialization on Gateway streaming fan-out and unsafe raw event payload splicing.
- Real environment tested: Local OpenClaw repo on macOS, Node 22 toolchain via repo scripts.
- Exact steps or command run after this patch: `pnpm test src/gateway/gateway-misc.test.ts src/gateway/node-registry.test.ts`; `pnpm tsgo`; `pnpm check:changed`; targeted `node --import tsx --input-type=module` harnesses for `toJSON("payload")`, raw payload rejection, and node subscription forwarding.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Targeted harness returned `{"toJSONKeys":["payload"],"broadcastRecipients":3,"nodeRecipients":2,"parsedNodePayload":0}`; malformed raw payload harness returned `okInvalid:false` and `okInject:false` with no malformed frame sent.
- Observed result after fix: Broadcast payload serialization preserves the old field key semantics while sharing one payload fragment; node fan-out forwards the branded serialized payload without parsing; invalid raw strings are rejected before socket send.
- What was not tested: Full live multi-client Gateway session with real streaming model output.
- Before evidence (optional but encouraged): Pre-fix harness showed `toJSONKeys:[""]` for broadcast payloads and `sendEventRaw` accepted malformed strings such as `not-json`.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: The hot path used object-level `JSON.stringify` at each recipient and the node subscription runtime discarded an already prepared `payloadJSON` by parsing it back to a value.
- Missing detection / guardrail: There was no focused test for shared broadcast payload shape, `toJSON(key)` compatibility, or rejecting untrusted raw JSON fragments.
- Contributing context (if known): Streaming chat deltas are throttled but still frequent enough that per-recipient serialization is costly.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/gateway-misc.test.ts`; `src/gateway/node-registry.test.ts`.
- Scenario the test should lock in: Multi-recipient broadcast keeps per-client seq while reusing one payload shape; `toJSON("payload")` compatibility is preserved; node subscription fan-out does not parse pre-serialized payloads; invalid raw payload strings are rejected.
- Why this is the smallest reliable guardrail: These tests exercise the changed Gateway broadcaster and NodeRegistry seams directly without requiring a live model stream.
- Existing test that already covers this (if any): Existing broadcaster and node subscription tests covered routing and seq behavior, but not serialization reuse or raw payload rejection.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
[chat delta] -> [broadcast loop stringify per WS client]
[chat delta] -> [payloadJSON] -> [parse] -> [stringify per node]

After:
[chat delta] -> [shared frame fragments] -> [per-client seq] -> [WS clients]
[chat delta] -> [branded serialized payload] -> [node event envelope]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 via repo scripts
- Model/provider: N/A
- Integration/channel (if any): Gateway WebSocket/node fan-out
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm test src/gateway/gateway-misc.test.ts src/gateway/node-registry.test.ts`.
2. Run `pnpm tsgo`.
3. Run `pnpm check:changed`.
4. Run targeted `node --import tsx --input-type=module` harnesses for broadcast `toJSON("payload")`, raw payload rejection, and node subscription forwarding.

### Expected

- Broadcast frames preserve old payload shape and per-client seq behavior.
- Node fan-out avoids parse/restringify and rejects unbranded raw strings.
- Targeted tests and changed checks pass.

### Actual

- `pnpm test src/gateway/gateway-misc.test.ts src/gateway/node-registry.test.ts`: passed, 2 files / 40 tests.
- `pnpm tsgo`: passed.
- `pnpm check:changed`: passed.
- `git diff HEAD~1..HEAD --check`: passed.
- Targeted harnesses confirmed `toJSONKeys:["payload"]`, `parsedNodePayload:0`, and invalid raw payload rejection.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Multi-client broadcast payload shape and seq behavior; node subscription raw payload forwarding; malformed raw payload rejection; narrow Gateway tests; typecheck; changed lint/import-cycle gate.
- Edge cases checked: `toJSON(key)` receives `"payload"`; `payload` omission still works for nullish serialized values; injected raw strings cannot add top-level frame fields.
- What you did **not** verify: Full live end-to-end streaming session with a real model and multiple connected external clients.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Manual JSON frame assembly could drift from `JSON.stringify` envelope semantics.
  - Mitigation: Field-level serialization preserves `toJSON("payload")`; tests lock payload shape, raw rejection, and routing behavior.
