### PR TITLE
fix(cron): allow pre-model watchdog tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: allow global and per-job tuning of the isolated agent-turn pre-model watchdog so slow cold-start/auth/context setup can extend or disable that guard without removing the outer job timeout.
 - Agents/image: honor explicit `image` tool model overrides even when `agents.defaults.imageModel` is unset, restoring one-off vision calls for configured multimodal providers. Fixes #79341. Thanks @haumanto.
 - Codex app-server: preserve prompt-local current-turn context through context-engine prompt projection, so replied-to Telegram messages stay visible to the Codex model input.
 - Telegram: pass agent-scoped media roots through gateway message actions so workspace-local media from the active agent is not rejected as cross-agent access. Thanks @frankekn.

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -53,7 +53,7 @@ Cron is the Gateway's built-in scheduler. It persists jobs, wakes the agent at t
 - Isolated cron runs prefer structured execution-denial metadata from the embedded run, then fall back to known final summary/output markers such as `SYSTEM_RUN_DENIED` and `INVALID_REQUEST`, so a blocked command is not reported as a green run.
 - Isolated cron runs also treat run-level agent failures as job errors even when no reply payload is produced, so model/provider failures increment error counters and trigger failure notifications instead of clearing the job as successful.
 - When an isolated agent-turn job reaches `timeoutSeconds`, cron aborts the underlying agent run and gives it a short cleanup window. If the run does not drain, Gateway-owned cleanup force-clears that run's session ownership before cron records the timeout, so queued chat work is not left behind a stale processing session.
-- If an isolated agent-turn stalls before the runner starts or before the first model call, cron records a phase-specific timeout such as `setup timed out before runner start` or `stalled before first model call (last phase: context-engine)`. These watchdogs cover embedded providers and CLI-backed providers before their external CLI process is actually started, and are capped independently from long `timeoutSeconds` values so cold-start/auth/context failures surface quickly instead of waiting for the full job budget.
+- If an isolated agent-turn stalls before the runner starts or before the first model call, cron records a phase-specific timeout such as `setup timed out before runner start` or `stalled before first model call (last phase: context-engine)`. These watchdogs cover embedded providers and CLI-backed providers before their external CLI process is actually started, and are capped independently from long `timeoutSeconds` values so cold-start/auth/context failures surface quickly instead of waiting for the full job budget. Configure the pre-model watchdog globally with `cron.agentTurnWatchdog.preModelTimeoutMs` or per job with `payload.preModelTimeoutMs`; `0` disables only the pre-model watchdog while `timeoutSeconds` still bounds the whole run.
 
 <a id="maintenance"></a>
 
@@ -269,7 +269,7 @@ Query-string tokens are rejected.
       -d '{"message":"Summarize inbox","name":"Email","model":"openai/gpt-5.4"}'
     ```
 
-    Fields: `message` (required), `name`, `agentId`, `wakeMode`, `deliver`, `channel`, `to`, `model`, `fallbacks`, `thinking`, `timeoutSeconds`.
+    Fields: `message` (required), `name`, `agentId`, `wakeMode`, `deliver`, `channel`, `to`, `model`, `fallbacks`, `thinking`, `timeoutSeconds`, `preModelTimeoutMs`.
 
   </Accordion>
   <Accordion title="Mapped hooks (POST /hooks/<name>)">
@@ -407,6 +407,9 @@ Model override note:
       backoffMs: [60000, 120000, 300000],
       retryOn: ["rate_limit", "overloaded", "network", "server_error"],
     },
+    agentTurnWatchdog: {
+      preModelTimeoutMs: 60000, // set 0 to disable only the pre-model watchdog
+    },
     webhookToken: "replace-with-dedicated-webhook-token",
     sessionRetention: "24h",
     runLog: { maxBytes: "2mb", keepLines: 2000 },
@@ -415,6 +418,8 @@ Model override note:
 ```
 
 `maxConcurrentRuns` limits both scheduled cron dispatch and isolated agent-turn execution. Isolated cron agent turns use the queue's dedicated `cron-nested` execution lane internally, so raising this value lets independent cron LLM runs progress in parallel instead of only starting their outer cron wrappers. The shared non-cron `nested` lane is not widened by this setting.
+
+`agentTurnWatchdog.preModelTimeoutMs` sets the global isolated agent-turn pre-model watchdog in milliseconds. Leave it unset to keep the default 60-second or half-job-timeout guard, set it higher for slow cold-start/auth/context setup, or set it to `0` to disable this watchdog while keeping the outer `timeoutSeconds` run limit. Individual jobs can override it with `payload.preModelTimeoutMs`.
 
 The runtime state sidecar is derived from `cron.store`: a `.json` store such as `~/clawd/cron/jobs.json` uses `~/clawd/cron/jobs-state.json`, while a store path without a `.json` suffix appends `-state.json`.
 

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -78,6 +78,10 @@ For CLI-backed providers, the pre-model watchdog stays active until the external
 CLI turn starts, so session lookup, hook, auth, prompt, and CLI setup stalls are
 reported as pre-model cron failures.
 
+Use `--pre-model-timeout-ms <ms>` on `cron add` or `cron edit` to tune the
+pre-model watchdog for one isolated agent-turn job. `0` disables only that
+watchdog; the job's outer `--timeout-seconds` value still bounds the run.
+
 ## Scheduling
 
 ### One-shot jobs
@@ -185,6 +189,12 @@ Enable lightweight bootstrap context for an isolated job:
 
 ```bash
 openclaw cron edit <job-id> --light-context
+```
+
+Disable the pre-model watchdog for a slow cold-start job:
+
+```bash
+openclaw cron edit <job-id> --pre-model-timeout-ms 0
 ```
 
 Announce to a specific channel:

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -377,6 +377,9 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
     enabled: true,
     store: "~/.openclaw/cron/cron.json",
     maxConcurrentRuns: 2, // cron dispatch + isolated cron agent-turn execution
+    agentTurnWatchdog: {
+      preModelTimeoutMs: 60000,
+    },
     sessionRetention: "24h",
     runLog: {
       maxBytes: "2mb",

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1225,6 +1225,9 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
   cron: {
     enabled: true,
     maxConcurrentRuns: 2, // cron dispatch + isolated cron agent-turn execution
+    agentTurnWatchdog: {
+      preModelTimeoutMs: 60000, // set 0 to disable only the pre-model watchdog
+    },
     webhook: "https://example.invalid/legacy", // deprecated fallback for stored notify:true jobs
     webhookToken: "replace-with-dedicated-token", // optional bearer token for outbound webhook auth
     sessionRetention: "24h", // duration string or false
@@ -1237,6 +1240,7 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
 ```
 
 - `sessionRetention`: how long to keep completed isolated cron run sessions before pruning from `sessions.json`. Also controls cleanup of archived deleted cron transcripts. Default: `24h`; set `false` to disable.
+- `agentTurnWatchdog.preModelTimeoutMs`: global isolated agent-turn pre-model watchdog in milliseconds. Unset keeps the default 60-second or half-job-timeout guard; `0` disables this watchdog while the outer job timeout still applies. Per-job `payload.preModelTimeoutMs` overrides this value.
 - `runLog.maxBytes`: max size per run log file (`cron/runs/<jobId>.jsonl`) before pruning. Default: `2_000_000` bytes.
 - `runLog.keepLines`: newest lines retained when run-log pruning is triggered. Default: `2000`.
 - `webhookToken`: bearer token used for cron webhook POST delivery (`delivery.mode = "webhook"`), if omitted no auth header is sent.

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -419,6 +419,9 @@ candidate contains redacted secret placeholders such as `***`.
       cron: {
         enabled: true,
         maxConcurrentRuns: 2, // cron dispatch + isolated cron agent-turn execution
+        agentTurnWatchdog: {
+          preModelTimeoutMs: 60000, // set 0 to disable only the pre-model watchdog
+        },
         sessionRetention: "24h",
         runLog: {
           maxBytes: "2mb",
@@ -429,6 +432,7 @@ candidate contains redacted secret placeholders such as `***`.
     ```
 
     - `sessionRetention`: prune completed isolated run sessions from `sessions.json` (default `24h`; set `false` to disable).
+    - `agentTurnWatchdog.preModelTimeoutMs`: tune the isolated agent-turn pre-model watchdog globally; individual cron job payloads can override it.
     - `runLog`: prune `cron/runs/<jobId>.jsonl` by size and retained lines.
     - See [Cron jobs](/automation/cron-jobs) for feature overview and CLI examples.
 

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -60,6 +60,7 @@ type CronUpdatePatch = {
       message?: string;
       model?: string;
       thinking?: string;
+      preModelTimeoutMs?: number | null;
       lightContext?: boolean;
       toolsAllow?: string[];
     };
@@ -79,6 +80,7 @@ type CronAddParams = {
   payload?: {
     model?: string;
     thinking?: string;
+    preModelTimeoutMs?: number;
     lightContext?: boolean;
     toolsAllow?: string[];
   };
@@ -687,6 +689,23 @@ describe("cron cli", () => {
     expect(params?.payload?.lightContext).toBe(true);
   });
 
+  it("sets preModelTimeoutMs on cron add when --pre-model-timeout-ms is passed", async () => {
+    const params = await runCronAddAndGetParams([
+      "--name",
+      "Custom watchdog",
+      "--cron",
+      "* * * * *",
+      "--session",
+      "isolated",
+      "--message",
+      "hello",
+      "--pre-model-timeout-ms",
+      "0",
+    ]);
+
+    expect(params?.payload?.preModelTimeoutMs).toBe(0);
+  });
+
   it("splits PowerShell-style space-separated --tools on cron add", async () => {
     const params = await runCronAddAndGetParams([
       "--name",
@@ -763,6 +782,23 @@ describe("cron cli", () => {
 
     const clearPatch = await runCronEditAndGetPatch(["--no-light-context", "--message", "hello"]);
     expect(clearPatch?.patch?.payload?.lightContext).toBe(false);
+  });
+
+  it("sets and clears preModelTimeoutMs on cron edit", async () => {
+    const setPatch = await runCronEditAndGetPatch([
+      "--pre-model-timeout-ms",
+      "120000",
+      "--message",
+      "hello",
+    ]);
+    expect(setPatch?.patch?.payload?.preModelTimeoutMs).toBe(120_000);
+
+    const clearPatch = await runCronEditAndGetPatch([
+      "--clear-pre-model-timeout",
+      "--message",
+      "hello",
+    ]);
+    expect(clearPatch?.patch?.payload?.preModelTimeoutMs).toBeNull();
   });
 
   it("updates delivery settings without requiring --message", async () => {

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -9,7 +9,7 @@ import {
 import { theme } from "../../terminal/theme.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
-import { parsePositiveIntOrUndefined } from "../program/helpers.js";
+import { parseNonNegativeIntOrUndefined, parsePositiveIntOrUndefined } from "../program/helpers.js";
 import { resolveCronCreateSchedule } from "./schedule-options.js";
 import {
   getCronChannelOptions,
@@ -108,6 +108,10 @@ export function registerCronAddCommand(cron: Command) {
       )
       .option("--model <model>", "Model override for agent jobs (provider/model or alias)")
       .option("--timeout-seconds <n>", "Timeout seconds for agent jobs")
+      .option(
+        "--pre-model-timeout-ms <ms>",
+        "Pre-model watchdog timeout in ms for isolated agent jobs (0 disables)",
+      )
       .option("--light-context", "Use lightweight bootstrap context for agent jobs", false)
       .option("--tools <list>", "Tool allow-list (e.g. exec,read,write or exec read write)")
       .option("--announce", "Fallback-deliver final text to a chat", false)
@@ -159,6 +163,10 @@ export function registerCronAddCommand(cron: Command) {
               return { kind: "systemEvent" as const, text: systemEvent };
             }
             const timeoutSeconds = parsePositiveIntOrUndefined(opts.timeoutSeconds);
+            const preModelTimeoutMs = parseNonNegativeIntOrUndefined(opts.preModelTimeoutMs);
+            if (opts.preModelTimeoutMs !== undefined && preModelTimeoutMs === undefined) {
+              throw new Error("Invalid --pre-model-timeout-ms (must be a non-negative integer).");
+            }
             return {
               kind: "agentTurn" as const,
               message,
@@ -166,6 +174,7 @@ export function registerCronAddCommand(cron: Command) {
               thinking: normalizeOptionalString(opts.thinking),
               timeoutSeconds:
                 timeoutSeconds && Number.isFinite(timeoutSeconds) ? timeoutSeconds : undefined,
+              preModelTimeoutMs,
               lightContext: opts.lightContext === true ? true : undefined,
               toolsAllow: parseCronToolsAllow(opts.tools),
             };

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -8,6 +8,7 @@ import {
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
+import { parseNonNegativeIntOrUndefined } from "../program/helpers.js";
 import {
   applyExistingCronSchedulePatch,
   resolveCronEditScheduleRequest,
@@ -95,6 +96,11 @@ export function registerCronEditCommand(cron: Command) {
       )
       .option("--model <model>", "Model override for agent jobs")
       .option("--timeout-seconds <n>", "Timeout seconds for agent jobs")
+      .option(
+        "--pre-model-timeout-ms <ms>",
+        "Pre-model watchdog timeout in ms for isolated agent jobs (0 disables)",
+      )
+      .option("--clear-pre-model-timeout", "Use global/default pre-model watchdog timeout", false)
       .option("--light-context", "Enable lightweight bootstrap context for agent jobs")
       .option("--no-light-context", "Disable lightweight bootstrap context for agent jobs")
       .option("--tools <list>", "Tool allow-list (e.g. exec,read,write or exec read write)")
@@ -230,6 +236,14 @@ export function registerCronEditCommand(cron: Command) {
             ? Number.parseInt(String(opts.timeoutSeconds), 10)
             : undefined;
           const hasTimeoutSeconds = Boolean(timeoutSeconds && Number.isFinite(timeoutSeconds));
+          if (opts.preModelTimeoutMs !== undefined && opts.clearPreModelTimeout) {
+            throw new Error("Use --pre-model-timeout-ms or --clear-pre-model-timeout, not both.");
+          }
+          const preModelTimeoutMs = parseNonNegativeIntOrUndefined(opts.preModelTimeoutMs);
+          if (opts.preModelTimeoutMs !== undefined && preModelTimeoutMs === undefined) {
+            throw new Error("Invalid --pre-model-timeout-ms (must be a non-negative integer).");
+          }
+          const hasPreModelTimeoutMs = opts.preModelTimeoutMs !== undefined;
           const hasDeliveryModeFlag = opts.announce || typeof opts.deliver === "boolean";
           const threadId = parseCronThreadIdOption(opts.threadId);
           const hasDeliveryThreadId = typeof threadId === "number";
@@ -242,6 +256,8 @@ export function registerCronEditCommand(cron: Command) {
             Boolean(model) ||
             Boolean(thinking) ||
             hasTimeoutSeconds ||
+            hasPreModelTimeoutMs ||
+            opts.clearPreModelTimeout ||
             typeof opts.lightContext === "boolean" ||
             typeof opts.tools === "string" ||
             Array.isArray(opts.tools) ||
@@ -264,6 +280,8 @@ export function registerCronEditCommand(cron: Command) {
             assignIf(payload, "model", model, Boolean(model));
             assignIf(payload, "thinking", thinking, Boolean(thinking));
             assignIf(payload, "timeoutSeconds", timeoutSeconds, hasTimeoutSeconds);
+            assignIf(payload, "preModelTimeoutMs", preModelTimeoutMs, hasPreModelTimeoutMs);
+            assignIf(payload, "preModelTimeoutMs", null, opts.clearPreModelTimeout);
             assignIf(
               payload,
               "lightContext",

--- a/src/cli/program/helpers.ts
+++ b/src/cli/program/helpers.ts
@@ -25,6 +25,27 @@ export function parsePositiveIntOrUndefined(value: unknown): number | undefined 
   return undefined;
 }
 
+export function parseNonNegativeIntOrUndefined(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      return undefined;
+    }
+    const parsed = Math.trunc(value);
+    return parsed >= 0 ? parsed : undefined;
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isNaN(parsed) || parsed < 0) {
+      return undefined;
+    }
+    return parsed;
+  }
+  return undefined;
+}
+
 export function resolveActionArgs(actionCommand?: Command): string[] {
   if (!actionCommand) {
     return [];

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -130,6 +130,8 @@ const TARGET_KEYS = [
   "cron.enabled",
   "cron.store",
   "cron.maxConcurrentRuns",
+  "cron.agentTurnWatchdog",
+  "cron.agentTurnWatchdog.preModelTimeoutMs",
   "cron.retry",
   "cron.retry.maxAttempts",
   "cron.retry.backoffMs",
@@ -692,6 +694,11 @@ describe("config help copy quality", () => {
     const token = FIELD_HELP["cron.webhookToken"];
     expect(/token|bearer/i.test(token)).toBe(true);
     expect(/secret|env|rotate/i.test(token)).toBe(true);
+
+    const preModel = FIELD_HELP["cron.agentTurnWatchdog.preModelTimeoutMs"];
+    expect(preModel.includes("60s")).toBe(true);
+    expect(preModel.includes("0")).toBe(true);
+    expect(/overall job timeout/i.test(preModel)).toBe(true);
   });
 
   it("documents session send-policy examples and prefix semantics", () => {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1575,6 +1575,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Path to the cron job store file used to persist scheduled jobs across restarts. Set an explicit path only when you need custom storage layout, backups, or mounted volumes.",
   "cron.maxConcurrentRuns":
     "Limits how many cron jobs can execute at the same time when multiple schedules fire together, including isolated agent-turn LLM execution on the dedicated cron-nested lane. Use lower values to protect CPU/memory under heavy automation load, or raise carefully for higher throughput.",
+  "cron.agentTurnWatchdog":
+    "Global watchdog tuning for isolated agent-turn cron jobs. Use this only when model/provider bootstrap is expected to take longer than the default guard.",
+  "cron.agentTurnWatchdog.preModelTimeoutMs":
+    "Milliseconds an isolated agent-turn cron job may spend after runner start before the first model call begins. Omit to keep the default 60s/half-job-timeout guard; set 0 to disable only this pre-model watchdog while the overall job timeout still applies.",
   "cron.retry":
     "Overrides the default retry policy for one-shot jobs when they fail with transient errors (rate limit, overloaded, network, server_error). Omit to use defaults: maxAttempts 3, backoffMs [30000, 60000, 300000], retry all transient types.",
   "cron.retry.maxAttempts":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -767,6 +767,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "cron.enabled": "Cron Enabled",
   "cron.store": "Cron Store Path",
   "cron.maxConcurrentRuns": "Cron Max Concurrent Runs",
+  "cron.agentTurnWatchdog": "Cron Agent Turn Watchdog",
+  "cron.agentTurnWatchdog.preModelTimeoutMs": "Cron Pre-model Watchdog Timeout (ms)",
   "cron.retry": "Cron Retry Policy",
   "cron.retry.maxAttempts": "Cron Retry Max Attempts",
   "cron.retry.backoffMs": "Cron Retry Backoff (ms)",

--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -28,10 +28,21 @@ export type CronFailureDestinationConfig = {
   mode?: "announce" | "webhook";
 };
 
+export type CronAgentTurnWatchdogConfig = {
+  /**
+   * Milliseconds an isolated agent-turn cron job may spend after runner start
+   * before the first model call begins. Omit to keep the default 60s/half-budget
+   * guard; set 0 to disable this pre-model watchdog.
+   */
+  preModelTimeoutMs?: number;
+};
+
 export type CronConfig = {
   enabled?: boolean;
   store?: string;
   maxConcurrentRuns?: number;
+  /** Global watchdog tuning for isolated agent-turn cron jobs. */
+  agentTurnWatchdog?: CronAgentTurnWatchdogConfig;
   /** Override default retry policy for one-shot jobs on transient errors. */
   retry?: CronRetryConfig;
   /**

--- a/src/config/zod-schema.cron-retention.test.ts
+++ b/src/config/zod-schema.cron-retention.test.ts
@@ -2,6 +2,30 @@ import { describe, expect, it } from "vitest";
 import { OpenClawSchema } from "./zod-schema.js";
 
 describe("OpenClawSchema cron retention and run-log validation", () => {
+  it("accepts cron agent-turn watchdog config", () => {
+    expect(
+      OpenClawSchema.safeParse({
+        cron: {
+          agentTurnWatchdog: {
+            preModelTimeoutMs: 120_000,
+          },
+        },
+      }),
+    ).toMatchObject({ success: true });
+  });
+
+  it("rejects negative cron agent-turn pre-model watchdog config", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        cron: {
+          agentTurnWatchdog: {
+            preModelTimeoutMs: -1,
+          },
+        },
+      }),
+    ).toThrow(/agentTurnWatchdog|preModelTimeoutMs/i);
+  });
+
   it("accepts valid cron.sessionRetention and runLog values", () => {
     expect(
       OpenClawSchema.safeParse({

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -685,6 +685,12 @@ export const OpenClawSchema = z
         enabled: z.boolean().optional(),
         store: z.string().optional(),
         maxConcurrentRuns: z.number().int().positive().optional(),
+        agentTurnWatchdog: z
+          .object({
+            preModelTimeoutMs: z.number().int().min(0).optional(),
+          })
+          .strict()
+          .optional(),
         retry: z
           .object({
             maxAttempts: z.number().int().min(0).max(10).optional(),

--- a/src/cron/delivery-field-schemas.ts
+++ b/src/cron/delivery-field-schemas.ts
@@ -30,6 +30,11 @@ export const TimeoutSecondsFieldSchema = z
   .finite()
   .transform((value) => Math.max(0, value));
 
+export const TimeoutMsFieldSchema = z
+  .number()
+  .finite()
+  .transform((value) => Math.max(0, Math.floor(value)));
+
 type ParsedDeliveryInput = {
   mode?: "announce" | "none" | "webhook";
   channel?: string;

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -445,6 +445,7 @@ describe("normalizeCronJobCreate", () => {
       model: " openrouter/deepseek/deepseek-r1 ",
       thinking: " high ",
       timeoutSeconds: 45,
+      preModelTimeoutMs: 120_000,
       toolsAllow: [" exec ", " read "],
       allowUnsafeExternalContent: true,
     }) as unknown as Record<string, unknown>;
@@ -453,6 +454,7 @@ describe("normalizeCronJobCreate", () => {
     expect(payload.model).toBe("openrouter/deepseek/deepseek-r1");
     expect(payload.thinking).toBe("high");
     expect(payload.timeoutSeconds).toBe(45);
+    expect(payload.preModelTimeoutMs).toBe(120_000);
     expect(payload.toolsAllow).toEqual(["exec", "read"]);
     expect(payload.allowUnsafeExternalContent).toBe(true);
     expect(validateCronAddParams(normalized)).toBe(true);
@@ -515,6 +517,18 @@ describe("normalizeCronJobCreate", () => {
     expect(payload.timeoutSeconds).toBe(0);
   });
 
+  it("preserves preModelTimeoutMs=0 for disabled pre-model watchdogs", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "disable pre-model watchdog",
+      schedule: { kind: "every", everyMs: 60_000 },
+      payload: { kind: "agentTurn", message: "hello" },
+      preModelTimeoutMs: 0,
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.preModelTimeoutMs).toBe(0);
+  });
+
   it("preserves fractional timeoutSeconds for short agentTurn deadlines", () => {
     const normalized = normalizeCronJobCreate({
       name: "fractional timeout",
@@ -557,6 +571,7 @@ describe("normalizeCronJobCreate", () => {
         fallbacks: ["openai/gpt-4.1-mini"],
         thinking: "high",
         timeoutSeconds: 45,
+        preModelTimeoutMs: 120_000,
         lightContext: true,
         toolsAllow: ["exec"],
         allowUnsafeExternalContent: true,
@@ -769,6 +784,19 @@ describe("normalizeCronJobPatch", () => {
     expect(payload.lightContext).toBe(true);
   });
 
+  it("infers agentTurn kind for preModelTimeoutMs-only payload patches", () => {
+    const normalized = normalizeCronJobPatch({
+      payload: {
+        preModelTimeoutMs: 120_000,
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.kind).toBe("agentTurn");
+    expect(payload.preModelTimeoutMs).toBe(120_000);
+    expect(validateCronUpdateParams({ id: "job-1", patch: normalized })).toBe(true);
+  });
+
   it("maps top-level fallback lists into agentTurn payload patches", () => {
     const normalized = normalizeCronJobPatch({
       fallbacks: [" openrouter/gpt-4.1-mini ", "anthropic/claude-haiku-3-5"],
@@ -933,6 +961,7 @@ describe("normalizeCronJobPatch", () => {
         fallbacks: ["openai/gpt-4.1-mini"],
         thinking: "high",
         timeoutSeconds: 15,
+        preModelTimeoutMs: 120_000,
         lightContext: true,
         toolsAllow: ["exec"],
         allowUnsafeExternalContent: true,

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -6,6 +6,7 @@ import {
 } from "../shared/string-coerce.js";
 import { isRecord } from "../utils.js";
 import {
+  TimeoutMsFieldSchema,
   TimeoutSecondsFieldSchema,
   TrimmedNonEmptyStringFieldSchema,
   parseDeliveryInput,
@@ -40,6 +41,7 @@ function hasAgentTurnPayloadHint(payload: UnknownRecord) {
     normalizeTrimmedStringArray(payload.toolsAllow, { allowNull: true }) !== undefined ||
     hasTrimmedStringValue(payload.thinking) ||
     typeof payload.timeoutSeconds === "number" ||
+    typeof payload.preModelTimeoutMs === "number" ||
     typeof payload.lightContext === "boolean" ||
     typeof payload.allowUnsafeExternalContent === "boolean"
   );
@@ -221,6 +223,14 @@ function coercePayload(payload: UnknownRecord) {
       delete next.timeoutSeconds;
     }
   }
+  if ("preModelTimeoutMs" in next) {
+    const preModelTimeoutMs = parseOptionalField(TimeoutMsFieldSchema, next.preModelTimeoutMs);
+    if (preModelTimeoutMs !== undefined) {
+      next.preModelTimeoutMs = preModelTimeoutMs;
+    } else {
+      delete next.preModelTimeoutMs;
+    }
+  }
   if ("fallbacks" in next) {
     const fallbacks = normalizeTrimmedStringArray(next.fallbacks);
     if (fallbacks !== undefined) {
@@ -249,6 +259,7 @@ function coercePayload(payload: UnknownRecord) {
     delete next.fallbacks;
     delete next.thinking;
     delete next.timeoutSeconds;
+    delete next.preModelTimeoutMs;
     delete next.lightContext;
     delete next.allowUnsafeExternalContent;
     delete next.toolsAllow;
@@ -382,6 +393,9 @@ function copyTopLevelAgentTurnFields(next: UnknownRecord, payload: UnknownRecord
   if (typeof payload.timeoutSeconds !== "number" && typeof next.timeoutSeconds === "number") {
     payload.timeoutSeconds = next.timeoutSeconds;
   }
+  if (typeof payload.preModelTimeoutMs !== "number" && typeof next.preModelTimeoutMs === "number") {
+    payload.preModelTimeoutMs = next.preModelTimeoutMs;
+  }
   if (!Array.isArray(payload.fallbacks) && Array.isArray(next.fallbacks)) {
     const fallbacks = normalizeTrimmedStringArray(next.fallbacks);
     if (fallbacks !== undefined) {
@@ -411,6 +425,7 @@ function stripLegacyTopLevelFields(next: UnknownRecord) {
   delete next.model;
   delete next.thinking;
   delete next.timeoutSeconds;
+  delete next.preModelTimeoutMs;
   delete next.fallbacks;
   delete next.lightContext;
   delete next.toolsAllow;

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -250,6 +250,44 @@ describe("applyJobPatch", () => {
     }
   });
 
+  it("persists and clears agentTurn payload.preModelTimeoutMs updates", () => {
+    const job = createIsolatedAgentTurnJob("job-pre-model-timeout", {
+      mode: "announce",
+      channel: "telegram",
+    });
+    job.payload = {
+      kind: "agentTurn",
+      message: "do it",
+      preModelTimeoutMs: 60_000,
+    };
+
+    applyJobPatch(job, {
+      payload: {
+        kind: "agentTurn",
+        message: "do it",
+        preModelTimeoutMs: 120_000,
+      },
+    });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.preModelTimeoutMs).toBe(120_000);
+    }
+
+    applyJobPatch(job, {
+      payload: {
+        kind: "agentTurn",
+        message: "do it",
+        preModelTimeoutMs: null,
+      },
+    });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.preModelTimeoutMs).toBeUndefined();
+    }
+  });
+
   it("applies payload.lightContext when replacing payload kind via patch", () => {
     const job = createIsolatedAgentTurnJob("job-light-context-switch", {
       mode: "announce",

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -840,6 +840,11 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
   if (typeof patch.timeoutSeconds === "number") {
     next.timeoutSeconds = patch.timeoutSeconds;
   }
+  if (typeof patch.preModelTimeoutMs === "number") {
+    next.preModelTimeoutMs = patch.preModelTimeoutMs;
+  } else if (patch.preModelTimeoutMs === null) {
+    delete next.preModelTimeoutMs;
+  }
   if (typeof patch.lightContext === "boolean") {
     next.lightContext = patch.lightContext;
   }
@@ -869,6 +874,8 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
     toolsAllow: Array.isArray(patch.toolsAllow) ? patch.toolsAllow : undefined,
     thinking: patch.thinking,
     timeoutSeconds: patch.timeoutSeconds,
+    preModelTimeoutMs:
+      typeof patch.preModelTimeoutMs === "number" ? patch.preModelTimeoutMs : undefined,
     lightContext: patch.lightContext,
     allowUnsafeExternalContent: patch.allowUnsafeExternalContent,
   };

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -49,6 +49,90 @@ function requireTimestamp(value: number | undefined, label: string): number {
   return value;
 }
 
+async function startStalledPreModelRun(params: {
+  id: string;
+  scheduledAt: number;
+  payload: Extract<CronJob["payload"], { kind: "agentTurn" }>;
+  cronConfig?: Parameters<typeof createCronServiceState>[0]["cronConfig"];
+}) {
+  const store = timerRegressionFixtures.makeStorePath();
+  const cronJob = createIsolatedRegressionJob({
+    id: params.id,
+    name: params.id,
+    scheduledAt: params.scheduledAt,
+    schedule: { kind: "at", at: new Date(params.scheduledAt).toISOString() },
+    payload: params.payload,
+    state: { nextRunAtMs: params.scheduledAt },
+  });
+  await writeCronJobs(store.storePath, [cronJob]);
+
+  vi.setSystemTime(params.scheduledAt);
+  let now = params.scheduledAt;
+  const started = createDeferred<void>();
+  let abortObserved = false;
+  const cleanupTimedOutAgentRun = vi.fn(async () => {});
+  const state = createCronServiceState({
+    cronEnabled: true,
+    storePath: store.storePath,
+    cronConfig: params.cronConfig,
+    log: noopLogger,
+    nowMs: () => now,
+    enqueueSystemEvent: vi.fn(),
+    requestHeartbeat: vi.fn(),
+    cleanupTimedOutAgentRun,
+    runIsolatedAgentJob: vi.fn(
+      async ({
+        abortSignal,
+        onExecutionStarted,
+        onExecutionPhase,
+      }: {
+        abortSignal?: AbortSignal;
+        onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
+        onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;
+      }) => {
+        const execution = {
+          jobId: params.id,
+          agentId: "main",
+          sessionId: "cron-run-session",
+          sessionKey: `agent:main:cron:${params.id}:run:cron-run-session`,
+        };
+        onExecutionStarted?.({
+          ...execution,
+          phase: "runner_entered",
+        });
+        onExecutionPhase?.({
+          ...execution,
+          phase: "context_engine",
+        });
+        abortSignal?.addEventListener(
+          "abort",
+          () => {
+            abortObserved = true;
+          },
+          { once: true },
+        );
+        started.resolve();
+        return await new Promise<never>(() => {});
+      },
+    ),
+  });
+
+  const timerPromise = onTimer(state);
+  await started.promise;
+  return {
+    state,
+    timerPromise,
+    cleanupTimedOutAgentRun,
+    get abortObserved() {
+      return abortObserved;
+    },
+    advance: async (ms: number) => {
+      await vi.advanceTimersByTimeAsync(ms);
+      now += ms;
+    },
+  };
+}
+
 describe("cron service timer regressions", () => {
   it("caps timer delay to 60s for far-future schedules", async () => {
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
@@ -1495,6 +1579,116 @@ describe("cron service timer regressions", () => {
         timeoutMs: 1_200_000,
         execution: expect.objectContaining({
           jobId: "isolated-pre-model-timeout-74803",
+          phase: "context_engine",
+        }),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("honors global pre-model watchdog config for isolated agent runs", async () => {
+    vi.useFakeTimers();
+    try {
+      const scheduledAt = Date.parse("2026-05-10T09:10:00.000Z");
+      const run = await startStalledPreModelRun({
+        id: "isolated-pre-model-global-timeout",
+        scheduledAt,
+        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 1_200 },
+        cronConfig: { agentTurnWatchdog: { preModelTimeoutMs: 90_000 } },
+      });
+
+      await run.advance(60_100);
+      expect(run.abortObserved).toBe(false);
+
+      await run.advance(30_000);
+      await run.timerPromise;
+
+      const job = requireJob(run.state, "isolated-pre-model-global-timeout");
+      expect(run.abortObserved).toBe(true);
+      expect(job.state.lastStatus).toBe("error");
+      expect(job.state.lastError).toContain("stalled before first model call");
+      expect(run.cleanupTimedOutAgentRun).toHaveBeenCalledWith({
+        job: expect.objectContaining({ id: "isolated-pre-model-global-timeout" }),
+        timeoutMs: 1_200_000,
+        execution: expect.objectContaining({
+          jobId: "isolated-pre-model-global-timeout",
+          phase: "context_engine",
+        }),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("lets per-job pre-model watchdog config override the global value", async () => {
+    vi.useFakeTimers();
+    try {
+      const scheduledAt = Date.parse("2026-05-10T09:15:00.000Z");
+      const run = await startStalledPreModelRun({
+        id: "isolated-pre-model-job-timeout",
+        scheduledAt,
+        payload: {
+          kind: "agentTurn",
+          message: "work",
+          timeoutSeconds: 120,
+          preModelTimeoutMs: 5_000,
+        },
+        cronConfig: { agentTurnWatchdog: { preModelTimeoutMs: 90_000 } },
+      });
+
+      await run.advance(5_100);
+      await run.timerPromise;
+
+      const job = requireJob(run.state, "isolated-pre-model-job-timeout");
+      expect(run.abortObserved).toBe(true);
+      expect(job.state.lastStatus).toBe("error");
+      expect(job.state.lastError).toContain("stalled before first model call");
+      expect(run.cleanupTimedOutAgentRun).toHaveBeenCalledWith({
+        job: expect.objectContaining({ id: "isolated-pre-model-job-timeout" }),
+        timeoutMs: 120_000,
+        execution: expect.objectContaining({
+          jobId: "isolated-pre-model-job-timeout",
+          phase: "context_engine",
+        }),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("lets per-job config disable only the pre-model watchdog", async () => {
+    vi.useFakeTimers();
+    try {
+      const scheduledAt = Date.parse("2026-05-10T09:20:00.000Z");
+      const run = await startStalledPreModelRun({
+        id: "isolated-pre-model-disabled",
+        scheduledAt,
+        payload: {
+          kind: "agentTurn",
+          message: "work",
+          timeoutSeconds: 120,
+          preModelTimeoutMs: 0,
+        },
+        cronConfig: { agentTurnWatchdog: { preModelTimeoutMs: 5_000 } },
+      });
+
+      await run.advance(60_100);
+      expect(run.abortObserved).toBe(false);
+
+      await run.advance(60_000);
+      await run.timerPromise;
+
+      const job = requireJob(run.state, "isolated-pre-model-disabled");
+      expect(run.abortObserved).toBe(true);
+      expect(job.state.lastStatus).toBe("error");
+      expect(job.state.lastError).toContain("job execution timed out");
+      expect(job.state.lastError).not.toContain("stalled before first model call");
+      expect(run.cleanupTimedOutAgentRun).toHaveBeenCalledWith({
+        job: expect.objectContaining({ id: "isolated-pre-model-disabled" }),
+        timeoutMs: 120_000,
+        execution: expect.objectContaining({
+          jobId: "isolated-pre-model-disabled",
           phase: "context_engine",
         }),
       });

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -54,7 +54,7 @@ export { DEFAULT_JOB_TIMEOUT_MS } from "./timeout-policy.js";
 const MAX_TIMER_DELAY_MS = 60_000;
 const CRON_TIMEOUT_CLEANUP_GUARD_MS = 20_000;
 const CRON_AGENT_SETUP_WATCHDOG_MS = 60_000;
-const CRON_AGENT_PRE_MODEL_WATCHDOG_MS = 60_000;
+const DEFAULT_CRON_AGENT_PRE_MODEL_WATCHDOG_MS = 60_000;
 const CRON_AGENT_PRE_MODEL_MIN_WATCHDOG_MS = 1_000;
 
 /**
@@ -132,6 +132,11 @@ export async function executeJobCoreWithTimeout(
 
   const deferTimeoutUntilExecutionStart =
     job.sessionTarget !== "main" && job.payload.kind === "agentTurn";
+  const preModelWatchdogMs = resolveCronAgentPreModelWatchdogMs({
+    job,
+    jobTimeoutMs,
+    cronConfig: state.deps.cronConfig,
+  });
   const triggerTimeout = (reason: string) => {
     if (runAbortController.signal.aborted) {
       return;
@@ -163,14 +168,14 @@ export async function executeJobCoreWithTimeout(
     setupTimeoutId = undefined;
   };
   const startPreModelTimeout = () => {
-    if (preModelTimeoutId || modelCallStarted) {
+    if (preModelTimeoutId || modelCallStarted || preModelWatchdogMs === undefined) {
       return;
     }
     preModelTimeoutId = setTimeout(() => {
       if (!modelCallStarted) {
         triggerTimeout(preModelTimeoutErrorMessage(activeExecution));
       }
-    }, resolveCronAgentPreModelWatchdogMs(jobTimeoutMs));
+    }, preModelWatchdogMs);
   };
   const clearPreModelTimeout = () => {
     if (!preModelTimeoutId) {
@@ -197,15 +202,15 @@ export async function executeJobCoreWithTimeout(
   const onExecutionPhase = (info: CronAgentExecutionPhaseUpdate) => {
     noteExecutionProgress(info);
   };
-  const corePromise = executeJobCore(state, job, runAbortController.signal, {
-    onExecutionStarted: deferTimeoutUntilExecutionStart ? onExecutionStarted : undefined,
-    onExecutionPhase: deferTimeoutUntilExecutionStart ? onExecutionPhase : undefined,
-  });
   if (!deferTimeoutUntilExecutionStart) {
     startTimeout();
   } else {
     startSetupTimeout();
   }
+  const corePromise = executeJobCore(state, job, runAbortController.signal, {
+    onExecutionStarted: deferTimeoutUntilExecutionStart ? onExecutionStarted : undefined,
+    onExecutionPhase: deferTimeoutUntilExecutionStart ? onExecutionPhase : undefined,
+  });
   void corePromise.catch((err) => {
     if (runAbortController.signal.aborted) {
       state.deps.log.warn(
@@ -300,10 +305,34 @@ function formatCronAgentExecutionPhase(execution?: CronAgentExecutionStarted): s
   return execution?.phase?.replaceAll("_", "-");
 }
 
-function resolveCronAgentPreModelWatchdogMs(jobTimeoutMs: number): number {
+function normalizeCronAgentPreModelWatchdogMs(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+function resolveCronAgentPreModelWatchdogMs(params: {
+  job: CronJob;
+  jobTimeoutMs: number;
+  cronConfig?: CronConfig;
+}): number | undefined {
+  const jobOverride =
+    params.job.payload.kind === "agentTurn"
+      ? normalizeCronAgentPreModelWatchdogMs(params.job.payload.preModelTimeoutMs)
+      : undefined;
+  const configured =
+    jobOverride ??
+    normalizeCronAgentPreModelWatchdogMs(params.cronConfig?.agentTurnWatchdog?.preModelTimeoutMs);
+  if (configured === 0) {
+    return undefined;
+  }
+  if (configured !== undefined) {
+    return Math.max(CRON_AGENT_PRE_MODEL_MIN_WATCHDOG_MS, configured);
+  }
   return Math.max(
     CRON_AGENT_PRE_MODEL_MIN_WATCHDOG_MS,
-    Math.min(CRON_AGENT_PRE_MODEL_WATCHDOG_MS, Math.floor(jobTimeoutMs / 2)),
+    Math.min(DEFAULT_CRON_AGENT_PRE_MODEL_WATCHDOG_MS, Math.floor(params.jobTimeoutMs / 2)),
   );
 }
 

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -176,6 +176,11 @@ type CronAgentTurnPayloadFields = {
   fallbacks?: string[];
   thinking?: string;
   timeoutSeconds?: number;
+  /**
+   * Milliseconds allowed after isolated runner start before the first model call.
+   * Omit to use global/default policy; set 0 to disable this pre-model watchdog.
+   */
+  preModelTimeoutMs?: number;
   allowUnsafeExternalContent?: boolean;
   /** Immutable external hook provenance for async dispatch. */
   externalContentSource?: HookExternalContentSource;
@@ -191,8 +196,9 @@ type CronAgentTurnPayload = {
 
 type CronAgentTurnPayloadPatch = {
   kind: "agentTurn";
-} & Partial<Omit<CronAgentTurnPayloadFields, "toolsAllow">> & {
+} & Partial<Omit<CronAgentTurnPayloadFields, "toolsAllow" | "preModelTimeoutMs">> & {
     toolsAllow?: string[] | null;
+    preModelTimeoutMs?: number | null;
   };
 export type CronJobState = {
   nextRunAtMs?: number;

--- a/src/gateway/protocol/cron-validators.test.ts
+++ b/src/gateway/protocol/cron-validators.test.ts
@@ -44,6 +44,31 @@ describe("cron protocol validators", () => {
     ).toBe(true);
   });
 
+  it("accepts agent-turn pre-model watchdog config on add and update params", () => {
+    expect(
+      validateCronAddParams({
+        ...minimalAddParams,
+        sessionTarget: "isolated",
+        payload: {
+          kind: "agentTurn",
+          message: "tick",
+          preModelTimeoutMs: 120_000,
+        },
+      }),
+    ).toBe(true);
+    expect(
+      validateCronUpdateParams({
+        id: "job-1",
+        patch: {
+          payload: {
+            kind: "agentTurn",
+            preModelTimeoutMs: null,
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("rejects add params when required scheduling fields are missing", () => {
     const { wakeMode: _wakeMode, ...withoutWakeMode } = minimalAddParams;
     expect(validateCronAddParams(withoutWakeMode)).toBe(false);

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -1,7 +1,11 @@
 import { Type, type TSchema } from "typebox";
 import { NonEmptyString } from "./primitives.js";
 
-function cronAgentTurnPayloadSchema(params: { message: TSchema; toolsAllow: TSchema }) {
+function cronAgentTurnPayloadSchema(params: {
+  message: TSchema;
+  toolsAllow: TSchema;
+  preModelTimeoutMs?: TSchema;
+}) {
   return Type.Object(
     {
       kind: Type.Literal("agentTurn"),
@@ -10,6 +14,7 @@ function cronAgentTurnPayloadSchema(params: { message: TSchema; toolsAllow: TSch
       fallbacks: Type.Optional(Type.Array(Type.String())),
       thinking: Type.Optional(Type.String()),
       timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
+      preModelTimeoutMs: Type.Optional(params.preModelTimeoutMs ?? Type.Number({ minimum: 0 })),
       allowUnsafeExternalContent: Type.Optional(Type.Boolean()),
       lightContext: Type.Optional(Type.Boolean()),
       toolsAllow: Type.Optional(params.toolsAllow),
@@ -193,6 +198,7 @@ export const CronPayloadPatchSchema = Type.Union([
   cronAgentTurnPayloadSchema({
     message: Type.Optional(NonEmptyString),
     toolsAllow: Type.Union([Type.Array(Type.String()), Type.Null()]),
+    preModelTimeoutMs: Type.Union([Type.Number({ minimum: 0 }), Type.Null()]),
   }),
 ]);
 


### PR DESCRIPTION
## Summary

- Add a global `cron.agentTurnWatchdog.preModelTimeoutMs` config knob and a per-cron `payload.preModelTimeoutMs` override for isolated `agentTurn` cron jobs.
- Preserve the existing default when unset: pre-model timeout remains capped at `min(60000, jobTimeout / 2)` with the existing 1s floor.
- Allow `0` to disable only the pre-model watchdog; the outer cron job `timeoutSeconds` budget still applies.
- Wire the knob through config schema/help/labels, cron normalization/storage, Gateway cron protocol validators, CLI add/edit flags, docs, and regression tests.
- Arm the setup/outer timeout before job core execution so synchronous runner-start callbacks can clear setup timing reliably before custom pre-model timing begins.

## Root Cause

The isolated cron agent turn watchdog was hardcoded to 60 seconds:

```ts
const CRON_AGENT_PRE_MODEL_WATCHDOG_MS = 60_000;
```

The effective pre-model deadline was then capped to `min(60000, jobTimeout / 2)`, so raising `payload.timeoutSeconds` could not give a slow model backend more startup time before the first model event. There was no global config key, no per-cron payload field, and no CLI/protocol schema support for overriding that behavior.

While adding the knob, the existing timeout setup also showed a race: `executeJobCoreWithTimeout` armed the setup/outer timeout after entering `executeJobCore`, but `executeJobCore` can invoke the runner-start callback synchronously. That meant setup timing could remain armed even after the run had moved into the pre-model phase.

## Real behavior proof

Behavior or issue addressed: isolated `agentTurn` cron jobs now honor both the global `cron.agentTurnWatchdog.preModelTimeoutMs` setting and the per-job `payload.preModelTimeoutMs` override. A value of `0` disables only the pre-model watchdog; the outer `payload.timeoutSeconds` budget still applies.

Real environment tested: disposable local OpenClaw Gateway from PR head `baf5648c43f9b40d98b1b96eade6ac03e6916fa0` on Linux, with scratch `OPENCLAW_CONFIG_PATH`, scratch `OPENCLAW_HOME`, a scratch plugin, and a scratch OpenAI-compatible probe server. No existing cron definitions were read or executed.

Exact steps or command run after this patch: started the scratch Gateway with this relevant config, connected over the real Gateway WebSocket RPC path, created two future-scheduled isolated `agentTurn` cron jobs with `cron.add`, and forced each with `cron.run`. Both jobs used `timeoutSeconds: 5`. The scratch plugin slept for 2500 ms in `before_agent_reply` before any model call. Job A left `payload.preModelTimeoutMs` unset so it used the global 1000 ms setting; Job B set `payload.preModelTimeoutMs: 0`.

```json
{
  "cron": { "enabled": true, "agentTurnWatchdog": { "preModelTimeoutMs": 1000 } },
  "plugins.entries.cron-proof-delay.hooks.timeouts.before_agent_reply": 5000,
  "models.providers.proof.baseUrl": "http://127.0.0.1:<scratch-port>/v1",
  "agents.defaults.model.primary": "proof/proof-model"
}
```

Evidence after fix: terminal output from the scratch Gateway run:

```json
{
  "configProof": {
    "globalPreModelTimeoutMs": 1000,
    "pluginHookTimeoutMs": 5000,
    "hookSleepMs": 2500,
    "outerJobTimeoutSeconds": 5
  },
  "jobs": [
    {
      "name": "proof-global-premodel-watchdog",
      "payloadPreModelTimeoutMs": "unset, uses global 1000ms",
      "runLogEntry": {
        "status": "error",
        "deliveryStatus": "not-requested",
        "error": "cron: isolated agent run stalled before first model call (last phase: runtime-plugins)",
        "diagnostics": {
          "summary": "cron: isolated agent run stalled before first model call (last phase: runtime-plugins)"
        }
      }
    },
    {
      "name": "proof-job-disable-premodel-watchdog",
      "payloadPreModelTimeoutMs": 0,
      "runLogEntry": {
        "status": "ok",
        "summary": "cron proof delayed hook completed",
        "deliveryStatus": "not-requested"
      }
    }
  ]
}
```

Gateway runtime log excerpt:

```text
[gateway] http server listening (1 plugin: cron-proof-delay; 1.1s)
[cron-proof-delay] before_agent_reply sleeping 2500ms before model call
[cron-proof-delay] before_agent_reply completed 2500ms sleep
[cron-proof-delay] before_agent_reply sleeping 2500ms before model call
[cron-proof-delay] before_agent_reply completed 2500ms sleep
[model-server] listening on <scratch-port>
[model-server] GET /v1/models
```

Observed result after fix: the global-only job failed with the expected pre-model watchdog error after the 2500 ms pre-model hook exceeded the configured 1000 ms global budget. The otherwise identical job with per-job `preModelTimeoutMs: 0` completed successfully and returned `cron proof delayed hook completed` before the 5 second outer job timeout. Delivery was not requested, and the probe server did not receive a chat completion call.

What was not tested: no existing/local user cron definitions, private agent config, or external provider was used. The proof intentionally used a disposable local Gateway, scratch config, scratch plugin, and scratch model probe. The focused automated tests below cover schema, normalization/storage, CLI flags, Gateway protocol validation, and fake-timer boundary cases.


## Verification

Dependencies were missing in the tmp worktree at first: `pnpm exec tsx` could not find `tsx`, and `pnpm test` could not find `vitest/package.json`. I ran `pnpm install` once, then reran validation successfully.

Pre-push proof passed:

```bash
pnpm docs:list
pnpm format:docs:check
pnpm exec oxfmt --check --threads=1 src/cli/cron-cli.test.ts src/cli/cron-cli/register.cron-add.ts src/cli/cron-cli/register.cron-edit.ts src/cli/program/helpers.ts src/config/schema.help.quality.test.ts src/config/schema.help.ts src/config/schema.labels.ts src/config/types.cron.ts src/config/zod-schema.cron-retention.test.ts src/config/zod-schema.ts src/cron/delivery-field-schemas.ts src/cron/normalize.test.ts src/cron/normalize.ts src/cron/service.jobs.test.ts src/cron/service/jobs.ts src/cron/service/timer.regression.test.ts src/cron/service/timer.ts src/cron/types.ts src/gateway/protocol/cron-validators.test.ts src/gateway/protocol/schema/cron.ts
pnpm tsgo:core
pnpm tsgo:core:test
git diff --check
pnpm check:changed
```

Focused tests passed after the final rebase:

```bash
pnpm test src/config/zod-schema.cron-retention.test.ts src/config/schema.help.quality.test.ts src/cron/normalize.test.ts src/cron/service.jobs.test.ts src/gateway/protocol/cron-validators.test.ts src/cli/cron-cli.test.ts src/cron/service/timer.regression.test.ts -- --run
```

Result: 5 Vitest shards passed in 9.55s:

- tooling: 1 file, 22 tests
- gateway: 1 file, 13 tests
- runtime-config: 1 file, 5 tests
- cron: 3 files, 152 tests
- cli: 1 file, 68 tests

Post-`oc-update` proof passed after applying PR #80361 locally. No existing cron definitions were read or executed for this proof.

```bash
oc-update
pnpm exec tsx -e 'import { OpenClawSchema } from "./src/config/zod-schema.ts"; const result = OpenClawSchema.safeParse({ cron: { agentTurnWatchdog: { preModelTimeoutMs: 120000 } } }); console.log(JSON.stringify({ accepted: result.success, issues: result.success ? [] : result.error.issues.map((issue) => ({ path: issue.path.join("."), message: issue.message })) }, null, 2));'
pnpm test src/config/zod-schema.cron-retention.test.ts src/cron/normalize.test.ts src/cron/service.jobs.test.ts src/gateway/protocol/cron-validators.test.ts src/cli/cron-cli.test.ts src/cron/service/timer.regression.test.ts -- --run
pnpm openclaw cron add --help | rg -- '--pre-model-timeout-ms'
pnpm openclaw cron edit --help | rg -- '--pre-model-timeout-ms|--clear-pre-model-timeout'
git diff --check
```

Post-`oc-update` results:

- `oc-update` applied PR #80361, installed dependencies, built core/UI, linked the CLI, reinstalled the daemon, ran the health check, and completed security audit with 0 critical findings.
- Schema command returned `{ "accepted": true, "issues": [] }`.
- Focused tests passed: 4 Vitest shards, 227 tests, 10.56s.
- `cron add --help` exposes `--pre-model-timeout-ms <ms>`.
- `cron edit --help` exposes `--pre-model-timeout-ms <ms>` and `--clear-pre-model-timeout`.
- `git diff --check` passed.

## What was not tested

- No existing/local user cron definitions, private agent config, or external provider was used for live proof; the real behavior proof uses a disposable local Gateway with scratch state and scratch plugin/model probe only.
- `pnpm test:changed` is currently blocked by unrelated agents shard failures. I reproduced the same representative failures on a clean `origin/main` worktree at `848c28537b`, including missing mock exports for `normalizeProviderCatalogModelsForConfig` and `syncPersistedExternalCliAuthProfiles`, plus an unrelated embedded subscribe expectation mismatch.
- Full repo-wide `pnpm format:check` is not clean on the current baseline. Scoped `oxfmt` over touched TypeScript files and `pnpm format:docs:check` both pass.
