### PR TITLE
fix(codex): add homeDir override to use real OS HOME while keeping CODEX_HOME isolated

### DIFF
--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -161,6 +161,9 @@
             "type": "array",
             "items": { "type": "string" }
           },
+          "homeDir": {
+            "type": "string"
+          },
           "requestTimeoutMs": {
             "type": "number",
             "minimum": 1,
@@ -324,6 +327,11 @@
     "appServer.clearEnv": {
       "label": "Clear Environment",
       "help": "Environment variable names removed from the spawned stdio app-server process after overrides are applied.",
+      "advanced": true
+    },
+    "appServer.homeDir": {
+      "label": "Home Directory",
+      "help": "Real user HOME for the Codex app-server process. Set to the OS user home (e.g. /home/user) to allow local CLI auth (gh, git, etc.) while keeping CODEX_HOME isolated. Also readable from OPENCLAW_CODEX_APP_SERVER_HOME_DIR.",
       "advanced": true
     },
     "appServer.requestTimeoutMs": {

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -179,6 +179,21 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
+  it("uses homeDir as HOME while keeping CODEX_HOME isolated", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const realHomeDir = os.homedir();
+    const startOptions = createStartOptions({ homeDir: realHomeDir });
+    try {
+      const codexHome = resolveCodexAppServerHomeDir(agentDir);
+      const result = await bridgeCodexAppServerStartOptions({ startOptions, agentDir });
+      expect(result.env?.CODEX_HOME).toBe(codexHome);
+      expect(result.env?.HOME).toBe(realHomeDir);
+      await expect(fs.access(codexHome)).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
   it("clears inherited API-key env vars when the default Codex profile is subscription auth", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const startOptions = createStartOptions({

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -200,9 +200,13 @@ async function withAgentCodexHomeEnvironment(
     : resolveCodexAppServerHomeDir(agentDir);
   const nativeHome = startOptions.env?.[HOME_ENV_VAR]?.trim()
     ? startOptions.env[HOME_ENV_VAR]
-    : path.join(codexHome, CODEX_APP_SERVER_NATIVE_HOME_DIRNAME);
+    : startOptions.homeDir?.trim()
+      ? startOptions.homeDir.trim()
+      : path.join(codexHome, CODEX_APP_SERVER_NATIVE_HOME_DIRNAME);
   await fs.mkdir(codexHome, { recursive: true });
-  await fs.mkdir(nativeHome, { recursive: true });
+  if (!startOptions.homeDir?.trim()) {
+    await fs.mkdir(nativeHome, { recursive: true });
+  }
   const nextStartOptions: CodexAppServerStartOptions = {
     ...startOptions,
     env: {

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -96,6 +96,7 @@ export type CodexAppServerStartOptions = {
   headers: Record<string, string>;
   env?: Record<string, string>;
   clearEnv?: string[];
+  homeDir?: string;
 };
 
 export type CodexAppServerRuntimeOptions = {
@@ -126,6 +127,7 @@ export type CodexPluginConfig = {
     authToken?: string;
     headers?: Record<string, string>;
     clearEnv?: string[];
+    homeDir?: string;
     requestTimeoutMs?: number;
     turnCompletionIdleTimeoutMs?: number;
     approvalPolicy?: CodexAppServerApprovalPolicy;
@@ -145,6 +147,7 @@ export const CODEX_APP_SERVER_CONFIG_KEYS = [
   "authToken",
   "headers",
   "clearEnv",
+  "homeDir",
   "requestTimeoutMs",
   "turnCompletionIdleTimeoutMs",
   "approvalPolicy",
@@ -332,6 +335,9 @@ export function resolveCodexAppServerRuntimeOptions(
   const args = resolveArgs(config.args, env.OPENCLAW_CODEX_APP_SERVER_ARGS);
   const headers = normalizeHeaders(config.headers);
   const clearEnv = normalizeStringList(config.clearEnv);
+  const homeDir =
+    readNonEmptyString(config.homeDir) ??
+    readNonEmptyString(env.OPENCLAW_CODEX_APP_SERVER_HOME_DIR);
   const authToken = readNonEmptyString(config.authToken);
   const url = readNonEmptyString(config.url);
   const explicitPolicyMode =
@@ -365,6 +371,7 @@ export function resolveCodexAppServerRuntimeOptions(
       ...(authToken ? { authToken } : {}),
       headers,
       ...(transport === "stdio" && clearEnv.length > 0 ? { clearEnv } : {}),
+      ...(homeDir ? { homeDir } : {}),
     },
     requestTimeoutMs: normalizePositiveNumber(config.requestTimeoutMs, 60_000),
     turnCompletionIdleTimeoutMs: normalizePositiveNumber(


### PR DESCRIPTION
## Summary

Adds `plugins.entries.codex.config.appServer.homeDir` config key and `OPENCLAW_CODEX_APP_SERVER_HOME_DIR` env fallback. When set, the Codex app-server process receives the configured path as `HOME` so local CLI auth (`gh`, Git credential helpers, Agent Bridge config, and other dotfile-backed integrations) continues to work. `CODEX_HOME` remains isolated under the per-agent directory.

Closes #80288

## Changes

**`extensions/codex/src/app-server/config.ts`**
- Add `homeDir?: string` to `CodexAppServerStartOptions` type
- Add `homeDir?: string` to `CodexPluginConfig.appServer` shape
- Add `"homeDir"` to `CODEX_APP_SERVER_CONFIG_KEYS` (keeps config key array in sync with manifest schema test)
- Read `config.homeDir ?? env.OPENCLAW_CODEX_APP_SERVER_HOME_DIR` in `resolveCodexAppServerRuntimeOptions` and pass it through to `start`

**`extensions/codex/src/app-server/auth-bridge.ts`**
- In `withAgentCodexHomeEnvironment`: use `startOptions.homeDir` as the resolved `HOME` when set (explicit `env.HOME` still takes priority, preserving existing override semantics). Skip `mkdir` for the native home dir when a real-home override is provided (the real home already exists).

**`extensions/codex/openclaw.plugin.json`**
- Add `homeDir` property to `configSchema.properties.appServer.properties`
- Add `appServer.homeDir` UI hint with label and help text

## Real behavior proof

**behavior:** `withAgentCodexHomeEnvironment` now uses `startOptions.homeDir` as `HOME` while keeping `CODEX_HOME` isolated under `<agentDir>/codex-home`

**environment:** Ubuntu 22.04 (DGX Spark), Node 22, vitest 4.1.5

**steps:**
1. Call `bridgeCodexAppServerStartOptions` with `startOptions = { homeDir: os.homedir(), ... }`
2. Observe the resulting `env.HOME` and `env.CODEX_HOME`

**evidence:**
```
 Test Files  2 passed (2)
      Tests  70 passed (70)
   Duration  7.34s
```
New test: `"uses homeDir as HOME while keeping CODEX_HOME isolated"` — asserts `env.CODEX_HOME` is the per-agent `codex-home` dir and `env.HOME` equals `os.homedir()`.

**observedResult:** `env.CODEX_HOME = <agentDir>/codex-home`, `env.HOME = /home/chenglunhu` (real OS home). 70/70 tests pass including 30 auth-bridge tests and 40 config tests.

**notTested:** Live Codex app-server spawn with real `gh auth status` verification; WebSocket transport (homeDir is stdio-only concern via `withAgentCodexHomeEnvironment`).