### PR TITLE
fix gateway message action media roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: pass agent-scoped media roots through gateway message actions so workspace-local media from the active agent is not rejected as cross-agent access. Thanks @frankekn.
 - CLI/gateway: keep `gateway status --deep` plugin-aware so configured plugin manifest warnings, including missing channel config metadata, stay visible during install and update smoke checks.
 - Doctor: stop flagging the live compatibility agent directory as orphaned when the configured default agent is not `main`. Fixes #74313. (#74438) Thanks @carlos4s.
 - Auth/Claude CLI: persist fresher managed external CLI OAuth credentials back to `auth-profiles.json`, preventing stale `anthropic:claude-cli` profiles from repeatedly bootstrapping and flooding debug logs. Fixes #80129. Thanks @Caulderein.

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -1035,6 +1035,50 @@ describe("gateway send mirroring", () => {
     );
   });
 
+  it("passes agent-scoped media roots to gateway message actions", async () => {
+    let capturedMediaLocalRoots: readonly string[] | undefined;
+    const mediaActionPlugin: ChannelPlugin = {
+      id: "telegram",
+      meta: {
+        id: "telegram",
+        label: "Telegram",
+        selectionLabel: "Telegram",
+        docsPath: "/channels/telegram",
+        blurb: "Telegram media action dispatch test plugin.",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({ enabled: true }),
+        isConfigured: () => true,
+      },
+      actions: {
+        describeMessageTool: () => ({ actions: ["sendAttachment"] }),
+        supportsAction: ({ action }) => action === "sendAttachment",
+        handleAction: async ({ mediaLocalRoots }) => {
+          capturedMediaLocalRoots = mediaLocalRoots;
+          return jsonResult({ ok: true });
+        },
+      },
+    };
+    mocks.getChannelPlugin.mockReturnValue(mediaActionPlugin);
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: mediaActionPlugin }]),
+      "send-test-message-action-media-roots",
+    );
+
+    const { respond } = await runMessageActionRequest({
+      channel: "telegram",
+      action: "sendAttachment",
+      params: { chatId: "123", mediaUrl: `${TEST_AGENT_WORKSPACE}/render.png` },
+      agentId: "work",
+      idempotencyKey: "idem-message-action-media-roots",
+    });
+
+    expect(firstRespondCall(respond)?.[0]).toBe(true);
+    expect(capturedMediaLocalRoots).toEqual(expect.arrayContaining([TEST_AGENT_WORKSPACE]));
+  });
+
   it("forces senderIsOwner=false for narrowly-scoped callers but honors it for full operators", async () => {
     const capture = { senderIsOwner: undefined as boolean | undefined };
     const reactPlugin: ChannelPlugin = {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -19,6 +19,7 @@ import { buildOutboundSessionContext } from "../../infra/outbound/session-contex
 import { maybeResolveIdLikeTarget } from "../../infra/outbound/target-resolver.js";
 import { resolveOutboundTarget } from "../../infra/outbound/targets.js";
 import { extractToolPayload } from "../../infra/outbound/tool-payload.js";
+import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { normalizePollInput } from "../../polls.js";
 import { parseThreadSessionSuffix } from "../../sessions/session-key-utils.js";
 import {
@@ -352,6 +353,10 @@ export const sendHandlers: GatewayRequestHandlers = {
           sessionKey: normalizeOptionalString(request.sessionKey) ?? undefined,
           sessionId: normalizeOptionalString(request.sessionId) ?? undefined,
           agentId: normalizeOptionalString(request.agentId) ?? undefined,
+          mediaLocalRoots: getAgentScopedMediaLocalRoots(
+            cfg,
+            normalizeOptionalString(request.agentId) ?? undefined,
+          ),
           toolContext: request.toolContext,
           dryRun: false,
         });


### PR DESCRIPTION
## Summary

- Pass agent-scoped `mediaLocalRoots` into gateway `message.action` plugin dispatch.
- Add a gateway regression test proving message actions receive the active agent workspace root.
- Add changelog credit for @frankekn.

## Root Cause

The gateway `message.action` WebSocket handler forwarded `agentId` but did not resolve and pass `mediaLocalRoots` into `dispatchChannelMessageAction`. Telegram action handlers then saw `mediaLocalRoots: undefined`, causing workspace-local media paths to fall back to the default media-root policy and be rejected as cross-agent access.

## Validation

- `pnpm test src/gateway/server-methods/send.test.ts` passed: 37 tests.
- `pnpm exec oxlint --tsconfig config/tsconfig/oxlint.core.json CHANGELOG.md src/gateway/server-methods/send.ts src/gateway/server-methods/send.test.ts` passed: 0 errors.
- `pnpm check:changed` passed conflict-marker, changelog attribution, duplicate coverage, core typecheck, and core test typecheck, but failed `lint:core` on unrelated existing files: `src/agents/harness/v2.test.ts`, `src/agents/tools/video-generate-tool.test.ts`, and `src/wizard/setup.finalize.test.ts`.
