### PR TITLE
[AI-assisted] fix(telegram): force document video media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: make `message send --force-document --media` route MP4/video uploads through `sendDocument` instead of `sendVideo`, matching the documented document-delivery override. Fixes #80389. Thanks @milo-operator.
 - Gateway: avoid synchronous restart-sentinel state probes during post-attach startup, preventing slow Windows or redirected state directories from blocking channel turns. Fixes #79264. Thanks @liyi58.
 - Agents/image: honor explicit `image` tool model overrides even when `agents.defaults.imageModel` is unset, restoring one-off vision calls for configured multimodal providers. Fixes #79341. Thanks @haumanto.
 - Codex app-server: preserve prompt-local current-turn context through context-engine prompt projection, so replied-to Telegram messages stay visible to the Codex model input.

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -809,7 +809,7 @@ openclaw message poll --channel telegram --target -1001234567890:topic:42 \
 
     - `--presentation` with `buttons` blocks for inline keyboards when `channels.telegram.capabilities.inlineButtons` allows it
     - `--pin` or `--delivery '{"pin":true}'` to request pinned delivery when the bot can pin in that chat
-    - `--force-document` to send outbound images and GIFs as documents instead of compressed photo or animated-media uploads
+    - `--force-document` to send outbound images, GIFs, and videos as documents instead of compressed photo, animated-media, or video uploads
 
     Action gating:
 

--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -72,7 +72,7 @@ Name lookup:
   - Optional: `--media`, `--presentation`, `--delivery`, `--pin`, `--reply-to`, `--thread-id`, `--gif-playback`, `--force-document`, `--silent`
   - Shared presentation payloads: `--presentation` sends semantic blocks (`text`, `context`, `divider`, `buttons`, `select`) that core renders through the selected channel's declared capabilities. See [Message Presentation](/plugins/message-presentation).
   - Generic delivery preferences: `--delivery` accepts delivery hints such as `{ "pin": true }`; `--pin` is shorthand for pinned delivery when the channel supports it.
-  - Telegram only: `--force-document` (send images and GIFs as documents to avoid Telegram compression)
+  - Telegram only: `--force-document` (send images, GIFs, and videos as documents to avoid Telegram compression)
   - Telegram only: `--thread-id` (forum topic id)
   - Slack only: `--thread-id` (thread timestamp; `--reply-to` uses the same field)
   - Telegram + Discord: `--silent`

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1115,6 +1115,43 @@ describe("sendMessageTelegram", () => {
     });
   });
 
+  it("sends video as document when forceDocument is true", async () => {
+    const chatId = "123";
+    const videoBuffer = Buffer.from("fake-video");
+    const sendDocument = vi.fn().mockResolvedValue({
+      message_id: 202,
+      chat: { id: chatId },
+    });
+    const sendVideo = vi.fn();
+    const api = { sendDocument, sendVideo } as unknown as {
+      sendDocument: typeof sendDocument;
+      sendVideo: typeof sendVideo;
+    };
+
+    mockLoadedMedia({
+      buffer: videoBuffer,
+      contentType: "video/mp4",
+      fileName: "video.mp4",
+    });
+
+    const res = await sendMessageTelegram(chatId, "my caption", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrl: "https://example.com/video.mp4",
+      forceDocument: true,
+    });
+
+    expect(probeVideoDimensions).not.toHaveBeenCalled();
+    expectMediaSendCall(sendDocument.mock.calls[0], "send document call", chatId, {
+      caption: "my caption",
+      parse_mode: "HTML",
+      disable_content_type_detection: true,
+    });
+    expect(sendVideo).not.toHaveBeenCalled();
+    expect(res.messageId).toBe("202");
+  });
+
   it("does not probe video dimensions for video notes", async () => {
     const chatId = "123";
     const sendVideoNote = vi.fn().mockResolvedValue({

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -845,7 +845,9 @@ export async function sendMessageTelegram(
       ...(!needsSeparateText && replyMarkup ? { reply_markup: replyMarkup } : {}),
     };
     const videoDimensions =
-      kind === "video" && !isVideoNote ? await probeVideoDimensions(media.buffer) : undefined;
+      kind === "video" && !isVideoNote && !opts.forceDocument
+        ? await probeVideoDimensions(media.buffer)
+        : undefined;
     const mediaParams = {
       ...(htmlCaption ? { caption: htmlCaption, parse_mode: "HTML" as const } : {}),
       ...baseMediaParams,
@@ -890,7 +892,7 @@ export async function sendMessageTelegram(
             ) as Promise<TelegramMessageLike>,
         };
       }
-      if (kind === "video") {
+      if (kind === "video" && !opts.forceDocument) {
         if (isVideoNote) {
           return {
             label: "video_note",
@@ -947,7 +949,7 @@ export async function sendMessageTelegram(
             chatId,
             file,
             // Only force Telegram to keep the uploaded media type when callers explicitly
-            // opt into document delivery for image/GIF uploads.
+            // opt into document delivery for typed media uploads.
             (opts.forceDocument
               ? { ...effectiveParams, disable_content_type_detection: true }
               : effectiveParams) as Parameters<typeof api.sendDocument>[2],

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -196,13 +196,14 @@ function buildSendSchema(options: { includePresentation: boolean; includeDeliver
     gifPlayback: Type.Optional(Type.Boolean()),
     forceDocument: Type.Optional(
       Type.Boolean({
-        description: "Send image/GIF as document to avoid Telegram compression (Telegram only).",
+        description:
+          "Send image/GIF/video as document to avoid Telegram compression (Telegram only).",
       }),
     ),
     asDocument: Type.Optional(
       Type.Boolean({
         description:
-          "Send image/GIF as document to avoid Telegram compression. Alias for forceDocument (Telegram only).",
+          "Send image/GIF/video as document to avoid Telegram compression. Alias for forceDocument (Telegram only).",
       }),
     ),
   };

--- a/src/cli/program/message/register.send.ts
+++ b/src/cli/program/message/register.send.ts
@@ -26,7 +26,7 @@ export function registerMessageSendCommand(message: Command, helpers: MessageCli
         .option("--gif-playback", "Treat video media as GIF playback (WhatsApp only).", false)
         .option(
           "--force-document",
-          "Send media as document to avoid Telegram compression (Telegram only). Applies to images and GIFs.",
+          "Send media as document to avoid Telegram compression (Telegram only). Applies to images, GIFs, and videos.",
           false,
         )
         .option(

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -625,7 +625,7 @@
           "type": "string"
         },
         "asDocument": {
-          "description": "Send image/GIF as document to avoid Telegram compression. Alias for forceDocument (Telegram only).",
+          "description": "Send image/GIF/video as document to avoid Telegram compression. Alias for forceDocument (Telegram only).",
           "type": "boolean"
         },
         "asVoice": {
@@ -665,7 +665,7 @@
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send image/GIF as document to avoid Telegram compression (Telegram only).",
+          "description": "Send image/GIF/video as document to avoid Telegram compression (Telegram only).",
           "type": "boolean"
         },
         "gatewayToken": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -625,7 +625,7 @@
           "type": "string"
         },
         "asDocument": {
-          "description": "Send image/GIF as document to avoid Telegram compression. Alias for forceDocument (Telegram only).",
+          "description": "Send image/GIF/video as document to avoid Telegram compression. Alias for forceDocument (Telegram only).",
           "type": "boolean"
         },
         "asVoice": {
@@ -665,7 +665,7 @@
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send image/GIF as document to avoid Telegram compression (Telegram only).",
+          "description": "Send image/GIF/video as document to avoid Telegram compression (Telegram only).",
           "type": "boolean"
         },
         "gatewayToken": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -625,7 +625,7 @@
           "type": "string"
         },
         "asDocument": {
-          "description": "Send image/GIF as document to avoid Telegram compression. Alias for forceDocument (Telegram only).",
+          "description": "Send image/GIF/video as document to avoid Telegram compression. Alias for forceDocument (Telegram only).",
           "type": "boolean"
         },
         "asVoice": {
@@ -665,7 +665,7 @@
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send image/GIF as document to avoid Telegram compression (Telegram only).",
+          "description": "Send image/GIF/video as document to avoid Telegram compression (Telegram only).",
           "type": "boolean"
         },
         "gatewayToken": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -598,7 +598,7 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
           "type": "string"
         },
         "asDocument": {
-          "description": "Send image/GIF as document to avoid Telegram compression. Alias for forceDocument (Telegram only).",
+          "description": "Send image/GIF/video as document to avoid Telegram compression. Alias for forceDocument (Telegram only).",
           "type": "boolean"
         },
         "asVoice": {
@@ -638,7 +638,7 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send image/GIF as document to avoid Telegram compression (Telegram only).",
+          "description": "Send image/GIF/video as document to avoid Telegram compression (Telegram only).",
           "type": "boolean"
         },
         "gatewayToken": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -575,7 +575,7 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "string"
         },
         "asDocument": {
-          "description": "Send image/GIF as document to avoid Telegram compression. Alias for forceDocument (Telegram only).",
+          "description": "Send image/GIF/video as document to avoid Telegram compression. Alias for forceDocument (Telegram only).",
           "type": "boolean"
         },
         "asVoice": {
@@ -615,7 +615,7 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send image/GIF as document to avoid Telegram compression (Telegram only).",
+          "description": "Send image/GIF/video as document to avoid Telegram compression (Telegram only).",
           "type": "boolean"
         },
         "gatewayToken": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -592,7 +592,7 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
           "type": "string"
         },
         "asDocument": {
-          "description": "Send image/GIF as document to avoid Telegram compression. Alias for forceDocument (Telegram only).",
+          "description": "Send image/GIF/video as document to avoid Telegram compression. Alias for forceDocument (Telegram only).",
           "type": "boolean"
         },
         "asVoice": {
@@ -632,7 +632,7 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send image/GIF as document to avoid Telegram compression (Telegram only).",
+          "description": "Send image/GIF/video as document to avoid Telegram compression (Telegram only).",
           "type": "boolean"
         },
         "gatewayToken": {


### PR DESCRIPTION
﻿## Summary

- Route Telegram video media through `sendDocument` when callers set `forceDocument` / `--force-document`, instead of reaching the `sendVideo` branch first.
- Skip video-dimension probing for forced document sends because Telegram document uploads do not use video width/height params.
- Update CLI help, message-tool schema text, docs, prompt snapshots, and the changelog so the public contract includes videos.

Fixes #80389.

## Real behavior proof

Behavior or issue addressed: Telegram `message send --media <file.mp4> --force-document` had a source-proven routing bug where `video/mp4` still selected `sendVideo`; the explicit document override now selects `sendDocument`.

Real environment tested: Local Windows checkout `C:\oc80389`, Node `v24.13.0`, pnpm `10.33.2`, rebased on `openclaw/openclaw:main` at `ed2c3a9b9d`. I ran the production Telegram `sendMessageTelegram` entrypoint from Node with a redacted token and a local MP4 fixture; the outbound API object recorded the selected Telegram method without sending to the external Telegram service.

Exact steps or command run after this patch:

```powershell
$proof = Join-Path $env:TEMP "openclaw-force-document-proof.mp4"
[IO.File]::WriteAllBytes($proof, [byte[]](0,0,0,24,102,116,121,112,109,112,52,50,0,0,0,0,109,112,52,50,105,115,111,109))
node --import tsx --input-type=module -e "<invoke sendMessageTelegram('123456', 'forced document proof', { cfg: {}, token: 'redacted-token', mediaUrl: $proof, mediaLocalRoots: [process.env.TEMP], forceDocument: true, api: recorder })>" $proof
Remove-Item -LiteralPath $proof
```

Evidence after fix: Terminal output from the production send entrypoint command:

```json
{
  "result": {
    "messageId": "202",
    "chatId": "123456"
  },
  "calls": [
    {
      "method": "sendDocument",
      "chatId": "123456",
      "caption": "forced document proof",
      "parse_mode": "HTML",
      "disable_content_type_detection": true,
      "fileClass": "InputFile"
    }
  ]
}
```

Observed result after fix: The only outbound media method recorded was `sendDocument`, with `disable_content_type_detection: true`; no `sendVideo`, `sendVideoNote`, `sendAnimation`, or `sendPhoto` call appeared.

What was not tested: No live Telegram Bot API upload was run from this machine. Automatic fallback from a failed `sendVideo` to `sendDocument` is intentionally out of scope because ClawSweeper called out duplicate-send risk for ambiguous network failures. The repository's focused automated coverage remains supplemental.

## Verification

- `corepack pnpm test extensions/telegram/src/send.test.ts src/cli/program/message/helpers.test.ts src/agents/tools/message-tool.test.ts`
- `corepack pnpm run tsgo:extensions:test`
- `corepack pnpm exec oxfmt --check --threads=1 ...changed files...`
- `corepack pnpm check:changed`
- `git diff --check origin/main...HEAD`
- `codex review --base origin/main -c model_reasoning_effort='"medium"'`

AI-assisted; I reviewed the diff and understand the change.
