### PR TITLE
Fix Telegram thinking status defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Feishu: make manual App ID/App Secret setup the default channel-binding path while keeping QR scan-to-create as an optional best-effort flow, and document the manual fallback for domestic Feishu mobile clients that do not react to the QR code. Fixes #80591. Thanks @wei-wei-zhao.
+- Telegram: show resolved thinking defaults in native `/status` and `/think` menus while preserving explicit session overrides. (#80341) Thanks @VACInc.
 - Gateway: scope `sessions.resolve` sessionId and label store loads to the requested agent so large unrelated agent stores are not parsed for scoped lookups. Fixes #51264. (#79474) Thanks @samzong.
 - Gateway: share serialized streaming event envelopes across eligible WebSocket and node subscribers while preserving per-client sequence numbers. (#80299) Thanks @samzong.
 - Browser: report Chrome MCP existing-session page readiness in browser status without letting status probes exceed the client timeout. Fixes #80268. (#80280) Thanks @ai-hpc.

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -28,6 +28,7 @@ type DispatchReplyWithBufferedBlockDispatcherResult = Awaited<
 >;
 type DeliverRepliesFn = typeof import("./bot/delivery.js").deliverReplies;
 type DeliverRepliesParams = Parameters<DeliverRepliesFn>[0];
+type LoadModelCatalogFn = typeof import("openclaw/plugin-sdk/agent-runtime").loadModelCatalog;
 type MatchPluginCommandFn = typeof import("./bot-native-commands.runtime.js").matchPluginCommand;
 
 const dispatchReplyResult: DispatchReplyWithBufferedBlockDispatcherResult = {
@@ -52,6 +53,16 @@ const sessionMocks = vi.hoisted(() => ({
 }));
 const commandAuthMocks = vi.hoisted(() => ({
   resolveCommandArgMenu: vi.fn(),
+}));
+const agentRuntimeMocks = vi.hoisted(() => ({
+  loadModelCatalog: vi.fn<LoadModelCatalogFn>(async () => [
+    {
+      provider: "openai",
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      reasoning: true,
+    },
+  ]),
 }));
 const pluginRuntimeMocks = vi.hoisted(() => ({
   executePluginCommand: vi.fn(async () => ({ text: "ok" })),
@@ -167,6 +178,15 @@ vi.mock("openclaw/plugin-sdk/command-auth-native", async () => {
   return {
     ...actual,
     resolveCommandArgMenu: commandAuthMocks.resolveCommandArgMenu,
+  };
+});
+vi.mock("openclaw/plugin-sdk/agent-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/agent-runtime")>(
+    "openclaw/plugin-sdk/agent-runtime",
+  );
+  return {
+    ...actual,
+    loadModelCatalog: agentRuntimeMocks.loadModelCatalog,
   };
 });
 vi.mock("./bot-native-commands.runtime.js", async () => {
@@ -524,6 +544,14 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     persistentBindingMocks.ensureConfiguredBindingRouteReady.mockClear();
     persistentBindingMocks.ensureConfiguredBindingRouteReady.mockResolvedValue({ ok: true });
     commandAuthMocks.resolveCommandArgMenu.mockClear();
+    agentRuntimeMocks.loadModelCatalog.mockClear().mockResolvedValue([
+      {
+        provider: "openai",
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        reasoning: true,
+      },
+    ]);
     sessionMocks.loadSessionStore.mockClear().mockReturnValue({});
     sessionMocks.recordSessionMetaFromInbound.mockClear().mockResolvedValue(undefined);
     sessionMocks.resolveAndPersistSessionFile.mockClear().mockImplementation(async (params) => {
@@ -697,6 +725,36 @@ describe("registerTelegramNativeCommands — session metadata", () => {
       textIncludes: "Current thinking level: medium.\nChoose level for /think.",
       requireReplyMarkup: true,
       label: "default model thinking menu",
+    });
+    expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("hydrates runtime catalog metadata for thinking menu defaults", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5" },
+        },
+      },
+    } as OpenClawConfig;
+    sessionMocks.loadSessionStore.mockReturnValue({});
+
+    const { handler, sendMessage } = registerAndResolveCommandHandler({
+      commandName: "think",
+      cfg,
+      allowFrom: ["*"],
+    });
+    await handler(createTelegramPrivateCommandContext());
+
+    expect(agentRuntimeMocks.loadModelCatalog).toHaveBeenCalledWith({
+      config: cfg,
+    });
+    expectSendMessageCall({
+      sendMessage,
+      chatId: 100,
+      textIncludes: "Current thinking level: medium.\nChoose level for /think.",
+      requireReplyMarkup: true,
+      label: "runtime catalog thinking menu",
     });
     expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { Bot, Context } from "grammy";
 import {
   buildConfiguredModelCatalog,
+  loadModelCatalog,
   resolveAgentConfig,
   resolveDefaultModelForAgent,
   resolveThinkingDefault,
@@ -256,13 +257,49 @@ function resolveTelegramCommandMenuModelContext(params: {
   }
 }
 
-function resolveTelegramThinkMenuCurrentLevel(params: {
+async function resolveTelegramDefaultThinkingLevel(params: {
+  cfg: OpenClawConfig;
+  provider: string;
+  model: string;
+}): Promise<string> {
+  const configuredCatalog = buildConfiguredModelCatalog({ cfg: params.cfg });
+  const configuredSelectedEntry = configuredCatalog.find(
+    (entry) => entry.provider === params.provider && entry.id === params.model,
+  );
+  const shouldHydrateRuntimeCatalog =
+    configuredCatalog.length === 0 ||
+    !configuredSelectedEntry ||
+    configuredSelectedEntry.reasoning === undefined;
+  let runtimeCatalog: Awaited<ReturnType<typeof loadModelCatalog>> | undefined;
+  if (shouldHydrateRuntimeCatalog) {
+    try {
+      runtimeCatalog = await loadModelCatalog({ config: params.cfg });
+    } catch {
+      runtimeCatalog = undefined;
+    }
+  }
+  const runtimeSelectedEntry = runtimeCatalog?.find(
+    (entry) => entry.provider === params.provider && entry.id === params.model,
+  );
+  const catalog =
+    runtimeSelectedEntry || configuredCatalog.length === 0
+      ? (runtimeCatalog ?? configuredCatalog)
+      : configuredCatalog;
+  return resolveThinkingDefault({
+    cfg: params.cfg,
+    provider: params.provider,
+    model: params.model,
+    catalog,
+  });
+}
+
+async function resolveTelegramThinkMenuCurrentLevel(params: {
   cfg: OpenClawConfig;
   agentId: string;
   provider?: string;
   model?: string;
   thinkingLevel?: string;
-}): string {
+}): Promise<string> {
   const explicit = normalizeOptionalString(params.thinkingLevel);
   if (explicit) {
     return explicit;
@@ -277,11 +314,10 @@ function resolveTelegramThinkMenuCurrentLevel(params: {
     cfg: params.cfg,
     agentId: params.agentId,
   });
-  return resolveThinkingDefault({
+  return await resolveTelegramDefaultThinkingLevel({
     cfg: params.cfg,
     provider: params.provider ?? defaultModel.provider,
     model: params.model ?? defaultModel.model,
-    catalog: buildConfiguredModelCatalog({ cfg: params.cfg }),
   });
 }
 
@@ -1050,7 +1086,7 @@ export const registerTelegramNativeCommands = ({
             menu,
             currentThinkingLevel:
               commandDefinition.key === "think"
-                ? resolveTelegramThinkMenuCurrentLevel({
+                ? await resolveTelegramThinkMenuCurrentLevel({
                     cfg: runtimeCfg,
                     agentId: route.agentId,
                     ...menuModelContext,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -2,11 +2,10 @@ import { randomUUID } from "node:crypto";
 import path from "node:path";
 import type { Bot, Context } from "grammy";
 import {
-  buildConfiguredModelCatalog,
   loadModelCatalog,
   resolveAgentConfig,
   resolveDefaultModelForAgent,
-  resolveThinkingDefault,
+  resolveThinkingDefaultWithRuntimeCatalog,
 } from "openclaw/plugin-sdk/agent-runtime";
 import { resolveChannelStreamingBlockEnabled } from "openclaw/plugin-sdk/channel-streaming";
 import { resolveNativeCommandSessionTargets } from "openclaw/plugin-sdk/command-auth-native";
@@ -262,34 +261,11 @@ async function resolveTelegramDefaultThinkingLevel(params: {
   provider: string;
   model: string;
 }): Promise<string> {
-  const configuredCatalog = buildConfiguredModelCatalog({ cfg: params.cfg });
-  const configuredSelectedEntry = configuredCatalog.find(
-    (entry) => entry.provider === params.provider && entry.id === params.model,
-  );
-  const shouldHydrateRuntimeCatalog =
-    configuredCatalog.length === 0 ||
-    !configuredSelectedEntry ||
-    configuredSelectedEntry.reasoning === undefined;
-  let runtimeCatalog: Awaited<ReturnType<typeof loadModelCatalog>> | undefined;
-  if (shouldHydrateRuntimeCatalog) {
-    try {
-      runtimeCatalog = await loadModelCatalog({ config: params.cfg });
-    } catch {
-      runtimeCatalog = undefined;
-    }
-  }
-  const runtimeSelectedEntry = runtimeCatalog?.find(
-    (entry) => entry.provider === params.provider && entry.id === params.model,
-  );
-  const catalog =
-    runtimeSelectedEntry || configuredCatalog.length === 0
-      ? (runtimeCatalog ?? configuredCatalog)
-      : configuredCatalog;
-  return resolveThinkingDefault({
+  return resolveThinkingDefaultWithRuntimeCatalog({
     cfg: params.cfg,
     provider: params.provider,
     model: params.model,
-    catalog,
+    loadModelCatalog: () => loadModelCatalog({ config: params.cfg }),
   });
 }
 

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -17,7 +17,10 @@ import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import { findModelInCatalog } from "./model-catalog-lookup.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
 import { splitTrailingAuthProfile } from "./model-ref-profile.js";
-export { resolveThinkingDefault } from "./model-thinking-default.js";
+export {
+  resolveThinkingDefault,
+  resolveThinkingDefaultWithRuntimeCatalog,
+} from "./model-thinking-default.js";
 import {
   type ModelRef,
   findNormalizedProviderKey,

--- a/src/agents/model-thinking-default.ts
+++ b/src/agents/model-thinking-default.ts
@@ -7,6 +7,7 @@ import {
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
 import { legacyModelKey, modelKey, normalizeProviderId } from "./model-selection-normalize.js";
 import { normalizeModelSelection } from "./model-selection-resolve.js";
+import { buildConfiguredModelCatalog } from "./model-selection-shared.js";
 
 type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive" | "max";
 
@@ -75,5 +76,35 @@ export function resolveThinkingDefault(params: {
     provider: params.provider,
     model: params.model,
     catalog: params.catalog,
+  });
+}
+
+export async function resolveThinkingDefaultWithRuntimeCatalog(params: {
+  cfg: OpenClawConfig;
+  provider: string;
+  model: string;
+  loadModelCatalog: () => Promise<ModelCatalogEntry[]>;
+}): Promise<ThinkLevel> {
+  const configuredCatalog = buildConfiguredModelCatalog({ cfg: params.cfg });
+  const configuredSelectedEntry = configuredCatalog.find(
+    (entry) => entry.provider === params.provider && entry.id === params.model,
+  );
+  const needsRuntimeCatalog =
+    configuredCatalog.length === 0 ||
+    !configuredSelectedEntry ||
+    configuredSelectedEntry.reasoning === undefined;
+  const runtimeCatalog = needsRuntimeCatalog ? await params.loadModelCatalog() : undefined;
+  const runtimeSelectedEntry = runtimeCatalog?.find(
+    (entry) => entry.provider === params.provider && entry.id === params.model,
+  );
+  const catalog =
+    runtimeSelectedEntry || configuredCatalog.length === 0
+      ? (runtimeCatalog ?? configuredCatalog)
+      : configuredCatalog;
+  return resolveThinkingDefault({
+    cfg: params.cfg,
+    provider: params.provider,
+    model: params.model,
+    catalog,
   });
 }

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -28,12 +28,11 @@ import { buildTaskStatusSnapshotForRelatedSessionKeyForOwner } from "../../tasks
 import { formatTaskStatusDetail, formatTaskStatusTitle } from "../../tasks/task-status.js";
 import { loadModelCatalog } from "../model-catalog.js";
 import {
-  buildConfiguredModelCatalog,
   buildModelAliasIndex,
   modelKey,
   resolveDefaultModelForAgent,
   resolveModelRefFromString,
-  resolveThinkingDefault,
+  resolveThinkingDefaultWithRuntimeCatalog,
 } from "../model-selection.js";
 import { createModelVisibilityPolicy } from "../model-visibility-policy.js";
 import {
@@ -713,32 +712,13 @@ export function createSessionStatusTool(opts?: {
         resolvedVerboseLevel: (statusSessionEntry.verboseLevel ?? "off") as VerboseLevel,
         resolvedReasoningLevel: (statusSessionEntry.reasoningLevel ?? "off") as ReasoningLevel,
         resolvedElevatedLevel: statusSessionEntry.elevatedLevel as ElevatedLevel | undefined,
-        resolveDefaultThinkingLevel: async () => {
-          const configuredCatalog = buildConfiguredModelCatalog({ cfg });
-          const configuredSelectedEntry = configuredCatalog.find(
-            (entry) => entry.provider === providerForCard && entry.id === defaultModelForCard,
-          );
-          const shouldHydrateRuntimeCatalog =
-            configuredCatalog.length === 0 ||
-            !configuredSelectedEntry ||
-            configuredSelectedEntry.reasoning === undefined;
-          const runtimeCatalog = shouldHydrateRuntimeCatalog
-            ? await loadModelCatalog({ config: cfg })
-            : undefined;
-          const runtimeSelectedEntry = runtimeCatalog?.find(
-            (entry) => entry.provider === providerForCard && entry.id === defaultModelForCard,
-          );
-          const catalog =
-            runtimeSelectedEntry || configuredCatalog.length === 0
-              ? (runtimeCatalog ?? configuredCatalog)
-              : configuredCatalog;
-          return resolveThinkingDefault({
+        resolveDefaultThinkingLevel: () =>
+          resolveThinkingDefaultWithRuntimeCatalog({
             cfg,
             provider: providerForCard,
             model: defaultModelForCard,
-            catalog,
-          });
-        },
+            loadModelCatalog: () => loadModelCatalog({ config: cfg }),
+          }),
         isGroup,
         defaultGroupActivation: () => "mention",
         taskLineOverride: taskLine,

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -135,9 +135,7 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
       });
       return resolvedDefaultThinkingLevel;
     };
-    const resolvedThinkLevel =
-      normalizeThinkLevel(targetSessionEntry?.thinkingLevel) ??
-      (await resolveDefaultThinkingLevel());
+    const resolvedThinkLevel = normalizeThinkLevel(targetSessionEntry?.thinkingLevel);
     const { buildStatusReply } = await loadStatusCommandRuntime();
     return {
       handled: true,

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -10,7 +10,7 @@ import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import type { GetReplyOptions } from "../get-reply-options.types.js";
 import type { ReplyPayload } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
-import type { ThinkLevel } from "../thinking.js";
+import { normalizeThinkLevel, type ThinkLevel } from "../thinking.js";
 import { buildCommandContext } from "./commands-context.js";
 import { clearInlineDirectives } from "./get-reply-directives-utils.js";
 import { resolveReplyDirectives } from "./get-reply-directives.js";
@@ -126,11 +126,18 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
   if (command.commandBodyNormalized === "/status") {
     const targetSessionEntry =
       sessionState.sessionStore[sessionState.sessionKey] ?? sessionState.sessionEntry;
-    const resolvedDefaultThinkingLevel = await resolveNativeSlashDefaultThinkingLevel({
-      cfg: params.cfg,
-      provider: params.provider,
-      model: params.model,
-    });
+    let resolvedDefaultThinkingLevel: ThinkLevel | undefined;
+    const resolveDefaultThinkingLevel = async () => {
+      resolvedDefaultThinkingLevel ??= await resolveNativeSlashDefaultThinkingLevel({
+        cfg: params.cfg,
+        provider: params.provider,
+        model: params.model,
+      });
+      return resolvedDefaultThinkingLevel;
+    };
+    const resolvedThinkLevel =
+      normalizeThinkLevel(targetSessionEntry?.thinkingLevel) ??
+      (await resolveDefaultThinkingLevel());
     const { buildStatusReply } = await loadStatusCommandRuntime();
     return {
       handled: true,
@@ -145,11 +152,11 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
         provider: params.provider,
         model: params.model,
         workspaceDir: params.workspaceDir,
-        resolvedThinkLevel: resolvedDefaultThinkingLevel,
+        resolvedThinkLevel,
         resolvedVerboseLevel: "off",
         resolvedReasoningLevel: "off",
         resolvedElevatedLevel: "off",
-        resolveDefaultThinkingLevel: async () => resolvedDefaultThinkingLevel,
+        resolveDefaultThinkingLevel,
         isGroup: sessionState.isGroup,
         defaultGroupActivation: () => "always",
         mediaDecisions: params.ctx.MediaUnderstandingDecisions,

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -1,10 +1,16 @@
-import type { ModelAliasIndex } from "../../agents/model-selection.js";
+import { loadModelCatalog } from "../../agents/model-catalog.js";
+import {
+  buildConfiguredModelCatalog,
+  resolveThinkingDefault,
+  type ModelAliasIndex,
+} from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import type { GetReplyOptions } from "../get-reply-options.types.js";
 import type { ReplyPayload } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
+import type { ThinkLevel } from "../thinking.js";
 import { buildCommandContext } from "./commands-context.js";
 import { clearInlineDirectives } from "./get-reply-directives-utils.js";
 import { resolveReplyDirectives } from "./get-reply-directives.js";
@@ -40,6 +46,42 @@ function resolveNativeSlashCommandName(ctx: MsgContext): string | undefined {
 function shouldRunNativeSlashCommandFastPath(ctx: MsgContext): boolean {
   const commandName = resolveNativeSlashCommandName(ctx);
   return Boolean(commandName && commandName !== "new" && commandName !== "reset");
+}
+
+async function resolveNativeSlashDefaultThinkingLevel(params: {
+  cfg: OpenClawConfig;
+  provider: string;
+  model: string;
+}): Promise<ThinkLevel> {
+  const configuredCatalog = buildConfiguredModelCatalog({ cfg: params.cfg });
+  const configuredSelectedEntry = configuredCatalog.find(
+    (entry) => entry.provider === params.provider && entry.id === params.model,
+  );
+  const shouldHydrateRuntimeCatalog =
+    configuredCatalog.length === 0 ||
+    !configuredSelectedEntry ||
+    configuredSelectedEntry.reasoning === undefined;
+  let runtimeCatalog: Awaited<ReturnType<typeof loadModelCatalog>> | undefined;
+  if (shouldHydrateRuntimeCatalog) {
+    try {
+      runtimeCatalog = await loadModelCatalog({ config: params.cfg });
+    } catch {
+      runtimeCatalog = undefined;
+    }
+  }
+  const runtimeSelectedEntry = runtimeCatalog?.find(
+    (entry) => entry.provider === params.provider && entry.id === params.model,
+  );
+  const catalog =
+    runtimeSelectedEntry || configuredCatalog.length === 0
+      ? (runtimeCatalog ?? configuredCatalog)
+      : configuredCatalog;
+  return resolveThinkingDefault({
+    cfg: params.cfg,
+    provider: params.provider,
+    model: params.model,
+    catalog,
+  });
 }
 
 export async function maybeResolveNativeSlashCommandFastReply(params: {
@@ -84,6 +126,11 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
   if (command.commandBodyNormalized === "/status") {
     const targetSessionEntry =
       sessionState.sessionStore[sessionState.sessionKey] ?? sessionState.sessionEntry;
+    const resolvedDefaultThinkingLevel = await resolveNativeSlashDefaultThinkingLevel({
+      cfg: params.cfg,
+      provider: params.provider,
+      model: params.model,
+    });
     const { buildStatusReply } = await loadStatusCommandRuntime();
     return {
       handled: true,
@@ -98,11 +145,11 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
         provider: params.provider,
         model: params.model,
         workspaceDir: params.workspaceDir,
-        resolvedThinkLevel: undefined,
+        resolvedThinkLevel: resolvedDefaultThinkingLevel,
         resolvedVerboseLevel: "off",
         resolvedReasoningLevel: "off",
         resolvedElevatedLevel: "off",
-        resolveDefaultThinkingLevel: async () => undefined,
+        resolveDefaultThinkingLevel: async () => resolvedDefaultThinkingLevel,
         isGroup: sessionState.isGroup,
         defaultGroupActivation: () => "always",
         mediaDecisions: params.ctx.MediaUnderstandingDecisions,

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -1,7 +1,6 @@
 import { loadModelCatalog } from "../../agents/model-catalog.js";
 import {
-  buildConfiguredModelCatalog,
-  resolveThinkingDefault,
+  resolveThinkingDefaultWithRuntimeCatalog,
   type ModelAliasIndex,
 } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -53,34 +52,11 @@ async function resolveNativeSlashDefaultThinkingLevel(params: {
   provider: string;
   model: string;
 }): Promise<ThinkLevel> {
-  const configuredCatalog = buildConfiguredModelCatalog({ cfg: params.cfg });
-  const configuredSelectedEntry = configuredCatalog.find(
-    (entry) => entry.provider === params.provider && entry.id === params.model,
-  );
-  const shouldHydrateRuntimeCatalog =
-    configuredCatalog.length === 0 ||
-    !configuredSelectedEntry ||
-    configuredSelectedEntry.reasoning === undefined;
-  let runtimeCatalog: Awaited<ReturnType<typeof loadModelCatalog>> | undefined;
-  if (shouldHydrateRuntimeCatalog) {
-    try {
-      runtimeCatalog = await loadModelCatalog({ config: params.cfg });
-    } catch {
-      runtimeCatalog = undefined;
-    }
-  }
-  const runtimeSelectedEntry = runtimeCatalog?.find(
-    (entry) => entry.provider === params.provider && entry.id === params.model,
-  );
-  const catalog =
-    runtimeSelectedEntry || configuredCatalog.length === 0
-      ? (runtimeCatalog ?? configuredCatalog)
-      : configuredCatalog;
-  return resolveThinkingDefault({
+  return resolveThinkingDefaultWithRuntimeCatalog({
     cfg: params.cfg,
     provider: params.provider,
     model: params.model,
-    catalog,
+    loadModelCatalog: () => loadModelCatalog({ config: params.cfg }),
   });
 }
 

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -18,11 +18,36 @@ import {
 import { loadGetReplyModuleForTest } from "./get-reply.test-loader.js";
 import "./get-reply.test-runtime-mocks.js";
 
+type LoadModelCatalogFn = typeof import("../../agents/model-catalog.js").loadModelCatalog;
+type ModelAliasIndex = import("../../agents/model-selection.js").ModelAliasIndex;
+
+function emptyAliasIndex(): ModelAliasIndex {
+  return { byAlias: new Map(), byKey: new Map() };
+}
+
 const mocks = vi.hoisted(() => ({
   ensureAgentWorkspace: vi.fn(),
   initSessionState: vi.fn(),
+  loadModelCatalog: vi.fn<LoadModelCatalogFn>(async () => [
+    {
+      provider: "openai",
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      reasoning: true,
+    },
+  ]),
   resolveReplyDirectives: vi.fn(),
 }));
+
+vi.mock("../../agents/model-catalog.js", async () => {
+  const actual = await vi.importActual<typeof import("../../agents/model-catalog.js")>(
+    "../../agents/model-catalog.js",
+  );
+  return {
+    ...actual,
+    loadModelCatalog: mocks.loadModelCatalog,
+  };
+});
 
 vi.mock("../../agents/workspace.js", () => ({
   DEFAULT_AGENT_WORKSPACE_DIR: "/tmp/openclaw-workspace",
@@ -31,11 +56,14 @@ vi.mock("../../agents/workspace.js", () => ({
 registerGetReplyRuntimeOverrides(mocks);
 
 let getReplyFromConfig: typeof import("./get-reply.js").getReplyFromConfig;
+let resolveDefaultModelMock: typeof import("./directive-handling.defaults.js").resolveDefaultModel;
 let loadConfigMock: typeof import("../../config/config.js").getRuntimeConfig;
 let runPreparedReplyMock: typeof import("./get-reply-run.js").runPreparedReply;
 
 async function loadGetReplyRuntimeForTest() {
   ({ getReplyFromConfig } = await loadGetReplyModuleForTest({ cacheKey: import.meta.url }));
+  ({ resolveDefaultModel: resolveDefaultModelMock } =
+    await import("./directive-handling.defaults.js"));
   ({ getRuntimeConfig: loadConfigMock } = await import("../../config/config.js"));
   ({ runPreparedReply: runPreparedReplyMock } = await import("./get-reply-run.js"));
 }
@@ -49,7 +77,22 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
     mocks.ensureAgentWorkspace.mockReset();
     mocks.initSessionState.mockReset();
+    mocks.loadModelCatalog.mockReset();
+    mocks.loadModelCatalog.mockResolvedValue([
+      {
+        provider: "openai",
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        reasoning: true,
+      },
+    ]);
     mocks.resolveReplyDirectives.mockReset();
+    vi.mocked(resolveDefaultModelMock).mockReset();
+    vi.mocked(resolveDefaultModelMock).mockReturnValue({
+      defaultProvider: "openai",
+      defaultModel: "gpt-4o-mini",
+      aliasIndex: emptyAliasIndex(),
+    });
     vi.mocked(loadConfigMock).mockReset();
     vi.mocked(runPreparedReplyMock).mockReset();
     vi.mocked(loadConfigMock).mockReturnValue({});
@@ -220,6 +263,11 @@ describe("getReplyFromConfig fast test bootstrap", () => {
       },
       session: { store: path.join(home, "sessions.json") },
     } as OpenClawConfig);
+    vi.mocked(resolveDefaultModelMock).mockReturnValueOnce({
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      aliasIndex: emptyAliasIndex(),
+    });
 
     const reply = await getReplyFromConfig(
       buildGetReplyCtx({
@@ -240,6 +288,8 @@ describe("getReplyFromConfig fast test bootstrap", () => {
       throw new Error("expected status reply text");
     }
     expect(reply.text.includes("OpenClaw")).toBe(true);
+    expect(reply.text.includes("Think: medium")).toBe(true);
+    expect(mocks.loadModelCatalog).toHaveBeenCalledWith({ config: cfg });
     expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
     expect(mocks.initSessionState).not.toHaveBeenCalled();
     expect(mocks.resolveReplyDirectives).not.toHaveBeenCalled();

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -323,7 +323,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     vi.mocked(resolveDefaultModelMock).mockReturnValueOnce({
       defaultProvider: "openai",
       defaultModel: "gpt-5.5",
-      aliasIndex: new Map(),
+      aliasIndex: emptyAliasIndex(),
     });
 
     const reply = await getReplyFromConfig(

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -296,6 +296,61 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     expect(vi.mocked(runPreparedReplyMock)).not.toHaveBeenCalled();
   });
 
+  it("uses the target session thinking override for native /status", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-status-think-"));
+    const storePath = path.join(home, "sessions.json");
+    const targetSessionKey = "agent:main:telegram:123";
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [targetSessionKey]: {
+          sessionId: "existing-telegram-session",
+          thinkingLevel: "xhigh",
+          updatedAt: 1,
+        },
+      }),
+      "utf8",
+    );
+    const cfg = markCompleteReplyConfig({
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.5",
+          workspace: path.join(home, "workspace"),
+        },
+      },
+      session: { store: storePath },
+    } as OpenClawConfig);
+    vi.mocked(resolveDefaultModelMock).mockReturnValueOnce({
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      aliasIndex: new Map(),
+    });
+
+    const reply = await getReplyFromConfig(
+      buildGetReplyCtx({
+        Body: "/status",
+        BodyForAgent: "/status",
+        RawBody: "/status",
+        CommandBody: "/status",
+        CommandSource: "native",
+        CommandAuthorized: true,
+        SessionKey: "telegram:slash:123",
+        CommandTargetSessionKey: targetSessionKey,
+      }),
+      undefined,
+      cfg,
+    );
+
+    expect(reply).toEqual(
+      expect.objectContaining({ text: expect.stringContaining("Think: xhigh") }),
+    );
+    expect(mocks.loadModelCatalog).not.toHaveBeenCalled();
+    expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
+    expect(mocks.initSessionState).not.toHaveBeenCalled();
+    expect(mocks.resolveReplyDirectives).not.toHaveBeenCalled();
+    expect(vi.mocked(runPreparedReplyMock)).not.toHaveBeenCalled();
+  });
+
   it("handles native slash directives before workspace bootstrap", async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-slash-fast-"));
     const targetSessionKey = "agent:main:telegram:123";

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -296,6 +296,56 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     expect(vi.mocked(runPreparedReplyMock)).not.toHaveBeenCalled();
   });
 
+  it("uses configured agent thinking defaults for native /status", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-status-agent-think-"));
+    const targetSessionKey = "agent:main:telegram:123";
+    const cfg = markCompleteReplyConfig({
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.5",
+          workspace: path.join(home, "workspace"),
+          thinkingDefault: "low",
+        },
+        list: [
+          {
+            id: "main",
+            thinkingDefault: "high",
+          },
+        ],
+      },
+      session: { store: path.join(home, "sessions.json") },
+    } as OpenClawConfig);
+    vi.mocked(resolveDefaultModelMock).mockReturnValueOnce({
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      aliasIndex: emptyAliasIndex(),
+    });
+
+    const reply = await getReplyFromConfig(
+      buildGetReplyCtx({
+        Body: "/status",
+        BodyForAgent: "/status",
+        RawBody: "/status",
+        CommandBody: "/status",
+        CommandSource: "native",
+        CommandAuthorized: true,
+        SessionKey: "telegram:slash:123",
+        CommandTargetSessionKey: targetSessionKey,
+      }),
+      undefined,
+      cfg,
+    );
+
+    expect(reply).toEqual(
+      expect.objectContaining({ text: expect.stringContaining("Think: high") }),
+    );
+    expect(mocks.loadModelCatalog).not.toHaveBeenCalled();
+    expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
+    expect(mocks.initSessionState).not.toHaveBeenCalled();
+    expect(mocks.resolveReplyDirectives).not.toHaveBeenCalled();
+    expect(vi.mocked(runPreparedReplyMock)).not.toHaveBeenCalled();
+  });
+
   it("uses the target session thinking override for native /status", async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-status-think-"));
     const storePath = path.join(home, "sessions.json");


### PR DESCRIPTION
## Summary
- Show the resolved model thinking default in native Telegram `/status` instead of falling through to `off`.
- Preserve explicit Telegram session thinking overrides so `/think high` and `/think xhigh` are reflected in `/status`.
- Hydrate runtime model catalog metadata for Telegram `/think` menus so reasoning-capable models such as `openai/gpt-5.5` show `medium` when no explicit override exists.
- Add sanitized regressions for native `/status`, Telegram session overrides, and Telegram `/think` menu defaults.

## Root Cause
Native Telegram command display paths bypassed the normal agent run default resolver. The native `/status` fast path passed `resolvedThinkLevel: undefined` and a default resolver that returned `undefined`, so the status formatter fell back to `Think: off`. The first default-display fix then passed the model default as an already-resolved value, which masked explicit per-session overrides such as `/think xhigh`. The Telegram `/think` menu used only configured catalog rows; when runtime model metadata was needed to know the selected model supports reasoning, it also fell back to `off`.

## Scope boundary
This changes command status/menu display defaults only. It does not change model execution options, Telegram reasoning visibility settings, or private reasoning text delivery.

## Real behavior proof
Behavior or issue addressed: Telegram native `/status` should show the effective thinking level after `/think default` instead of falling back to `Think: off`; explicit session overrides such as `/think xhigh` should remain visible in `/status`.

Real environment tested: local OpenClaw Telegram DM against the user instance, with redacted user-uploaded Telegram screenshots from the real chat. Screenshots were taken from OpenClaw 2026.5.10-beta.1 builds `83390ad` and `20479bf`.

Exact steps or command run after this patch: In the Telegram DM, send `/think default`, send a normal message to refresh the session, then send `/status` and inspect the returned status bubble.

Evidence after fix: Redacted screenshot proof is posted at https://github.com/openclaw/openclaw/pull/80341#issuecomment-4416050586. Direct redacted after screenshot: https://raw.githubusercontent.com/VACInc/openclaw/telegram-thinking-status-proof-80341-20260510/manual/telegram-thinking-status/pr-80341/2026-05-10-redacted-dm-screenshots/telegram-status-after-redacted.png. Direct redacted before screenshot: https://raw.githubusercontent.com/VACInc/openclaw/telegram-thinking-status-proof-80341-20260510/manual/telegram-thinking-status/pr-80341/2026-05-10-redacted-dm-screenshots/telegram-status-before-redacted.png.

Observed result after fix: The before screenshot shows `/think default` followed by `/status` reporting `Think: off` on `83390ad`. The after screenshot shows `/think default` followed by `/status` reporting `Think: medium` on `20479bf`. Session ID and visible auth/email text were redacted before posting. The later explicit-session override regression covers `Think: xhigh` for a target Telegram session.

What was not tested: No new live Telegram `/think high` or `/think xhigh` manual rerun after the session-override fix; that path is covered by the focused sanitized regression. No full `pnpm check`; validation was limited to the changed-surface gate and focused regressions.

Before evidence optional: Before native `/status`: in a temp before worktree from `origin/main` with only the regression test applied, `pnpm test src/auto-reply/reply/get-reply.fast-path.test.ts -- --reporter=verbose -t "handles native /status before workspace bootstrap"` failed. The sanitized received text included `Model: openai/gpt-5.5` and `Think: off` where the regression expected `Think: medium`.

Before Telegram `/think`: in the same before worktree, `pnpm test extensions/telegram/src/bot-native-commands.session-meta.test.ts -- --reporter=verbose -t "hydrates runtime catalog metadata for thinking menu defaults"` failed with `Number of calls: 0` for `loadModelCatalog({ config })`, proving the menu did not hydrate runtime catalog metadata.

Evidence: After native `/status`: in the temp PR worktree, `pnpm test src/auto-reply/reply/get-reply.fast-path.test.ts -- --reporter=verbose` passed with `14 passed`; the regressions cover sanitized native `/status` showing `Think: medium` for model default, `Think: high` for an explicit configured agent default, and `Think: xhigh` for an explicit Telegram session override.

After Telegram `/think`: in the temp PR worktree, `pnpm test extensions/telegram/src/bot-native-commands.session-meta.test.ts -- --reporter=verbose` passed with `25 passed`; the regression covers Telegram `/think` menu text `Current thinking level: medium.`.

End-to-end changed-surface proof: in the temp PR worktree, `pnpm changed:lanes --json` selected `core`, `coreTests`, `extensions`, and `extensionTests`, and `pnpm check:changed` passed after rebasing onto the current `main` at the time of push. This exercises the touched native Telegram command registration/dispatch/menu path and the auto-reply native slash `/status` fast path with synthetic fixtures and no PII.

## Verification
- `pnpm install` in the temp PR worktree after the initial fresh-worktree attempt reported `Command "oxfmt" not found`.
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/get-reply-native-slash-fast-path.ts src/auto-reply/reply/get-reply.fast-path.test.ts extensions/telegram/src/bot-native-commands.ts extensions/telegram/src/bot-native-commands.session-meta.test.ts` passed.
- `pnpm test src/auto-reply/reply/get-reply.fast-path.test.ts -- --reporter=verbose` passed, `14 passed`.
- `pnpm test extensions/telegram/src/bot-native-commands.session-meta.test.ts -- --reporter=verbose` passed, `25 passed`.
- `pnpm changed:lanes --json` selected the expected core/extensions lanes.
- `pnpm check:changed` passed.
- After rebasing onto current `main` at `97c1fd51`, `pnpm check:test-types` reached `tsgo:extensions:test` and failed on `extensions/feishu/src/monitor.comment.test.ts(831,69): error TS2493`; current `main` CI run `25637033569` fails on the same untouched Feishu test-type error.

## What was not tested
- No new live Telegram `/think high` or `/think xhigh` manual rerun after the session-override fix; that path is covered by the focused sanitized regression.
- No full `pnpm check`; validation was limited to the changed-surface gate and focused regressions.



