### PR TITLE
fix(doctor): preserve agent description and root defaultModel on --fix

### DIFF
--- a/src/commands/doctor-config-analysis.test.ts
+++ b/src/commands/doctor-config-analysis.test.ts
@@ -31,4 +31,23 @@ describe("doctor config analysis helpers", () => {
     expect((result.config as Record<string, unknown>).unexpected).toBeUndefined();
     expect((result.config as Record<string, unknown>).hooks).toStrictEqual({});
   });
+
+  it("preserves root-level defaultModel and agent description fields", () => {
+    const result = stripUnknownConfigKeys({
+      defaultModel: "openrouter/openrouter/free",
+      agents: {
+        list: [
+          {
+            id: "main",
+            description: "Main agent for general tasks",
+          },
+        ],
+      },
+    } as never);
+    expect(result.removed).toHaveLength(0);
+    const cfg = result.config as Record<string, unknown>;
+    expect(cfg.defaultModel).toBe("openrouter/openrouter/free");
+    const agents = cfg.agents as { list: Array<Record<string, unknown>> };
+    expect(agents.list[0].description).toBe("Main agent for general tasks");
+  });
 });

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -856,6 +856,7 @@ export const AgentEntrySchema = z
     id: z.string(),
     default: z.boolean().optional(),
     name: z.string().optional(),
+    description: z.string().optional(),
     workspace: z.string().optional(),
     agentDir: z.string().optional(),
     systemPromptOverride: z.string().optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -350,6 +350,7 @@ const CommitmentsSchema = z
 export const OpenClawSchema = z
   .object({
     $schema: z.string().optional(),
+    defaultModel: z.string().optional(),
     meta: z
       .object({
         lastTouchedVersion: z.string().optional(),


### PR DESCRIPTION
## Summary

Fixes #78858.

`openclaw doctor --fix` was silently deleting `description` fields from agent entries and the root-level `defaultModel` key from `openclaw.json`. The root cause: neither field was present in the Zod schema, so `stripUnknownConfigKeys` flagged them as unrecognized and removed them on every `--fix` run.

This caused immediate MCP tool failure and loss of agent configuration, with no warning about which fields were removed.

### Changes

- **`src/config/zod-schema.agent-runtime.ts`**: Add `description: z.string().optional()` to `AgentEntrySchema` so agent description fields are preserved.
- **`src/config/zod-schema.ts`**: Add `defaultModel: z.string().optional()` to the root `OpenClawSchema` so the top-level model shorthand is recognized and not stripped.
- **`src/commands/doctor-config-analysis.test.ts`**: Add regression test asserting both fields survive a `stripUnknownConfigKeys` round-trip.

### Why these were missing

`AgentEntrySchema` and the root schema both use `.strict()` — any field not explicitly declared is treated as an error. The `description` and `defaultModel` fields were valid user config but never added to the schema definitions, making them invisible to Zod while the gateway runtime still read and honoured them.

## Real behavior proof

**Behavior or issue addressed**: `doctor --fix` deletes `agents.list[*].description` and root `defaultModel` fields, breaking MCP tools and removing agent config silently.

**Real environment tested**: Local `vitest` against the Zod schema layer that drives `stripUnknownConfigKeys`.

**Exact steps or command run after this patch**:
```
pnpm vitest run src/commands/doctor-config-analysis.test.ts
```

**Evidence after fix**: New test `preserves root-level defaultModel and agent description fields` asserts both fields survive after `stripUnknownConfigKeys`.

**Observed result after fix**:
```
Test Files  1 passed (1)
     Tests  4 passed (4)
```
All 4 tests pass, including the new regression test.

**What was not tested**: End-to-end `openclaw doctor --fix` CLI run on a real config file with description/defaultModel set (no local gateway available), but the fix is at the schema layer that `stripUnknownConfigKeys` uses directly.