### PR TITLE
fix(gateway): avoid sync restart sentinel startup probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway: avoid synchronous restart-sentinel state probes during post-attach startup, preventing slow Windows or redirected state directories from blocking channel turns. Fixes #79264. Thanks @liyi58.
 - Agents/image: honor explicit `image` tool model overrides even when `agents.defaults.imageModel` is unset, restoring one-off vision calls for configured multimodal providers. Fixes #79341. Thanks @haumanto.
 - Codex app-server: preserve prompt-local current-turn context through context-engine prompt projection, so replied-to Telegram messages stay visible to the Codex model input.
 - Telegram: pass agent-scoped media roots through gateway message actions so workspace-local media from the active agent is not rejected as cross-agent access. Thanks @frankekn.

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -308,7 +308,7 @@ describe("startGatewayPostAttachRuntime", () => {
     fs.rmSync(stateDir, { recursive: true, force: true });
   });
 
-  it("expands tilde-based restart sentinel state paths", () => {
+  it("expands tilde-based restart sentinel state paths", async () => {
     const osHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-home-"));
     try {
       const openclawHome = path.join(osHome, "openclaw-home");
@@ -317,7 +317,7 @@ describe("startGatewayPostAttachRuntime", () => {
       fs.writeFileSync(path.join(stateDirFromHome, "restart-sentinel.json"), "{}\n");
 
       expect(
-        __testing.hasRestartSentinelFileFast({
+        await __testing.hasRestartSentinelFileFast({
           HOME: osHome,
           OPENCLAW_HOME: "~/openclaw-home",
         } as NodeJS.ProcessEnv),
@@ -328,13 +328,41 @@ describe("startGatewayPostAttachRuntime", () => {
       fs.writeFileSync(path.join(backslashStateDir, "restart-sentinel.json"), "{}\n");
 
       expect(
-        __testing.hasRestartSentinelFileFast({
+        await __testing.hasRestartSentinelFileFast({
           HOME: osHome,
           OPENCLAW_STATE_DIR: "~\\openclaw-state",
         } as NodeJS.ProcessEnv),
       ).toBe(true);
     } finally {
       fs.rmSync(osHome, { recursive: true, force: true });
+    }
+  });
+
+  it("avoids sync filesystem probes while checking restart sentinel presence", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-async-sentinel-"));
+    try {
+      fs.writeFileSync(path.join(stateDir, "restart-sentinel.json"), "{}\n");
+      const actualExistsSync = fs.existsSync;
+      const existsSync = vi.spyOn(fs, "existsSync").mockImplementation((candidate) => {
+        if (String(candidate).startsWith(stateDir)) {
+          throw new Error("sync restart sentinel probe");
+        }
+        return actualExistsSync(candidate);
+      });
+      try {
+        await expect(
+          __testing.hasRestartSentinelFileFast({
+            OPENCLAW_STATE_DIR: stateDir,
+          } as NodeJS.ProcessEnv),
+        ).resolves.toBe(true);
+        expect(
+          existsSync.mock.calls.filter((call) => String(call[0]).startsWith(stateDir)),
+        ).toHaveLength(0);
+      } finally {
+        existsSync.mockRestore();
+      }
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
     }
   });
 

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -144,7 +144,18 @@ function schedulePostReadySidecarTask(params: {
   handle.unref?.();
 }
 
-function resolveRestartSentinelPathFast(env: NodeJS.ProcessEnv = process.env): string {
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.promises.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveRestartSentinelPathFast(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string> {
   const normalizePathEnv = (value: string | undefined) => {
     const trimmed = value?.trim();
     return trimmed && trimmed !== "undefined" && trimmed !== "null" ? trimmed : undefined;
@@ -172,19 +183,19 @@ function resolveRestartSentinelPathFast(env: NodeJS.ProcessEnv = process.env): s
   }
   const home = resolveHome();
   const newStateDir = path.join(home, ".openclaw");
-  if (env.OPENCLAW_TEST_FAST === "1" || fs.existsSync(newStateDir)) {
+  if (env.OPENCLAW_TEST_FAST === "1" || (await pathExists(newStateDir))) {
     return path.join(newStateDir, RESTART_SENTINEL_FILENAME);
   }
   const legacyStateDir = path.join(home, ".clawdbot");
-  if (fs.existsSync(legacyStateDir)) {
+  if (await pathExists(legacyStateDir)) {
     return path.join(legacyStateDir, RESTART_SENTINEL_FILENAME);
   }
   return path.join(newStateDir, RESTART_SENTINEL_FILENAME);
 }
 
-function hasRestartSentinelFileFast(env: NodeJS.ProcessEnv = process.env): boolean {
+async function hasRestartSentinelFileFast(env: NodeJS.ProcessEnv = process.env): Promise<boolean> {
   try {
-    return fs.existsSync(resolveRestartSentinelPathFast(env));
+    return await pathExists(await resolveRestartSentinelPathFast(env));
   } catch {
     return false;
   }
@@ -193,7 +204,7 @@ function hasRestartSentinelFileFast(env: NodeJS.ProcessEnv = process.env): boole
 async function refreshLatestUpdateRestartSentinelIfPresent(): Promise<Awaited<
   ReturnType<typeof refreshLatestUpdateRestartSentinel>
 > | null> {
-  if (!hasRestartSentinelFileFast()) {
+  if (!(await hasRestartSentinelFileFast())) {
     return null;
   }
   return await (await import("./server-restart-sentinel.js")).refreshLatestUpdateRestartSentinel();
@@ -589,7 +600,7 @@ export async function startGatewaySidecars(params: {
       if (!shouldCheckRestartSentinel()) {
         return;
       }
-      if (!hasRestartSentinelFileFast()) {
+      if (!(await hasRestartSentinelFileFast())) {
         return;
       }
       setTimeout(() => {


### PR DESCRIPTION
## Summary

- Fixes #79264 by moving restart-sentinel state-dir and sentinel-file probes off synchronous `fs.existsSync` during gateway post-attach startup.
- Keeps the existing restart-sentinel refresh/wake behavior, including `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and legacy `.clawdbot` fallback handling.
- Adds a regression test that fails if the restart-sentinel presence check uses sync filesystem probes on the state path.

## Real behavior proof

- Behavior or issue addressed: gateway post-attach restart-sentinel presence checks no longer synchronously probe the configured state directory, so slow Windows or redirected state dirs cannot block the event loop on this path.
- Real environment tested: local OpenClaw checkout on macOS, Node 26.0.0, with a real temporary `OPENCLAW_STATE_DIR` containing `restart-sentinel.json`.
- Exact steps or command run after this patch: ran a live `node --import tsx` command that monkey-patched `fs.existsSync` to throw for the configured state path, imported the gateway startup module, and called the restart-sentinel presence check against the real temp state directory.
- Evidence after fix:

```console
$ OPENCLAW_STATE_DIR="$tmp" node --import tsx --input-type=module - <<'EOF'
import fs from "node:fs";
const actualExistsSync = fs.existsSync;
fs.existsSync = (candidate) => {
  if (String(candidate).startsWith(process.env.OPENCLAW_STATE_DIR ?? "")) {
    throw new Error("sync restart-sentinel state probe used");
  }
  return actualExistsSync(candidate);
};
const { __testing } = await import("./src/gateway/server-startup-post-attach.ts");
const present = await __testing.hasRestartSentinelFileFast({
  OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR,
});
console.log(JSON.stringify({ restartSentinelPresent: present, syncStateProbe: "not called" }));
EOF
{"restartSentinelPresent":true,"syncStateProbe":"not called"}
```

- Observed result after fix: the real temp restart sentinel was detected and the injected synchronous state-path probe trap was not hit.
- What was not tested: Windows redirected-home latency was not reproduced directly; this proof verifies the blocking sync filesystem call is gone from the implicated startup path.

## Verification

- `pnpm test src/gateway/server-startup-post-attach.test.ts`
- `env -u OPENCLAW_TESTBOX -u OPENCLAW_TESTBOX_REMOTE_RUN -u OPENCLAW_TESTBOX_ID pnpm check:changed`
- `git diff --check origin/main...HEAD`
