### PR TITLE
Fix Opik visibility for Codex-native tool completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - Auth/Claude CLI: persist fresher managed external CLI OAuth credentials back to `auth-profiles.json`, preventing stale `anthropic:claude-cli` profiles from repeatedly bootstrapping and flooding debug logs. Fixes #80129. Thanks @Caulderein.
 - Context: render `/context map` only from actual run context and persist Codex app-server run reports without counting deferred tool-search schemas as prompt-loaded tool schemas.
 - Codex app-server: report Codex-native tool execution to diagnostics so long-running native `bash`, web, file, and MCP tools no longer look like stale embedded runs to the watchdog. (#80217)
+- Codex app-server: emit async `after_tool_call` observations for native tool completions not covered by the native hook relay so observability plugins can record Codex-native tools.
 - Tasks: route group and channel task completions through the requester session so the parent agent can send the visible summary instead of stopping at a generic task-status line. Fixes #77251. (#77365) Thanks @funmerlin.
 - Telegram: preserve blank lines between manually indented bullet blocks and following numbered sections in rendered replies. Fixes #76998. Thanks @evgyur.
 - Slack: pass configured agent identity through draft preview sends so partial streaming replies keep custom username/avatar on the initial Slack message. Fixes #38235. (#38237) Thanks @lacymorrow.

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -80,6 +80,11 @@ OpenClaw can mirror selected events, but it cannot rewrite the native Codex
 thread unless Codex exposes that operation through app-server or native hook
 callbacks.
 
+Codex app-server item notifications also provide async `after_tool_call`
+observations for native tool completions that are not already covered by the
+native `PostToolUse` relay. These observations are for telemetry and plugin
+compatibility only; they cannot block, delay, or mutate the native tool call.
+
 Compaction and LLM lifecycle projections come from Codex app-server
 notifications and OpenClaw adapter state, not native Codex hook commands.
 OpenClaw's `before_compaction`, `after_compaction`, `llm_input`, and

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -17,6 +17,7 @@ import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtim
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CodexAppServerEventProjector,
+  type CodexAppServerEventProjectorOptions,
   type CodexAppServerToolTelemetry,
 } from "./event-projector.js";
 import { rememberCodexRateLimits, resetCodexRateLimitCacheForTests } from "./rate-limit-cache.js";
@@ -72,9 +73,10 @@ async function createParams(): Promise<EmbeddedRunAttemptParams> {
 
 async function createProjector(
   params?: EmbeddedRunAttemptParams,
+  options?: CodexAppServerEventProjectorOptions,
 ): Promise<CodexAppServerEventProjector> {
   const resolvedParams = params ?? (await createParams());
-  return new CodexAppServerEventProjector(resolvedParams, THREAD_ID, TURN_ID);
+  return new CodexAppServerEventProjector(resolvedParams, THREAD_ID, TURN_ID, options);
 }
 
 async function createProjectorWithAssistantHooks() {
@@ -1005,6 +1007,134 @@ describe("CodexAppServerEventProjector", () => {
         toolCallId: "cmd-declined",
       },
     ]);
+  });
+
+  it("emits after_tool_call observations for Codex-native tool item completions", async () => {
+    const afterToolCall = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "after_tool_call", handler: afterToolCall }]),
+    );
+    const projector = await createProjector({
+      ...(await createParams()),
+      agentId: "main",
+      sessionKey: "agent:main:session-1",
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-observed",
+          command: "pnpm test extensions/codex",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "inProgress",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-observed",
+          command: "pnpm test extensions/codex",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: "ok",
+          exitCode: 0,
+          durationMs: 42,
+        },
+      }),
+    );
+
+    await vi.waitFor(() => expect(afterToolCall).toHaveBeenCalledTimes(1));
+    const event = requireRecord(
+      mockCallArg(afterToolCall, 0, 0, "after_tool_call event"),
+      "after_tool_call event",
+    );
+    expect(event).toMatchObject({
+      toolName: "bash",
+      params: { command: "pnpm test extensions/codex", cwd: "/workspace" },
+      runId: "run-1",
+      toolCallId: "cmd-observed",
+      result: { status: "completed", exitCode: 0, durationMs: 42 },
+    });
+    expect(event.durationMs).toBeGreaterThanOrEqual(42);
+    const context = requireRecord(
+      mockCallArg(afterToolCall, 0, 1, "after_tool_call context"),
+      "after_tool_call context",
+    );
+    expect(context).toMatchObject({
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      runId: "run-1",
+      toolName: "bash",
+      toolCallId: "cmd-observed",
+    });
+  });
+
+  it("does not duplicate native items already covered by PostToolUse relay", async () => {
+    const afterToolCall = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "after_tool_call", handler: afterToolCall }]),
+    );
+    const projector = await createProjector(
+      { ...(await createParams()), sessionKey: "agent:main:session-1" },
+      { nativePostToolUseRelayEnabled: true },
+    );
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-relayed",
+          command: "pnpm test extensions/codex",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: "ok",
+          exitCode: 0,
+          durationMs: 42,
+        },
+      }),
+    );
+    expect(afterToolCall).not.toHaveBeenCalled();
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "webSearch",
+          id: "search-observed",
+          query: "opik openclaw codex",
+          status: "completed",
+          durationMs: 5,
+        },
+      }),
+    );
+
+    await vi.waitFor(() => expect(afterToolCall).toHaveBeenCalledTimes(1));
+    const event = requireRecord(
+      mockCallArg(afterToolCall, 0, 0, "after_tool_call event"),
+      "after_tool_call event",
+    );
+    expect(event).toMatchObject({
+      toolName: "web_search",
+      params: { query: "opik openclaw codex" },
+      runId: "run-1",
+      toolCallId: "search-observed",
+      result: { status: "completed" },
+    });
   });
 
   it("records dynamic OpenClaw tool calls in mirrored transcript snapshots", async () => {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -9,6 +9,7 @@ import {
   inferToolMetaFromArgs,
   normalizeUsage,
   runAgentHarnessAfterCompactionHook,
+  runAgentHarnessAfterToolCallHook,
   runAgentHarnessBeforeCompactionHook,
   TOOL_PROGRESS_OUTPUT_MAX_CHARS,
   type AgentMessage,
@@ -48,6 +49,10 @@ export type CodexAppServerToolTelemetry = {
   toolMediaUrls?: string[];
   toolAudioAsVoice?: boolean;
   successfulCronAdds?: number;
+};
+
+export type CodexAppServerEventProjectorOptions = {
+  nativePostToolUseRelayEnabled?: boolean;
 };
 
 const ZERO_USAGE: Usage = {
@@ -118,6 +123,7 @@ export class CodexAppServerEventProjector {
   private readonly toolTranscriptResultIds = new Set<string>();
   private readonly nativeGeneratedMediaUrls = new Set<string>();
   private readonly diagnosticToolStartedAtByItem = new Map<string, number>();
+  private readonly afterToolCallObservedItemIds = new Set<string>();
   private assistantStarted = false;
   private reasoningStarted = false;
   private reasoningEnded = false;
@@ -134,6 +140,7 @@ export class CodexAppServerEventProjector {
     private readonly params: EmbeddedRunAttemptParams,
     private readonly threadId: string,
     private readonly turnId: string,
+    private readonly options: CodexAppServerEventProjectorOptions = {},
   ) {}
 
   async handleNotification(notification: CodexServerNotification): Promise<void> {
@@ -609,6 +616,7 @@ export class CodexAppServerEventProjector {
       this.recordToolMeta(item);
       this.recordNativeToolTranscriptCall(item);
       this.recordNativeToolTranscriptResult(item);
+      this.emitAfterToolCallObservation(item);
       this.emitToolResultSummary(item);
       this.emitToolResultOutput(item);
     }
@@ -786,6 +794,9 @@ export class CodexAppServerEventProjector {
           : {}),
       },
     });
+    if (params.phase === "result") {
+      this.emitAfterToolCallObservation(item);
+    }
   }
 
   private emitDiagnosticToolExecutionEvent(params: {
@@ -834,6 +845,53 @@ export class CodexAppServerEventProjector {
               durationMs,
             };
     emitTrustedDiagnosticEvent({ ...base, ...terminalEvent });
+  }
+
+  private emitAfterToolCallObservation(item: CodexThreadItem): void {
+    if (!this.shouldEmitAfterToolCallObservation(item)) {
+      return;
+    }
+    const name = itemName(item);
+    if (!name) {
+      return;
+    }
+    const status = itemStatus(item);
+    if (status === "running") {
+      return;
+    }
+    this.afterToolCallObservedItemIds.add(item.id);
+    const result = itemToolResult(item).result;
+    const error = itemToolError(item, status);
+    const startedAt =
+      typeof item.durationMs === "number" ? Date.now() - Math.max(0, item.durationMs) : undefined;
+    const hookParams = {
+      toolName: name,
+      toolCallId: item.id,
+      runId: this.params.runId,
+      agentId: this.params.agentId,
+      sessionId: this.params.sessionId,
+      sessionKey: this.params.sessionKey,
+      startArgs: itemToolArgs(item) ?? {},
+      ...(result !== undefined ? { result } : {}),
+      ...(error ? { error } : {}),
+      ...(startedAt !== undefined ? { startedAt } : {}),
+    };
+    setImmediate(() => {
+      void runAgentHarnessAfterToolCallHook(hookParams);
+    });
+  }
+
+  private shouldEmitAfterToolCallObservation(item: CodexThreadItem): boolean {
+    if (
+      !shouldSynthesizeToolProgressForItem(item) ||
+      this.afterToolCallObservedItemIds.has(item.id)
+    ) {
+      return false;
+    }
+    if (this.options.nativePostToolUseRelayEnabled && isNativePostToolUseRelayItem(item)) {
+      return false;
+    }
+    return true;
   }
 
   private emitToolResultSummary(item: CodexThreadItem | undefined): void {
@@ -1393,6 +1451,17 @@ function shouldSynthesizeToolProgressForItem(item: CodexThreadItem): boolean {
   }
 }
 
+function isNativePostToolUseRelayItem(item: CodexThreadItem): boolean {
+  switch (item.type) {
+    case "commandExecution":
+    case "fileChange":
+    case "mcpToolCall":
+      return true;
+    default:
+      return false;
+  }
+}
+
 function shouldSuppressChannelProgressForItem(item: CodexThreadItem): boolean {
   if (shouldSynthesizeToolProgressForItem(item)) {
     return true;
@@ -1408,6 +1477,11 @@ function itemToolArgs(item: CodexThreadItem): Record<string, unknown> | undefine
     return sanitizeCodexAgentEventRecord({
       command: item.command,
       ...(typeof item.cwd === "string" ? { cwd: item.cwd } : {}),
+    });
+  }
+  if (item.type === "fileChange") {
+    return sanitizeCodexAgentEventRecord({
+      changes: itemFileChanges(item),
     });
   }
   if (item.type === "webSearch" && typeof item.query === "string") {
@@ -1433,7 +1507,7 @@ function itemToolResult(item: CodexThreadItem): { result?: Record<string, unknow
     return {
       result: sanitizeCodexAgentEventRecord({
         status: item.status,
-        changes: item.changes.map((change) => ({ path: change.path, kind: change.kind })),
+        changes: itemFileChanges(item),
       }),
     };
   }
@@ -1451,6 +1525,25 @@ function itemToolResult(item: CodexThreadItem): { result?: Record<string, unknow
     return { result: sanitizeCodexAgentEventRecord({ status: "completed" }) };
   }
   return {};
+}
+
+function itemFileChanges(item: CodexThreadItem): Array<{ path: string; kind: string }> {
+  return Array.isArray(item.changes)
+    ? item.changes.map((change) => ({ path: change.path, kind: change.kind }))
+    : [];
+}
+
+function itemToolError(
+  item: CodexThreadItem,
+  status: ReturnType<typeof itemStatus>,
+): string | undefined {
+  if (status === "blocked") {
+    return "codex native tool blocked";
+  }
+  if (status !== "failed") {
+    return undefined;
+  }
+  return itemOutputText(item) ?? "codex native tool failed";
 }
 
 function itemMeta(

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1372,7 +1372,10 @@ export async function runCodexAppServerAttempt(
     prompt: promptBuild.prompt,
     imagesCount: params.images?.length ?? 0,
   });
-  projector = new CodexAppServerEventProjector(params, thread.threadId, activeTurnId);
+  projector = new CodexAppServerEventProjector(params, thread.threadId, activeTurnId, {
+    nativePostToolUseRelayEnabled:
+      nativeHookRelay?.allowedEvents.includes("post_tool_use") === true,
+  });
   emitLifecycleStart();
   const activeProjector = projector;
   for (const notification of pendingNotifications.splice(0)) {


### PR DESCRIPTION
## Summary

- Emit async `after_tool_call` observations for Codex app-server native tool completions that are not already covered by the native `PostToolUse` relay.
- Preserve the existing native relay path for shell, patch, and MCP tools so those tool calls do not double-fire plugin hooks.
- Document the Codex harness contract for telemetry-only native completion observations.
- Companion Opik plugin PR: https://github.com/comet-ml/opik-openclaw/pull/91

cc @vincentkoc

## Root Cause

Before the Codex runtime/backend switch, Opik generally saw OpenClaw-owned tool calls with a paired `before_tool_call` and `after_tool_call` lifecycle. In Codex mode, Codex owns native tool execution and OpenClaw only observes selected native events. OpenClaw already relays Codex `PostToolUse` into `after_tool_call` for the native hook relay path, but app-server native item completions were only projected into agent/diagnostic events. Observability plugins that consume OpenClaw plugin hooks could therefore miss Codex-native completions outside the relay-backed path.

## Real Behavior Proof

Behavior or issue addressed: Codex-native completed tool items now produce plugin-observable `after_tool_call` telemetry when no native `PostToolUse` relay already covers them, allowing the Opik companion plugin fix to record native Codex tools instead of dropping after-only completions.

Real environment tested: Local OpenClaw gateway checkout with this PR applied as an `oc-update` PR overlay, plus the locally installed `opik-openclaw` plugin updated from the companion branch before running `oc-update`.

Exact steps or command run after this patch: Updated the installed Opik plugin source and built `dist` from `VACInc/opik-openclaw:opik-after-only-tool-spans`, verified the installed runtime contains `completedToolCallIds` / `after-only` handling with `rg`, then ran `oc-update`.

Evidence after fix: Terminal output from the local OpenClaw setup shows the PR overlay was applied, the gateway built/restarted, and the enabled Opik plugin remained installed after update:

```text
==> Applying open PR overlays
applied: #80369 Fix Opik visibility for Codex-native tool completions

==> Building core
> openclaw@2026.5.10-beta.1 build /home/vac/openclaw
> node scripts/build-all.mjs
...
==> Building UI
> openclaw-control-ui@ build /home/vac/openclaw/ui
> vite build
✓ built in 521ms

==> Reinstalling daemon
Installed systemd service: /home/vac/.config/systemd/user/openclaw-gateway.service

==> Running health check
Discord: configured
Signal: configured
Telegram: configured
Matrix: configured
Agents: main (default), case, atlas, data

==> Running security audit
OpenClaw security audit
Summary: 0 critical · 5 warn · 3 info
plugins.tools_reachable_permissive_policy Extension plugin tools may be reachable under permissive tool policy
  Enabled extension plugins: opik-openclaw.
```

Installed plugin runtime evidence after `oc-update`:

```text
dist/src/service/hooks/tool.js:169:                deps.warn(`opik: after-only tool span creation failed (sessionKey=${sessionKey}, tool=${event.toolName}): ${deps.formatError(err)}`);
dist/src/service/hooks/tool.js:172:            matchedKey = `after-only:${sessionKey}:${completedKey}`;
dist/src/service/hooks/tool.js:173:            active.completedToolCallIds.add(completedKey);
dist/src/service/hooks/llm.js:98:                completedToolCallIds: new Set(),
```

Observed result after fix: `oc-update` completed successfully with #80369 applied, rebuilt and restarted the local gateway, and the installed Opik plugin runtime still contained the after-only span/dedupe code needed to consume the new OpenClaw `after_tool_call` observations.

What was not tested: Live Opik backend ingestion from a real Codex tool run was not tested; the companion Opik PR verifies plugin span creation/update/end with mocked Opik spans, and this PR verifies OpenClaw hook projection with focused Codex projector tests.

Before evidence optional: In the previous OpenClaw code path, `extensions/codex/src/app-server/event-projector.ts` emitted normalized `tool` agent events and diagnostics for app-server native item completions, but did not call `runAgentHarnessAfterToolCallHook` from the projector. `src/agents/harness/native-hook-relay.ts` mapped Codex `PostToolUse` to `after_tool_call`, but only for relay-backed native events.

## Verification

- `pnpm docs:list`
- `pnpm exec oxfmt --write extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/run-attempt.ts`
- `pnpm test extensions/codex/src/app-server/event-projector.test.ts`
- `git diff --check origin/main...HEAD`
- `oc-update` after updating the local Opik plugin to the companion branch build

## What was not tested

- Live Opik ingestion against a real Opik backend from an OpenClaw Codex run was not tested in this PR; the companion Opik plugin PR covers the plugin-side span behavior with unit tests.
- Full OpenClaw test suite was not run; this is scoped to the Codex event projector and docs contract.
