### PR TITLE
[Fix] Cache selected channel registry lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 
 - Feishu: make manual App ID/App Secret setup the default channel-binding path while keeping QR scan-to-create as an optional best-effort flow, and document the manual fallback for domestic Feishu mobile clients that do not react to the QR code. Fixes #80591. Thanks @wei-wei-zhao.
 - Telegram: show resolved thinking defaults in native `/status` and `/think` menus while preserving explicit session overrides. (#80341) Thanks @VACInc.
+- Channels: cache selected channel registry lookups against the active fallback snapshot so pinned-empty registries refresh native command and alias routing after active registry swaps. (#80333) Thanks @samzong.
 - Gateway: scope `sessions.resolve` sessionId and label store loads to the requested agent so large unrelated agent stores are not parsed for scoped lookups. Fixes #51264. (#79474) Thanks @samzong.
 - Gateway: share serialized streaming event envelopes across eligible WebSocket and node subscribers while preserving per-client sequence numbers. (#80299) Thanks @samzong.
 - Browser: report Chrome MCP existing-session page readiness in browser status without letting status probes exceed the client timeout. Fixes #80268. (#80280) Thanks @ai-hpc.

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { setActivePluginRegistry } from "../plugins/runtime.js";
+import {
+  pinActivePluginChannelRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import {
   buildCommandText,
@@ -82,12 +86,27 @@ function installOllamaThinkingProvider() {
   setActivePluginRegistry(registry);
 }
 
+function createNativeCommandsRegistry(id: "discord" | "slack") {
+  return createTestRegistry([
+    {
+      pluginId: id,
+      plugin: createChannelTestPluginBase({
+        id,
+        capabilities: { nativeCommands: true, chatTypes: ["direct"] },
+      }),
+      source: "test",
+    },
+  ]);
+}
+
 beforeEach(() => {
   vi.doUnmock("../channels/plugins/index.js");
+  resetPluginRuntimeStateForTest();
   setActivePluginRegistry(createTestRegistry([]));
 });
 
 afterEach(() => {
+  resetPluginRuntimeStateForTest();
   setActivePluginRegistry(createTestRegistry([]));
 });
 
@@ -453,6 +472,65 @@ describe("commands registry", () => {
         commandSource: "native",
       }),
     ).toBe(true);
+  });
+
+  it("refreshes dock commands when pinned-empty fallback active registry changes", () => {
+    const pinnedEmptyRegistry = createTestRegistry([]);
+    setActivePluginRegistry(pinnedEmptyRegistry);
+    pinActivePluginChannelRegistry(pinnedEmptyRegistry);
+
+    setActivePluginRegistry(createNativeCommandsRegistry("discord"));
+    expect([...commandKeySet(listChatCommands())]).toEqual(
+      expect.arrayContaining(["dock:discord"]),
+    );
+    expect([...commandKeySet(listChatCommands())]).not.toEqual(
+      expect.arrayContaining(["dock:slack"]),
+    );
+
+    setActivePluginRegistry(createNativeCommandsRegistry("slack"));
+    expect([...commandKeySet(listChatCommands())]).not.toEqual(
+      expect.arrayContaining(["dock:discord"]),
+    );
+    expect([...commandKeySet(listChatCommands())]).toEqual(expect.arrayContaining(["dock:slack"]));
+  });
+
+  it("refreshes text-command gating when pinned-empty fallback active registry changes", () => {
+    const cfg = { commands: { text: false } };
+    const pinnedEmptyRegistry = createTestRegistry([]);
+    setActivePluginRegistry(pinnedEmptyRegistry);
+    pinActivePluginChannelRegistry(pinnedEmptyRegistry);
+
+    setActivePluginRegistry(createNativeCommandsRegistry("discord"));
+    expect(
+      shouldHandleTextCommands({
+        cfg,
+        surface: "discord",
+        commandSource: "text",
+      }),
+    ).toBe(false);
+    expect(
+      shouldHandleTextCommands({
+        cfg,
+        surface: "slack",
+        commandSource: "text",
+      }),
+    ).toBe(true);
+
+    setActivePluginRegistry(createNativeCommandsRegistry("slack"));
+    expect(
+      shouldHandleTextCommands({
+        cfg,
+        surface: "discord",
+        commandSource: "text",
+      }),
+    ).toBe(true);
+    expect(
+      shouldHandleTextCommands({
+        cfg,
+        surface: "slack",
+        commandSource: "text",
+      }),
+    ).toBe(false);
   });
 
   it("normalizes telegram-style command mentions for the current bot", () => {

--- a/src/channels/registry-lookup.ts
+++ b/src/channels/registry-lookup.ts
@@ -1,0 +1,95 @@
+import type {
+  ActivePluginChannelRegistration,
+  ActivePluginChannelRegistry,
+} from "../plugins/channel-registry-state.types.js";
+import { getActivePluginChannelRegistrySnapshotFromState } from "../plugins/runtime-channel-state.js";
+import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
+
+export type RegisteredChannelPluginEntry = ActivePluginChannelRegistration & {
+  plugin: ActivePluginChannelRegistration["plugin"] & {
+    id?: string | null;
+    meta?: {
+      aliases?: readonly string[];
+      markdownCapable?: boolean;
+    } | null;
+  };
+};
+
+type RegisteredChannelPluginLookup = {
+  registry: ActivePluginChannelRegistry | null;
+  channels: ActivePluginChannelRegistration[] | undefined;
+  channelCount: number;
+  version: number;
+  entries: RegisteredChannelPluginEntry[];
+  byKey: Map<string, RegisteredChannelPluginEntry>;
+  byId: Map<string, RegisteredChannelPluginEntry>;
+};
+
+let registeredChannelPluginLookup: RegisteredChannelPluginLookup | undefined;
+
+function setLookupEntry(
+  map: Map<string, RegisteredChannelPluginEntry>,
+  key: string | undefined,
+  entry: RegisteredChannelPluginEntry,
+): void {
+  if (key && !map.has(key)) {
+    map.set(key, entry);
+  }
+}
+
+function buildRegisteredChannelPluginLookup(): RegisteredChannelPluginLookup {
+  const { registry, version } = getActivePluginChannelRegistrySnapshotFromState();
+  const channels = Array.isArray(registry?.channels) ? registry.channels : undefined;
+  const channelCount = channels?.length ?? 0;
+  const cached = registeredChannelPluginLookup;
+  if (
+    cached &&
+    cached.registry === registry &&
+    cached.channels === channels &&
+    cached.channelCount === channelCount &&
+    cached.version === version
+  ) {
+    return cached;
+  }
+  const entries = channelCount > 0 ? (channels as RegisteredChannelPluginEntry[]) : [];
+  const byKey = new Map<string, RegisteredChannelPluginEntry>();
+  const byId = new Map<string, RegisteredChannelPluginEntry>();
+  for (const entry of entries) {
+    const id = normalizeOptionalLowercaseString(entry.plugin.id ?? "");
+    setLookupEntry(byKey, id, entry);
+    setLookupEntry(byId, id, entry);
+    for (const alias of entry.plugin.meta?.aliases ?? []) {
+      setLookupEntry(byKey, normalizeOptionalLowercaseString(alias), entry);
+    }
+  }
+  registeredChannelPluginLookup = {
+    registry,
+    channels,
+    channelCount,
+    version,
+    entries,
+    byKey,
+    byId,
+  };
+  return registeredChannelPluginLookup;
+}
+
+export function listRegisteredChannelPluginEntries(): RegisteredChannelPluginEntry[] {
+  return buildRegisteredChannelPluginLookup().entries;
+}
+
+export function findRegisteredChannelPluginEntry(
+  normalizedKey: string,
+): RegisteredChannelPluginEntry | undefined {
+  return buildRegisteredChannelPluginLookup().byKey.get(normalizedKey);
+}
+
+export function findRegisteredChannelPluginEntryById(
+  id: string,
+): RegisteredChannelPluginEntry | undefined {
+  const normalizedId = normalizeOptionalLowercaseString(id);
+  if (!normalizedId) {
+    return undefined;
+  }
+  return buildRegisteredChannelPluginLookup().byId.get(normalizedId);
+}

--- a/src/channels/registry-normalize.ts
+++ b/src/channels/registry-normalize.ts
@@ -1,30 +1,11 @@
-import type { ActivePluginChannelRegistration } from "../plugins/channel-registry-state.types.js";
-import { getActivePluginChannelRegistryFromState } from "../plugins/runtime-channel-state.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import type { ChannelId } from "./plugins/channel-id.types.js";
-
-function listRegisteredChannelPluginEntries(): ActivePluginChannelRegistration[] {
-  const channelRegistry = getActivePluginChannelRegistryFromState();
-  if (channelRegistry?.channels && channelRegistry.channels.length > 0) {
-    return channelRegistry.channels;
-  }
-  return [];
-}
+import { findRegisteredChannelPluginEntry } from "./registry-lookup.js";
 
 export function normalizeAnyChannelId(raw?: string | null): ChannelId | null {
   const key = normalizeOptionalLowercaseString(raw);
   if (!key) {
     return null;
   }
-  return (
-    listRegisteredChannelPluginEntries().find((entry) => {
-      const id = normalizeOptionalLowercaseString(entry.plugin.id ?? "") ?? "";
-      if (id && id === key) {
-        return true;
-      }
-      return (entry.plugin.meta?.aliases ?? []).some(
-        (alias) => normalizeOptionalLowercaseString(alias) === key,
-      );
-    })?.plugin.id ?? null
-  );
+  return findRegisteredChannelPluginEntry(key)?.plugin.id ?? null;
 }

--- a/src/channels/registry.helpers.test.ts
+++ b/src/channels/registry.helpers.test.ts
@@ -2,12 +2,16 @@ import { afterEach, describe, expect, it } from "vitest";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import {
   pinActivePluginChannelRegistry,
+  getActivePluginChannelRegistryVersion,
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
 } from "../plugins/runtime.js";
+import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import { listChatChannels } from "./chat-meta.js";
+import { normalizeAnyChannelId as normalizeAnyChannelIdLight } from "./registry-normalize.js";
 import {
   formatChannelSelectionLine,
+  getRegisteredChannelPluginMeta,
   listRegisteredChannelPluginIds,
   normalizeAnyChannelId,
 } from "./registry.js";
@@ -32,6 +36,16 @@ describe("channel registry helpers", () => {
     return label ?? path ?? "";
   }
 
+  function createRegistryWithRegisteredChannel(id: string, aliases: string[] = []) {
+    return createTestRegistry([
+      {
+        pluginId: id,
+        plugin: { id, meta: { aliases } },
+        source: "test",
+      },
+    ]);
+  }
+
   it("keeps Feishu first in the current default order", () => {
     const channels = listChatChannels();
     expect(channels[0]?.id).toBe("feishu");
@@ -53,29 +67,16 @@ describe("channel registry helpers", () => {
   });
 
   it("prefers the pinned channel registry when resolving registered plugin channels", () => {
-    const startupRegistry = createEmptyPluginRegistry();
-    startupRegistry.channels = [
-      {
-        pluginId: "openclaw-weixin",
-        plugin: { id: "openclaw-weixin", meta: { aliases: ["weixin"] } },
-        source: "test",
-      },
-    ] as never;
+    const startupRegistry = createRegistryWithRegisteredChannel("openclaw-weixin", ["weixin"]);
     setActivePluginRegistry(startupRegistry);
     pinActivePluginChannelRegistry(startupRegistry);
 
-    const replacementRegistry = createEmptyPluginRegistry();
-    replacementRegistry.channels = [
-      {
-        pluginId: "qqbot",
-        plugin: { id: "qqbot", meta: { aliases: ["qq"] } },
-        source: "test",
-      },
-    ] as never;
+    const replacementRegistry = createRegistryWithRegisteredChannel("qqbot", ["qq"]);
     setActivePluginRegistry(replacementRegistry);
 
     expect(listRegisteredChannelPluginIds()).toEqual(["openclaw-weixin"]);
     expect(normalizeAnyChannelId("weixin")).toBe("openclaw-weixin");
+    expect(getRegisteredChannelPluginMeta("OPENCLAW-WEIXIN")?.aliases).toEqual(["weixin"]);
   });
 
   it("falls back to the active registry when the pinned channel registry has no channels", () => {
@@ -83,17 +84,45 @@ describe("channel registry helpers", () => {
     setActivePluginRegistry(startupRegistry);
     pinActivePluginChannelRegistry(startupRegistry);
 
-    const replacementRegistry = createEmptyPluginRegistry();
-    replacementRegistry.channels = [
-      {
-        pluginId: "qqbot",
-        plugin: { id: "qqbot", meta: { aliases: ["qq"] } },
-        source: "test",
-      },
-    ] as never;
+    const replacementRegistry = createRegistryWithRegisteredChannel("qqbot", ["qq"]);
     setActivePluginRegistry(replacementRegistry);
 
     expect(listRegisteredChannelPluginIds()).toEqual(["qqbot"]);
     expect(normalizeAnyChannelId("qq")).toBe("qqbot");
+  });
+
+  it("rebuilds registered channel lookups when pinned-empty fallback active registry changes", () => {
+    const startupRegistry = createEmptyPluginRegistry();
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginChannelRegistry(startupRegistry);
+
+    const alphaRegistry = createRegistryWithRegisteredChannel("alpha", ["a"]);
+    setActivePluginRegistry(alphaRegistry);
+
+    const channelVersion = getActivePluginChannelRegistryVersion();
+    expect(normalizeAnyChannelId("a")).toBe("alpha");
+    expect(normalizeAnyChannelIdLight("a")).toBe("alpha");
+
+    const betaRegistry = createRegistryWithRegisteredChannel("beta", ["b"]);
+    setActivePluginRegistry(betaRegistry);
+
+    expect(getActivePluginChannelRegistryVersion()).not.toBe(channelVersion);
+    expect(normalizeAnyChannelId("a")).toBeNull();
+    expect(normalizeAnyChannelId("b")).toBe("beta");
+    expect(normalizeAnyChannelIdLight("a")).toBeNull();
+    expect(normalizeAnyChannelIdLight("b")).toBe("beta");
+  });
+
+  it("refreshes registered channel lookups when selected registry channels grow in place", () => {
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry);
+
+    expect(normalizeAnyChannelId("a")).toBeNull();
+    expect(normalizeAnyChannelIdLight("a")).toBeNull();
+
+    registry.channels.push(createRegistryWithRegisteredChannel("alpha", ["a"]).channels[0]);
+
+    expect(normalizeAnyChannelId("a")).toBe("alpha");
+    expect(normalizeAnyChannelIdLight("a")).toBe("alpha");
   });
 });

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -1,4 +1,3 @@
-import { getActivePluginChannelRegistryFromState } from "../plugins/runtime-channel-state.js";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -6,50 +5,14 @@ import {
 import { normalizeChatChannelId, type ChatChannelId } from "./ids.js";
 import type { ChannelId } from "./plugins/channel-id.types.js";
 import type { ChannelMeta } from "./plugins/types.core.js";
+import {
+  findRegisteredChannelPluginEntry,
+  findRegisteredChannelPluginEntryById,
+  listRegisteredChannelPluginEntries,
+} from "./registry-lookup.js";
 export { getChatChannelMeta } from "./chat-meta.js";
 export { CHAT_CHANNEL_ORDER } from "./ids.js";
 export type { ChatChannelId } from "./ids.js";
-
-type RegisteredChannelPluginEntry = {
-  plugin: {
-    id?: string | null;
-    meta?: Pick<ChannelMeta, "aliases" | "markdownCapable"> | null;
-  };
-};
-
-function listRegisteredChannelPluginEntries(): RegisteredChannelPluginEntry[] {
-  const channelRegistry = getActivePluginChannelRegistryFromState();
-  if (channelRegistry && channelRegistry.channels && channelRegistry.channels.length > 0) {
-    return channelRegistry.channels;
-  }
-  return [];
-}
-
-function findRegisteredChannelPluginEntry(
-  normalizedKey: string,
-): RegisteredChannelPluginEntry | undefined {
-  return listRegisteredChannelPluginEntries().find((entry) => {
-    const id = normalizeOptionalLowercaseString(entry.plugin.id ?? "") ?? "";
-    if (id && id === normalizedKey) {
-      return true;
-    }
-    return (entry.plugin.meta?.aliases ?? []).some(
-      (alias) => normalizeOptionalLowercaseString(alias) === normalizedKey,
-    );
-  });
-}
-
-function findRegisteredChannelPluginEntryById(
-  id: string,
-): RegisteredChannelPluginEntry | undefined {
-  const normalizedId = normalizeOptionalLowercaseString(id);
-  if (!normalizedId) {
-    return undefined;
-  }
-  return listRegisteredChannelPluginEntries().find(
-    (entry) => normalizeOptionalLowercaseString(entry.plugin.id) === normalizedId,
-  );
-}
 export { normalizeChatChannelId };
 
 // Channel docking: prefer this helper in shared code. Importing from

--- a/src/plugins/runtime-channel-state.ts
+++ b/src/plugins/runtime-channel-state.ts
@@ -13,24 +13,68 @@ type GlobalChannelRegistryState = typeof globalThis & {
   };
 };
 
+type GlobalChannelRegistryRuntimeState = GlobalChannelRegistryState[typeof PLUGIN_REGISTRY_STATE];
+
+export type ActivePluginChannelRegistrySnapshot = {
+  registry: ActivePluginChannelRegistry | null;
+  version: number;
+};
+
+let activePluginChannelRegistrySnapshot:
+  | {
+      state: GlobalChannelRegistryRuntimeState;
+      pinnedRegistry: ActivePluginChannelRegistry | null;
+      activeRegistry: ActivePluginChannelRegistry | null;
+      pinnedChannelCount: number;
+      activeChannelCount: number;
+      snapshot: ActivePluginChannelRegistrySnapshot;
+    }
+  | undefined;
+
 function countChannels(registry: ActivePluginChannelRegistry | null | undefined): number {
   return registry?.channels?.length ?? 0;
 }
 
-export function getActivePluginChannelRegistryFromState(): ActivePluginChannelRegistry | null {
+export function getActivePluginChannelRegistrySnapshotFromState(): ActivePluginChannelRegistrySnapshot {
   const state = (globalThis as GlobalChannelRegistryState)[PLUGIN_REGISTRY_STATE];
   const pinnedRegistry = state?.channel?.registry ?? null;
-  if (countChannels(pinnedRegistry) > 0) {
-    return pinnedRegistry;
-  }
   const activeRegistry = state?.activeRegistry ?? null;
-  if (countChannels(activeRegistry) > 0) {
-    return activeRegistry;
+  const pinnedChannelCount = countChannels(pinnedRegistry);
+  const activeChannelCount = countChannels(activeRegistry);
+  const selectedPinnedRegistry =
+    pinnedChannelCount > 0 || (pinnedRegistry !== null && activeChannelCount === 0);
+  const version = selectedPinnedRegistry
+    ? (state?.channel?.version ?? 0)
+    : (state?.activeVersion ?? 0);
+  const cached = activePluginChannelRegistrySnapshot;
+  if (
+    cached &&
+    cached.state === state &&
+    cached.pinnedRegistry === pinnedRegistry &&
+    cached.activeRegistry === activeRegistry &&
+    cached.pinnedChannelCount === pinnedChannelCount &&
+    cached.activeChannelCount === activeChannelCount &&
+    cached.snapshot.version === version
+  ) {
+    return cached.snapshot;
   }
-  return pinnedRegistry ?? activeRegistry;
+  const registry = selectedPinnedRegistry ? pinnedRegistry : activeRegistry;
+  const snapshot = { registry, version };
+  activePluginChannelRegistrySnapshot = {
+    state,
+    pinnedRegistry,
+    activeRegistry,
+    pinnedChannelCount,
+    activeChannelCount,
+    snapshot,
+  };
+  return snapshot;
+}
+
+export function getActivePluginChannelRegistryFromState(): ActivePluginChannelRegistry | null {
+  return getActivePluginChannelRegistrySnapshotFromState().registry;
 }
 
 export function getActivePluginChannelRegistryVersionFromState(): number {
-  const state = (globalThis as GlobalChannelRegistryState)[PLUGIN_REGISTRY_STATE];
-  return state?.channel?.registry ? (state.channel.version ?? 0) : (state?.activeVersion ?? 0);
+  return getActivePluginChannelRegistrySnapshotFromState().version;
 }

--- a/src/plugins/runtime.channel-pin.test.ts
+++ b/src/plugins/runtime.channel-pin.test.ts
@@ -124,6 +124,19 @@ describe("channel registry pinning", () => {
     expect(isPluginRegistryRetired(startup)).toBe(true);
   });
 
+  it("falls back to the active channel registry when the pinned registry is empty", () => {
+    const startup = createEmptyPluginRegistry();
+    const { registry: replacement } = createRegistryWithChannel("replacement-channel");
+    setActivePluginRegistry(startup);
+    pinActivePluginChannelRegistry(startup);
+
+    const channelVersionBeforeSwap = getActivePluginChannelRegistryVersion();
+    setActivePluginRegistry(replacement);
+
+    expectActiveChannelRegistry(replacement);
+    expect(getActivePluginChannelRegistryVersion()).not.toBe(channelVersionBeforeSwap);
+  });
+
   it("re-pin invalidates cached channel lookups", () => {
     const { first, second } = createChannelRegistryPair();
     const { registry: setup, plugin: setupPlugin } = first;

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -7,6 +7,7 @@ import {
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { markPluginRegistryActive, markPluginRegistryRetired } from "./registry-lifecycle.js";
 import type { PluginRegistry } from "./registry-types.js";
+import { getActivePluginChannelRegistrySnapshotFromState } from "./runtime-channel-state.js";
 import {
   PLUGIN_REGISTRY_STATE,
   type RegistryState,
@@ -277,10 +278,6 @@ export function resolveActivePluginHttpRouteRegistry(fallback: PluginRegistry): 
   return routeRegistry;
 }
 
-/** Pin the channel registry so that subsequent `setActivePluginRegistry` calls
- *  do not replace the channel snapshot used by `getChannelPlugin`. Call at
- *  gateway startup after the initial plugin load so that config-schema reads
- *  and other non-primary registry loads cannot evict channel plugins. */
 export function pinActivePluginChannelRegistry(registry: PluginRegistry) {
   const previousRegistry = asPluginRegistry(state.channel.registry);
   installSurfaceRegistry(state.channel, registry, true);
@@ -303,15 +300,12 @@ export function releasePinnedPluginChannelRegistry(registry?: PluginRegistry) {
   }
 }
 
-/** Return the registry that should be used for channel plugin resolution.
- *  When pinned, this returns the startup registry regardless of subsequent
- *  `setActivePluginRegistry` calls. */
 export function getActivePluginChannelRegistry(): PluginRegistry | null {
-  return asPluginRegistry(state.channel.registry ?? state.activeRegistry);
+  return getActivePluginChannelRegistrySnapshotFromState().registry as PluginRegistry | null;
 }
 
 export function getActivePluginChannelRegistryVersion(): number {
-  return state.channel.registry ? state.channel.version : state.activeVersion;
+  return getActivePluginChannelRegistrySnapshotFromState().version;
 }
 
 export function requireActivePluginChannelRegistry(): PluginRegistry {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: channel registry helpers rebuilt id/alias lookups with repeated scans, and version-only caches could go stale when a pinned empty channel registry fell back to a changed active registry.
- Why it matters: inbound channel and native-command routing can call these helpers on hot paths, so stale or repeated lookup work affects message handling correctness and cost.
- What changed: shared registered-channel lookup maps now cache by the selected registry snapshot, public channel registry/version helpers use the same selected snapshot semantics, and regression tests cover pinned-empty fallback swaps.
- What did NOT change (scope boundary): no channel plugin loading policy, config contract, docs, or user-facing defaults changed.
- AI-assisted: implemented and verified with Codex.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- Related #N/A
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: pinned-empty channel registry fallback could leave native command surface routing cached for the previous active registry.
- Real environment tested: local OpenClaw worktree on Darwin 25.4.0 arm64, Node v24.14.0, pnpm 10.33.2.
- Exact steps or command run after this patch: `node --import tsx --eval '<pinned-empty native command surface probe>'`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
{"phase":"discord","discord":true,"slack":false}
{"phase":"slack","discord":false,"slack":true}
```

- Observed result after fix: after swapping the active fallback registry from Discord to Slack, Discord is no longer treated as native and Slack is treated as native.
- What was not tested: full live channel gateway traffic; this patch was validated with deterministic registry/runtime probes and targeted tests.
- Before evidence (optional but encouraged): before the final cache-key fix, the same probe returned `{"phase":"slack","discord":true,"slack":false}` after switching to Slack.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: channel lookup and command routing caches used version keys that did not consistently represent the registry actually selected by pinned-empty fallback logic.
- Missing detection / guardrail: tests covered pinned registries and active registries separately, but not the pinned-empty fallback active-registry swap path across dock commands and text-command gating.
- Contributing context (if known): registered channel id/alias lookup helpers were duplicated across registry modules, which made it easier for cache semantics to drift.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/channels/registry.helpers.test.ts`, `src/plugins/runtime.channel-pin.test.ts`, `src/auto-reply/commands-registry.test.ts`.
- Scenario the test should lock in: pinned empty channel registry falls back to the active registry, then active registry swaps from one native channel to another.
- Why this is the smallest reliable guardrail: it exercises the runtime registry state, registered channel lookup cache, dock command cache, and native text-command gating without requiring live channel credentials.
- Existing test that already covers this (if any): new tests added in this PR cover the missing cases.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Channel alias and native command routing now refresh correctly when a pinned empty channel registry falls back to a changed active registry. No config, CLI, docs, or defaults changed.

## Diagram (if applicable)

```text
Before:
[pinned empty channel registry] -> [active discord registry] -> [cache key uses pinned version]
[active slack registry] -> [same pinned cache key] -> [stale discord native surface]

After:
[pinned empty channel registry] -> [selected active discord registry/version] -> [discord native surface]
[active slack registry] -> [selected active slack registry/version] -> [slack native surface]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Darwin 25.4.0 arm64
- Runtime/container: Node v24.14.0, pnpm 10.33.2
- Model/provider: N/A
- Integration/channel (if any): synthetic Discord and Slack channel plugin registries
- Relevant config (redacted): N/A

### Steps

1. Start with an empty channel registry, pin it, then set the active registry to a Discord native-command channel.
2. Query native command surface handling for Discord and Slack.
3. Swap the active registry to a Slack native-command channel and query again.

### Expected

- Discord is native in the Discord phase and not native in the Slack phase.
- Slack is not native in the Discord phase and native in the Slack phase.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: pinned-empty fallback registry swap for registered channel normalization, dock command generation, native text-command gating, and public channel registry/version helpers.
- Edge cases checked: selected registry grows in place, pinned non-empty registry remains preferred, pinned-empty active fallback refreshes after registry swap.
- What you did **not** verify: live channel gateway traffic with real Discord or Slack credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversations exist yet for this PR.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: public channel registry helper semantics now match selected fallback behavior, which could change callers that expected pinned-empty registries to stay selected.
  - Mitigation: existing pinned non-empty behavior is preserved, and new tests cover pinned-empty fallback plus public helper version refresh.
