### PR TITLE
Oc-path: add document API seam

### DIFF
--- a/docs/cli/path.md
+++ b/docs/cli/path.md
@@ -203,6 +203,17 @@ Use `--dry-run` before user-visible writes when the exact bytes matter. The
 substrate preserves byte-identical output for parse/emit round-trips, but a
 mutation can canonicalize the edited region or file depending on kind.
 
+## Extension API shape
+
+Plugin authors can stay on the document-level surface for ordinary use:
+`parseOcDocument(raw, { fileName })`, `resolveOcPath(ast, path)`,
+`setOcPath(ast, path, value)`, and `emitOcDocument(ast)`. The document parser
+infers markdown, JSONC, or JSONL from the filename, while emit dispatches from
+the AST kind.
+
+The per-kind parsers and emitters remain available for low-level callers that
+already need concrete markdown, JSONC, or JSONL behavior.
+
 ## Examples
 
 ```bash

--- a/extensions/oc-path/api.ts
+++ b/extensions/oc-path/api.ts
@@ -1,0 +1,5 @@
+export type { Diagnostic, MdAst } from "./src/oc-path/ast.js";
+export type { JsoncAst, JsoncValue } from "./src/oc-path/jsonc/ast.js";
+export { emitOcDocument, parseOcDocument } from "./src/oc-path/document.js";
+export { parseOcPath } from "./src/oc-path/oc-path.js";
+export { resolveOcPath, setOcPath } from "./src/oc-path/universal.js";

--- a/extensions/oc-path/src/cli.ts
+++ b/extensions/oc-path/src/cli.ts
@@ -13,15 +13,11 @@ import {
   OcEmitSentinelError,
   OcPathError,
   REDACTED_SENTINEL,
-  emitJsonc,
-  emitJsonl,
-  emitMd,
+  emitOcDocument,
   findOcPaths,
   formatOcPath,
   inferKind,
-  parseJsonc,
-  parseJsonl,
-  parseMd,
+  parseOcDocument,
   parseOcPath,
   resolveOcPath,
   setOcPath,
@@ -63,13 +59,19 @@ const defaultRuntime: OutputRuntimeEnv = {
 // Defense-in-depth: replace the redaction sentinel with `[REDACTED]`
 // before writing, even if upstream emits it.
 export function scrubSentinel(s: string): string {
-  if (!s.includes(REDACTED_SENTINEL)) {return s;}
+  if (!s.includes(REDACTED_SENTINEL)) {
+    return s;
+  }
   return s.split(REDACTED_SENTINEL).join(SCRUB_PLACEHOLDER);
 }
 
 function detectMode(options: PathCommandOptions): OutputMode {
-  if (options.json === true) {return "json";}
-  if (options.human === true) {return "human";}
+  if (options.json === true) {
+    return "json";
+  }
+  if (options.human === true) {
+    return "human";
+  }
   return process.stdout.isTTY ? "human" : "json";
 }
 
@@ -116,11 +118,7 @@ function requireArg<T>(
 }
 
 /** Parse an oc-path string; emit structured error and return null on failure. */
-function tryParse(
-  pathStr: string,
-  runtime: OutputRuntimeEnv,
-  mode: OutputMode,
-): OcPath | null {
+function tryParse(pathStr: string, runtime: OutputRuntimeEnv, mode: OutputMode): OcPath | null {
   try {
     return parseOcPath(pathStr);
   } catch (err) {
@@ -156,28 +154,19 @@ function catchSentinel<T>(
 
 async function loadAst(absPath: string, fileName: string): Promise<OcAst> {
   const raw = await fs.readFile(absPath, "utf-8");
-  const kind = inferKind(fileName);
-  if (kind === "jsonc") {return parseJsonc(raw).ast;}
-  if (kind === "jsonl") {return parseJsonl(raw).ast;}
-  return parseMd(raw).ast;
+  return parseOcDocument(raw, { fileName, kind: inferKind(fileName) ?? "md" }).ast;
 }
 
 function emitForKind(ast: OcAst, fileName?: string): string {
   // Plumb fileName so sentinel errors carry file context.
   const opts = fileName !== undefined ? { fileNameForGuard: fileName } : {};
-  switch (ast.kind) {
-    case "jsonc":
-      return emitJsonc(ast, opts);
-    case "jsonl":
-      return emitJsonl(ast, opts);
-    case "md":
-      return emitMd(ast, opts);
-  }
-  return "";
+  return emitOcDocument(ast, opts);
 }
 
 function resolveFsPath(path: OcPath, options: PathCommandOptions): string {
-  if (options.file !== undefined) {return resolvePath(options.file);}
+  if (options.file !== undefined) {
+    return resolvePath(options.file);
+  }
   return resolvePath(options.cwd ?? process.cwd(), path.file);
 }
 
@@ -185,7 +174,9 @@ function formatMatchHuman(match: OcMatch): string {
   if (match.kind === "leaf") {
     return `leaf @ L${match.line}: ${JSON.stringify(match.valueText)} (${match.leafType})`;
   }
-  if (match.kind === "node") {return `node @ L${match.line} [${match.descriptor}]`;}
+  if (match.kind === "node") {
+    return `node @ L${match.line} [${match.descriptor}]`;
+  }
   if (match.kind === "insertion-point") {
     return `insertion-point @ L${match.line} [${match.container}]`;
   }
@@ -200,9 +191,13 @@ export async function pathResolveCommand(
   runtime: OutputRuntimeEnv,
 ): Promise<void> {
   const mode = detectMode(options);
-  if (!requireArg(pathStr, "resolve: missing <oc-path> argument", runtime, mode)) {return;}
+  if (!requireArg(pathStr, "resolve: missing <oc-path> argument", runtime, mode)) {
+    return;
+  }
   const ocPath = tryParse(pathStr, runtime, mode);
-  if (ocPath === null) {return;}
+  if (ocPath === null) {
+    return;
+  }
   const ast = await loadAst(resolveFsPath(ocPath, options), ocPath.file);
   let match: OcMatch | null;
   try {
@@ -231,15 +226,23 @@ export async function pathSetCommand(
   runtime: OutputRuntimeEnv,
 ): Promise<void> {
   const mode = detectMode(options);
-  if (!requireArg(pathStr, "set: requires <oc-path> <value>", runtime, mode)) {return;}
-  if (!requireArg(value, "set: requires <oc-path> <value>", runtime, mode)) {return;}
+  if (!requireArg(pathStr, "set: requires <oc-path> <value>", runtime, mode)) {
+    return;
+  }
+  if (!requireArg(value, "set: requires <oc-path> <value>", runtime, mode)) {
+    return;
+  }
   const ocPath = tryParse(pathStr, runtime, mode);
-  if (ocPath === null) {return;}
+  if (ocPath === null) {
+    return;
+  }
   const fsPath = resolveFsPath(ocPath, options);
   const ast = await loadAst(fsPath, ocPath.file);
 
   const result = catchSentinel("set", runtime, mode, () => setOcPath(ast, ocPath, value));
-  if (result === null) {return;}
+  if (result === null) {
+    return;
+  }
   if (!result.ok) {
     const detail = "detail" in result ? result.detail : undefined;
     emit(
@@ -252,10 +255,10 @@ export async function pathSetCommand(
     return;
   }
   // Per-kind emit can still refuse the sentinel even after set succeeds.
-  const newBytes = catchSentinel("emit", runtime, mode, () =>
-    emitForKind(result.ast, ocPath.file),
-  );
-  if (newBytes === null) {return;}
+  const newBytes = catchSentinel("emit", runtime, mode, () => emitForKind(result.ast, ocPath.file));
+  if (newBytes === null) {
+    return;
+  }
 
   if (options.dryRun === true) {
     emit(
@@ -281,9 +284,13 @@ export async function pathFindCommand(
   runtime: OutputRuntimeEnv,
 ): Promise<void> {
   const mode = detectMode(options);
-  if (!requireArg(patternStr, "find: missing <pattern> argument", runtime, mode)) {return;}
+  if (!requireArg(patternStr, "find: missing <pattern> argument", runtime, mode)) {
+    return;
+  }
   const pattern = tryParse(patternStr, runtime, mode);
-  if (pattern === null) {return;}
+  if (pattern === null) {
+    return;
+  }
   // File-slot wildcards would silently ENOENT during readFile; reject.
   if (/[*?]/.test(pattern.file)) {
     emitError(
@@ -307,7 +314,9 @@ export async function pathFindCommand(
       matches: matches.map((m) => ({ path: formatOcPath(m.path), match: m.match })),
     },
     () => {
-      if (matches.length === 0) {return `0 matches for ${patternStr}`;}
+      if (matches.length === 0) {
+        return `0 matches for ${patternStr}`;
+      }
       const plural = matches.length === 1 ? "" : "es";
       const lines = [`${matches.length} match${plural} for ${patternStr}:`];
       for (const m of matches) {
@@ -316,7 +325,9 @@ export async function pathFindCommand(
       return lines.join("\n");
     },
   );
-  if (matches.length === 0) {runtime.exit(1);}
+  if (matches.length === 0) {
+    runtime.exit(1);
+  }
 }
 
 export function pathValidateCommand(
@@ -325,7 +336,9 @@ export function pathValidateCommand(
   runtime: OutputRuntimeEnv,
 ): void {
   const mode = detectMode(options);
-  if (!requireArg(pathStr, "validate: missing <oc-path> argument", runtime, mode)) {return;}
+  if (!requireArg(pathStr, "validate: missing <oc-path> argument", runtime, mode)) {
+    return;
+  }
   try {
     const ocPath = parseOcPath(pathStr);
     emit(
@@ -345,10 +358,18 @@ export function pathValidateCommand(
       },
       () => {
         const lines = [`valid: ${pathStr}`, `  file:    ${ocPath.file}`];
-        if (ocPath.section !== undefined) {lines.push(`  section: ${ocPath.section}`);}
-        if (ocPath.item !== undefined) {lines.push(`  item:    ${ocPath.item}`);}
-        if (ocPath.field !== undefined) {lines.push(`  field:   ${ocPath.field}`);}
-        if (ocPath.session !== undefined) {lines.push(`  session: ${ocPath.session}`);}
+        if (ocPath.section !== undefined) {
+          lines.push(`  section: ${ocPath.section}`);
+        }
+        if (ocPath.item !== undefined) {
+          lines.push(`  item:    ${ocPath.item}`);
+        }
+        if (ocPath.field !== undefined) {
+          lines.push(`  field:   ${ocPath.field}`);
+        }
+        if (ocPath.session !== undefined) {
+          lines.push(`  session: ${ocPath.session}`);
+        }
         return lines.join("\n");
       },
     );
@@ -373,7 +394,9 @@ export async function pathEmitCommand(
   runtime: OutputRuntimeEnv,
 ): Promise<void> {
   const mode = detectMode(options);
-  if (!requireArg(fileArg, "emit: missing <file> argument", runtime, mode)) {return;}
+  if (!requireArg(fileArg, "emit: missing <file> argument", runtime, mode)) {
+    return;
+  }
   const fsPath =
     options.file !== undefined
       ? resolvePath(options.file)
@@ -381,7 +404,9 @@ export async function pathEmitCommand(
   const fileName = fsPath.split(/[\\/]/).pop() ?? fileArg;
   const ast = await loadAst(fsPath, fileName);
   const bytes = catchSentinel("emit", runtime, mode, () => emitForKind(ast, fileName));
-  if (bytes === null) {return;}
+  if (bytes === null) {
+    return;
+  }
   if (mode === "json") {
     runtime.writeStdout(scrubSentinel(JSON.stringify({ ok: true, kind: ast.kind, bytes })));
     return;

--- a/extensions/oc-path/src/oc-path/dispatch.ts
+++ b/extensions/oc-path/src/oc-path/dispatch.ts
@@ -1,11 +1,7 @@
 /**
- * Cross-kind utilities. `inferKind` is a convention helper for callers
- * who want to map filename to the parser they should use before calling
- * the universal verbs (`resolveOcPath`, `findOcPaths`, `setOcPath`).
- *
- * Encoding remains per-kind (`parseMd`, `parseJsonc`, `parseJsonl`),
- * while addressing and mutation dispatch are universal once callers
- * have an AST carrying its `kind` discriminator.
+ * Cross-kind utilities. `inferKind` backs the document-level parser in
+ * `document.ts`, so callers can parse by filename before using the
+ * universal verbs (`resolveOcPath`, `findOcPaths`, `setOcPath`).
  *
  * @module @openclaw/oc-path/dispatch
  */

--- a/extensions/oc-path/src/oc-path/document.ts
+++ b/extensions/oc-path/src/oc-path/document.ts
@@ -1,0 +1,73 @@
+/**
+ * Document-level parse / emit helpers.
+ *
+ * `parseOcPath` parses an `oc://` address. These helpers parse and
+ * emit the document that address points into, using the filename to
+ * choose the concrete markdown / jsonc / jsonl codec.
+ *
+ * @module @openclaw/oc-path/document
+ */
+
+import type { Diagnostic } from "./ast.js";
+import type { OcKind } from "./dispatch.js";
+import { inferKind } from "./dispatch.js";
+import type { EmitOptions } from "./emit.js";
+import { emitMd } from "./emit.js";
+import type { JsoncEmitOptions } from "./jsonc/emit.js";
+import { emitJsonc } from "./jsonc/emit.js";
+import { parseJsonc } from "./jsonc/parse.js";
+import type { JsonlEmitOptions } from "./jsonl/emit.js";
+import { emitJsonl } from "./jsonl/emit.js";
+import { parseJsonl } from "./jsonl/parse.js";
+import { parseMd } from "./parse.js";
+import type { OcAst } from "./universal.js";
+
+export interface ParseOcDocumentOptions {
+  readonly fileName: string;
+  readonly kind?: OcKind;
+}
+
+export interface ParseOcDocumentResult {
+  readonly ast: OcAst;
+  readonly diagnostics: readonly Diagnostic[];
+  readonly kind: OcKind;
+}
+
+export type EmitOcDocumentOptions = EmitOptions & JsoncEmitOptions & JsonlEmitOptions;
+
+export class OcDocumentKindError extends Error {
+  constructor(fileName: string) {
+    super(`Could not infer oc-path document kind from '${fileName}'.`);
+    this.name = "OcDocumentKindError";
+  }
+}
+
+export function parseOcDocument(
+  raw: string,
+  options: ParseOcDocumentOptions,
+): ParseOcDocumentResult {
+  const kind = options.kind ?? inferKind(options.fileName);
+  if (kind === null) {
+    throw new OcDocumentKindError(options.fileName);
+  }
+
+  switch (kind) {
+    case "md":
+      return { ...parseMd(raw), kind };
+    case "jsonc":
+      return { ...parseJsonc(raw), kind };
+    case "jsonl":
+      return { ...parseJsonl(raw), kind };
+  }
+}
+
+export function emitOcDocument(ast: OcAst, options: EmitOcDocumentOptions = {}): string {
+  switch (ast.kind) {
+    case "md":
+      return emitMd(ast, options);
+    case "jsonc":
+      return emitJsonc(ast, options);
+    case "jsonl":
+      return emitJsonl(ast, options);
+  }
+}

--- a/extensions/oc-path/src/oc-path/index.ts
+++ b/extensions/oc-path/src/oc-path/index.ts
@@ -3,14 +3,16 @@
  *
  * **Strategic frame**: workspace files are byte-stable and addressable
  * via the `oc://` scheme — the addressing scheme is universal across
- * file kinds (md / jsonc / jsonl). Encoding (parse/emit) is per-kind;
- * addressing (resolve/set) is universal.
+ * file kinds (md / jsonc / jsonl). Callers can parse / emit a document
+ * by filename and then use the universal addressing verbs.
  *
  * **Public verbs**:
  *   - One `resolveOcPath(ast, path)` - concrete, kind-dispatched
  *   - One `findOcPaths(ast, pattern)` - multi-match, kind-dispatched
  *   - One `setOcPath(ast, path, value)` - concrete mutation / insertion
- *   - Per-kind `parseXxx` / `emitXxx` (parsing is per-kind by nature)
+ *   - One `parseOcDocument(raw, { fileName })` - kind-inferred parse
+ *   - One `emitOcDocument(ast)` - kind-dispatched emit
+ *   - Per-kind `parseXxx` / `emitXxx` for low-level callers
  *
  * `setOcPath` accepts a string value; the substrate coerces based on
  * AST shape at the path location. The OcPath syntax encodes the
@@ -27,21 +29,14 @@
 /**
  * SDK version this build of `@openclaw/oc-path` exposes. Bumped on
  * every breaking change to AST shape, OcPath syntax, or universal
- * verbs (`resolveOcPath`, `setOcPath`, `findOcPaths`, `parseXxx`,
- * `emitXxx`). Plugin packs that depend on the substrate declare the
+ * verbs (`resolveOcPath`, `setOcPath`, `findOcPaths`, `parseOcDocument`,
+ * `emitOcDocument`). Plugin packs that depend on the substrate declare the
  * version they were authored against and the host warns on mismatch.
  */
 export const SDK_VERSION = "0.1.0";
 
 // AST types
-export type {
-  AstBlock,
-  AstItem,
-  Diagnostic,
-  FrontmatterEntry,
-  ParseResult,
-  MdAst,
-} from "./ast.js";
+export type { AstBlock, AstItem, Diagnostic, FrontmatterEntry, ParseResult, MdAst } from "./ast.js";
 export type { JsoncAst, JsoncEntry, JsoncValue } from "./jsonc/ast.js";
 export type { JsonlAst, JsonlLine } from "./jsonl/ast.js";
 
@@ -77,7 +72,15 @@ export {
 // Callers that need their behavior should round-trip through
 // `parseOcPath` / `formatOcPath` / `findOcPaths`.
 
-// Per-kind parse / emit (encoding is genuinely per-kind)
+// Document parse / emit (filename-inferred parser; AST-kind emitter)
+export { OcDocumentKindError, emitOcDocument, parseOcDocument } from "./document.js";
+export type {
+  EmitOcDocumentOptions,
+  ParseOcDocumentOptions,
+  ParseOcDocumentResult,
+} from "./document.js";
+
+// Per-kind parse / emit (for callers that already know the concrete kind)
 export { parseMd } from "./parse.js";
 export { parseJsonc } from "./jsonc/parse.js";
 export { parseJsonl } from "./jsonl/parse.js";

--- a/extensions/oc-path/src/oc-path/tests/document.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/document.test.ts
@@ -7,6 +7,9 @@ describe("parseOcDocument", () => {
 
     expect(parsed.kind).toBe("md");
     expect(parsed.ast.kind).toBe("md");
+    if (parsed.ast.kind !== "md") {
+      throw new Error("expected markdown AST");
+    }
     expect(parsed.ast.blocks[0]?.slug).toBe("tools");
   });
 

--- a/extensions/oc-path/src/oc-path/tests/document.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/document.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { OcDocumentKindError, emitOcDocument, parseOcDocument } from "../document.js";
+
+describe("parseOcDocument", () => {
+  it("infers markdown from filename", () => {
+    const parsed = parseOcDocument("## Tools\n\n- gh: GitHub\n", { fileName: "TOOLS.md" });
+
+    expect(parsed.kind).toBe("md");
+    expect(parsed.ast.kind).toBe("md");
+    expect(parsed.ast.blocks[0]?.slug).toBe("tools");
+  });
+
+  it("infers jsonc from filename", () => {
+    const parsed = parseOcDocument('{ "enabled": true }\n', { fileName: "policy.jsonc" });
+
+    expect(parsed.kind).toBe("jsonc");
+    expect(parsed.ast.kind).toBe("jsonc");
+    expect(parsed.diagnostics).toHaveLength(0);
+  });
+
+  it("infers jsonl from filename", () => {
+    const parsed = parseOcDocument('{"event":"start"}\n', { fileName: "session.jsonl" });
+
+    expect(parsed.kind).toBe("jsonl");
+    expect(parsed.ast.kind).toBe("jsonl");
+    expect(parsed.diagnostics).toHaveLength(0);
+  });
+
+  it("lets callers override the filename-inferred kind", () => {
+    const parsed = parseOcDocument('{ "enabled": true }\n', {
+      fileName: "policy.txt",
+      kind: "jsonc",
+    });
+
+    expect(parsed.kind).toBe("jsonc");
+    expect(parsed.ast.kind).toBe("jsonc");
+  });
+
+  it("throws when kind cannot be inferred", () => {
+    expect(() => parseOcDocument("value", { fileName: "policy.txt" })).toThrow(OcDocumentKindError);
+  });
+});
+
+describe("emitOcDocument", () => {
+  it("dispatches emit by AST kind", () => {
+    const parsed = parseOcDocument('{ "enabled": true }\n', { fileName: "policy.jsonc" });
+
+    expect(emitOcDocument(parsed.ast)).toBe('{ "enabled": true }\n');
+  });
+});

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -144,6 +144,10 @@ export const sharedVitestConfig = {
         replacement: path.join(repoRoot, "extensions", "discord", "api.ts"),
       },
       {
+        find: "@openclaw/oc-path/api.js",
+        replacement: path.join(repoRoot, "extensions", "oc-path", "api.ts"),
+      },
+      {
         find: "@openclaw/slack/api.js",
         replacement: path.join(repoRoot, "extensions", "slack", "api.ts"),
       },


### PR DESCRIPTION
# Oc-path: add document API seam

Branch: `oc-path-api-seam`
GitHub base: `main`
Head: `8b4b209fd2`

## Title

Oc-path: add document API seam

## Summary

This PR adds the document-level oc-path helper layer and exposes it through a
small bundled-extension API seam.

It introduces `@openclaw/oc-path/api.js` with the document-level helpers that
policy and future bundled extensions need:

- `parseOcDocument(raw, { fileName })`
- `emitOcDocument(ast)`
- `parseOcPath(...)`
- `resolveOcPath(...)`
- `setOcPath(...)`

The goal is to keep follow-up extensions and doctor health checks from knowing
whether a workspace file is markdown, JSONC, or JSONL when they only need to
address workspace objects by oc-path.

This is intentionally split out from the policy PR so maintainers can review
the package/API boundary separately from policy semantics.

## Motivation

Oc-path already gives callers one address format and one resolve/set vocabulary
across markdown, JSONC, and JSONL. The remaining format-specific step was
document loading: callers still had to choose `parseMd`, `parseJsonc`, or
`parseJsonl`, then choose the matching emitter later.

This PR closes that gap for ordinary use. Callers can parse a workspace
document by filename, resolve or set an `oc://` address against the AST, and
emit the document by AST kind.

That matters for lint and doctor rules because the rule can stay focused on the
domain question: find the governed object, report the `ocPath`, and optionally
repair that object. The rule does not need a markdown/JSONC switch just to load
the file or emit a safe update.

Policy needs this helper layer to report findings against canonical object
identity without caring whether the source is `TOOLS.md` or `policy.jsonc`.
That dependency should be reviewed separately from policy semantics and from
the doctor health contract in PR 1.

This PR keeps the question narrow: is `@openclaw/oc-path/api.js` the right
bundled-extension package seam for document-level oc-path usage? It can land
independently of PR 1, but PR 1 plus this seam is what makes future
lint/doctor rules straightforward to write.

## What Changed

- Added the document helper layer: `parseOcDocument`, `emitOcDocument`, and
  `OcDocumentKindError`.
- Added `extensions/oc-path/api.ts` as the package API entrypoint for bundled
  extensions.
- Refactored the path CLI to use the document-level parser/emitter.
- Added document helper tests for markdown and JSONC.
- Updated path docs with the extension API shape.
- Added the Vitest resolver alias for `@openclaw/oc-path/api.js`.

## Behavior

The new document helpers keep the existing oc-path model intact:

- `parseOcPath` still parses the `oc://` address.
- `parseOcDocument` parses the document by filename or explicit kind.
- `resolveOcPath` and `setOcPath` continue to operate on the AST.
- `emitOcDocument` emits by AST kind.

The CLI now uses the same document-level helpers, so the new API is exercised
by existing path command behavior instead of sitting beside it unused.

End-to-end, a bundled extension can stay on one surface:

```ts
import {
  emitOcDocument,
  parseOcDocument,
  parseOcPath,
  resolveOcPath,
  setOcPath,
} from "@openclaw/oc-path/api.js";

const parsed = parseOcDocument(raw, { fileName: "policy.jsonc" });
const path = parseOcPath("oc://policy.jsonc/tools.generatedFrom.hash");
const current = resolveOcPath(parsed.ast, path);
const updated = setOcPath(parsed.ast, path, nextHash);
const nextRaw = updated.ok ? emitOcDocument(parsed.ast) : raw;
```

The caller does not need to know whether `policy.jsonc` uses the JSONC parser
or emitter. For a markdown file such as `TOOLS.md`, the same loop uses the
markdown codec by filename.

For a health check, that same loop becomes:

1. `parseOcDocument(...)` to load the relevant workspace artifact.
2. `resolveOcPath(...)` to verify or read the governed field.
3. Emit a `HealthFinding` with the same `ocPath`.
4. Use `setOcPath(...)` plus `emitOcDocument(...)` only when a repair is
   explicitly allowed.

## Maintainer Input Requested

1. **Is this the right package seam for bundled extensions?**

   This avoids adding `openclaw/plugin-sdk/oc-path` while still letting bundled
   extensions consume oc-path without importing extension internals.

2. **Should document parse/emit be part of the oc-path public surface?**

   The per-kind parsers remain available, but most consumers should be able to
   parse by filename and emit by AST kind.

## Real Behavior Proof

**Behavior addressed**: Consumers can parse a markdown or JSONC document with
one document-level helper, resolve an oc-path, and emit the document by AST
kind.

**Real environment tested**: Local OpenClaw source checkout on Windows.

**Exact steps or command run after the patch**:

```bash
pnpm exec vitest run extensions/oc-path/src/oc-path/tests/document.test.ts extensions/oc-path/src/oc-path/tests/universal.test.ts --config test/vitest/vitest.extensions.config.ts
pnpm exec oxlint extensions/oc-path/api.ts extensions/oc-path/src/cli.ts extensions/oc-path/src/oc-path/dispatch.ts extensions/oc-path/src/oc-path/document.ts extensions/oc-path/src/oc-path/index.ts extensions/oc-path/src/oc-path/tests/document.test.ts test/vitest/vitest.shared.config.ts
node node_modules/oxfmt/bin/oxfmt --check --threads=1 --config .oxfmtrc.jsonc docs/cli/path.md extensions/oc-path/api.ts extensions/oc-path/src/cli.ts extensions/oc-path/src/oc-path/dispatch.ts extensions/oc-path/src/oc-path/document.ts extensions/oc-path/src/oc-path/index.ts extensions/oc-path/src/oc-path/tests/document.test.ts test/vitest/vitest.shared.config.ts
```

**Evidence after fix**:

![Oc-path document API proof](https://gist.githubusercontent.com/giodl73-repo/0afb30dfd59fd1d90b36c6ea18137d85/raw/pr2a-oc-path-api-proof.svg)

**Observed result after fix**: The local terminal proof shows the document API
parsing JSONC/Markdown by filename, resolving and setting oc-path addresses,
and emitting by AST kind. Focused oc-path tests passed, oxlint reported no
issues, and formatting check passed.

**What was not tested**: No third-party extension consumed the new API in this
PR. Follow-up policy PRs consume the seam from bundled extension code.

## Testing

```bash
pnpm exec vitest run extensions/oc-path/src/oc-path/tests/document.test.ts extensions/oc-path/src/oc-path/tests/universal.test.ts --config test/vitest/vitest.extensions.config.ts
pnpm exec oxlint extensions/oc-path/api.ts extensions/oc-path/src/cli.ts extensions/oc-path/src/oc-path/dispatch.ts extensions/oc-path/src/oc-path/document.ts extensions/oc-path/src/oc-path/index.ts extensions/oc-path/src/oc-path/tests/document.test.ts test/vitest/vitest.shared.config.ts
node node_modules/oxfmt/bin/oxfmt --check --threads=1 --config .oxfmtrc.jsonc docs/cli/path.md extensions/oc-path/api.ts extensions/oc-path/src/cli.ts extensions/oc-path/src/oc-path/dispatch.ts extensions/oc-path/src/oc-path/document.ts extensions/oc-path/src/oc-path/index.ts extensions/oc-path/src/oc-path/tests/document.test.ts test/vitest/vitest.shared.config.ts
```

## Review Notes

This PR does not add a public `openclaw/plugin-sdk/oc-path` subpath. The seam
is the bundled extension package API: `@openclaw/oc-path/api.js`.

The follow-up policy PR consumes this seam so policy can report findings
against canonical oc-path object identities without importing oc-path extension
internals.
