### PR TITLE
fix(agents): allow read-only agent mount reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ Docs: https://docs.openclaw.ai
 - Codex app-server: refresh Codex account rate limits after subscription usage-limit failures so Discord and other channel replies can show the next reset time instead of saying Codex returned none. Thanks @pashpashpash.
 - Tasks: route group and channel task completions through the requester session so the parent agent can send the visible summary instead of stopping at a generic task-status line. Fixes #77251. (#77365) Thanks @funmerlin.
 - Telegram: preserve blank lines between manually indented bullet blocks and following numbered sections in rendered replies. Fixes #76998. Thanks @evgyur.
-- Agents/sandbox: allow read-only sandbox sessions to read the `/agent` workspace mount while keeping write/edit/apply_patch workspace-only guarded, restoring `read /agent/...` for `workspaceAccess: "ro"`. Fixes #39497. Thanks @teosborne.
+- Agents/sandbox: allow read-only sandbox sessions to read the `/agent` workspace mount while keeping write/edit/apply_patch workspace-only guarded, restoring `read /agent/...` for `workspaceAccess: "ro"`. Fixes #39497. Thanks @stainlu and @teosborne.
 - Slack: pass configured agent identity through draft preview sends so partial streaming replies keep custom username/avatar on the initial Slack message. Fixes #38235. (#38237) Thanks @lacymorrow.
 - Slack: support `allowBots: "mentions"` for bot-authored messages that mention the receiving bot, matching the documented Discord-style mode without accepting every bot message. Fixes #43587. (#43588) Thanks @raw34.
 - Slack: refresh private file URLs with `files.info` when inbound DM file events omit or stale attachment URLs, preventing file attachments from being dropped before media hydration. Fixes #50129. (#50200) Thanks @smartchainark.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Docs: https://docs.openclaw.ai
 - Codex app-server: refresh Codex account rate limits after subscription usage-limit failures so Discord and other channel replies can show the next reset time instead of saying Codex returned none. Thanks @pashpashpash.
 - Tasks: route group and channel task completions through the requester session so the parent agent can send the visible summary instead of stopping at a generic task-status line. Fixes #77251. (#77365) Thanks @funmerlin.
 - Telegram: preserve blank lines between manually indented bullet blocks and following numbered sections in rendered replies. Fixes #76998. Thanks @evgyur.
+- Agents/sandbox: allow read-only sandbox sessions to read the `/agent` workspace mount while keeping write/edit/apply_patch workspace-only guarded, restoring `read /agent/...` for `workspaceAccess: "ro"`. Fixes #39497. Thanks @teosborne.
 - Slack: pass configured agent identity through draft preview sends so partial streaming replies keep custom username/avatar on the initial Slack message. Fixes #38235. (#38237) Thanks @lacymorrow.
 - Slack: support `allowBots: "mentions"` for bot-authored messages that mention the receiving bot, matching the documented Discord-style mode without accepting every bot message. Fixes #43587. (#43588) Thanks @raw34.
 - Slack: refresh private file URLs with `files.info` when inbound DM file events omit or stale attachment URLs, preventing file attachments from being dropped before media hydration. Fixes #50129. (#50200) Thanks @smartchainark.

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -351,19 +351,15 @@ function mapContainerPathToWorkspaceRoot(params: {
   root: string;
   containerWorkdir?: string;
 }): string {
-  const containerWorkdir = params.containerWorkdir?.trim();
-  if (!containerWorkdir) {
-    return params.filePath;
-  }
-  const normalizedWorkdir = containerWorkdir.replace(/\\/g, "/").replace(/\/+$/, "");
-  if (!normalizedWorkdir.startsWith("/")) {
-    return params.filePath;
-  }
-  if (!normalizedWorkdir) {
-    return params.filePath;
-  }
+  return mapContainerPathToRoot({
+    filePath: params.filePath,
+    root: params.root,
+    containerRoot: params.containerWorkdir,
+  }).filePath;
+}
 
-  let candidate = params.filePath.startsWith("@") ? params.filePath.slice(1) : params.filePath;
+function resolveContainerPathCandidate(filePath: string): string | null {
+  let candidate = filePath.startsWith("@") ? filePath.slice(1) : filePath;
   if (/^file:\/\//i.test(candidate)) {
     const localFilePath = trySafeFileURLToPath(candidate);
     if (localFilePath) {
@@ -375,47 +371,65 @@ function mapContainerPathToWorkspaceRoot(params: {
       try {
         parsed = new URL(candidate);
       } catch {
-        return params.filePath;
+        return filePath;
       }
       if (parsed.protocol !== "file:") {
-        return params.filePath;
+        return filePath;
       }
       const host = parsed.hostname.trim().toLowerCase();
       if (host && host !== "localhost") {
-        return params.filePath;
+        return filePath;
       }
       if (hasEncodedFileUrlSeparator(parsed.pathname)) {
-        return params.filePath;
+        return filePath;
       }
       let normalizedPathname: string;
       try {
         normalizedPathname = decodeURIComponent(parsed.pathname).replace(/\\/g, "/");
       } catch {
-        return params.filePath;
-      }
-      if (
-        normalizedPathname !== normalizedWorkdir &&
-        !normalizedPathname.startsWith(`${normalizedWorkdir}/`)
-      ) {
-        return params.filePath;
+        return filePath;
       }
       candidate = normalizedPathname;
     }
   }
+  return candidate;
+}
+
+function mapContainerPathToRoot(params: {
+  filePath: string;
+  root: string;
+  containerRoot?: string;
+}): { filePath: string; matched: boolean } {
+  const containerRoot = params.containerRoot?.trim();
+  if (!containerRoot) {
+    return { filePath: params.filePath, matched: false };
+  }
+  const normalizedRoot = containerRoot.replace(/\\/g, "/").replace(/\/+$/, "");
+  if (!normalizedRoot.startsWith("/") || !normalizedRoot) {
+    return { filePath: params.filePath, matched: false };
+  }
+
+  const candidate = resolveContainerPathCandidate(params.filePath);
+  if (candidate === null) {
+    return { filePath: params.filePath, matched: false };
+  }
 
   const normalizedCandidate = candidate.replace(/\\/g, "/");
-  if (normalizedCandidate === normalizedWorkdir) {
-    return path.resolve(params.root);
+  if (normalizedCandidate === normalizedRoot) {
+    return { filePath: path.resolve(params.root), matched: true };
   }
-  const prefix = `${normalizedWorkdir}/`;
+  const prefix = `${normalizedRoot}/`;
   if (!normalizedCandidate.startsWith(prefix)) {
-    return candidate;
+    return { filePath: candidate, matched: false };
   }
   const relative = normalizedCandidate.slice(prefix.length);
   if (!relative) {
-    return path.resolve(params.root);
+    return { filePath: path.resolve(params.root), matched: true };
   }
-  return path.resolve(params.root, ...relative.split("/").filter(Boolean));
+  return {
+    filePath: path.resolve(params.root, ...relative.split("/").filter(Boolean)),
+    matched: true,
+  };
 }
 
 export function resolveToolPathAgainstWorkspaceRoot(params: {
@@ -576,6 +590,10 @@ export function wrapToolWorkspaceRootGuardWithOptions(
   tool: AnyAgentTool,
   root: string,
   options?: {
+    additionalContainerMounts?: readonly {
+      containerRoot: string;
+      hostRoot: string;
+    }[];
     containerWorkdir?: string;
     pathParamKeys?: readonly string[];
     normalizeGuardedPathParams?: boolean;
@@ -593,12 +611,32 @@ export function wrapToolWorkspaceRootGuardWithOptions(
         if (typeof filePath !== "string" || !filePath.trim()) {
           continue;
         }
-        const sandboxPath = mapContainerPathToWorkspaceRoot({
+        let guardedRoot = root;
+        const workspaceMapping = mapContainerPathToRoot({
           filePath,
           root,
-          containerWorkdir: options?.containerWorkdir,
+          containerRoot: options?.containerWorkdir,
         });
-        const sandboxResult = await assertSandboxPath({ filePath: sandboxPath, cwd: root, root });
+        let sandboxPath = workspaceMapping.filePath;
+        if (!workspaceMapping.matched) {
+          for (const mount of options?.additionalContainerMounts ?? []) {
+            const mountMapping = mapContainerPathToRoot({
+              filePath,
+              root: mount.hostRoot,
+              containerRoot: mount.containerRoot,
+            });
+            if (mountMapping.matched) {
+              guardedRoot = path.resolve(mount.hostRoot);
+              sandboxPath = mountMapping.filePath;
+              break;
+            }
+          }
+        }
+        const sandboxResult = await assertSandboxPath({
+          filePath: sandboxPath,
+          cwd: guardedRoot,
+          root: guardedRoot,
+        });
         if (options?.normalizeGuardedPathParams && record) {
           normalizedRecord ??= { ...record };
           normalizedRecord[key] = sandboxResult.resolved;

--- a/src/agents/pi-tools.read.workspace-root-guard.test.ts
+++ b/src/agents/pi-tools.read.workspace-root-guard.test.ts
@@ -173,6 +173,40 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
     });
   });
 
+  it("maps additional container mounts to their own guarded host roots", async () => {
+    const { tool } = createToolHarness();
+    const agentRoot = "/tmp/agent-root";
+    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
+      additionalContainerMounts: [{ containerRoot: "/agent", hostRoot: agentRoot }],
+      containerWorkdir: "/workspace",
+    });
+
+    await wrapped.execute("tc-agent-mount", { path: "/agent/docs/readme.md" });
+
+    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
+      filePath: path.resolve(agentRoot, "docs", "readme.md"),
+      cwd: agentRoot,
+      root: agentRoot,
+    });
+  });
+
+  it("maps file URLs under additional container mounts", async () => {
+    const { tool } = createToolHarness();
+    const agentRoot = "/tmp/agent-root";
+    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
+      additionalContainerMounts: [{ containerRoot: "/agent", hostRoot: agentRoot }],
+      containerWorkdir: "/workspace",
+    });
+
+    await wrapped.execute("tc-agent-file-url", { path: "file:///agent/docs/readme.md" });
+
+    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
+      filePath: path.resolve(agentRoot, "docs", "readme.md"),
+      cwd: agentRoot,
+      root: agentRoot,
+    });
+  });
+
   it("does not guard outPath by default", async () => {
     const { tool } = createToolHarness();
     const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {

--- a/src/agents/pi-tools.sandbox-mounted-paths.workspace-only.test.ts
+++ b/src/agents/pi-tools.sandbox-mounted-paths.workspace-only.test.ts
@@ -9,6 +9,7 @@ import {
   createSandboxedWriteTool,
   wrapToolWorkspaceRootGuardWithOptions,
 } from "./pi-tools.read.js";
+import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./sandbox/constants.js";
 import {
   expectReadWriteEditTools,
   expectReadWriteTools,
@@ -68,6 +69,15 @@ function createSandboxFsTools(params: { sandbox: UnsafeMountedSandbox; workspace
   }
   return tools.map((tool) =>
     wrapToolWorkspaceRootGuardWithOptions(tool, params.sandbox.workspaceDir, {
+      additionalContainerMounts:
+        tool.name === "read" && params.sandbox.workspaceAccess === "ro"
+          ? [
+              {
+                containerRoot: SANDBOX_AGENT_WORKSPACE_MOUNT,
+                hostRoot: params.sandbox.agentWorkspaceDir,
+              },
+            ]
+          : undefined,
       containerWorkdir: params.sandbox.containerWorkdir,
     }),
   );
@@ -113,6 +123,34 @@ describe("tools.fs.workspaceOnly", () => {
       ).rejects.toThrow(/Path escapes sandbox root/i);
       expect(await fs.readFile(path.join(agentRoot, "secret.txt"), "utf8")).toBe("shh");
     });
+  });
+
+  it("allows read-only agent workspace mounts for sandbox reads only", async () => {
+    await withUnsafeMountedSandboxHarness(
+      async ({ agentRoot, sandbox }) => {
+        await fs.writeFile(path.join(agentRoot, "secret.txt"), "shh", "utf8");
+
+        const tools = createSandboxFsTools({ sandbox, workspaceOnly: true });
+        const { readTool, writeTool, editTool } = expectReadWriteEditTools(tools);
+
+        const readResult = await readTool?.execute("t1", { path: "/agent/secret.txt" });
+        expect(getTextContent(readResult)).toContain("shh");
+
+        await expect(
+          writeTool?.execute("t2", { path: "/agent/owned.txt", content: "x" }),
+        ).rejects.toThrow(/Path escapes sandbox root/i);
+        const missingOwnedFile = await fs
+          .stat(path.join(agentRoot, "owned.txt"))
+          .catch((error: unknown) => error);
+        expect((missingOwnedFile as NodeJS.ErrnoException).code).toBe("ENOENT");
+
+        await expect(
+          editTool?.execute("t3", { path: "/agent/secret.txt", oldText: "shh", newText: "nope" }),
+        ).rejects.toThrow(/Path escapes sandbox root/i);
+        expect(await fs.readFile(path.join(agentRoot, "secret.txt"), "utf8")).toBe("shh");
+      },
+      { workspaceAccess: "ro" },
+    );
   });
 
   it("enforces apply_patch workspace-only in sandbox mounts by default", async () => {

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -56,6 +56,7 @@ import {
 import { cleanToolSchemaForGemini, normalizeToolParameters } from "./pi-tools.schema.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 import type { SandboxContext } from "./sandbox.js";
+import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./sandbox/constants.js";
 import {
   isSubagentEnvelopeSession,
   resolveSubagentCapabilityStore,
@@ -96,6 +97,29 @@ function isOpenAIProvider(provider?: string) {
 }
 
 const MEMORY_FLUSH_ALLOWED_TOOL_NAMES = new Set(["read", "write"]);
+
+type GuardContainerMount = {
+  containerRoot: string;
+  hostRoot: string;
+};
+
+function readOnlyAgentWorkspaceMount(
+  sandbox: SandboxContext | null | undefined,
+): GuardContainerMount[] | undefined {
+  if (
+    !sandbox ||
+    sandbox.workspaceAccess !== "ro" ||
+    sandbox.agentWorkspaceDir === sandbox.workspaceDir
+  ) {
+    return undefined;
+  }
+  return [
+    {
+      containerRoot: SANDBOX_AGENT_WORKSPACE_MOUNT,
+      hostRoot: sandbox.agentWorkspaceDir,
+    },
+  ];
+}
 
 type BashToolsModule = typeof import("./bash-tools.js");
 
@@ -592,6 +616,7 @@ export function createOpenClawCodingTools(options?: {
           base.push(
             workspaceOnly
               ? wrapToolWorkspaceRootGuardWithOptions(sandboxed, sandboxRoot, {
+                  additionalContainerMounts: readOnlyAgentWorkspaceMount(sandbox),
                   containerWorkdir: sandbox.containerWorkdir,
                 })
               : sandboxed,

--- a/src/agents/test-helpers/unsafe-mounted-sandbox.ts
+++ b/src/agents/test-helpers/unsafe-mounted-sandbox.ts
@@ -49,6 +49,7 @@ function createUnsafeMountedBridge(params: {
 export function createUnsafeMountedSandbox(params: {
   sandboxRoot: string;
   agentRoot: string;
+  workspaceAccess?: "none" | "ro" | "rw";
   workspaceContainerRoot?: string;
 }): SandboxContext {
   const bridge = createUnsafeMountedBridge({
@@ -59,7 +60,7 @@ export function createUnsafeMountedSandbox(params: {
   return createPiToolsSandboxContext({
     workspaceDir: params.sandboxRoot,
     agentWorkspaceDir: params.agentRoot,
-    workspaceAccess: "rw",
+    workspaceAccess: params.workspaceAccess ?? "rw",
     fsBridge: bridge,
     tools: { allow: [], deny: [] },
   });
@@ -67,13 +68,18 @@ export function createUnsafeMountedSandbox(params: {
 
 export async function withUnsafeMountedSandboxHarness(
   run: (ctx: { sandboxRoot: string; agentRoot: string; sandbox: SandboxContext }) => Promise<void>,
+  options?: { workspaceAccess?: "none" | "ro" | "rw" },
 ) {
   const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sbx-mounts-"));
   const sandboxRoot = path.join(stateDir, "sandbox");
   const agentRoot = path.join(stateDir, "agent");
   await fs.mkdir(sandboxRoot, { recursive: true });
   await fs.mkdir(agentRoot, { recursive: true });
-  const sandbox = createUnsafeMountedSandbox({ sandboxRoot, agentRoot });
+  const sandbox = createUnsafeMountedSandbox({
+    sandboxRoot,
+    agentRoot,
+    workspaceAccess: options?.workspaceAccess,
+  });
   try {
     await run({ sandboxRoot, agentRoot, sandbox });
   } finally {


### PR DESCRIPTION
## Summary

- Problem: `workspaceAccess: "ro"` sandbox sessions expose the agent workspace at `/agent`, but the read tool workspace guard only mapped `/workspace` container paths and rejected valid `/agent/...` reads.
- Why it matters: sandboxed agents can be asked to inspect their mounted agent workspace, and read-only sessions should allow reads without broadening mutation access.
- What changed: read-tool guarding now accepts explicitly configured additional container mounts and maps `/agent` to the agent workspace root only for read-only sandbox sessions.
- What did NOT change: write, edit, and apply_patch remain workspace-only guarded and still reject `/agent/...` in this mode.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39497
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: read tool path guard rejected valid `/agent/...` paths in read-only sandbox-mounted sessions.
- Real environment tested: local macOS OpenClaw checkout running the source tool factory with a real temporary filesystem workspace, a separate agent workspace root, and the sandbox fs bridge path mapping used by the tool layer.
- Exact steps or command run after this patch: ran a local `node --import tsx --input-type=module` command that created a read-only sandbox context, wrote `secret.txt` under the agent workspace mount, constructed OpenClaw coding tools with `tools.fs.workspaceOnly`, and invoked the read tool on `/agent/secret.txt`.
- Evidence after fix: console output from that command:

```text
OpenClaw console output: read /agent/secret.txt -> read-ok
OpenClaw console output: workspaceAccess=ro, separateAgentRoot= true
```

- Observed result after fix: OpenClaw read tooling successfully read `/agent/secret.txt` from a separate read-only agent workspace mount.
- What was not tested: full Docker agent session or live provider run, because this change is isolated to deterministic path guard and fs bridge behavior.

## Root Cause

- Root cause: the sandbox workspace root guard knew how to translate the primary container workdir mount into the host sandbox root, but it had no mount-aware path for the read-only agent workspace mount.
- Missing detection / guardrail: coverage existed for workspace-mount reads and mutation blocking, but not the read-only `/agent` mount case from #39497.
- Contributing context: `/agent` is intentionally a separate container mount from `/workspace`, so validating it against the workspace root alone produced a false escape.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-tools.read.workspace-root-guard.test.ts` and `src/agents/pi-tools.sandbox-mounted-paths.workspace-only.test.ts`
- Scenario the test should lock in: extra mount mapping validates against its own host root, and read-only sandbox sessions can read `/agent` while mutation tools cannot write or edit it.
- Why this is the smallest reliable guardrail: it exercises the exact path guard and mounted fs bridge boundary without requiring provider or container scheduling.
- Existing test that already covers this: none for `/agent` read-only mount reads.

## User-visible / Behavior Changes

Read-only sandboxed sessions can read valid `/agent/...` mounted workspace paths again. Mutation behavior is unchanged.

## Diagram

```text
Before:
read /agent/file -> workspace guard checks only /workspace -> rejected as escape

After:
read /agent/file -> read-only agent mount maps to agent workspace root -> read allowed
write/edit /agent/file -> no mutation mount allowance -> rejected as escape
```

## Security Impact

- New permissions/capabilities? Yes
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? Yes
- If any Yes, explain risk + mitigation: this restores read access to the existing read-only `/agent` mount only when the sandbox context already declares `workspaceAccess: "ro"` and the host path is validated against `agentWorkspaceDir`. Mutation tools do not receive this additional mount mapping.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 repo test wrapper, mounted sandbox fs bridge harness
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: sandbox `workspaceAccess: "ro"`, container workdir `/workspace`, agent mount `/agent`

### Steps

1. Create a read-only sandbox context with separate sandbox and agent workspace roots.
2. Write `secret.txt` under the agent workspace root.
3. Run read, write, and edit tools against `/agent/...` paths.

### Expected

- Read succeeds for `/agent/secret.txt`.
- Write and edit reject `/agent/...` as outside the mutable workspace.

### Actual

- Before this patch, read rejected the valid `/agent` path.
- After this patch, read succeeds and mutation still rejects.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

## Human Verification

- Verified scenarios: additional mount path mapping, file URL mapping under `/agent`, read-only sandbox read success, write/edit mutation blocking.
- Edge cases checked: host-root validation remains per mount; workspace mount behavior remains unchanged.
- What you did not verify: full live agent session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: accidentally broadening `/agent` access beyond read-only sessions.
  - Mitigation: the additional mount is only attached for read tools when `workspaceAccess` is `ro`, and regression tests assert write/edit remain blocked.

## Validation

- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/pi-tools.read.ts src/agents/pi-tools.ts src/agents/pi-tools.read.workspace-root-guard.test.ts src/agents/pi-tools.sandbox-mounted-paths.workspace-only.test.ts src/agents/test-helpers/unsafe-mounted-sandbox.ts`
- `git diff --check`
- `pnpm test src/agents/pi-tools.read.workspace-root-guard.test.ts src/agents/pi-tools.sandbox-mounted-paths.workspace-only.test.ts src/agents/pi-tools.create-openclaw-coding-tools.test.ts`
- `pnpm check:changed --base upstream/main` reached core typecheck and test typecheck, then failed in unrelated current-main lint errors in existing test files outside this PR.
- `pnpm check:test-types` currently reproduces unrelated extension test type failures outside this PR in clickclack, diffs, irc, line, lmstudio, nextcloud-talk, qqbot, searxng, and tavily.