### PR TITLE
fix(sessions): expose subagent runtime parent metadata in --json output

### DIFF
--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -25,6 +25,16 @@ export type SessionDisplayRow = {
   providerOverride?: string;
   modelOverride?: string;
   contextTokens?: number;
+  spawnedBy?: string;
+  spawnedWorkspaceDir?: string;
+  spawnDepth?: number;
+  subagentRole?: string;
+  subagentControlScope?: string;
+  label?: string;
+  status?: string;
+  sessionStartedAt?: number;
+  lastInteractionAt?: number;
+  sessionFile?: string;
 };
 
 export const SESSION_KEY_PAD = 26;
@@ -56,6 +66,16 @@ export function toSessionDisplayRow(key: string, entry: SessionEntry): SessionDi
     providerOverride: entry?.providerOverride,
     modelOverride: entry?.modelOverride,
     contextTokens: entry?.contextTokens,
+    spawnedBy: entry?.spawnedBy,
+    spawnedWorkspaceDir: entry?.spawnedWorkspaceDir,
+    spawnDepth: entry?.spawnDepth,
+    subagentRole: entry?.subagentRole,
+    subagentControlScope: entry?.subagentControlScope,
+    label: entry?.label,
+    status: entry?.status,
+    sessionStartedAt: entry?.sessionStartedAt,
+    lastInteractionAt: entry?.lastInteractionAt,
+    sessionFile: entry?.sessionFile,
   };
 }
 

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -338,4 +338,51 @@ describe("sessionsCommand", () => {
 
     fs.rmSync(store);
   });
+
+  it("exposes subagent runtime parent metadata in JSON output", async () => {
+    const store = writeStore({
+      "sub:abc123": {
+        sessionId: "sub-session",
+        updatedAt: Date.now() - 2 * 60_000,
+        spawnedBy: "main",
+        spawnedWorkspaceDir: "/workspace/abc",
+        spawnDepth: 1,
+        subagentRole: "leaf",
+        subagentControlScope: "none",
+        label: "Research agent",
+        status: "done",
+        sessionStartedAt: Date.now() - 10 * 60_000,
+        lastInteractionAt: Date.now() - 3 * 60_000,
+        sessionFile: "/path/to/transcript.jsonl",
+      },
+    });
+
+    const payload = await runSessionsJson<{
+      sessions?: Array<{
+        key: string;
+        spawnedBy?: string;
+        spawnedWorkspaceDir?: string;
+        spawnDepth?: number;
+        subagentRole?: string;
+        subagentControlScope?: string;
+        label?: string;
+        status?: string;
+        sessionStartedAt?: number;
+        lastInteractionAt?: number;
+        sessionFile?: string;
+      }>;
+    }>(sessionsCommand, store);
+
+    const sub = payload.sessions?.find((row) => row.key === "sub:abc123");
+    expect(sub?.spawnedBy).toBe("main");
+    expect(sub?.spawnedWorkspaceDir).toBe("/workspace/abc");
+    expect(sub?.spawnDepth).toBe(1);
+    expect(sub?.subagentRole).toBe("leaf");
+    expect(sub?.subagentControlScope).toBe("none");
+    expect(sub?.label).toBe("Research agent");
+    expect(sub?.status).toBe("done");
+    expect(typeof sub?.sessionStartedAt).toBe("number");
+    expect(typeof sub?.lastInteractionAt).toBe("number");
+    expect(sub?.sessionFile).toBe("/path/to/transcript.jsonl");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #80286.

`openclaw sessions --json` did not expose `spawnedBy`, `label`, `status`, `sessionFile`, `sessionStartedAt`, `lastInteractionAt`, `subagentRole`, `subagentControlScope`, `spawnedWorkspaceDir`, or `spawnDepth` fields, even though they are present in the underlying `sessions.json` store. Read-only consumers (lineage detectors, fleet observability) had no supported surface to access subagent runtime parent metadata.

### Changes

- **`src/commands/sessions-table.ts`**: Add 10 new optional fields (`spawnedBy`, `spawnedWorkspaceDir`, `spawnDepth`, `subagentRole`, `subagentControlScope`, `label`, `status`, `sessionStartedAt`, `lastInteractionAt`, `sessionFile`) to `SessionDisplayRow` type and `toSessionDisplayRow` function. Fields are `undefined` when absent in the store entry — fully backward-compatible.
- **`src/commands/sessions.test.ts`**: New test asserting that all 10 fields flow through to `--json` output when present in the store.

## Real behavior proof

**Behavior or issue addressed:** `openclaw sessions --agent <agent> --json` returned a thin projection of session fields, omitting `spawnedBy` and related subagent runtime parent metadata that is present in the `sessions.json` store. Consumers following substrate-discipline (CLI as authoritative surface) had no supported way to reason about subagent lineage.

**Real environment tested:** Node 22.14.0, openclaw dev build from main, mock session store with a subagent entry containing all 10 new fields.

**Exact steps or command run after this patch:**
```
node node_modules/.bin/vitest run --project commands src/commands/sessions.test.ts
```

**Evidence after fix:**
```
 RUN  v4.1.5 /home/runner/_work/openclaw/openclaw

 ✓ |commands| src/commands/sessions.test.ts (14 tests) 848ms
   ✓ exposes subagent runtime parent metadata in JSON output 3ms

 Test Files  1 passed (1)
      Tests  14 passed (14)
   Duration  2.0s
```
All 10 new fields (`spawnedBy`, `spawnedWorkspaceDir`, `spawnDepth`, `subagentRole`, `subagentControlScope`, `label`, `status`, `sessionStartedAt`, `lastInteractionAt`, `sessionFile`) verified present in JSON output with correct values.

**Observed result after fix:** `--json` sessions output includes all requested subagent runtime parent fields when present in the store. Fields absent in the store entry are omitted (not null-padded).

**What was not tested:** Live `openclaw sessions --json` against a real deployment with active subagents. The fix is a pure pass-through — `SessionEntry` already contains these fields; only the projection was missing them.

## Test plan

- [x] All 14 sessions tests pass (13 existing + 1 new metadata test).
- [x] New test verifies all 10 new fields round-trip through `toSessionDisplayRow` → JSON output.
- [x] `oxlint` reports 0 errors on both modified files.
- [x] Fully backward-compatible: existing fields unchanged, new fields optional and omitted when absent.