### PR TITLE
entrypoint: add featherless provider + Railway proxy trust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,11 @@ FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS ext-deps
 ARG OPENCLAW_EXTENSIONS
 ARG OPENCLAW_BUNDLED_PLUGIN_DIR
 # Copy package.json for opted-in extensions so pnpm resolves their deps.
-RUN --mount=type=bind,source=${OPENCLAW_BUNDLED_PLUGIN_DIR},target=/tmp/${OPENCLAW_BUNDLED_PLUGIN_DIR},readonly \
-    mkdir -p /out && \
+# Railway's builder doesn't support `--mount=type=bind` so we COPY the
+# plugin dir from the build context instead. Same end-state, slightly
+# bigger intermediate layer.
+COPY ${OPENCLAW_BUNDLED_PLUGIN_DIR} /tmp/${OPENCLAW_BUNDLED_PLUGIN_DIR}
+RUN mkdir -p /out && \
     for ext in $(printf '%s\n' "$OPENCLAW_EXTENSIONS" | tr ',' ' '); do \
       if [ -f "/tmp/${OPENCLAW_BUNDLED_PLUGIN_DIR}/$ext/package.json" ]; then \
         mkdir -p "/out/$ext" && \
@@ -62,8 +65,7 @@ COPY --from=ext-deps /out/ ./${OPENCLAW_BUNDLED_PLUGIN_DIR}/
 
 # Reduce OOM risk on low-memory hosts during dependency installation.
 # Docker builds on small VMs may otherwise fail with "Killed" (exit 137).
-RUN --mount=type=cache,id=openclaw-pnpm-store,target=/root/.local/share/pnpm/store,sharing=locked \
-    NODE_OPTIONS=--max-old-space-size=2048 pnpm install --frozen-lockfile
+RUN NODE_OPTIONS=--max-old-space-size=2048 pnpm install --frozen-lockfile
 
 # pnpm v10+ may append peer-resolution hashes to virtual-store folder names; do not hardcode `.pnpm/...`
 # paths. Matrix's native downloader can hit transient release CDN errors while
@@ -156,9 +158,7 @@ WORKDIR /app
 # so it must be installed explicitly here. Without it `/etc/ssl/certs/`
 # stays empty and every HTTPS outbound dies at TLS handshake with
 # `error setting certificate file`.
-RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
-    apt-get update && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       ca-certificates procps hostname curl git lsof openssl python3 tini && \
     update-ca-certificates
@@ -195,9 +195,7 @@ RUN install -d -m 0755 "$COREPACK_HOME" && \
 # Install additional system packages needed by your skills or extensions.
 # Example: docker build --build-arg OPENCLAW_DOCKER_APT_PACKAGES="python3 wget" .
 ARG OPENCLAW_DOCKER_APT_PACKAGES=""
-RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
-    if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
+RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
       apt-get update && \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $OPENCLAW_DOCKER_APT_PACKAGES; \
     fi
@@ -207,9 +205,7 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
 # Adds ~300MB but eliminates the 60-90s Playwright install on every container start.
 # Must run after node_modules COPY so playwright-core is available.
 ARG OPENCLAW_INSTALL_BROWSER=""
-RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
-    if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
+RUN if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
       apt-get update && \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends xvfb && \
       mkdir -p /home/node/.cache/ms-playwright && \
@@ -224,9 +220,7 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
 # Required for agents.defaults.sandbox to function in Docker deployments.
 ARG OPENCLAW_INSTALL_DOCKER_CLI=""
 ARG OPENCLAW_DOCKER_GPG_FINGERPRINT="9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
-RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
-    if [ -n "$OPENCLAW_INSTALL_DOCKER_CLI" ]; then \
+RUN if [ -n "$OPENCLAW_INSTALL_DOCKER_CLI" ]; then \
       apt-get update && \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates curl gnupg && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -160,7 +160,7 @@ WORKDIR /app
 # `error setting certificate file`.
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      ca-certificates procps hostname curl git lsof openssl python3 tini && \
+      ca-certificates procps hostname curl git lsof openssl python3 tini gosu && \
     update-ca-certificates
 
 RUN chown node:node /app
@@ -262,10 +262,18 @@ RUN install -d -m 0700 -o node -g node /home/node/.openclaw && \
 
 ENV NODE_ENV=production
 
-# Security hardening: Run as non-root user
-# The node:24-bookworm image includes a 'node' user (uid 1000)
-# This reduces the attack surface by preventing container escape via root privileges
-USER node
+# Custom entrypoint that runs briefly as root to chown the persistent
+# state-dir volume (Railway-managed volumes are root-owned by default,
+# which crashes the gateway with EACCES on first start). The
+# entrypoint drops privileges to `node` via gosu before executing the
+# CMD — the container effectively still runs unprivileged once the
+# permission bootstrap is done.
+COPY scripts/docker/openclaw-entrypoint.sh /usr/local/bin/openclaw-entrypoint.sh
+RUN chmod +x /usr/local/bin/openclaw-entrypoint.sh
+
+# NOTE: USER node would normally go here, but the entrypoint needs
+# root briefly to chown the volume mount. The entrypoint script
+# drops to node before exec'ing the CMD.
 
 # Start gateway server with default config.
 # Binds to loopback (127.0.0.1) by default for security.
@@ -281,5 +289,5 @@ USER node
 # For external access from host/ingress, override bind to "lan" and set auth.
 HEALTHCHECK --interval=3m --timeout=10s --start-period=15s --retries=3 \
   CMD node -e "fetch('http://127.0.0.1:18789/healthz').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
-ENTRYPOINT ["tini", "-s", "--"]
+ENTRYPOINT ["/usr/local/bin/openclaw-entrypoint.sh"]
 CMD ["node", "openclaw.mjs", "gateway", "--allow-unconfigured"]

--- a/scripts/docker/openclaw-entrypoint.sh
+++ b/scripts/docker/openclaw-entrypoint.sh
@@ -48,6 +48,19 @@
 #                                   the API rejects the value.
 #   OPENCLAW_OLLAMA_MAX_TOKENS      output token cap per turn. Default
 #                                   8000.
+#   OPENCLAW_PROVIDER_BASE_URL      Override the OpenAI-compatible
+#                                   provider base URL. Default
+#                                   https://ollama.com/v1 (Ollama
+#                                   Cloud). Set to e.g.
+#                                   https://api.featherless.ai/v1
+#                                   for Featherless, or
+#                                   https://openrouter.ai/api/v1
+#                                   for OpenRouter, etc. Auth still
+#                                   flows through OPENAI_API_KEY.
+#                                   Provider key in the config stays
+#                                   "ollama" for stability across
+#                                   redeploys, but the actual HTTP
+#                                   target is whatever URL you set.
 set -e
 
 STATE_DIR="${OPENCLAW_STATE_DIR:-/root/.openclaw}"
@@ -66,12 +79,13 @@ if true; then
     "${OPENCLAW_OLLAMA_MODEL:-}" \
     "${OPENCLAW_COMPACTION_RESERVE:-20000}" \
     "${OPENCLAW_OLLAMA_CONTEXT_WINDOW:-128000}" \
-    "${OPENCLAW_OLLAMA_MAX_TOKENS:-8000}" <<'PY' || true
+    "${OPENCLAW_OLLAMA_MAX_TOKENS:-8000}" \
+    "${OPENCLAW_PROVIDER_BASE_URL:-https://ollama.com/v1}" <<'PY' || true
 import json, os, sys
 (
     config_path, public_origin, disable_dev_auth, ollama_model,
-    compaction_reserve, ollama_ctx, ollama_max,
-) = sys.argv[1:8]
+    compaction_reserve, ollama_ctx, ollama_max, provider_base_url,
+) = sys.argv[1:9]
 config = {}
 if os.path.exists(config_path):
     try:
@@ -114,7 +128,7 @@ if ollama_model:
     models = config.setdefault("models", {})
     providers = models.setdefault("providers", {})
     providers["ollama"] = {
-        "baseUrl": "https://ollama.com/v1",
+        "baseUrl": provider_base_url or "https://ollama.com/v1",
         "apiKey": {"source": "env", "provider": "default", "id": "OPENAI_API_KEY"},
         "api": "openai-completions",
         "models": [
@@ -135,18 +149,17 @@ if ollama_model:
         model_cfg["primary"] = f"ollama/{model_ids[0]}"
 with open(config_path, "w") as f:
     json.dump(config, f, indent=2)
-_provider_models = (
-    config.get("models", {})
-    .get("providers", {})
-    .get("ollama", {})
-    .get("models", [])
+_provider_block = (
+    config.get("models", {}).get("providers", {}).get("ollama", {})
 )
+_provider_models = _provider_block.get("models", [])
 _ctx = _provider_models[0].get("contextWindow") if _provider_models else None
 _max = _provider_models[0].get("maxTokens") if _provider_models else None
 print(
     "openclaw.json patched: "
     f"origins={ui.get('allowedOrigins')} "
     f"disableDeviceAuth={ui.get('dangerouslyDisableDeviceAuth', False)} "
+    f"providerBaseUrl={_provider_block.get('baseUrl')} "
     f"primaryModel={defaults.get('model', {}).get('primary')} "
     f"contextWindow={_ctx} "
     f"maxTokens={_max} "

--- a/scripts/docker/openclaw-entrypoint.sh
+++ b/scripts/docker/openclaw-entrypoint.sh
@@ -31,6 +31,16 @@
 #                                   recommended floor; raise if you
 #                                   still hit "context limit
 #                                   exceeded — reset our conversation").
+#   OPENCLAW_OLLAMA_CONTEXT_WINDOW  models.providers.ollama.models[0]
+#                                   .contextWindow — total token
+#                                   budget. Default 128000 (Kimi K2,
+#                                   most modern Ollama Cloud models).
+#                                   gpt-oss:120b also 128K; deepseek
+#                                   v3.1 supports 128K too. Lower
+#                                   for older / smaller models if
+#                                   the API rejects the value.
+#   OPENCLAW_OLLAMA_MAX_TOKENS      output token cap per turn. Default
+#                                   8000.
 set -e
 
 STATE_DIR="${OPENCLAW_STATE_DIR:-/root/.openclaw}"
@@ -47,9 +57,14 @@ if true; then
     "${OPENCLAW_PUBLIC_ORIGIN:-}" \
     "${OPENCLAW_DISABLE_DEVICE_AUTH:-0}" \
     "${OPENCLAW_OLLAMA_MODEL:-}" \
-    "${OPENCLAW_COMPACTION_RESERVE:-20000}" <<'PY' || true
+    "${OPENCLAW_COMPACTION_RESERVE:-20000}" \
+    "${OPENCLAW_OLLAMA_CONTEXT_WINDOW:-128000}" \
+    "${OPENCLAW_OLLAMA_MAX_TOKENS:-8000}" <<'PY' || true
 import json, os, sys
-config_path, public_origin, disable_dev_auth, ollama_model, compaction_reserve = sys.argv[1:6]
+(
+    config_path, public_origin, disable_dev_auth, ollama_model,
+    compaction_reserve, ollama_ctx, ollama_max,
+) = sys.argv[1:8]
 config = {}
 if os.path.exists(config_path):
     try:
@@ -76,6 +91,14 @@ except ValueError:
 compaction = defaults.setdefault("compaction", {})
 compaction["reserveTokensFloor"] = reserve_tokens
 if ollama_model:
+    try:
+        ctx_window = int(ollama_ctx)
+    except ValueError:
+        ctx_window = 128000
+    try:
+        max_tokens = int(ollama_max)
+    except ValueError:
+        max_tokens = 8000
     models = config.setdefault("models", {})
     providers = models.setdefault("providers", {})
     providers["ollama"] = {
@@ -89,8 +112,8 @@ if ollama_model:
                 "reasoning": False,
                 "input": ["text"],
                 "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
-                "contextWindow": 32000,
-                "maxTokens": 8000,
+                "contextWindow": ctx_window,
+                "maxTokens": max_tokens,
             }
         ],
     }
@@ -98,11 +121,21 @@ if ollama_model:
     model_cfg["primary"] = f"ollama/{ollama_model}"
 with open(config_path, "w") as f:
     json.dump(config, f, indent=2)
+_provider_models = (
+    config.get("models", {})
+    .get("providers", {})
+    .get("ollama", {})
+    .get("models", [])
+)
+_ctx = _provider_models[0].get("contextWindow") if _provider_models else None
+_max = _provider_models[0].get("maxTokens") if _provider_models else None
 print(
     "openclaw.json patched: "
     f"origins={ui.get('allowedOrigins')} "
     f"disableDeviceAuth={ui.get('dangerouslyDisableDeviceAuth', False)} "
     f"primaryModel={defaults.get('model', {}).get('primary')} "
+    f"contextWindow={_ctx} "
+    f"maxTokens={_max} "
     f"compactionReserve={compaction['reserveTokensFloor']}",
     file=sys.stderr,
 )

--- a/scripts/docker/openclaw-entrypoint.sh
+++ b/scripts/docker/openclaw-entrypoint.sh
@@ -17,12 +17,19 @@
 # Env-driven config:
 #   OPENCLAW_PUBLIC_ORIGIN          gateway.controlUi.allowedOrigins
 #   OPENCLAW_DISABLE_DEVICE_AUTH    gateway.controlUi.dangerouslyDisableDeviceAuth
-#   OPENCLAW_OLLAMA_MODEL           registers Ollama as an OpenAI-
-#                                   compatible provider, sets it as
-#                                   the default agent model. Key is
-#                                   read from OPENAI_API_KEY at
-#                                   runtime via Openclaw's env-ref
-#                                   shape.
+#   OPENCLAW_OLLAMA_MODEL           comma-separated Ollama model ids.
+#                                   First entry becomes the default
+#                                   (agents.defaults.model.primary);
+#                                   every entry is registered in
+#                                   models.providers.ollama.models[]
+#                                   so the operator can swap between
+#                                   them in the Control UI. Auth key
+#                                   is read from OPENAI_API_KEY via
+#                                   Openclaw's env-ref shape.
+#                                   Single-model and multi-model
+#                                   shapes both accepted, e.g.:
+#                                     OPENCLAW_OLLAMA_MODEL=kimi-k2.6:cloud
+#                                     OPENCLAW_OLLAMA_MODEL=kimi-k2.6:cloud,gpt-oss:120b,qwen3-coder:480b
 #   OPENCLAW_COMPACTION_RESERVE     agents.defaults.compaction
 #                                   .reserveTokensFloor — bytes the
 #                                   agent must keep free for compaction
@@ -99,6 +106,11 @@ if ollama_model:
         max_tokens = int(ollama_max)
     except ValueError:
         max_tokens = 8000
+    # Comma-separated list. First entry becomes the default; every
+    # entry is registered as an available model so the operator can
+    # swap in the Control UI without redeploying. Whitespace and
+    # empty entries are ignored.
+    model_ids = [m.strip() for m in ollama_model.split(",") if m.strip()]
     models = config.setdefault("models", {})
     providers = models.setdefault("providers", {})
     providers["ollama"] = {
@@ -107,18 +119,20 @@ if ollama_model:
         "api": "openai-completions",
         "models": [
             {
-                "id": ollama_model,
-                "name": ollama_model,
+                "id": mid,
+                "name": mid,
                 "reasoning": False,
                 "input": ["text"],
                 "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
                 "contextWindow": ctx_window,
                 "maxTokens": max_tokens,
             }
+            for mid in model_ids
         ],
     }
-    model_cfg = defaults.setdefault("model", {})
-    model_cfg["primary"] = f"ollama/{ollama_model}"
+    if model_ids:
+        model_cfg = defaults.setdefault("model", {})
+        model_cfg["primary"] = f"ollama/{model_ids[0]}"
 with open(config_path, "w") as f:
     json.dump(config, f, indent=2)
 _provider_models = (

--- a/scripts/docker/openclaw-entrypoint.sh
+++ b/scripts/docker/openclaw-entrypoint.sh
@@ -15,30 +15,41 @@
 # SSH'ing into the container. Idempotent: rerunning is a no-op.
 #
 # Env-driven config:
-#   OPENCLAW_PUBLIC_ORIGIN       gateway.controlUi.allowedOrigins
-#   OPENCLAW_DISABLE_DEVICE_AUTH gateway.controlUi.dangerouslyDisableDeviceAuth
-#   OPENCLAW_OLLAMA_MODEL        registers Ollama as an OpenAI-
-#                                compatible provider, sets it as the
-#                                default agent model. API key is
-#                                read from OPENAI_API_KEY at runtime
-#                                via Openclaw's env-ref shape.
+#   OPENCLAW_PUBLIC_ORIGIN          gateway.controlUi.allowedOrigins
+#   OPENCLAW_DISABLE_DEVICE_AUTH    gateway.controlUi.dangerouslyDisableDeviceAuth
+#   OPENCLAW_OLLAMA_MODEL           registers Ollama as an OpenAI-
+#                                   compatible provider, sets it as
+#                                   the default agent model. Key is
+#                                   read from OPENAI_API_KEY at
+#                                   runtime via Openclaw's env-ref
+#                                   shape.
+#   OPENCLAW_COMPACTION_RESERVE     agents.defaults.compaction
+#                                   .reserveTokensFloor — bytes the
+#                                   agent must keep free for compaction
+#                                   to survive a long session. Default
+#                                   20000 if unset (covers Kimi K2's
+#                                   recommended floor; raise if you
+#                                   still hit "context limit
+#                                   exceeded — reset our conversation").
 set -e
 
 STATE_DIR="${OPENCLAW_STATE_DIR:-/root/.openclaw}"
 mkdir -p "$STATE_DIR"
 
-if [ -n "$OPENCLAW_PUBLIC_ORIGIN" ] \
-  || [ "$OPENCLAW_DISABLE_DEVICE_AUTH" = "1" ] \
-  || [ -n "$OPENCLAW_OLLAMA_MODEL" ]; then
+# Patch is unconditional now: compaction reserve floor always applied
+# (default 20k) so a fresh deployment doesn't crashloop the very first
+# long chat. Other config blocks remain env-gated.
+if true; then
   CONFIG_PATH="$STATE_DIR/openclaw.json"
   # Merge (or create) gateway config idempotently. Uses python because
   # jq isn't installed in the upstream image.
   python3 - "$CONFIG_PATH" \
     "${OPENCLAW_PUBLIC_ORIGIN:-}" \
     "${OPENCLAW_DISABLE_DEVICE_AUTH:-0}" \
-    "${OPENCLAW_OLLAMA_MODEL:-}" <<'PY' || true
+    "${OPENCLAW_OLLAMA_MODEL:-}" \
+    "${OPENCLAW_COMPACTION_RESERVE:-20000}" <<'PY' || true
 import json, os, sys
-config_path, public_origin, disable_dev_auth, ollama_model = sys.argv[1:5]
+config_path, public_origin, disable_dev_auth, ollama_model, compaction_reserve = sys.argv[1:6]
 config = {}
 if os.path.exists(config_path):
     try:
@@ -56,6 +67,14 @@ if public_origin:
             origins.append(o)
 if disable_dev_auth == "1":
     ui["dangerouslyDisableDeviceAuth"] = True
+agents = config.setdefault("agents", {})
+defaults = agents.setdefault("defaults", {})
+try:
+    reserve_tokens = int(compaction_reserve)
+except ValueError:
+    reserve_tokens = 20000
+compaction = defaults.setdefault("compaction", {})
+compaction["reserveTokensFloor"] = reserve_tokens
 if ollama_model:
     models = config.setdefault("models", {})
     providers = models.setdefault("providers", {})
@@ -75,8 +94,6 @@ if ollama_model:
             }
         ],
     }
-    agents = config.setdefault("agents", {})
-    defaults = agents.setdefault("defaults", {})
     model_cfg = defaults.setdefault("model", {})
     model_cfg["primary"] = f"ollama/{ollama_model}"
 with open(config_path, "w") as f:
@@ -85,7 +102,8 @@ print(
     "openclaw.json patched: "
     f"origins={ui.get('allowedOrigins')} "
     f"disableDeviceAuth={ui.get('dangerouslyDisableDeviceAuth', False)} "
-    f"primaryModel={config.get('agents', {}).get('defaults', {}).get('model', {}).get('primary')}",
+    f"primaryModel={defaults.get('model', {}).get('primary')} "
+    f"compactionReserve={compaction['reserveTokensFloor']}",
     file=sys.stderr,
 )
 PY

--- a/scripts/docker/openclaw-entrypoint.sh
+++ b/scripts/docker/openclaw-entrypoint.sh
@@ -17,6 +17,18 @@
 # Env-driven config:
 #   OPENCLAW_PUBLIC_ORIGIN          gateway.controlUi.allowedOrigins
 #   OPENCLAW_DISABLE_DEVICE_AUTH    gateway.controlUi.dangerouslyDisableDeviceAuth
+#   OPENCLAW_TRUSTED_PROXIES        gateway.trustedProxies — comma-separated
+#                                   list of IPs/CIDRs whose X-Forwarded-For
+#                                   headers we honor. Default
+#                                   100.64.0.0/10 (Tailscale CGNAT range,
+#                                   which is what Railway's edge proxy
+#                                   uses). Without this set, the gateway
+#                                   logs "Proxy headers detected from
+#                                   untrusted address" on every WS
+#                                   connection and refuses to treat the
+#                                   webchat client as local — webchat
+#                                   handshakes then close 1008 → browser
+#                                   sees code=1006 and chat is broken.
 #   OPENCLAW_OLLAMA_MODEL           comma-separated Ollama model ids.
 #                                   First entry becomes the default
 #                                   (agents.defaults.model.primary);
@@ -61,6 +73,34 @@
 #                                   "ollama" for stability across
 #                                   redeploys, but the actual HTTP
 #                                   target is whatever URL you set.
+#                                   This legacy path is kept for
+#                                   backwards compatibility; new
+#                                   deployments should use the
+#                                   first-class FEATHERLESS_API_KEY
+#                                   path below instead.
+#   FEATHERLESS_API_KEY             Featherless.ai API key. When set,
+#                                   registers a real models.providers
+#                                   .featherless block (separate from
+#                                   the ollama legacy alias) so the
+#                                   operator can route to featherless
+#                                   models by their canonical id
+#                                   (e.g. featherless/moonshotai/Kimi-K2-Instruct-0905)
+#                                   in the Control UI without losing
+#                                   ollama as a co-installed option.
+#                                   Models are also auto-allowlisted
+#                                   in agents.defaults.model.fallbacks
+#                                   so the main agent can route to
+#                                   them.
+#   FEATHERLESS_MODELS              Comma-separated featherless model
+#                                   ids to register. Default:
+#                                     moonshotai/Kimi-K2-Instruct-0905,
+#                                     deepseek-ai/DeepSeek-V3.1-Terminus,
+#                                     meta-llama/Meta-Llama-3.1-70B-Instruct,
+#                                     zai-org/GLM-4.7,
+#                                     Qwen/QwQ-32B
+#                                   Verify ids against your featherless
+#                                   plan at https://featherless.ai/models
+#                                   before changing.
 set -e
 
 STATE_DIR="${OPENCLAW_STATE_DIR:-/root/.openclaw}"
@@ -80,12 +120,16 @@ if true; then
     "${OPENCLAW_COMPACTION_RESERVE:-20000}" \
     "${OPENCLAW_OLLAMA_CONTEXT_WINDOW:-128000}" \
     "${OPENCLAW_OLLAMA_MAX_TOKENS:-8000}" \
-    "${OPENCLAW_PROVIDER_BASE_URL:-https://ollama.com/v1}" <<'PY' || true
+    "${OPENCLAW_PROVIDER_BASE_URL:-https://ollama.com/v1}" \
+    "${OPENCLAW_TRUSTED_PROXIES:-100.64.0.0/10}" \
+    "${FEATHERLESS_API_KEY:-}" \
+    "${FEATHERLESS_MODELS:-moonshotai/Kimi-K2-Instruct-0905,deepseek-ai/DeepSeek-V3.1-Terminus,meta-llama/Meta-Llama-3.1-70B-Instruct,zai-org/GLM-4.7,Qwen/QwQ-32B}" <<'PY' || true
 import json, os, sys
 (
     config_path, public_origin, disable_dev_auth, ollama_model,
     compaction_reserve, ollama_ctx, ollama_max, provider_base_url,
-) = sys.argv[1:9]
+    trusted_proxies, featherless_api_key, featherless_models,
+) = sys.argv[1:12]
 config = {}
 if os.path.exists(config_path):
     try:
@@ -103,6 +147,12 @@ if public_origin:
             origins.append(o)
 if disable_dev_auth == "1":
     ui["dangerouslyDisableDeviceAuth"] = True
+# trustedProxies: array of IP/CIDR strings whose X-Forwarded-For we trust.
+# Without this set, the gateway flags every WS connection from Railway's
+# edge proxy as untrusted and webchat handshakes close 1008.
+proxy_list = [p.strip() for p in trusted_proxies.split(",") if p.strip()]
+if proxy_list:
+    gw["trustedProxies"] = proxy_list
 agents = config.setdefault("agents", {})
 defaults = agents.setdefault("defaults", {})
 try:
@@ -147,6 +197,29 @@ if ollama_model:
     if model_ids:
         model_cfg = defaults.setdefault("model", {})
         model_cfg["primary"] = f"ollama/{model_ids[0]}"
+# Featherless.ai as a first-class provider (separate from the ollama
+# legacy alias). When FEATHERLESS_API_KEY is set, register the provider
+# block, materialize the configured model list, and auto-allowlist each
+# entry in agents.defaults so the main agent can actually route to them.
+if featherless_api_key:
+    feather_ids = [m.strip() for m in featherless_models.split(",") if m.strip()]
+    models = config.setdefault("models", {})
+    providers = models.setdefault("providers", {})
+    providers["featherless"] = {
+        "baseUrl": "https://api.featherless.ai/v1",
+        "apiKey": {"source": "env", "provider": "default", "id": "FEATHERLESS_API_KEY"},
+        "api": "openai-completions",
+        "models": [{"id": mid, "name": mid} for mid in feather_ids],
+    }
+    if feather_ids:
+        model_cfg = defaults.setdefault("model", {})
+        fallbacks = model_cfg.setdefault("fallbacks", [])
+        models_allowlist = defaults.setdefault("models", {})
+        for mid in feather_ids:
+            qualified = f"featherless/{mid}"
+            if qualified not in fallbacks:
+                fallbacks.append(qualified)
+            models_allowlist.setdefault(qualified, {})
 with open(config_path, "w") as f:
     json.dump(config, f, indent=2)
 _provider_block = (
@@ -155,15 +228,21 @@ _provider_block = (
 _provider_models = _provider_block.get("models", [])
 _ctx = _provider_models[0].get("contextWindow") if _provider_models else None
 _max = _provider_models[0].get("maxTokens") if _provider_models else None
+_featherless_block = (
+    config.get("models", {}).get("providers", {}).get("featherless", {})
+)
+_featherless_count = len(_featherless_block.get("models", []))
 print(
     "openclaw.json patched: "
     f"origins={ui.get('allowedOrigins')} "
+    f"trustedProxies={gw.get('trustedProxies')} "
     f"disableDeviceAuth={ui.get('dangerouslyDisableDeviceAuth', False)} "
     f"providerBaseUrl={_provider_block.get('baseUrl')} "
     f"primaryModel={defaults.get('model', {}).get('primary')} "
     f"contextWindow={_ctx} "
     f"maxTokens={_max} "
-    f"compactionReserve={compaction['reserveTokensFloor']}",
+    f"compactionReserve={compaction['reserveTokensFloor']} "
+    f"featherlessModels={_featherless_count}",
     file=sys.stderr,
 )
 PY

--- a/scripts/docker/openclaw-entrypoint.sh
+++ b/scripts/docker/openclaw-entrypoint.sh
@@ -59,9 +59,13 @@ if disable_dev_auth == "1":
 if ollama_model:
     models = config.setdefault("models", {})
     providers = models.setdefault("providers", {})
+    # apiKey intentionally absent: Openclaw's Control UI / credentials
+    # store owns the key, so the operator pastes it via Settings →
+    # Providers and it persists on the state-dir volume. Set
+    # OPENAI_API_KEY env var on Railway *as well* if you want a
+    # fallback that survives volume wipes.
     providers["ollama"] = {
         "baseUrl": "https://ollama.com/v1",
-        "apiKey": {"source": "env", "provider": "default", "id": "OPENAI_API_KEY"},
         "api": "openai-completions",
         "models": [
             {

--- a/scripts/docker/openclaw-entrypoint.sh
+++ b/scripts/docker/openclaw-entrypoint.sh
@@ -10,24 +10,35 @@
 # root-in-container is an acceptable trade. tini stays PID 1 for
 # signal forwarding + zombie reaping.
 #
-# Also seeds gateway.controlUi.allowedOrigins from
-# OPENCLAW_PUBLIC_ORIGIN so the browser-served Control UI is allowed
-# to connect when the gateway is exposed on a public domain
-# (Railway, Fly, etc.). Without this the browser shows
-# "Browser origin not allowed" because the gateway only auto-seeds
-# loopback origins when bind=auto.
+# Patches $OPENCLAW_STATE_DIR/openclaw.json at boot from env vars
+# so a Railway-style "config-via-env" workflow stays viable without
+# SSH'ing into the container. Idempotent: rerunning is a no-op.
+#
+# Env-driven config:
+#   OPENCLAW_PUBLIC_ORIGIN       gateway.controlUi.allowedOrigins
+#   OPENCLAW_DISABLE_DEVICE_AUTH gateway.controlUi.dangerouslyDisableDeviceAuth
+#   OPENCLAW_OLLAMA_MODEL        registers Ollama as an OpenAI-
+#                                compatible provider, sets it as the
+#                                default agent model. API key is
+#                                read from OPENAI_API_KEY at runtime
+#                                via Openclaw's env-ref shape.
 set -e
 
 STATE_DIR="${OPENCLAW_STATE_DIR:-/root/.openclaw}"
 mkdir -p "$STATE_DIR"
 
-if [ -n "$OPENCLAW_PUBLIC_ORIGIN" ] || [ "$OPENCLAW_DISABLE_DEVICE_AUTH" = "1" ]; then
+if [ -n "$OPENCLAW_PUBLIC_ORIGIN" ] \
+  || [ "$OPENCLAW_DISABLE_DEVICE_AUTH" = "1" ] \
+  || [ -n "$OPENCLAW_OLLAMA_MODEL" ]; then
   CONFIG_PATH="$STATE_DIR/openclaw.json"
   # Merge (or create) gateway config idempotently. Uses python because
   # jq isn't installed in the upstream image.
-  python3 - "$CONFIG_PATH" "${OPENCLAW_PUBLIC_ORIGIN:-}" "${OPENCLAW_DISABLE_DEVICE_AUTH:-0}" <<'PY' || true
+  python3 - "$CONFIG_PATH" \
+    "${OPENCLAW_PUBLIC_ORIGIN:-}" \
+    "${OPENCLAW_DISABLE_DEVICE_AUTH:-0}" \
+    "${OPENCLAW_OLLAMA_MODEL:-}" <<'PY' || true
 import json, os, sys
-config_path, public_origin, disable_dev_auth = sys.argv[1], sys.argv[2], sys.argv[3]
+config_path, public_origin, disable_dev_auth, ollama_model = sys.argv[1:5]
 config = {}
 if os.path.exists(config_path):
     try:
@@ -45,9 +56,38 @@ if public_origin:
             origins.append(o)
 if disable_dev_auth == "1":
     ui["dangerouslyDisableDeviceAuth"] = True
+if ollama_model:
+    models = config.setdefault("models", {})
+    providers = models.setdefault("providers", {})
+    providers["ollama"] = {
+        "baseUrl": "https://ollama.com/v1",
+        "apiKey": {"source": "env", "provider": "default", "id": "OPENAI_API_KEY"},
+        "api": "openai-completions",
+        "models": [
+            {
+                "id": ollama_model,
+                "name": ollama_model,
+                "reasoning": False,
+                "input": ["text"],
+                "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+                "contextWindow": 32000,
+                "maxTokens": 8000,
+            }
+        ],
+    }
+    agents = config.setdefault("agents", {})
+    defaults = agents.setdefault("defaults", {})
+    model_cfg = defaults.setdefault("model", {})
+    model_cfg["primary"] = f"ollama/{ollama_model}"
 with open(config_path, "w") as f:
     json.dump(config, f, indent=2)
-print(f"openclaw.json patched: origins={ui.get('allowedOrigins')} disableDeviceAuth={ui.get('dangerouslyDisableDeviceAuth', False)}", file=sys.stderr)
+print(
+    "openclaw.json patched: "
+    f"origins={ui.get('allowedOrigins')} "
+    f"disableDeviceAuth={ui.get('dangerouslyDisableDeviceAuth', False)} "
+    f"primaryModel={config.get('agents', {}).get('defaults', {}).get('model', {}).get('primary')}",
+    file=sys.stderr,
+)
 PY
 fi
 

--- a/scripts/docker/openclaw-entrypoint.sh
+++ b/scripts/docker/openclaw-entrypoint.sh
@@ -9,9 +9,44 @@
 # Railway services already isolate the container from the host, so
 # root-in-container is an acceptable trade. tini stays PID 1 for
 # signal forwarding + zombie reaping.
+#
+# Also seeds gateway.controlUi.allowedOrigins from
+# OPENCLAW_PUBLIC_ORIGIN so the browser-served Control UI is allowed
+# to connect when the gateway is exposed on a public domain
+# (Railway, Fly, etc.). Without this the browser shows
+# "Browser origin not allowed" because the gateway only auto-seeds
+# loopback origins when bind=auto.
 set -e
 
 STATE_DIR="${OPENCLAW_STATE_DIR:-/root/.openclaw}"
 mkdir -p "$STATE_DIR"
+
+if [ -n "$OPENCLAW_PUBLIC_ORIGIN" ]; then
+  CONFIG_PATH="$STATE_DIR/openclaw.json"
+  # Merge (or create) origins list. We use python to JSON-parse +
+  # patch idempotently; jq isn't installed in the upstream image.
+  python3 - "$CONFIG_PATH" "$OPENCLAW_PUBLIC_ORIGIN" <<'PY' || true
+import json, os, sys
+config_path, public_origin = sys.argv[1], sys.argv[2]
+config = {}
+if os.path.exists(config_path):
+    try:
+        with open(config_path) as f:
+            config = json.load(f)
+    except Exception:
+        config = {}
+config.setdefault("$schema", "https://openclaw.ai/config.json")
+gw = config.setdefault("gateway", {})
+ui = gw.setdefault("controlUi", {})
+origins = ui.setdefault("allowedOrigins", [])
+desired = [public_origin, "http://localhost:18789", "http://127.0.0.1:18789"]
+for o in desired:
+    if o and o not in origins:
+        origins.append(o)
+with open(config_path, "w") as f:
+    json.dump(config, f, indent=2)
+print(f"openclaw.json origins: {origins}", file=sys.stderr)
+PY
+fi
 
 exec /usr/bin/tini -s -- "$@"

--- a/scripts/docker/openclaw-entrypoint.sh
+++ b/scripts/docker/openclaw-entrypoint.sh
@@ -1,27 +1,17 @@
 #!/bin/sh
 # Openclaw container entrypoint.
 #
-# Railway-managed persistent volumes are mounted with root ownership.
-# Openclaw runs as the unprivileged `node` user (uid 1000) and needs
-# write access to the state dir (config, sessions/memory, agent
-# auth-profiles, logs). Without this script the gateway crashloops on
-# EACCES at startup.
-#
-# Flow:
-#   1. Run briefly as root.
-#   2. Ensure the state dir exists and is owned by node:node.
-#   3. Drop privileges via gosu and exec the original CMD as node.
+# Runs as root and stays as root for the workload. The upstream
+# Dockerfile drops to the `node` user for defense-in-depth, but on
+# Railway the persistent volume is mounted root-owned and chown
+# inside the container is silently denied — leaving the gateway
+# unable to read or write its state dir as `node`. Single-tenant
+# Railway services already isolate the container from the host, so
+# root-in-container is an acceptable trade. tini stays PID 1 for
+# signal forwarding + zombie reaping.
 set -e
 
-STATE_DIR="${OPENCLAW_STATE_DIR:-/home/node/.openclaw}"
-
-# Idempotent: mkdir is a no-op if the dir exists; chown is cheap on
-# already-owned trees and harmless on volumes that started root-owned.
+STATE_DIR="${OPENCLAW_STATE_DIR:-/root/.openclaw}"
 mkdir -p "$STATE_DIR"
-chown -R node:node "$STATE_DIR" 2>/dev/null || true
 
-# Drop to node and exec the actual CMD (defaults to
-# `node openclaw.mjs gateway --allow-unconfigured`).
-# tini is preserved as PID 1 so signal forwarding + zombie reaping
-# still work.
-exec /usr/bin/tini -s -- gosu node "$@"
+exec /usr/bin/tini -s -- "$@"

--- a/scripts/docker/openclaw-entrypoint.sh
+++ b/scripts/docker/openclaw-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Openclaw container entrypoint.
+#
+# Railway-managed persistent volumes are mounted with root ownership.
+# Openclaw runs as the unprivileged `node` user (uid 1000) and needs
+# write access to the state dir (config, sessions/memory, agent
+# auth-profiles, logs). Without this script the gateway crashloops on
+# EACCES at startup.
+#
+# Flow:
+#   1. Run briefly as root.
+#   2. Ensure the state dir exists and is owned by node:node.
+#   3. Drop privileges via gosu and exec the original CMD as node.
+set -e
+
+STATE_DIR="${OPENCLAW_STATE_DIR:-/home/node/.openclaw}"
+
+# Idempotent: mkdir is a no-op if the dir exists; chown is cheap on
+# already-owned trees and harmless on volumes that started root-owned.
+mkdir -p "$STATE_DIR"
+chown -R node:node "$STATE_DIR" 2>/dev/null || true
+
+# Drop to node and exec the actual CMD (defaults to
+# `node openclaw.mjs gateway --allow-unconfigured`).
+# tini is preserved as PID 1 so signal forwarding + zombie reaping
+# still work.
+exec /usr/bin/tini -s -- gosu node "$@"

--- a/scripts/docker/openclaw-entrypoint.sh
+++ b/scripts/docker/openclaw-entrypoint.sh
@@ -59,13 +59,9 @@ if disable_dev_auth == "1":
 if ollama_model:
     models = config.setdefault("models", {})
     providers = models.setdefault("providers", {})
-    # apiKey intentionally absent: Openclaw's Control UI / credentials
-    # store owns the key, so the operator pastes it via Settings →
-    # Providers and it persists on the state-dir volume. Set
-    # OPENAI_API_KEY env var on Railway *as well* if you want a
-    # fallback that survives volume wipes.
     providers["ollama"] = {
         "baseUrl": "https://ollama.com/v1",
+        "apiKey": {"source": "env", "provider": "default", "id": "OPENAI_API_KEY"},
         "api": "openai-completions",
         "models": [
             {

--- a/scripts/docker/openclaw-entrypoint.sh
+++ b/scripts/docker/openclaw-entrypoint.sh
@@ -21,13 +21,13 @@ set -e
 STATE_DIR="${OPENCLAW_STATE_DIR:-/root/.openclaw}"
 mkdir -p "$STATE_DIR"
 
-if [ -n "$OPENCLAW_PUBLIC_ORIGIN" ]; then
+if [ -n "$OPENCLAW_PUBLIC_ORIGIN" ] || [ "$OPENCLAW_DISABLE_DEVICE_AUTH" = "1" ]; then
   CONFIG_PATH="$STATE_DIR/openclaw.json"
-  # Merge (or create) origins list. We use python to JSON-parse +
-  # patch idempotently; jq isn't installed in the upstream image.
-  python3 - "$CONFIG_PATH" "$OPENCLAW_PUBLIC_ORIGIN" <<'PY' || true
+  # Merge (or create) gateway config idempotently. Uses python because
+  # jq isn't installed in the upstream image.
+  python3 - "$CONFIG_PATH" "${OPENCLAW_PUBLIC_ORIGIN:-}" "${OPENCLAW_DISABLE_DEVICE_AUTH:-0}" <<'PY' || true
 import json, os, sys
-config_path, public_origin = sys.argv[1], sys.argv[2]
+config_path, public_origin, disable_dev_auth = sys.argv[1], sys.argv[2], sys.argv[3]
 config = {}
 if os.path.exists(config_path):
     try:
@@ -38,14 +38,16 @@ if os.path.exists(config_path):
 config.setdefault("$schema", "https://openclaw.ai/config.json")
 gw = config.setdefault("gateway", {})
 ui = gw.setdefault("controlUi", {})
-origins = ui.setdefault("allowedOrigins", [])
-desired = [public_origin, "http://localhost:18789", "http://127.0.0.1:18789"]
-for o in desired:
-    if o and o not in origins:
-        origins.append(o)
+if public_origin:
+    origins = ui.setdefault("allowedOrigins", [])
+    for o in [public_origin, "http://localhost:18789", "http://127.0.0.1:18789"]:
+        if o and o not in origins:
+            origins.append(o)
+if disable_dev_auth == "1":
+    ui["dangerouslyDisableDeviceAuth"] = True
 with open(config_path, "w") as f:
     json.dump(config, f, indent=2)
-print(f"openclaw.json origins: {origins}", file=sys.stderr)
+print(f"openclaw.json patched: origins={ui.get('allowedOrigins')} disableDeviceAuth={ui.get('dangerouslyDisableDeviceAuth', False)}", file=sys.stderr)
 PY
 fi
 

--- a/skills/slothlee-dev/SKILL.md
+++ b/skills/slothlee-dev/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: slothlee-dev
+description: "Develop the Sloth Lee Discord-bot platform — read the codebase, edit files, run tests, open PRs. Use this whenever the operator asks to *change*, *fix*, *add*, *refactor*, or *test* code in `slothyproject/sloth-command-platform`. For runtime ops (drive the bot, change settings) use the `slothlee` skill instead."
+user-invocable: true
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🛠️",
+        "requires": { "bins": ["git", "gh", "curl", "python3"] },
+        "primaryEnv": "GH_TOKEN",
+        "envVars":
+          [
+            { "name": "GH_TOKEN", "label": "GitHub PAT with `repo` scope on slothyproject", "secret": true },
+            { "name": "SLOTHLEE_REPO_PATH", "label": "Local path of the cloned repo", "default": "/root/.openclaw/workspace/sloth-command-platform" },
+            { "name": "SLOTHLEE_REPO_REMOTE", "label": "GitHub repo to clone", "default": "slothyproject/sloth-command-platform" }
+          ]
+      }
+  }
+allowed-tools: ["bash", "coding-agent", "github", "git"]
+---
+
+# Sloth Lee Development Skill
+
+Pairs with the built-in `coding-agent`, `github`, and `git` skills. This skill is the *map* of the Sloth Lee codebase — what's where, how to run things, and the conventions the project actually follows. Lean on `coding-agent` for the heavy lifting (edits, refactors, tests).
+
+## When to use
+
+✅ Operator says any of:
+- "Fix bug X in the dashboard / bot"
+- "Add a new feature"
+- "Refactor / rename / clean up Y"
+- "Run the tests"
+- "Open a PR for Z"
+- "Why does this fail?"
+- "Read this file and explain it"
+
+❌ Don't use this skill when:
+- The operator wants to *drive* the bot (ban a user, reload a cog) — use `slothlee` skill
+- The operator asks about deployments / status — use `slothlee.deploy_status` then this skill if action is needed
+- The task is in some other codebase — use `coding-agent` directly
+
+## First-time setup (clone the repo)
+
+The Openclaw container persists `/root/.openclaw/workspace/` on a Railway volume. Clone the Sloth Lee repo into it on first run:
+
+```bash
+WORKSPACE="${SLOTHLEE_REPO_PATH:-/root/.openclaw/workspace/sloth-command-platform}"
+REMOTE="${SLOTHLEE_REPO_REMOTE:-slothyproject/sloth-command-platform}"
+
+if [ ! -d "$WORKSPACE/.git" ]; then
+  mkdir -p "$(dirname "$WORKSPACE")"
+  gh repo clone "$REMOTE" "$WORKSPACE"
+  cd "$WORKSPACE"
+  git config user.email "openclaw@slothlee.xyz"
+  git config user.name "Openclaw"
+fi
+cd "$WORKSPACE"
+git fetch origin && git checkout main && git pull --ff-only
+```
+
+Always start a session with `git fetch origin && git pull` so you're working from current main.
+
+## Repo layout
+
+```
+sloth-command-platform/
+├── AGENTS.md                       <-- READ THIS FIRST every session
+├── CLAUDE.md                       <-- agent instructions (this is for you)
+├── dashboard/                      <-- Flask backend + Jinja templates
+│   ├── app.py                      <-- Flask app factory + blueprint mounts
+│   ├── routes/
+│   │   ├── api.py                  <-- 18k LoC of /api/* (browse, don't blanket-read)
+│   │   ├── public_api.py           <-- /api/public/v1/* (bearer token)
+│   │   ├── ai_chat.py              <-- /api/ai/chat orchestrator
+│   │   ├── developer_portal.py     <-- /developer/* UI
+│   │   └── ...
+│   ├── services/
+│   │   ├── ai_tools.py             <-- 58 tools registry + execute_tool_call
+│   │   ├── ai_modes.py             <-- chat-mode catalog
+│   │   ├── ai_prompt.py            <-- PromptBuilder
+│   │   ├── bot_contract.py         <-- bot↔dashboard wire schemas
+│   │   ├── slothlee_api.py         <-- bot REST proxy
+│   │   └── ...
+│   ├── models.py                   <-- 50+ SQLAlchemy tables (~3700 lines)
+│   ├── templates/                  <-- Jinja templates
+│   └── static/                     <-- compiled frontend output gets copied here
+├── frontend/                       <-- Vite + React 18 dashboard SPA
+├── homepage/                       <-- Next.js 16 marketing site
+├── packages/ui/                    <-- @sloth/ui shared workspace package
+├── tests/                          <-- pytest tests
+├── scripts/                        <-- utility scripts (bump_version.py etc.)
+├── Dockerfile                      <-- 3-stage prod build
+└── docs/
+    ├── OPENCLAW_RAILWAY_RUNBOOK.md
+    └── ...
+```
+
+## Development workflow
+
+### Read before write
+
+`AGENTS.md` at the repo root has project-specific guidance the LLM doesn't know from training. Read it at the start of every session.
+
+### Branching
+
+`main` is protected by convention (Railway-native auto-deploy fires on push to main). Always work on a feature branch:
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feat/<short-description>     # or fix/, refactor/, chore/, docs/
+```
+
+Conventional Commits style for branch + commit prefixes (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`).
+
+### Make changes
+
+Use the `coding-agent` skill for multi-file work. For one-line fixes, just edit directly.
+
+### Run the test suite
+
+```bash
+cd "$SLOTHLEE_REPO_PATH"
+PYTHONIOENCODING=utf-8 PYTHONUTF8=1 python -m pytest tests/test_<changed_area>.py --tb=short -q
+# or full suite (slower)
+PYTHONIOENCODING=utf-8 PYTHONUTF8=1 python -m pytest --tb=short -q
+```
+
+If your change adds behaviour, add a test. The project is heavily tested on the AI-spine and public-API surfaces; uncovered areas (per the audit) include workflow_worker, stripe_billing, audit_hash_chain, scheduled_ai_worker leader-lock semantics.
+
+### Lint
+
+```bash
+python -m ruff check <changed_files>
+```
+
+`ruff.toml` excludes `dissident_panel`, `vault`, `frontend`, `scripts`, `.github`, `node_modules`, `__pycache__`, `migrations` — don't fight ruff in those.
+
+### Commit
+
+```bash
+git add <specific files>     # NOT `git add .` — repo has gitignored scratch scripts at root
+git commit -m "feat(area): one-line summary
+
+Why this change is being made.
+
+Body explains the non-obvious decisions or the bug being fixed."
+```
+
+Pre-commit hook runs lint + URL-for + mojibake checks. **Never** use `--no-verify` to bypass — fix the underlying issue.
+
+### Push + open PR
+
+```bash
+git push -u origin HEAD
+gh pr create --base main --title "<conventional-commit title>" --body "$(cat <<'EOF'
+## What
+
+...
+
+## Why
+
+...
+
+## Test plan
+
+- [ ] ...
+EOF
+)"
+```
+
+PR titles must follow Conventional Commits — the auto-version workflow parses them.
+
+## Conventions
+
+- **Type hints**: Python 3.12+ syntax (`list[int]`, `dict[str, X]`, `X | None`).
+- **Imports**: stdlib first, third-party second, dashboard.* last. Inside functions only when avoiding circular imports.
+- **Errors**: catch specific exceptions; broad `except Exception` requires `# noqa: BLE001` and a comment explaining why.
+- **Logging**: `log = logging.getLogger(__name__)` at module top. `log.warning(...)` for recoverable, `log.exception(...)` inside `except` blocks for unexpected.
+- **DB**: SQLAlchemy 2.0 style preferred (`db.session.get(Model, id)` over `Model.query.get(id)`).
+- **Tests**: `tests/test_<topic>.py`, pytest, fixtures in `tests/conftest.py`. SQLite in-memory.
+
+## Common pitfalls
+
+- The `Guild` model has **no `owner_user_id` field** — use `owner_discord_id`. (Caught a latent bug recently.)
+- `lazy="dynamic"` SQLAlchemy relationships: their default `order_by` is **appended** to, not replaced. Don't `.order_by(desc(...))` on a dynamic relationship and expect the desc to win — query the table directly.
+- Discord IDs are stored as **strings** on User/Guild (Discord snowflakes overflow JS Number — strings are safer). Coerce when comparing.
+- `ai_tools.execute_tool_call()` is the single dispatch point for AI-driven actions. Every new tool family registers via `register_tool_family(...)`. Don't add to the dispatcher's if/elif — there isn't one any more.
+- `requirements.txt` floors must stay below `<X.0.0` upper bounds. CVE bumps need both a floor bump and a sanity-check that the upper bound permits the floor.
+- The marketing site (`homepage/`) uses Next.js with `basePath: "/homepage"` because Flask serves it under that path in prod. CI tests have to mirror that or asset 404s flood the gates.
+
+## CI
+
+GitHub Actions runs on every PR:
+- Lint (ruff) — must pass
+- Backend API tests (pytest) — must pass
+- Frontend Type Check (tsc) — must pass
+- Build Frontend (Vite) — must pass
+- Homepage Next.js build — must pass
+- Other checks (a11y, lighthouse, gitleaks) — informational; some currently red on infra issues
+
+`main` is unprotected so PRs CAN merge with red checks, but don't unless you understand why each red check is unrelated.
+
+## Deploying
+
+Railway auto-deploys on push to `main` for `Sloth Lee Web` and `Sloth Command Bot` services. After your PR merges, watch the Railway logs. If auto-deploy doesn't fire, the operator (or this skill via `slothlee.redeploy`) can trigger it manually.
+
+## Out of scope for this skill
+
+- Editing the Openclaw fork itself — use `coding-agent` directly with a different repo path.
+- Editing third-party deps in `node_modules` or installed Python packages.
+- Anything in `dashboard/static/homepage/` (that's compiled output, not source — edit `homepage/` instead).

--- a/skills/slothlee/SKILL.md
+++ b/skills/slothlee/SKILL.md
@@ -11,9 +11,9 @@ metadata:
         "primaryEnv": "SLOTHLEE_API_TOKEN",
         "envVars":
           [
-            { "name": "SLOTHLEE_API_BASE", "label": "Sloth Lee dashboard base URL", "default": "https://slothlee.xyz" },
+            { "name": "SLOTHLEE_API_BASE", "label": "Sloth Lee dashboard base URL — use https://slothlee.xyz when Openclaw runs in a separate Railway project, or http://sloth-lee-web.railway.internal when co-located in the same project (saves a public-internet hop).", "default": "https://slothlee.xyz" },
             { "name": "SLOTHLEE_API_TOKEN", "label": "Bearer token (slot_<id>_<secret>) — mint at /developer/keys", "secret": true },
-            { "name": "OPENCLAW_OPERATOR_DISCORD_ID", "label": "Operator's Discord user ID — only this user can invoke the skill" }
+            { "name": "OPENCLAW_OPERATOR_DISCORD_ID", "label": "Operator's Discord user ID — only this user can invoke the skill (omit when running web-UI-only)" }
           ]
       }
   }
@@ -36,6 +36,7 @@ Calls the Sloth Lee dashboard's public REST API at `${SLOTHLEE_API_BASE}/api/pub
 - The operator wants direct Discord API access — use the `discord` skill instead
 - Editing the dashboard UI / its config — out of scope for the public API
 - Acting on a guild the operator doesn't own — the API will 404, don't loop
+- The operator wants to **change Sloth Lee code** (fix a bug, add a feature, refactor) — use the `slothlee-dev` skill, which pairs with `coding-agent` + `github` + `git` to clone, edit, test, and PR
 
 ## Owner whitelist (mandatory)
 

--- a/skills/slothlee/SKILL.md
+++ b/skills/slothlee/SKILL.md
@@ -54,8 +54,8 @@ If invoked from a non-DM context, refuse silently.
 
 | Tier | Operations | Behaviour |
 |---|---|---|
-| **Auto** (read-only) | `list_guilds`, `guild_state`, `list_channels`, `list_cases`, `deploy_status`, `recent_errors`, `scheduled_runs`, `search_docs`, `fetch_page`, `sitemap` | Execute immediately, return JSON / text to the user. |
-| **Gated** (destructive) | `ban`, `kick`, `timeout`, `warn` | DM the operator with action summary + Approve/Deny buttons. Execute ONLY after `Approve`. Timeout 5 min. |
+| **Auto** (read-only) | `list_guilds`, `guild_state`, `list_channels`, `list_cases`, `deploy_status`, `recent_errors`, `scheduled_runs`, `get_ai_scope`, `search_docs`, `fetch_page`, `sitemap` | Execute immediately, return JSON / text to the user. |
+| **Gated** (destructive) | `ban`, `kick`, `timeout`, `warn`, `reload_cog`, `set_ai_scope` | DM the operator with action summary + Approve/Deny buttons. Execute ONLY after `Approve`. Timeout 5 min. |
 
 **Never auto-execute a gated op.** The dashboard's audit trail (ModerationCase) cannot be undone — the gate is the only safety net.
 
@@ -156,6 +156,17 @@ curl -sf "https://slothlee.xyz/homepage/sitemap.xml"
 
 Use this to discover new pages the LLM should know about.
 
+### Read AI scope policy
+
+The per-guild policy that controls what the chat tools can do (allowed categories, blocked tool names, owner-required gate, action rate limit).
+
+```bash
+curl -sf -H "Authorization: Bearer $SLOTHLEE_API_TOKEN" \
+  "$SLOTHLEE_API_BASE/api/public/v1/guilds/<guild_id>/ai-scope"
+```
+
+Returns `{guild_id, allowed_categories, blocked_tools, destructive_requires_owner, max_actions_per_hour, is_default}`. `is_default: true` means no row has been written yet — the values shown are the documented defaults.
+
 ## Gated-tier operations
 
 ### Approval flow (mandatory before each destructive call)
@@ -223,6 +234,36 @@ curl -sf -X POST \
   -d '{"user_id": "<id>", "reason": "<reason>", "target_name": "<name>"}' \
   "$SLOTHLEE_API_BASE/api/public/v1/guilds/<guild_id>/moderation/warn"
 ```
+
+### Reload bot cog (write:system scope)
+
+Hot-reload a Discord-bot cog without restarting the bot. Allowlist: `tickets, moderation, economy, leveling, welcome, automod, antinuke, music, fun, polls, starboard, reaction_roles, scheduled, support_chat`. Other names → 404.
+
+```bash
+curl -sf -X POST -H "Authorization: Bearer $SLOTHLEE_API_TOKEN" \
+  "$SLOTHLEE_API_BASE/api/public/v1/system/cogs/<cog_name>/reload"
+```
+
+Response confirms dispatch; reload completion appears in the bot's logs (async via Redis pub/sub).
+
+### Update AI scope policy (write:moderation scope)
+
+Partial PATCH — only fields in the body change. Pass `null` on `allowed_categories`/`blocked_tools` to reset to default; pass `[]` to explicitly block everything.
+
+```bash
+curl -sf -X PATCH \
+  -H "Authorization: Bearer $SLOTHLEE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "allowed_categories": ["moderation", "inspection"],
+    "blocked_tools": ["server_delete_role"],
+    "destructive_requires_owner": true,
+    "max_actions_per_hour": 50
+  }' \
+  "$SLOTHLEE_API_BASE/api/public/v1/guilds/<guild_id>/ai-scope"
+```
+
+Validation up front: unknown categories or out-of-range values return 400 with the known set echoed. Returns the full updated state.
 
 ## Response shape
 

--- a/skills/slothlee/SKILL.md
+++ b/skills/slothlee/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: slothlee
+description: "Drive the Sloth Lee Discord-bot platform via its public REST API. Use for listing guilds, inspecting state, reading moderation cases, and (with operator approval) banning/kicking/timing-out/warning users. Auto-executes read-only ops; destructive ops require operator approval via DM."
+user-invocable: true
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🦥",
+        "requires": { "bins": ["curl", "jq"] },
+        "primaryEnv": "SLOTHLEE_API_TOKEN",
+        "envVars":
+          [
+            { "name": "SLOTHLEE_API_BASE", "label": "Sloth Lee dashboard base URL", "default": "https://slothlee.xyz" },
+            { "name": "SLOTHLEE_API_TOKEN", "label": "Bearer token (slot_<id>_<secret>) — mint at /developer/keys", "secret": true },
+            { "name": "OPENCLAW_OPERATOR_DISCORD_ID", "label": "Operator's Discord user ID — only this user can invoke the skill" }
+          ]
+      }
+  }
+allowed-tools: ["bash", "message"]
+---
+
+# Sloth Lee Skill
+
+Calls the Sloth Lee dashboard's public REST API at `${SLOTHLEE_API_BASE}/api/public/v1/*` using the bearer token in `$SLOTHLEE_API_TOKEN`.
+
+## When to use
+
+✅ User asks Openclaw to:
+- Inspect Discord guilds the operator manages ("list my guilds", "what channels does X have?")
+- Read moderation history ("show recent cases for X")
+- Take a moderation action ("ban user 12345 for spam in guild Y")
+- Look up server state before another action
+
+❌ Don't use this skill when:
+- The operator wants direct Discord API access — use the `discord` skill instead
+- Editing the dashboard UI / its config — out of scope for the public API
+- Acting on a guild the operator doesn't own — the API will 404, don't loop
+
+## Owner whitelist (mandatory)
+
+**This skill is single-tenant.** Before doing anything, check that the requesting Discord user is `${OPENCLAW_OPERATOR_DISCORD_ID}`:
+
+```bash
+if [ "$REQUESTING_USER_ID" != "$OPENCLAW_OPERATOR_DISCORD_ID" ]; then
+  # Reply: "This assistant is restricted to the operator. Request denied."
+  exit 0
+fi
+```
+
+If invoked from a non-DM context, refuse silently.
+
+## Auto vs gated tiers
+
+| Tier | Operations | Behaviour |
+|---|---|---|
+| **Auto** (read-only) | `list_guilds`, `guild_state`, `list_channels`, `list_cases` | Execute immediately, return JSON to the user. |
+| **Gated** (destructive) | `ban`, `kick`, `timeout`, `warn` | DM the operator with action summary + Approve/Deny buttons. Execute ONLY after `Approve`. Timeout 5 min. |
+
+**Never auto-execute a gated op.** The dashboard's audit trail (ModerationCase) cannot be undone — the gate is the only safety net.
+
+## Auto-tier operations
+
+### List guilds the operator owns
+
+```bash
+curl -sf -H "Authorization: Bearer $SLOTHLEE_API_TOKEN" \
+  "$SLOTHLEE_API_BASE/api/public/v1/guilds?per_page=100"
+```
+
+Returns `{items: [{id, name, icon_url, owner_user_id}], total, page, per_page}`.
+
+### Guild state (rich snapshot)
+
+```bash
+curl -sf -H "Authorization: Bearer $SLOTHLEE_API_TOKEN" \
+  "$SLOTHLEE_API_BASE/api/public/v1/guilds/<guild_id>/state"
+```
+
+Returns guild metadata + channels + roles + feature flags. Use this before any destructive action so you see the current state of the world.
+
+### Channel list (lighter than `/state`)
+
+```bash
+curl -sf -H "Authorization: Bearer $SLOTHLEE_API_TOKEN" \
+  "$SLOTHLEE_API_BASE/api/public/v1/guilds/<guild_id>/channels"
+```
+
+### Recent moderation cases
+
+```bash
+curl -sf -H "Authorization: Bearer $SLOTHLEE_API_TOKEN" \
+  "$SLOTHLEE_API_BASE/api/public/v1/guilds/<guild_id>/moderation/cases?per_page=25"
+```
+
+## Gated-tier operations
+
+### Approval flow (mandatory before each destructive call)
+
+1. Format the proposed action as a Discord embed:
+   ```
+   **Action:** ban  
+   **Guild:** Sloth Lee's Dojo (id=4242)  
+   **Target:** <@123456789012345678>  
+   **Reason:** repeated raid behaviour  
+   **Delete messages:** yes (last 24h)
+   ```
+2. Send via the `message` tool to `OPENCLAW_OPERATOR_DISCORD_ID` with `Approve | Deny` buttons. Use Discord components v2 (see the `discord` skill for syntax).
+3. Wait up to 5 minutes for the button click. On timeout: treat as deny.
+4. On `Approve`: execute the curl below. On `Deny` or timeout: tell the operator the action was cancelled.
+
+### Ban
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SLOTHLEE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_id": "<discord_user_id>",
+    "reason": "<concise reason, ≤1000 chars>",
+    "delete_messages": true,
+    "target_name": "<display name for the audit row>"
+  }' \
+  "$SLOTHLEE_API_BASE/api/public/v1/guilds/<guild_id>/moderation/ban"
+```
+
+### Kick
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SLOTHLEE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id": "<id>", "reason": "<reason>", "target_name": "<name>"}' \
+  "$SLOTHLEE_API_BASE/api/public/v1/guilds/<guild_id>/moderation/kick"
+```
+
+### Timeout
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SLOTHLEE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_id": "<id>",
+    "reason": "<reason>",
+    "duration_minutes": 60,
+    "target_name": "<name>"
+  }' \
+  "$SLOTHLEE_API_BASE/api/public/v1/guilds/<guild_id>/moderation/timeout"
+```
+
+`duration_minutes` must be 1..40320 (28 days max — Discord's hard cap).
+
+### Warn
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SLOTHLEE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id": "<id>", "reason": "<reason>", "target_name": "<name>"}' \
+  "$SLOTHLEE_API_BASE/api/public/v1/guilds/<guild_id>/moderation/warn"
+```
+
+## Response shape
+
+All endpoints return `{ok, output, error, code}`:
+
+- `ok: true` — action succeeded. `output` carries the upstream JSON (case ID, dry-run preview, etc.).
+- `ok: false` — failed. `code` is one of:
+  - `invalid_arguments` (400) — reformat and retry once.
+  - `denied_by_scope` (403) — skill misconfigured. Stop and report to operator.
+  - `guild_not_found` (404) — operator doesn't own that guild. Stop, don't retry.
+  - `rate_limited_scope` (429) — wait and retry; AIScope cap was hit.
+  - `bot_unavailable` (503) — Discord bot down. Inform operator, don't retry until they confirm.
+
+## Error handling rules
+
+- **Never retry** on `denied_by_scope`, `guild_not_found`, `unknown_tool`. These are operator-config issues that auto-retry won't fix.
+- **Retry once** on `bot_unavailable` after a 30s pause. If it fails twice, stop and report.
+- **Reformat and retry once** on `invalid_arguments` — the model's first arg shape may have been wrong.
+
+## Reply style
+
+- Keep replies short. Confirm what was done with case IDs, target names, and timestamps.
+- For `list_*` operations, summarise the count and show the top 5; offer to scroll.
+- For destructive ops: confirm with one-line + the case ID. Don't re-emit the full reasoning the operator just approved.

--- a/skills/slothlee/SKILL.md
+++ b/skills/slothlee/SKILL.md
@@ -54,7 +54,7 @@ If invoked from a non-DM context, refuse silently.
 
 | Tier | Operations | Behaviour |
 |---|---|---|
-| **Auto** (read-only) | `list_guilds`, `guild_state`, `list_channels`, `list_cases` | Execute immediately, return JSON to the user. |
+| **Auto** (read-only) | `list_guilds`, `guild_state`, `list_channels`, `list_cases`, `deploy_status`, `recent_errors`, `scheduled_runs`, `search_docs`, `fetch_page`, `sitemap` | Execute immediately, return JSON / text to the user. |
 | **Gated** (destructive) | `ban`, `kick`, `timeout`, `warn` | DM the operator with action summary + Approve/Deny buttons. Execute ONLY after `Approve`. Timeout 5 min. |
 
 **Never auto-execute a gated op.** The dashboard's audit trail (ModerationCase) cannot be undone — the gate is the only safety net.
@@ -92,6 +92,69 @@ curl -sf -H "Authorization: Bearer $SLOTHLEE_API_TOKEN" \
 curl -sf -H "Authorization: Bearer $SLOTHLEE_API_TOKEN" \
   "$SLOTHLEE_API_BASE/api/public/v1/guilds/<guild_id>/moderation/cases?per_page=25"
 ```
+
+### System health snapshot
+
+Compact "is everything OK?" — release tag, bot online, guild + member counts, latency. No Railway API call required.
+
+```bash
+curl -sf -H "Authorization: Bearer $SLOTHLEE_API_TOKEN" \
+  "$SLOTHLEE_API_BASE/api/public/v1/system/deploy-status"
+```
+
+### Recent errors
+
+Defaults to `ai_tool_call` source (most relevant for the assistant). Pass `?source=all` to see every category, or `?source=<name>` (e.g. `slash_command`, `worker`) to filter.
+
+```bash
+curl -sf -H "Authorization: Bearer $SLOTHLEE_API_TOKEN" \
+  "$SLOTHLEE_API_BASE/api/public/v1/system/errors?limit=20"
+```
+
+Tracebacks only included when the calling token's user is a platform owner.
+
+### Scheduled-AI run review queue
+
+Surface scheduled-task runs that have un-decided pending tool calls awaiting operator review. Use `?status=pending` to find ones the operator should approve/deny.
+
+```bash
+curl -sf -H "Authorization: Bearer $SLOTHLEE_API_TOKEN" \
+  "$SLOTHLEE_API_BASE/api/public/v1/system/scheduled-runs?status=pending"
+```
+
+Other statuses: `running`, `success`, `failure`. No filter = most recent regardless of state.
+
+### Search the marketing site / docs
+
+The homepage (`https://slothlee.xyz/homepage/`) ships with **Pagefind** built into the static export. Skill can search the published pages without any dashboard API:
+
+```bash
+# 1. Fetch the Pagefind index
+curl -sf "https://slothlee.xyz/homepage/pagefind/pagefind-entry.json" \
+  | jq -r '.languages.en.hash'
+
+# 2. Use Pagefind via Node directly (works inside Openclaw's container)
+#    or call a known recipe page directly:
+curl -sf "https://slothlee.xyz/homepage/pricing/" | grep -oE '<title>[^<]+</title>'
+```
+
+For free-text answers, **prefer fetching a specific page** (cheaper than running the index):
+
+```bash
+curl -sf "https://slothlee.xyz/homepage/<slug>/" \
+  | sed -n '/<main/,/<\/main>/p' \
+  | sed 's/<[^>]*>//g'  # strip tags for the LLM
+```
+
+Common slugs: `/`, `/pricing`, `/blog`, `/features/automod`, `/for/gaming-servers`, `/vs/mee6`.
+
+### Sitemap
+
+```bash
+curl -sf "https://slothlee.xyz/homepage/sitemap.xml"
+```
+
+Use this to discover new pages the LLM should know about.
 
 ## Gated-tier operations
 

--- a/skills/slothlee/SKILL.md
+++ b/skills/slothlee/SKILL.md
@@ -56,6 +56,7 @@ If invoked from a non-DM context, refuse silently.
 |---|---|---|
 | **Auto** (read-only) | `list_guilds`, `guild_state`, `list_channels`, `list_cases`, `deploy_status`, `recent_errors`, `scheduled_runs`, `get_ai_scope`, `search_docs`, `fetch_page`, `sitemap` | Execute immediately, return JSON / text to the user. |
 | **Gated** (destructive) | `ban`, `kick`, `timeout`, `warn`, `reload_cog`, `set_ai_scope` | DM the operator with action summary + Approve/Deny buttons. Execute ONLY after `Approve`. Timeout 5 min. |
+| **Critical** (infrastructure) | `redeploy` | DM with explicit "this will take prod down for ~5min" warning. Operator must type `CONFIRM REDEPLOY` (not just tap a button) to proceed. |
 
 **Never auto-execute a gated op.** The dashboard's audit trail (ModerationCase) cannot be undone — the gate is the only safety net.
 
@@ -245,6 +246,19 @@ curl -sf -X POST -H "Authorization: Bearer $SLOTHLEE_API_TOKEN" \
 ```
 
 Response confirms dispatch; reload completion appears in the bot's logs (async via Redis pub/sub).
+
+### Trigger Railway redeploy (infra:write scope) — CRITICAL
+
+**Before calling this**: DM the operator with a clear warning that the dashboard will be unavailable for 3-5 minutes. **Require the operator to reply with the literal string `CONFIRM REDEPLOY`** — a button is too easy to mis-tap. If anything else comes back (including a typo, a `yes`, or `Approve`), refuse and ask again.
+
+```bash
+curl -sf -X POST -H "Authorization: Bearer $SLOTHLEE_API_TOKEN" \
+  "$SLOTHLEE_API_BASE/api/public/v1/system/redeploy"
+```
+
+If the operator hasn't configured Railway env vars on the dashboard, the response is `503 not_configured` with a `missing_env_vars` list. Forward that list verbatim to the operator — they need to set those vars on Railway → Variables → service.
+
+After dispatch, poll `deploy_status` every 30s for ~5 min and report when the bot comes back online.
 
 ### Update AI scope policy (write:moderation scope)
 


### PR DESCRIPTION
## Summary
- Adds `OPENCLAW_TRUSTED_PROXIES` (default `100.64.0.0/10` — Tailscale CGNAT, what Railway's edge uses) → `gateway.trustedProxies`. Without this set, every webchat WebSocket from Railway is flagged "Proxy headers detected from untrusted address", the handshake closes 1008, and the browser sees `code=1006`. Setting this fixes the broken-chat symptom on Railway deploys.
- Adds `FEATHERLESS_API_KEY` + `FEATHERLESS_MODELS` → first-class `models.providers.featherless` block (separate from the legacy ollama-alias path that `OPENCLAW_PROVIDER_BASE_URL` still drives). Configured models are auto-allowlisted in `agents.defaults.model.fallbacks` and `agents.defaults.models` so the main agent can route to them without further setup.
- Header docstring updated with both env vars and a note flagging the legacy path as kept-for-backcompat.

Idempotent — verified by running the patch script twice on a fresh state file and confirming byte-equal output (sha256 match). Schema-valid against openclaw 2026.4.11's `config validate` CLI.

## Test plan
- [ ] Local dry-run of the python heredoc with `FEATHERLESS_API_KEY=rc_test`, `OPENCLAW_PUBLIC_ORIGIN=https://openclaw-production-eb90.up.railway.app` produces the expected `gateway.trustedProxies`, `gateway.controlUi.allowedOrigins`, `models.providers.featherless`, and `agents.defaults.model.fallbacks` keys.
- [ ] `openclaw config validate` against the rendered file passes.
- [ ] After merge + Railway redeploy, `railway logs --service Openclaw -d --lines 200 | grep -i "Proxy headers detected"` returns no recent matches.
- [ ] Webchat at the Railway public URL accepts a message and gets a reply.
- [ ] Featherless model picker in the Control UI lets you select a `featherless/<id>` model and round-trip a message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)