### PR TITLE
[Fix] Block memory extra path symlink traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory: reject symlinked directory components in configured extra memory paths before reading Markdown files. (#80331) Thanks @samzong.
 - WhatsApp: apply hot-reloaded `dmPolicy` and `allowFrom` settings to the active Web listener before processing new inbound DMs. Fixes #80538. Thanks @Ampaskopi129.
 - Plugins: let `openclaw doctor --fix` repair managed plugin installs whose package entrypoints fail package-directory boundary validation after local state moves. Fixes #80592. Thanks @wei-wei-zhao.
 - Voice-call: resume voice-originated exec approval follow-ups as internal non-delivery turns instead of rejecting them as `unknown channel: voice`. Fixes #80540. Thanks @patrickmch.

--- a/packages/memory-host-sdk/src/host/fs-utils.ts
+++ b/packages/memory-host-sdk/src/host/fs-utils.ts
@@ -18,12 +18,13 @@ if (!hasPythonModeOverride) {
 
 export function isFileMissingError(
   err: unknown,
-): err is NodeJS.ErrnoException & { code: "ENOENT" } {
+): err is NodeJS.ErrnoException & { code: "ENOENT" | "ENOTDIR" | "not-found" } {
   return Boolean(
     err &&
     typeof err === "object" &&
     "code" in err &&
     ((err as Partial<NodeJS.ErrnoException>).code === "ENOENT" ||
+      (err as Partial<NodeJS.ErrnoException>).code === "ENOTDIR" ||
       (err as { code?: unknown }).code === "not-found"),
   );
 }

--- a/packages/memory-host-sdk/src/host/fs-utils.ts
+++ b/packages/memory-host-sdk/src/host/fs-utils.ts
@@ -1,7 +1,8 @@
 import { configureFsSafePython } from "@openclaw/fs-safe/config";
 export { root } from "@openclaw/fs-safe/root";
-export { isPathInside } from "@openclaw/fs-safe/path";
+export { isPathInside, isPathInsideWithRealpath } from "@openclaw/fs-safe/path";
 export {
+  assertNoSymlinkParents,
   readRegularFile,
   statRegularFile,
   type RegularFileStatResult,

--- a/packages/memory-host-sdk/src/host/read-file.test.ts
+++ b/packages/memory-host-sdk/src/host/read-file.test.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { readMemoryFile } from "./read-file.js";
+
+async function createDirectorySymlink(target: string, linkPath: string): Promise<boolean> {
+  try {
+    await fs.symlink(target, linkPath, "dir");
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "EPERM" || code === "EACCES") {
+      return false;
+    }
+    throw err;
+  }
+}
+
+describe("readMemoryFile", () => {
+  it("returns empty text for missing files under extra path directories", async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-read-file-"));
+    try {
+      const workspaceDir = path.join(tmpRoot, "workspace");
+      const extraDir = path.join(tmpRoot, "extra");
+      const missingPath = path.join(extraDir, "missing.md");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(extraDir, { recursive: true });
+
+      const result = await readMemoryFile({
+        workspaceDir,
+        extraPaths: [extraDir],
+        relPath: missingPath,
+      });
+
+      expect(result).toEqual({
+        text: "",
+        path: path.relative(workspaceDir, missingPath).replace(/\\/g, "/"),
+      });
+    } finally {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects extra path reads through symlinked directory components", async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-read-file-"));
+    try {
+      const workspaceDir = path.join(tmpRoot, "workspace");
+      const extraDir = path.join(tmpRoot, "extra");
+      const outsideDir = path.join(tmpRoot, "outside");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(extraDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      await fs.writeFile(path.join(extraDir, "inside.md"), "inside", "utf-8");
+      await fs.writeFile(path.join(outsideDir, "private.md"), "private", "utf-8");
+
+      const inside = await readMemoryFile({
+        workspaceDir,
+        extraPaths: [extraDir],
+        relPath: path.join(extraDir, "inside.md"),
+      });
+      expect(inside.text).toBe("inside");
+
+      const insideLinkPath = path.join(extraDir, "inside-link");
+      if (!(await createDirectorySymlink(extraDir, insideLinkPath))) {
+        return;
+      }
+      await expect(
+        readMemoryFile({
+          workspaceDir,
+          extraPaths: [extraDir],
+          relPath: path.join(insideLinkPath, "inside.md"),
+        }),
+      ).rejects.toThrow("path required");
+
+      const outsideLinkPath = path.join(extraDir, "link");
+      if (!(await createDirectorySymlink(outsideDir, outsideLinkPath))) {
+        return;
+      }
+
+      await expect(
+        readMemoryFile({
+          workspaceDir,
+          extraPaths: [extraDir],
+          relPath: path.join(outsideLinkPath, "private.md"),
+        }),
+      ).rejects.toThrow("path required");
+      await expect(
+        readMemoryFile({
+          workspaceDir,
+          extraPaths: [extraDir],
+          relPath: path.join(outsideLinkPath, "missing.md"),
+        }),
+      ).rejects.toThrow("path required");
+    } finally {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/memory-host-sdk/src/host/read-file.test.ts
+++ b/packages/memory-host-sdk/src/host/read-file.test.ts
@@ -37,6 +37,19 @@ describe("readMemoryFile", () => {
         text: "",
         path: path.relative(workspaceDir, missingPath).replace(/\\/g, "/"),
       });
+
+      const nonDirectoryParentPath = path.join(extraDir, "note.md", "child.md");
+      await fs.writeFile(path.join(extraDir, "note.md"), "note", "utf-8");
+      await expect(
+        readMemoryFile({
+          workspaceDir,
+          extraPaths: [extraDir],
+          relPath: nonDirectoryParentPath,
+        }),
+      ).resolves.toEqual({
+        text: "",
+        path: path.relative(workspaceDir, nonDirectoryParentPath).replace(/\\/g, "/"),
+      });
     } finally {
       await fs.rm(tmpRoot, { recursive: true, force: true });
     }

--- a/packages/memory-host-sdk/src/host/read-file.ts
+++ b/packages/memory-host-sdk/src/host/read-file.ts
@@ -7,8 +7,10 @@ import {
   type OpenClawConfig,
 } from "./config-utils.js";
 import {
+  assertNoSymlinkParents,
   isFileMissingError,
   isPathInside,
+  isPathInsideWithRealpath,
   readRegularFile,
   root,
   statRegularFile,
@@ -19,6 +21,29 @@ import {
   DEFAULT_MEMORY_READ_LINES,
   type MemoryReadResult,
 } from "./read-file-shared.js";
+
+async function isAllowedAdditionalDirectoryPath(
+  additionalPath: string,
+  absPath: string,
+): Promise<boolean> {
+  if (!isPathInside(additionalPath, absPath)) {
+    return false;
+  }
+  try {
+    await assertNoSymlinkParents({ rootDir: additionalPath, targetPath: absPath });
+  } catch {
+    return false;
+  }
+  if (!isPathInsideWithRealpath(additionalPath, absPath)) {
+    try {
+      await fs.lstat(absPath);
+    } catch (err) {
+      return isFileMissingError(err);
+    }
+    return false;
+  }
+  return true;
+}
 
 export async function readMemoryFile(params: {
   workspaceDir: string;
@@ -49,7 +74,7 @@ export async function readMemoryFile(params: {
           continue;
         }
         if (stat.isDirectory()) {
-          if (isPathInside(additionalPath, absPath)) {
+          if (await isAllowedAdditionalDirectoryPath(additionalPath, absPath)) {
             const candidateStat = await fs.lstat(absPath).catch(() => null);
             if (candidateStat?.isSymbolicLink()) {
               continue;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: `memory_get` authorized `extraPaths` directory reads with lexical containment, so symlinked intermediate components could redirect reads outside the configured memory corpus.
- Why it matters: a configured extra memory root must not allow path traversal through attacker-controlled symlinks.
- What changed: directory-root authorization now rejects symlinked path components, verifies realpath containment, preserves missing-file empty results, and adds focused regression coverage.
- What did NOT change (scope boundary): this does not redesign the lower-level file-open primitive for full active-race/path-pinning semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: `readMemoryFile` / `memory_get` extra path reads through symlinked directory components.
- Real environment tested: local macOS worktree, Node 22 repo runtime, OpenClaw test wrapper.
- Exact steps or command run after this patch: `pnpm test packages/memory-host-sdk/src/host/read-file.test.ts extensions/memory-core/src/memory/manager.read-file.test.ts -- --reporter=verbose`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied terminal output showed 2/2 `read-file.test.ts` tests passing and 13/13 `manager.read-file.test.ts` tests passing.
- Observed result after fix: normal extra path reads still work, missing extra path `.md` returns empty text, symlinked directory component reads reject with `path required`.
- What was not tested: full active-race replacement during the final file open.
- Before evidence (optional but encouraged): local repro before the fix returned outside content through `extra/link/private.md`.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the `extraPaths` directory branch used lexical `isPathInside(additionalPath, absPath)` and only `lstat`ed the leaf path, so an intermediate symlink could escape the configured root.
- Missing detection / guardrail: there was coverage for a leaf symlink but not for symlinked directory components or missing files under extra roots.
- Contributing context (if known): `readRegularFile` protects regular-file identity and leaf symlinks, but it does not authorize the whole path against the configured memory corpus root.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `packages/memory-host-sdk/src/host/read-file.test.ts`.
- Scenario the test should lock in: extra path directory reads reject symlinked components, including symlinks pointing outside and back inside the extra root; missing files under valid extra roots still return empty text.
- Why this is the smallest reliable guardrail: it directly exercises `readMemoryFile`, the authorization seam used by `memory_get`.
- Existing test that already covers this (if any): `extensions/memory-core/src/memory/manager.read-file.test.ts` covered leaf symlink rejection and general read behavior.
- If no new test is added, why not: new tests are added.

## User-visible / Behavior Changes

`memory_get` rejects extra path requests that traverse symlinked directory components instead of reading through them.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[memory_get extra/link/private.md] -> [lexical containment passes] -> [outside file read]

After:
[memory_get extra/link/private.md] -> [symlink component rejected] -> [path required]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): Yes
- If any `Yes`, explain risk + mitigation: data access is narrowed for configured memory extra paths by rejecting symlink traversal through directory components.

## Repro + Verification

### Environment

- OS: macOS local worktree
- Runtime/container: Node 22 repo runtime via `pnpm`
- Model/provider: N/A
- Integration/channel (if any): memory host SDK / memory-core tests
- Relevant config (redacted): `extraPaths` configured to a temporary directory in tests

### Steps

1. Create an extra memory root with `inside.md`.
2. Create `extra/link` as a directory symlink.
3. Request `readMemoryFile` for normal, missing, and symlinked paths.

### Expected

- Normal extra path file reads succeed.
- Missing `.md` under a valid extra root returns empty text.
- Symlinked directory component paths reject with `path required`.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: symlink escape rejection, symlink-to-inside rejection, missing extra path empty result, existing memory-core read behavior.
- Edge cases checked: symlink creation permission fallback for `EPERM` / `EACCES`; format, lint, and package test typecheck.
- What you did **not** verify: full active-race/path-pinning behavior beyond static symlink traversal.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: lower-level active race/path replacement is not fully redesigned here.
  - Mitigation: this patch blocks static symlink traversal and records the broader race-proofing as out of scope for a lower-level primitive.

## Considered and deferred

- packages/memory-host-sdk/src/host/read-file.ts:77 [BOT-SCOPE]: Fully race-proof parent traversal would need a lower-level pinned/openat-style primitive; this diff fixes static symlink traversal and rejects symlink components before read.
