### PR TITLE
chore(protocol): refresh Swift gateway models

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -716,6 +716,7 @@ public struct AgentParams: Codable, Sendable {
     public let bootstrapcontextmode: AnyCodable?
     public let bootstrapcontextrunkind: AnyCodable?
     public let acpturnsource: String?
+    public let internalruntimehandoffid: String?
     public let internalevents: [[String: AnyCodable]]?
     public let inputprovenance: [String: AnyCodable]?
     public let voicewaketrigger: String?
@@ -752,6 +753,7 @@ public struct AgentParams: Codable, Sendable {
         bootstrapcontextmode: AnyCodable?,
         bootstrapcontextrunkind: AnyCodable?,
         acpturnsource: String?,
+        internalruntimehandoffid: String?,
         internalevents: [[String: AnyCodable]]?,
         inputprovenance: [String: AnyCodable]?,
         voicewaketrigger: String?,
@@ -787,6 +789,7 @@ public struct AgentParams: Codable, Sendable {
         self.bootstrapcontextmode = bootstrapcontextmode
         self.bootstrapcontextrunkind = bootstrapcontextrunkind
         self.acpturnsource = acpturnsource
+        self.internalruntimehandoffid = internalruntimehandoffid
         self.internalevents = internalevents
         self.inputprovenance = inputprovenance
         self.voicewaketrigger = voicewaketrigger
@@ -824,6 +827,7 @@ public struct AgentParams: Codable, Sendable {
         case bootstrapcontextmode = "bootstrapContextMode"
         case bootstrapcontextrunkind = "bootstrapContextRunKind"
         case acpturnsource = "acpTurnSource"
+        case internalruntimehandoffid = "internalRuntimeHandoffId"
         case internalevents = "internalEvents"
         case inputprovenance = "inputProvenance"
         case voicewaketrigger = "voiceWakeTrigger"


### PR DESCRIPTION
## Summary
- Refresh the generated shared Swift gateway protocol model.
- Add the generated `internalRuntimeHandoffId` Codable property/mapping to `AgentParams` in `apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift`.

## Why
`pnpm protocol:check` on current `main` regenerates this file and reports a dirty diff, which causes `checks-fast-protocol` to fail on unrelated PRs rebased onto current main.

## Real behavior proof
- **Behavior or issue addressed:** Current `main` regenerates `apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift` with a missing `internalRuntimeHandoffId` mapping, leaving the protocol output dirty.
- **Real environment tested:** Disposable OpenClaw source checkout on Linux arm64 using Node 22 and the repo-declared pnpm via Corepack; no live Gateway, service config, or production state was used.
- **Exact steps or command run after the patch:** Regenerated the protocol schema and Swift model output, then compared the generated artifacts with `git diff --exit-code`.
- **Evidence after fix:** Terminal output from the after-fix run:

```console
$ corepack pnpm protocol:gen
wrote dist/protocol.schema.json

$ corepack pnpm protocol:gen:swift
wrote apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift

$ git diff --exit-code -- dist/protocol.schema.json apps/macos/Sources/OpenClawProtocol/GatewayModels.swift apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
exit code: 0; no diff
```

- **Observed result after fix:** The regenerated protocol artifacts matched the committed tree, so the generated Swift protocol model is no longer dirty after regeneration.
- **What was not tested:** No live Gateway/runtime canary was run because this PR only refreshes generated protocol output.

## Validation
- Reproduced the drift from latest upstream `main` with the protocol generation/check sequence.
- Confirmed the generated diff is limited to one file: `apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift` (4 insertions).
- After committing the generated output, reran the same protocol generation/check sequence and it exited cleanly with no working-tree diff.

