### PR TITLE
Expose native tool completions to plugin hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ Docs: https://docs.openclaw.ai
 - Codex app-server: report Codex-native tool execution to diagnostics so long-running native `bash`, web, file, and MCP tools no longer look like stale embedded runs to the watchdog. (#80217)
 - Codex app-server: refresh Codex account rate limits after subscription usage-limit failures so Discord and other channel replies can show the next reset time instead of saying Codex returned none. Thanks @pashpashpash.
 - Agents/auth: let Codex-backed OpenAI agent turns use `auth.order.openai` entries for Codex-compatible OAuth and API-key profiles while keeping existing `openai-codex` profile ordering valid.
+- Codex app-server: emit async `after_tool_call` observations for native tool completions not covered by the native hook relay so observability plugins can record Codex-native tools. (#80372) Thanks @VACInc.
 - Tasks: route group and channel task completions through the requester session so the parent agent can send the visible summary instead of stopping at a generic task-status line. Fixes #77251. (#77365) Thanks @funmerlin.
 - Telegram: preserve blank lines between manually indented bullet blocks and following numbered sections in rendered replies. Fixes #76998. Thanks @evgyur.
 - Agents/sandbox: allow read-only sandbox sessions to read the `/agent` workspace mount while keeping write/edit/apply_patch workspace-only guarded, restoring `read /agent/...` for `workspaceAccess: "ro"`. Fixes #39497. Thanks @stainlu and @teosborne.

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -80,6 +80,11 @@ OpenClaw can mirror selected events, but it cannot rewrite the native Codex
 thread unless Codex exposes that operation through app-server or native hook
 callbacks.
 
+Codex app-server item notifications also provide async `after_tool_call`
+observations for native tool completions that are not already covered by the
+native `PostToolUse` relay. These observations are for telemetry and plugin
+compatibility only; they cannot block, delay, or mutate the native tool call.
+
 Compaction and LLM lifecycle projections come from Codex app-server
 notifications and OpenClaw adapter state, not native Codex hook commands.
 OpenClaw's `before_compaction`, `after_compaction`, `llm_input`, and

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -17,6 +17,7 @@ import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtim
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CodexAppServerEventProjector,
+  type CodexAppServerEventProjectorOptions,
   type CodexAppServerToolTelemetry,
 } from "./event-projector.js";
 import { rememberCodexRateLimits, resetCodexRateLimitCacheForTests } from "./rate-limit-cache.js";
@@ -72,9 +73,10 @@ async function createParams(): Promise<EmbeddedRunAttemptParams> {
 
 async function createProjector(
   params?: EmbeddedRunAttemptParams,
+  options?: CodexAppServerEventProjectorOptions,
 ): Promise<CodexAppServerEventProjector> {
   const resolvedParams = params ?? (await createParams());
-  return new CodexAppServerEventProjector(resolvedParams, THREAD_ID, TURN_ID);
+  return new CodexAppServerEventProjector(resolvedParams, THREAD_ID, TURN_ID, options);
 }
 
 async function createProjectorWithAssistantHooks() {
@@ -1032,6 +1034,134 @@ describe("CodexAppServerEventProjector", () => {
         toolCallId: "cmd-declined",
       },
     ]);
+  });
+
+  it("emits after_tool_call observations for Codex-native tool item completions", async () => {
+    const afterToolCall = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "after_tool_call", handler: afterToolCall }]),
+    );
+    const projector = await createProjector({
+      ...(await createParams()),
+      agentId: "main",
+      sessionKey: "agent:main:session-1",
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-observed",
+          command: "pnpm test extensions/codex",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "inProgress",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-observed",
+          command: "pnpm test extensions/codex",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: "ok",
+          exitCode: 0,
+          durationMs: 42,
+        },
+      }),
+    );
+
+    await vi.waitFor(() => expect(afterToolCall).toHaveBeenCalledTimes(1));
+    const event = requireRecord(
+      mockCallArg(afterToolCall, 0, 0, "after_tool_call event"),
+      "after_tool_call event",
+    );
+    expect(event).toMatchObject({
+      toolName: "bash",
+      params: { command: "pnpm test extensions/codex", cwd: "/workspace" },
+      runId: "run-1",
+      toolCallId: "cmd-observed",
+      result: { status: "completed", exitCode: 0, durationMs: 42 },
+    });
+    expect(event.durationMs).toBeGreaterThanOrEqual(42);
+    const context = requireRecord(
+      mockCallArg(afterToolCall, 0, 1, "after_tool_call context"),
+      "after_tool_call context",
+    );
+    expect(context).toMatchObject({
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      runId: "run-1",
+      toolName: "bash",
+      toolCallId: "cmd-observed",
+    });
+  });
+
+  it("does not duplicate native items already covered by PostToolUse relay", async () => {
+    const afterToolCall = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "after_tool_call", handler: afterToolCall }]),
+    );
+    const projector = await createProjector(
+      { ...(await createParams()), sessionKey: "agent:main:session-1" },
+      { nativePostToolUseRelayEnabled: true },
+    );
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-relayed",
+          command: "pnpm test extensions/codex",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: "ok",
+          exitCode: 0,
+          durationMs: 42,
+        },
+      }),
+    );
+    expect(afterToolCall).not.toHaveBeenCalled();
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "webSearch",
+          id: "search-observed",
+          query: "opik openclaw codex",
+          status: "completed",
+          durationMs: 5,
+        },
+      }),
+    );
+
+    await vi.waitFor(() => expect(afterToolCall).toHaveBeenCalledTimes(1));
+    const event = requireRecord(
+      mockCallArg(afterToolCall, 0, 0, "after_tool_call event"),
+      "after_tool_call event",
+    );
+    expect(event).toMatchObject({
+      toolName: "web_search",
+      params: { query: "opik openclaw codex" },
+      runId: "run-1",
+      toolCallId: "search-observed",
+      result: { status: "completed" },
+    });
   });
 
   it("records dynamic OpenClaw tool calls in mirrored transcript snapshots", async () => {

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1143,7 +1143,7 @@ describe("CodexAppServerEventProjector", () => {
         item: {
           type: "webSearch",
           id: "search-observed",
-          query: "opik openclaw codex",
+          query: "native tool observability",
           status: "completed",
           durationMs: 5,
         },
@@ -1157,7 +1157,7 @@ describe("CodexAppServerEventProjector", () => {
     );
     expect(event).toMatchObject({
       toolName: "web_search",
-      params: { query: "opik openclaw codex" },
+      params: { query: "native tool observability" },
       runId: "run-1",
       toolCallId: "search-observed",
       result: { status: "completed" },

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -9,6 +9,7 @@ import {
   inferToolMetaFromArgs,
   normalizeUsage,
   runAgentHarnessAfterCompactionHook,
+  runAgentHarnessAfterToolCallHook,
   runAgentHarnessBeforeCompactionHook,
   TOOL_PROGRESS_OUTPUT_MAX_CHARS,
   type AgentMessage,
@@ -48,6 +49,10 @@ export type CodexAppServerToolTelemetry = {
   toolMediaUrls?: string[];
   toolAudioAsVoice?: boolean;
   successfulCronAdds?: number;
+};
+
+export type CodexAppServerEventProjectorOptions = {
+  nativePostToolUseRelayEnabled?: boolean;
 };
 
 const ZERO_USAGE: Usage = {
@@ -118,6 +123,7 @@ export class CodexAppServerEventProjector {
   private readonly toolTranscriptResultIds = new Set<string>();
   private readonly nativeGeneratedMediaUrls = new Set<string>();
   private readonly diagnosticToolStartedAtByItem = new Map<string, number>();
+  private readonly afterToolCallObservedItemIds = new Set<string>();
   private assistantStarted = false;
   private reasoningStarted = false;
   private reasoningEnded = false;
@@ -134,6 +140,7 @@ export class CodexAppServerEventProjector {
     private readonly params: EmbeddedRunAttemptParams,
     private readonly threadId: string,
     private readonly turnId: string,
+    private readonly options: CodexAppServerEventProjectorOptions = {},
   ) {}
 
   async handleNotification(notification: CodexServerNotification): Promise<void> {
@@ -613,6 +620,7 @@ export class CodexAppServerEventProjector {
       this.recordToolMeta(item);
       this.recordNativeToolTranscriptCall(item);
       this.recordNativeToolTranscriptResult(item);
+      this.emitAfterToolCallObservation(item);
       this.emitToolResultSummary(item);
       this.emitToolResultOutput(item);
     }
@@ -790,6 +798,9 @@ export class CodexAppServerEventProjector {
           : {}),
       },
     });
+    if (params.phase === "result") {
+      this.emitAfterToolCallObservation(item);
+    }
   }
 
   private emitDiagnosticToolExecutionEvent(params: {
@@ -838,6 +849,53 @@ export class CodexAppServerEventProjector {
               durationMs,
             };
     emitTrustedDiagnosticEvent({ ...base, ...terminalEvent });
+  }
+
+  private emitAfterToolCallObservation(item: CodexThreadItem): void {
+    if (!this.shouldEmitAfterToolCallObservation(item)) {
+      return;
+    }
+    const name = itemName(item);
+    if (!name) {
+      return;
+    }
+    const status = itemStatus(item);
+    if (status === "running") {
+      return;
+    }
+    this.afterToolCallObservedItemIds.add(item.id);
+    const result = itemToolResult(item).result;
+    const error = itemToolError(item, status);
+    const startedAt =
+      typeof item.durationMs === "number" ? Date.now() - Math.max(0, item.durationMs) : undefined;
+    const hookParams = {
+      toolName: name,
+      toolCallId: item.id,
+      runId: this.params.runId,
+      agentId: this.params.agentId,
+      sessionId: this.params.sessionId,
+      sessionKey: this.params.sessionKey,
+      startArgs: itemToolArgs(item) ?? {},
+      ...(result !== undefined ? { result } : {}),
+      ...(error ? { error } : {}),
+      ...(startedAt !== undefined ? { startedAt } : {}),
+    };
+    setImmediate(() => {
+      void runAgentHarnessAfterToolCallHook(hookParams);
+    });
+  }
+
+  private shouldEmitAfterToolCallObservation(item: CodexThreadItem): boolean {
+    if (
+      !shouldSynthesizeToolProgressForItem(item) ||
+      this.afterToolCallObservedItemIds.has(item.id)
+    ) {
+      return false;
+    }
+    if (this.options.nativePostToolUseRelayEnabled && isNativePostToolUseRelayItem(item)) {
+      return false;
+    }
+    return true;
   }
 
   private emitToolResultSummary(item: CodexThreadItem | undefined): void {
@@ -1397,6 +1455,17 @@ function shouldSynthesizeToolProgressForItem(item: CodexThreadItem): boolean {
   }
 }
 
+function isNativePostToolUseRelayItem(item: CodexThreadItem): boolean {
+  switch (item.type) {
+    case "commandExecution":
+    case "fileChange":
+    case "mcpToolCall":
+      return true;
+    default:
+      return false;
+  }
+}
+
 function shouldSuppressChannelProgressForItem(item: CodexThreadItem): boolean {
   if (shouldSynthesizeToolProgressForItem(item)) {
     return true;
@@ -1412,6 +1481,11 @@ function itemToolArgs(item: CodexThreadItem): Record<string, unknown> | undefine
     return sanitizeCodexAgentEventRecord({
       command: item.command,
       ...(typeof item.cwd === "string" ? { cwd: item.cwd } : {}),
+    });
+  }
+  if (item.type === "fileChange") {
+    return sanitizeCodexAgentEventRecord({
+      changes: itemFileChanges(item),
     });
   }
   if (item.type === "webSearch" && typeof item.query === "string") {
@@ -1437,7 +1511,7 @@ function itemToolResult(item: CodexThreadItem): { result?: Record<string, unknow
     return {
       result: sanitizeCodexAgentEventRecord({
         status: item.status,
-        changes: item.changes.map((change) => ({ path: change.path, kind: change.kind })),
+        changes: itemFileChanges(item),
       }),
     };
   }
@@ -1455,6 +1529,25 @@ function itemToolResult(item: CodexThreadItem): { result?: Record<string, unknow
     return { result: sanitizeCodexAgentEventRecord({ status: "completed" }) };
   }
   return {};
+}
+
+function itemFileChanges(item: CodexThreadItem): Array<{ path: string; kind: string }> {
+  return Array.isArray(item.changes)
+    ? item.changes.map((change) => ({ path: change.path, kind: change.kind }))
+    : [];
+}
+
+function itemToolError(
+  item: CodexThreadItem,
+  status: ReturnType<typeof itemStatus>,
+): string | undefined {
+  if (status === "blocked") {
+    return "codex native tool blocked";
+  }
+  if (status !== "failed") {
+    return undefined;
+  }
+  return itemOutputText(item) ?? "codex native tool failed";
 }
 
 function itemMeta(

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1448,7 +1448,10 @@ export async function runCodexAppServerAttempt(
     prompt: promptBuild.prompt,
     imagesCount: params.images?.length ?? 0,
   });
-  projector = new CodexAppServerEventProjector(params, thread.threadId, activeTurnId);
+  projector = new CodexAppServerEventProjector(params, thread.threadId, activeTurnId, {
+    nativePostToolUseRelayEnabled:
+      nativeHookRelay?.allowedEvents.includes("post_tool_use") === true,
+  });
   emitLifecycleStart();
   const activeProjector = projector;
   for (const notification of pendingNotifications.splice(0)) {

--- a/src/plugin-sdk/channel-streaming.test.ts
+++ b/src/plugin-sdk/channel-streaming.test.ts
@@ -243,14 +243,14 @@ describe("channel-streaming", () => {
         entry: { streaming: { progress: { label: false } } },
         lines: line ? [line] : [],
       }),
-    ).toBe("🩹 1 modified; extensions/discord/src/monitor/message-handler.draft-prev…");
+    ).toBe("🩹 1 modified; extensions/discord/src/monitor/message-handler.draft-preview.ts");
   });
 
   it("bounds progress draft line length to reduce edit reflow", () => {
     expect(
       formatChannelProgressDraftText({
         entry: { streaming: { progress: { label: "Shelling" } } },
-        lines: ["x".repeat(80)],
+        lines: ["x".repeat(160)],
         formatLine: (line) => `\`${line}\``,
       }),
     ).toBe(`Shelling\n• \`${"x".repeat(107)}…\``);


### PR DESCRIPTION
## Summary

- Emit asynchronous `after_tool_call` observations for Codex app-server native tool completions that are not already covered by the native `PostToolUse` hook relay.
- Keep shell, file-change, and MCP native tool events on the existing `PostToolUse` relay path to avoid duplicate plugin observations.
- Document the app-server completion observation contract for plugin authors.
- Companion consumer PR: https://github.com/comet-ml/opik-openclaw/pull/91

cc @vincentkoc

## Root Cause

Before the Codex runtime/backend switch, OpenClaw-owned tool execution produced the paired plugin hook lifecycle that observability plugins expected. In Codex mode, Codex owns native tool execution. Some native tool completions only reach OpenClaw as completed app-server items, while only the native hook relay path was exposed to plugin `after_tool_call` observers. That left plugin authors without a generic completion signal for app-server-only native tools.

## Real behavior proof

- Behavior or issue addressed: Codex-native completed tool items now produce plugin-observable `after_tool_call` telemetry when no native `PostToolUse` relay already covers them, so observability plugins can record native tool completions without special-casing a single provider/plugin.
- Real environment tested: local OpenClaw gateway checkout in `/home/vac/openclaw` with this PR applied by the open PR overlay helper, and the locally installed `opik-openclaw` consumer plugin updated from https://github.com/comet-ml/opik-openclaw/pull/91 before running `oc-update`.
- Exact steps or command run after this patch: updated the installed plugin from the companion branch, then ran `oc-update` after this replacement PR was open. A first update attempt was blocked by unrelated local dirty test files, so those local edits were stashed and restored after the update. One retry hit a transient `write-cli-compat` generated-file timing race; `node scripts/write-cli-compat.ts` passed immediately afterward, and the final `oc-update` rerun completed.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
==> Applying open PR overlays
forced: #73694 Restore Codex OAuth model routes (state=closed; applying current PR branch head)
applied: #73694 Restore Codex OAuth model routes
applied: #80341 Fix Telegram thinking status defaults
applied: #80361 fix(cron): allow pre-model watchdog tuning
applied: #80372 Expose native tool completions to plugin hooks

==> Building core
[build-all] write-cli-compat

==> Building UI
✓ built in 499ms

==> Reinstalling daemon
Installed systemd service: /home/vac/.config/systemd/user/openclaw-gateway.service
Previous unit backed up to: /home/vac/.config/systemd/user/openclaw-gateway.service.bak

==> Running health check
Discord: configured
Signal: configured
Telegram: configured
Matrix: configured
Gateway event loop: degraded reasons=cpu max=487ms p99=298ms util=0.792 cpu=1.795
Agents: main (default), case, atlas, data

==> Running security audit
OpenClaw security audit
Summary: 0 critical · 5 warn · 3 info
plugins.tools_reachable_permissive_policy Extension plugin tools may be reachable under permissive tool policy
  Enabled extension plugins: opik-openclaw.
```

- Observed result after fix: `oc-update` applied this PR as the active OpenClaw overlay, built core and UI, reinstalled the daemon, completed the health check, and confirmed the fixed local consumer plugin was enabled. The audit warnings are the existing local security posture warnings, not failures from this PR.
- What was not tested: live upload to a third-party telemetry backend was not tested from this core PR; the companion consumer PR verifies span creation/update/end behavior with mocked traces/spans.
- Before evidence (optional but encouraged): before this change, completed app-server native tool items were projected into the transcript/run stream, but app-server-only completions did not emit plugin `after_tool_call` observations. Plugins consuming tool lifecycle hooks could therefore miss Codex-native completed tools unless a `PostToolUse` relay event existed.

## Verification

- `pnpm docs:list`
- `pnpm exec oxfmt --write extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/run-attempt.ts`
- `pnpm test extensions/codex/src/app-server/event-projector.test.ts`
- `git diff --check origin/main...HEAD`
- `oc-update` after the local consumer plugin was updated from the companion PR

## What was not tested

- A live third-party telemetry backend ingestion was not tested from this core PR; the companion consumer PR verifies span creation behavior with mocked traces/spans.
- The first `oc-update` rerun hit an unrelated transient `write-cli-compat` generated-file timing race (`No daemon-cli bundle found in dist`); the failed step passed immediately when rerun directly, and the final `oc-update` rerun completed.