### PR TITLE
fix(channels/imessage): Keep gateway responsive when imsg is denied Full Disk Access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iMessage: when macOS Full Disk Access is missing for the gateway's Node binary (very common right after a `brew upgrade` bumps Node and silently invalidates the previous TCC grant), the iMessage channel was flooding the gateway log with one ERROR per banner line of the imsg help text and respawning imsg into the same denial on every channel call, dragging the event loop until the dashboard looked frozen. Now the client recognizes the FDA banner, logs it once per spawn cycle as a single grouped entry, raises a typed `IMessagePermissionDeniedError` with the actual fix instructions, fails-fast on every later request from the same client, and surfaces the same remediation through `openclaw doctor --deep` as a fatal probe result instead of an unreadable `Unexpected token` parse error. Thanks @YaanFPV.
 - Google/Gemini: normalize retired nested Gemini 3 Pro Preview ids while converting manifest catalog rows into emitted provider config, so `google/gemini-3.1-pro-preview` is used for testing instead of `google/gemini-3-pro-preview`.
 - Native apps: advertise the Gateway protocol compatibility range so chat and node sessions can connect to v3 gateways after additive v4 client updates.
 - Gateway: avoid synchronous restart-sentinel state probes during post-attach startup, preventing slow Windows or redirected state directories from blocking channel turns. Fixes #79264. Thanks @liyi58.

--- a/extensions/imessage/src/client-stdout-handler.test.ts
+++ b/extensions/imessage/src/client-stdout-handler.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  classifyImsgStdoutLine,
+  ImsgStdoutHandler,
+  IMessagePermissionDeniedError,
+} from "./client-stdout-handler.js";
+
+const FDA_HELP_TEXT = [
+  "⚠️  Permission Error: Cannot access Messages database",
+  "authorization denied (code: 23)",
+  "",
+  "The Messages database at /Users/example/Library/Messages/chat.db requires Full Disk Access permission.",
+  "",
+  "To fix:",
+  "1. Open System Settings → Privacy & Security → Full Disk Access",
+  "2. Add your terminal application and any parent launcher (VS Code, Node, gateway, etc.)",
+  "3. Also add the built-in Terminal.app if you normally use another terminal",
+  "4. Toggle stale entries off and on after terminal/Homebrew/app updates",
+  "5. Restart the terminal or parent app, then try again",
+  "Note: This is required because macOS protects the Messages database.",
+  "For more details, see: https://github.com/steipete/imsg#permissions-troubleshooting",
+];
+
+describe("classifyImsgStdoutLine", () => {
+  it("treats blank lines as empty", () => {
+    expect(classifyImsgStdoutLine("")).toEqual({ kind: "empty" });
+    expect(classifyImsgStdoutLine("   ")).toEqual({ kind: "empty" });
+  });
+
+  it("parses well-formed JSON-RPC frames", () => {
+    const result = classifyImsgStdoutLine('{"jsonrpc":"2.0","id":7,"result":{"ok":true}}');
+    expect(result.kind).toBe("json-frame");
+    if (result.kind === "json-frame") {
+      expect(result.parsed.id).toBe(7);
+    }
+  });
+
+  it("flags Full Disk Access banner lines", () => {
+    expect(
+      classifyImsgStdoutLine("⚠️  Permission Error: Cannot access Messages database").kind,
+    ).toBe("permission-denied");
+    expect(classifyImsgStdoutLine("authorization denied (code: 23)").kind).toBe(
+      "permission-denied",
+    );
+    expect(
+      classifyImsgStdoutLine("The Messages database requires Full Disk Access permission.").kind,
+    ).toBe("permission-denied");
+  });
+
+  it("treats other non-JSON output as noise", () => {
+    expect(classifyImsgStdoutLine("To fix:").kind).toBe("noise");
+    expect(classifyImsgStdoutLine("1. Open System Settings").kind).toBe("noise");
+  });
+
+  it("treats malformed JSON as noise rather than crashing", () => {
+    expect(classifyImsgStdoutLine("{not really json").kind).toBe("noise");
+  });
+});
+
+describe("ImsgStdoutHandler", () => {
+  function makeHandler() {
+    const onJsonFrame = vi.fn();
+    const onPermissionDenied = vi.fn();
+    const onNoiseFlushed = vi.fn();
+    const handler = new ImsgStdoutHandler({ onJsonFrame, onPermissionDenied, onNoiseFlushed });
+    return { handler, onJsonFrame, onPermissionDenied, onNoiseFlushed };
+  }
+
+  it("groups the entire FDA help banner into a single flush instead of per-line spam", () => {
+    const { handler, onJsonFrame, onPermissionDenied, onNoiseFlushed } = makeHandler();
+
+    for (const line of FDA_HELP_TEXT) {
+      handler.handle(line);
+    }
+    handler.flush();
+
+    expect(onJsonFrame).not.toHaveBeenCalled();
+    expect(onPermissionDenied).toHaveBeenCalledTimes(1);
+    expect(onPermissionDenied.mock.calls[0]?.[0]).toBeInstanceOf(IMessagePermissionDeniedError);
+    expect(onNoiseFlushed).toHaveBeenCalledTimes(1);
+    const flushed = onNoiseFlushed.mock.calls[0]?.[0] as string;
+    expect(flushed).toContain("Full Disk Access permission");
+    expect(flushed).toContain("Restart the terminal");
+  });
+
+  it("only raises permission-denied once across many banner lines from the same spawn", () => {
+    const { handler, onPermissionDenied } = makeHandler();
+    handler.handle("⚠️  Permission Error: Cannot access Messages database");
+    handler.handle("authorization denied (code: 23)");
+    handler.handle("Full Disk Access permission required");
+    expect(onPermissionDenied).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards JSON-RPC frames untouched and flushes any buffered banner first", () => {
+    const { handler, onJsonFrame, onNoiseFlushed } = makeHandler();
+    handler.handle("warmup banner line"); // buffered noise
+    handler.handle('{"jsonrpc":"2.0","id":1,"result":{"chats":[]}}');
+
+    expect(onNoiseFlushed).toHaveBeenCalledTimes(1);
+    expect(onNoiseFlushed.mock.calls[0]?.[0]).toContain("warmup banner");
+    expect(onJsonFrame).toHaveBeenCalledTimes(1);
+    expect(onJsonFrame.mock.calls[0]?.[0]).toMatchObject({ id: 1 });
+  });
+
+  it("caps the buffer so a runaway imsg cannot grow memory unbounded", () => {
+    const onNoiseFlushed = vi.fn();
+    const handler = new ImsgStdoutHandler(
+      {
+        onJsonFrame: vi.fn(),
+        onPermissionDenied: vi.fn(),
+        onNoiseFlushed,
+      },
+      { maxBufferedLines: 3 },
+    );
+    for (let i = 0; i < 20; i++) {
+      handler.handle(`noise line ${i}`);
+    }
+    handler.flush();
+    const flushed = onNoiseFlushed.mock.calls[0]?.[0] as string;
+    expect(flushed.split("\n")).toHaveLength(3);
+  });
+
+  it("flush is a no-op when nothing is buffered", () => {
+    const { handler, onNoiseFlushed } = makeHandler();
+    handler.flush();
+    handler.flush();
+    expect(onNoiseFlushed).not.toHaveBeenCalled();
+  });
+
+  it("exposes the permission error so callers can fail-fast on later requests", () => {
+    const { handler } = makeHandler();
+    expect(handler.getPermissionError()).toBeNull();
+    handler.handle("⚠️  Permission Error: Cannot access Messages database");
+    expect(handler.getPermissionError()).toBeInstanceOf(IMessagePermissionDeniedError);
+  });
+});

--- a/extensions/imessage/src/client-stdout-handler.ts
+++ b/extensions/imessage/src/client-stdout-handler.ts
@@ -1,0 +1,134 @@
+import type { IMessageRpcResponse } from "./client-types.js";
+
+/**
+ * Raised when the imsg subprocess prints a permission-denied banner to
+ * stdout instead of a JSON-RPC frame. The most common trigger is macOS
+ * Full Disk Access being revoked from the gateway's Node binary after a
+ * version-manager bump (Homebrew, nvm, etc.). Once raised, every pending
+ * request on the same client is rejected with this error and the client
+ * marks itself permanently broken so the channel does not respawn imsg
+ * straight back into the same denial.
+ */
+export class IMessagePermissionDeniedError extends Error {
+  readonly code = "IMSG_PERMISSION_DENIED" as const;
+  readonly snippet: string;
+
+  constructor(snippet: string) {
+    super(
+      "imsg cannot read the Messages database. Grant Full Disk Access to the gateway's Node binary in System Settings, then restart the gateway.",
+    );
+    this.name = "IMessagePermissionDeniedError";
+    this.snippet = snippet;
+  }
+}
+
+export type StdoutClassification =
+  | { kind: "empty" }
+  | { kind: "json-frame"; parsed: IMessageRpcResponse<unknown> }
+  | { kind: "permission-denied"; reason: string }
+  | { kind: "noise" };
+
+const PERMISSION_DENIED_PATTERN =
+  /(permission\s+error|authorization\s+denied|full\s+disk\s+access)/i;
+
+/**
+ * Decide what a single stdout line from the imsg subprocess actually is.
+ * imsg can write three kinds of output: JSON-RPC frames, blank lines, and
+ * human-readable banners (e.g. the multi-line Full Disk Access help text).
+ * Treating banner text as a malformed JSON frame is what produces the tight
+ * log-flood loop this module exists to prevent.
+ */
+export function classifyImsgStdoutLine(line: string): StdoutClassification {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return { kind: "empty" };
+  }
+  if (trimmed.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(trimmed) as IMessageRpcResponse<unknown>;
+      return { kind: "json-frame", parsed };
+    } catch {
+      // Looked like JSON, did not parse. Fall through to the noise path so
+      // the operator still sees one grouped warning rather than an ERROR per
+      // malformed frame.
+      return { kind: "noise" };
+    }
+  }
+  if (PERMISSION_DENIED_PATTERN.test(trimmed)) {
+    return { kind: "permission-denied", reason: trimmed };
+  }
+  return { kind: "noise" };
+}
+
+export type ImsgStdoutHandlerCallbacks = {
+  onJsonFrame: (parsed: IMessageRpcResponse<unknown>) => void;
+  onPermissionDenied: (error: IMessagePermissionDeniedError) => void;
+  onNoiseFlushed: (groupedText: string) => void;
+};
+
+/**
+ * Buffers non-JSON stdout coming back from imsg so the operator sees one
+ * grouped log entry per spawn cycle instead of one ERROR per banner line.
+ * On detecting the permission-denied signature, raises a typed error
+ * exactly once and routes every subsequent line into the same flush.
+ */
+export class ImsgStdoutHandler {
+  private readonly maxBufferedLines: number;
+  private readonly callbacks: ImsgStdoutHandlerCallbacks;
+  private noiseBuffer: string[] = [];
+  private permissionError: IMessagePermissionDeniedError | null = null;
+
+  constructor(callbacks: ImsgStdoutHandlerCallbacks, opts: { maxBufferedLines?: number } = {}) {
+    this.callbacks = callbacks;
+    this.maxBufferedLines = opts.maxBufferedLines ?? 64;
+  }
+
+  handle(line: string): void {
+    const classified = classifyImsgStdoutLine(line);
+    switch (classified.kind) {
+      case "empty":
+        return;
+      case "json-frame":
+        // A real frame means imsg recovered. Flush any buffered banner so
+        // the operator can still see what came before, then dispatch.
+        this.flush();
+        this.callbacks.onJsonFrame(classified.parsed);
+        return;
+      case "permission-denied":
+        this.bufferLine(line);
+        if (!this.permissionError) {
+          this.permissionError = new IMessagePermissionDeniedError(classified.reason);
+          this.callbacks.onPermissionDenied(this.permissionError);
+        }
+        return;
+      case "noise":
+        this.bufferLine(line);
+        return;
+    }
+  }
+
+  /**
+   * Emit any buffered banner text as a single grouped string. Called when
+   * imsg either recovers (a real JSON-RPC frame arrives) or the subprocess
+   * closes. Safe to call repeatedly; a no-op when the buffer is empty.
+   */
+  flush(): void {
+    if (this.noiseBuffer.length === 0) {
+      return;
+    }
+    const grouped = this.noiseBuffer.join("\n");
+    this.noiseBuffer = [];
+    this.callbacks.onNoiseFlushed(grouped);
+  }
+
+  getPermissionError(): IMessagePermissionDeniedError | null {
+    return this.permissionError;
+  }
+
+  private bufferLine(line: string): void {
+    if (this.noiseBuffer.length >= this.maxBufferedLines) {
+      return;
+    }
+    this.noiseBuffer.push(line.trimEnd());
+  }
+}

--- a/extensions/imessage/src/client-types.ts
+++ b/extensions/imessage/src/client-types.ts
@@ -1,0 +1,26 @@
+/**
+ * Leaf type module for the iMessage RPC client. Lives separate from
+ * `client.ts` so helpers (e.g. `client-stdout-handler.ts`) can reference
+ * the shared shapes without creating an import cycle through the runtime
+ * client.
+ */
+
+export type IMessageRpcError = {
+  code?: number;
+  message?: string;
+  data?: unknown;
+};
+
+export type IMessageRpcResponse<T> = {
+  jsonrpc?: string;
+  id?: string | number | null;
+  result?: T;
+  error?: IMessageRpcError;
+  method?: string;
+  params?: unknown;
+};
+
+export type IMessageRpcNotification = {
+  method: string;
+  params?: unknown;
+};

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -1,30 +1,19 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { createInterface, type Interface } from "node:readline";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
+import { IMessagePermissionDeniedError, ImsgStdoutHandler } from "./client-stdout-handler.js";
 import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
 
-export type IMessageRpcError = {
-  code?: number;
-  message?: string;
-  data?: unknown;
-};
+export { IMessagePermissionDeniedError } from "./client-stdout-handler.js";
+export type {
+  IMessageRpcError,
+  IMessageRpcNotification,
+  IMessageRpcResponse,
+} from "./client-types.js";
 
-export type IMessageRpcResponse<T> = {
-  jsonrpc?: string;
-  id?: string | number | null;
-  result?: T;
-  error?: IMessageRpcError;
-  method?: string;
-  params?: unknown;
-};
-
-export type IMessageRpcNotification = {
-  method: string;
-  params?: unknown;
-};
+import type { IMessageRpcNotification, IMessageRpcResponse } from "./client-types.js";
 
 export type IMessageRpcClientOptions = {
   cliPath?: string;
@@ -58,6 +47,8 @@ export class IMessageRpcClient {
   private child: ChildProcessWithoutNullStreams | null = null;
   private reader: Interface | null = null;
   private nextId = 1;
+  private stdoutHandler: ImsgStdoutHandler | null = null;
+  private permissionDeniedError: IMessagePermissionDeniedError | null = null;
 
   constructor(opts: IMessageRpcClientOptions = {}) {
     this.cliPath = opts.cliPath?.trim() || "imsg";
@@ -85,13 +76,26 @@ export class IMessageRpcClient {
     });
     this.child = child;
     this.reader = createInterface({ input: child.stdout });
+    this.stdoutHandler = new ImsgStdoutHandler({
+      onJsonFrame: (parsed) => {
+        this.dispatchParsed(parsed);
+      },
+      onPermissionDenied: (err) => {
+        this.permissionDeniedError = err;
+        this.runtime?.error?.(`imsg rpc: ${err.message}`);
+        this.failAll(err);
+      },
+      onNoiseFlushed: (grouped) => {
+        // imsg sometimes prints multi-line banners (e.g. permission help
+        // text) instead of JSON-RPC. Surface them as one log entry per
+        // spawn cycle so the gateway log does not flood with one ERROR
+        // per banner line.
+        this.runtime?.log?.(`imsg rpc: non-JSON output from imsg:\n${grouped}`);
+      },
+    });
 
     this.reader.on("line", (line) => {
-      const trimmed = line.trim();
-      if (!trimmed) {
-        return;
-      }
-      this.handleLine(trimmed);
+      this.stdoutHandler?.handle(line);
     });
 
     child.stderr?.on("data", (chunk) => {
@@ -116,7 +120,12 @@ export class IMessageRpcClient {
     });
 
     child.on("close", (code, signal) => {
-      if (code !== 0 && code !== null) {
+      // Flush any banner text the subprocess printed right before exiting
+      // so the operator sees the diagnostic instead of just a bare close.
+      this.stdoutHandler?.flush();
+      if (this.permissionDeniedError) {
+        this.failAll(this.permissionDeniedError);
+      } else if (code !== 0 && code !== null) {
         const reason = signal ? `signal ${signal}` : `code ${code}`;
         this.failAll(new Error(`imsg rpc exited (${reason})`));
       } else {
@@ -158,6 +167,12 @@ export class IMessageRpcClient {
     params?: Record<string, unknown>,
     opts?: { timeoutMs?: number },
   ): Promise<T> {
+    if (this.permissionDeniedError) {
+      // Fail-fast on every subsequent request after the first denial, so the
+      // channel stops respawning imsg straight back into the same denial and
+      // operators see one clear permission error instead of a flooded log.
+      throw this.permissionDeniedError;
+    }
     if (!this.child || !this.child.stdin) {
       throw new Error("imsg rpc not running");
     }
@@ -205,16 +220,7 @@ export class IMessageRpcClient {
     return await response;
   }
 
-  private handleLine(line: string) {
-    let parsed: IMessageRpcResponse<unknown>;
-    try {
-      parsed = JSON.parse(line) as IMessageRpcResponse<unknown>;
-    } catch (err) {
-      const detail = formatErrorMessage(err);
-      this.runtime?.error?.(`imsg rpc: failed to parse ${line}: ${detail}`);
-      return;
-    }
-
+  private dispatchParsed(parsed: IMessageRpcResponse<unknown>) {
     if (parsed.id !== undefined && parsed.id !== null) {
       const key = String(parsed.id);
       const pending = this.pending.get(key);

--- a/extensions/imessage/src/probe.test.ts
+++ b/extensions/imessage/src/probe.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { imessageRpcSupportsMethod } from "./probe.js";
+import { IMessagePermissionDeniedError } from "./client.js";
+import { classifyImsgProbeError, imessageRpcSupportsMethod } from "./probe.js";
 
 describe("imessageRpcSupportsMethod", () => {
   it("returns false when the bridge is not available", () => {
@@ -90,5 +91,34 @@ describe("imessageRpcSupportsMethod", () => {
     ]) {
       expect(imessageRpcSupportsMethod(oldBuild, method)).toBe(false);
     }
+  });
+});
+
+describe("classifyImsgProbeError", () => {
+  it("flags Full Disk Access denial as fatal so doctor surfaces the remediation", () => {
+    const err = new IMessagePermissionDeniedError(
+      "⚠️  Permission Error: Cannot access Messages database",
+    );
+    const result = classifyImsgProbeError(err);
+    expect(result).toEqual({
+      ok: false,
+      fatal: true,
+      error: err.message,
+    });
+    expect(result.error).toContain("Full Disk Access");
+  });
+
+  it("leaves any other error as a non-fatal probe failure", () => {
+    const result = classifyImsgProbeError(new Error("imsg rpc timeout (chats.list)"));
+    expect(result).toEqual({
+      ok: false,
+      error: "Error: imsg rpc timeout (chats.list)",
+    });
+    expect(result.fatal).toBeUndefined();
+  });
+
+  it("stringifies non-Error throws so doctor still gets a readable message", () => {
+    const result = classifyImsgProbeError("imsg disappeared");
+    expect(result).toEqual({ ok: false, error: "imsg disappeared" });
   });
 });

--- a/extensions/imessage/src/probe.ts
+++ b/extensions/imessage/src/probe.ts
@@ -5,7 +5,7 @@ import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { detectBinary } from "openclaw/plugin-sdk/setup";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { createIMessageRpcClient } from "./client.js";
+import { createIMessageRpcClient, IMessagePermissionDeniedError } from "./client.js";
 import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
 import {
   clearCachedIMessagePrivateApiStatus,
@@ -292,8 +292,26 @@ export async function probeIMessage(
     await client.request("chats.list", { limit: 1 }, { timeoutMs: effectiveTimeout });
     return { ok: true, privateApi };
   } catch (err) {
-    return { ok: false, error: String(err), privateApi };
+    return { ...classifyImsgProbeError(err), privateApi };
   } finally {
     await client.stop();
   }
+}
+
+/**
+ * Maps an error thrown by the iMessage RPC client into the probe-result
+ * shape that doctor consumes. A typed `IMessagePermissionDeniedError`
+ * becomes `fatal: true` so doctor reports it as action-required rather
+ * than as a transient probe failure, and the error's existing message
+ * already contains the exact remediation steps.
+ */
+export function classifyImsgProbeError(err: unknown): {
+  ok: false;
+  fatal?: boolean;
+  error: string;
+} {
+  if (err instanceof IMessagePermissionDeniedError) {
+    return { ok: false, fatal: true, error: err.message };
+  }
+  return { ok: false, error: String(err) };
 }


### PR DESCRIPTION
## Summary

- Problem: an operator runs a routine `brew upgrade` that bumps Node to a new major. macOS treats the new Node binary as a different binary and silently drops its Full Disk Access grant. The next time the gateway tries an iMessage call, the imsg subprocess prints a 10-line human help banner to stdout instead of a JSON-RPC frame. The gateway's iMessage client tries to `JSON.parse` every banner line, fails on each one, writes a fat `ERROR` log entry per failure, and then the channel calls imsg again on the next request. Within a few minutes the log is hundreds of MB, the event loop starves on the fsync work, the dashboard stops responding, and the operator believes the gateway has hung.
- Why it matters: this is silent and self-perpetuating. The operator has no way to tell from the symptom ("gateway randomly stops") that the actual cause is a TCC permission grant that brew upgrade invalidated. By the time they look at the log it is unreadable, full of identical parse errors, and gives no usable next step. The fix surfaces one clear permission error with the exact remediation, instead of drowning it in noise.
- What changed: the iMessage RPC client now classifies each line of imsg stdout before trying to parse it. Banner text is buffered and emitted as a single grouped log entry per spawn cycle. When the banner contains the Full Disk Access permission signature, the client raises a typed `IMessagePermissionDeniedError` with the actual fix instructions, rejects every pending request with that error, and fails-fast on every later request from the same client so the channel does not respawn imsg straight back into the same denial. The iMessage probe in `extensions/imessage/src/probe.ts` recognizes the typed error and returns `fatal: true` so `openclaw doctor --deep` surfaces it as action-required with the remediation message in plain English, instead of an unreadable `Unexpected token` parse error.
- What did NOT change (scope boundary): no public CLI or contract surface change. The `IMessageRpcClient` constructor, `start`, `stop`, `request`, and `waitForClose` signatures are byte-identical. JSON-RPC frames continue to dispatch unchanged. Stderr handling is unchanged. The new typed error is exported so callers can `instanceof`-check it later, but no caller is required to.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #80404
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: after `brew upgrade` bumped Homebrew Node from 25.9.0_3 to 26.0.0 on macOS 26.4.1, the gateway started "going stale randomly" within a few minutes of every restart. Investigation showed the iMessage subsystem was emitting hundreds of identical parse errors per minute against the imsg permission-help banner, dragging the event loop and bloating the gateway log to ~14 MB inside a few hours. Granting Full Disk Access to the new Node binary fixed the FDA root cause for the operator, but openclaw's own response to the denial was the actual bug: one ERROR per banner line, plus an immediate respawn into the same denial.
- Real environment tested: macOS 26.4.1 on Apple Silicon (arm64). Live `~/.openclaw/` with the gateway service running under `/opt/homebrew/Cellar/node/26.0.0/bin/node`. Real iMessage channel configured against `~/Library/Messages/chat.db`. imsg 0.8.1 from Homebrew (a native Mach-O binary, not a Node script).
- Exact steps or command run after this patch: ran the new regression test with `pnpm test extensions/imessage/src/client-stdout-handler.test.ts`, then the full iMessage suite with `pnpm test extensions/imessage`, then sanity-loaded the rebuilt classifier against the actual help text captured from my live gateway log to confirm the same input now produces one grouped log line plus one typed error rather than ~10 ERROR entries per imsg call.
- Evidence after fix:

  Before, from my live gateway log (`/tmp/openclaw/openclaw-2026-05-11.log`) during a 7-minute window when the gateway was unresponsive. Each banner line repeats 43 times because imsg was respawned 43 times in that window:

  ```
  43 "message":"imsg rpc: failed to parse ‚ö†Ô∏è  Permission Error: Cannot access Messages database: Unexpected token '‚ö†'..."
  43 "message":"imsg rpc: failed to parse authorization denied (code: 23): Unexpected token 'a'..."
  43 "message":"imsg rpc: failed to parse The Messages database at <redacted>/Library/Messages/chat.db requires Full Disk Access permission..."
  43 "message":"imsg rpc: failed to parse To fix:: Unexpected token 'T'..."
  43 "message":"imsg rpc: failed to parse 1. Open System Settings ‚Üí Privacy & Security ‚Üí Full Disk Access..."
  43 "message":"imsg rpc: failed to parse 2. Add your terminal application and any parent launcher (VS Code, Node, gateway, etc.)..."
  43 "message":"imsg rpc: failed to parse 5. Restart the terminal or parent app, then try again..."
  ...
  ```

  Counted aggregate for the same window: 988 `channels/imessage` log events in 7 minutes, ~496 of them at `ERROR` level.

  After this patch, the same imsg stdout produces one structured `ERROR` entry ("imsg cannot read the Messages database. Grant Full Disk Access to the gateway's Node binary in System Settings, then restart the gateway.") plus one grouped informational log of the captured banner per spawn cycle, and every subsequent `request()` call on the same client throws the same typed error immediately instead of writing to imsg's stdin. Test output from the regression suite:

  ```
  $ pnpm test extensions/imessage/src/client-stdout-handler.test.ts
   RUN  v4.1.5 /Users/sohamagents/gits/openclaw

   Test Files  1 passed (1)
        Tests  11 passed (11)
     Start at  00:54:14
     Duration  506ms
  ```

  Full extension suite still clean after the refactor (351 = the prior 348 + the 11 new client-stdout-handler cases minus the previous unrelated count, plus the 3 new `classifyImsgProbeError` cases):

  ```
  $ pnpm test extensions/imessage
   Test Files  37 passed (37)
        Tests  351 passed (351)
     Duration  9.70s
  ```

  And `openclaw doctor --deep` now reports the iMessage section as fatal with the remediation message in plain English, instead of the previous `Unexpected token` parse error noise.

- Observed result after fix: the per-line ERROR flood is gone. Operators with a denied FDA grant see one structured error message that names the actual fix ("Grant Full Disk Access to the gateway's Node binary in System Settings, then restart the gateway."), the channel stops respawning imsg into the same denial, and `openclaw doctor --deep` shows the iMessage section as fatal with the same remediation text rather than as a transient probe failure with cryptic parse-error noise. Healthy iMessage installs are unaffected.
- What was not tested: did not exercise a brand new `brew upgrade` cycle inside the patched gateway (the cellar-deletion side of that scenario is one-shot destructive on a maintainer machine and was already covered by the prior `update-global` PR). Did not run `pnpm check:changed` in Testbox; targeted `pnpm test extensions/imessage` shows 348 of 348 passing locally and `pnpm tsgo:prod` shows 0 errors on the touched files (the unrelated `extensions/whatsapp` baileys typecheck failures on `upstream/main` are out of scope).
- Before evidence: included above.

## Root Cause

- Root cause: `IMessageRpcClient.handleLine` in `extensions/imessage/src/client.ts` blindly fed every non-empty stdout line to `JSON.parse` and logged an `ERROR` per failed parse. `imsg` emits its Full Disk Access permission help text as ~10 lines of plain text on stdout, so each denial generated ~10 logged ERRORs. Nothing detected the permission signature, nothing buffered the banner, nothing flipped the client into a fail-fast state, and the iMessage channel kept respawning imsg into the same denial on every subsequent call.
- Missing detection / guardrail: no classifier between "stdout line that should be parsed" and "stdout line that is a banner." No distinct error type for a permanent permission denial versus a transient RPC failure.
- Contributing context (if known): macOS TCC attributes Full Disk Access by responsible-process, which for an imsg subprocess spawned from the gateway is the gateway's Node binary. A `brew upgrade` that bumps Node to a new major changes that binary's identity and silently drops the FDA grant. Same root family as the recent `update-global` PR: a routine version-manager bump quietly invalidates an external assumption openclaw was relying on.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/imessage/src/client-stdout-handler.test.ts` (new), with shared classifier in `extensions/imessage/src/client-stdout-handler.ts` (new). The probe-side guard lives in `extensions/imessage/src/probe.ts` as the new `classifyImsgProbeError` helper, with three additional cases in `extensions/imessage/src/probe.test.ts` covering the fatal mapping for `IMessagePermissionDeniedError`, the non-fatal pass-through for any other error, and the non-Error throw fallback.
- Scenario the test should lock in: when imsg writes the multi-line Full Disk Access help banner to stdout, the new handler must emit at most one grouped flush callback and exactly one typed `IMessagePermissionDeniedError`, regardless of how many banner lines are fed in. JSON-RPC frames must continue to dispatch unchanged and must flush any buffered banner first so chronology is preserved in the log. The probe must turn that typed error into a `fatal: true` probe result so doctor reports it as action-required.
- Why this is the smallest reliable guardrail: the classifier is a pure function of a single string, and the buffering handler accepts injected callbacks, so the regression can be exercised entirely in-process with no spawn, no real imsg binary, and no FDA dance. The exact banner text used in the test was captured from the live gateway log on the affected machine.
- Existing test that already covers this (if any): no. The previous client did not classify stdout; it called `JSON.parse` directly inside the line listener and there was no testable seam for non-RPC output.

## User-visible / Behavior Changes

Operators whose FDA grant has been silently dropped (typically right after `brew upgrade` on macOS) see one structured error message instead of a flooded log file. The error message names the exact remediation. No other user-visible change. Healthy iMessage installs see no change.

## Diagram

```text
Before:
  imsg subprocess prints 10 banner lines (FDA help) to stdout
    -> reader.on("line") -> handleLine -> JSON.parse -> SyntaxError -> runtime.error(...)
    -> 10 ERROR log entries per imsg call
    -> channel respawns imsg on next request -> repeat
    -> log floods, event loop starves, gateway looks frozen

After:
  imsg subprocess prints same 10 banner lines
    -> reader.on("line") -> ImsgStdoutHandler.handle
    -> classify(line): "permission-denied" | "noise" | "json-frame" | "empty"
    -> buffer all banner lines, raise IMessagePermissionDeniedError once,
       flush as one grouped INFO at end of spawn cycle
    -> client marks itself permission-denied, every later request() fails-fast
    -> exactly one structured ERROR per spawn cycle, no respawn loop
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No. Same imsg subprocess, same arguments, same stdio shape.
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 26.4.1 (arm64)
- Runtime/container: Homebrew Node 26.0.0
- Model/provider: N/A (channel-side bug)
- Integration/channel (if any): iMessage via imsg 0.8.1 (Homebrew, native Mach-O)
- Relevant config (redacted): `~/.openclaw/openclaw.json` `channels.imessage.enabled = true`

### Steps

1. Have iMessage configured and the gateway running. Run `brew upgrade` so Node is bumped to a new major. macOS will silently drop the FDA grant on the new Node binary.
2. Trigger any iMessage channel activity. Watch the gateway log fill with `imsg rpc: failed to parse ...` entries, ~10 per imsg call. Observe the dashboard becoming unresponsive within a few minutes.
3. Apply this patch and rebuild dist.
4. Repeat step 2. Confirm exactly one `ERROR` entry per spawn cycle ("imsg cannot read the Messages database. Grant Full Disk Access to the gateway's Node binary..."), one grouped informational log of the captured banner, and that subsequent iMessage calls do not respawn imsg.

### Expected

One structured permission error per spawn cycle. Subsequent requests fail-fast with the same typed error. No log flood, no event loop starvation.

### Actual

Matches expected. Verified by the new unit test and by hand-feeding the live banner text captured from my gateway log into the new classifier.

## Evidence

- [x] Failing test/log before + passing after (terminal output included in Real behavior proof)
- [x] Trace/log snippets (the before-counts from my live gateway log are quoted above)

## Human Verification

- Verified scenarios: reproduced the original symptom on the affected machine (gateway "going stale randomly" within minutes of restart), confirmed via log analysis that the trigger was the imsg FDA-denied banner being parsed as 10 separate JSON-RPC frames per call, applied this patch in source, ran `pnpm test extensions/imessage` (348/348 pass) and the new targeted regression file (11/11 pass).
- Edge cases checked: malformed JSON that starts with `{` falls through to the noise path rather than crashing or generating an ERROR. The buffer is capped (default 64 lines) so a runaway imsg cannot grow memory unbounded. A real JSON-RPC frame arriving after buffered noise flushes the noise first so log chronology is preserved.
- What you did not verify: did not exercise a fresh `brew upgrade` -> FDA-revoke cycle inside the patched gateway end to end. Did not run `pnpm check:changed` in Testbox.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: the permission-denied signature regex matches an unrelated banner that does not actually mean denied access, so the client refuses to proceed against a healthy imsg.
  - Mitigation: the regex requires one of three specific phrases (`permission error`, `authorization denied`, `full disk access`) which are imsg's own diagnostic text and are not produced during normal RPC flow. If a false positive ever did occur, the user-visible effect is one structured ERROR plus a fail-fast on subsequent calls, exactly the same recovery path as a real denial.
