### PR TITLE
fix(cron): consult durable store in hasBackingSession after restart

### DIFF
--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -600,4 +600,72 @@ describe("task-registry maintenance issue #60299", () => {
     }
     expect(hookNow).toBeGreaterThanOrEqual(beforeMaintenance);
   });
+
+  it("keeps cron tasks live when in-memory active set is empty but durable store shows runningAtMs", async () => {
+    const startedAt = Date.now() - 6 * 60_000;
+    const task = makeStaleTask({
+      runtime: "cron",
+      sourceId: "my-job",
+      runId: `cron:my-job:${startedAt}`,
+      startedAt,
+      lastEventAt: startedAt,
+    });
+    // No activeCronJobIds — simulates post-restart state where in-memory set is empty.
+    // Durable store shows the job still running (runningAtMs matches task startedAt).
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [task],
+      activeCronJobIds: [],
+      cronRuntimeAuthoritative: true,
+      cronStore: {
+        version: 1,
+        jobs: [
+          {
+            id: "my-job",
+            label: "Test job",
+            schedule: "*/5 * * * *",
+            payload: { kind: "agentTurn" },
+            state: {
+              runningAtMs: startedAt,
+            },
+          } as any,
+        ],
+      },
+    });
+    const result = await runTaskRegistryMaintenance();
+    expectMaintenanceCounts(result, { reconciled: 0, recovered: 0 });
+    expectTaskStatus(currentTasks, task.taskId, "running");
+  });
+
+  it("marks cron tasks lost when durable store runningAtMs does not match task start", async () => {
+    const startedAt = Date.now() - 6 * 60_000;
+    const task = makeStaleTask({
+      runtime: "cron",
+      sourceId: "my-job",
+      runId: `cron:my-job:${startedAt}`,
+      startedAt,
+      lastEventAt: startedAt,
+    });
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [task],
+      activeCronJobIds: [],
+      cronRuntimeAuthoritative: true,
+      cronStore: {
+        version: 1,
+        jobs: [
+          {
+            id: "my-job",
+            label: "Test job",
+            schedule: "*/5 * * * *",
+            payload: { kind: "agentTurn" },
+            state: {
+              runningAtMs: startedAt - 300_000, // Different start — stale record
+            },
+          } as any,
+        ],
+      },
+    });
+    const result = await runTaskRegistryMaintenance();
+    expectMaintenanceCounts(result, { reconciled: 1, recovered: 0 });
+    expectTaskStatus(currentTasks, task.taskId, "lost");
+  });
 });

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -444,13 +444,48 @@ function hasCliRunIdentity(task: TaskRecord): boolean {
   return [task.sourceId, task.runId].some((candidate) => Boolean(candidate?.trim()));
 }
 
+/**
+ * Check durable cron store to determine if a job is genuinely in-flight.
+ * After a gateway restart the in-memory activeJobIds set is empty, but the
+ * on-disk store still records `runningAtMs` for jobs that were executing at
+ * shutdown time. If the stored `runningAtMs` matches the task's execution
+ * start timestamp, the job is (or was) legitimately in-flight and should not
+ * be marked lost by this sweep. The grace period handles the case where the
+ * job actually died during restart — after 5 minutes with no progress event
+ * it will be re-evaluated and marked lost on a subsequent sweep.
+ */
+function isCronJobInFlightFromStore(task: TaskRecord): boolean {
+  const execution = parseCronExecutionId(task);
+  if (!execution) {
+    return false;
+  }
+  let store: CronStoreFile | null;
+  try {
+    store = taskRegistryMaintenanceRuntime.loadCronStoreSync(
+      taskRegistryMaintenanceRuntime.resolveCronStorePath(),
+    );
+  } catch {
+    return false;
+  }
+  if (!store) {
+    return false;
+  }
+  const job = store.jobs.find((entry) => entry.id === execution.jobId);
+  return Boolean(job?.state.runningAtMs && job.state.runningAtMs === execution.startedAt);
+}
+
 function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupContext): boolean {
   if (task.runtime === "cron") {
     if (!taskRegistryMaintenanceRuntime.isCronRuntimeAuthoritative()) {
       return true;
     }
     const jobId = task.sourceId?.trim();
-    return jobId ? taskRegistryMaintenanceRuntime.isCronJobActive(jobId) : false;
+    if (jobId && taskRegistryMaintenanceRuntime.isCronJobActive(jobId)) {
+      return true;
+    }
+    // After a gateway restart the in-memory active-jobs set is empty.
+    // Fall back to durable store to avoid false-positive lost findings.
+    return isCronJobInFlightFromStore(task);
   }
 
   if (task.runtime === "cli" && hasActiveCliRun(task)) {


### PR DESCRIPTION
## Problem

After a gateway restart, the in-memory `activeJobIds` set is empty. `hasBackingSession()` calls `isCronJobActive(jobId)` which checks this set and returns `false` for every cron job. The maintenance sweep (60s timer, with a 5s deferred initial sweep) then marks any still-running cron task as `lost / backing session missing` — a false positive.

This is the remaining gap called out in 148ea001:

> A follow-up is still warranted to reconcile cron tasks left in 'running' state across gateway restarts (no in-memory active-jobs state to vouch for them on first sweep), but that touches startup reconciliation and is intentionally out of scope for this change.

## When this fires

The cron service startup (`ops.ts start()`) calls `markInterruptedStartupRun()` to clear `runningAtMs` for interrupted jobs. In the normal case this completes before the first maintenance sweep (5s deferred). However:

1. **Startup ordering race:** If the cron service start is slow (large store, missed-job catch-up), the maintenance sweep can observe `runningAtMs` still set before the cron startup path clears it.
2. **Non-authoritative-to-authoritative transition:** If `cronRuntimeAuthoritative` is toggled after the cron service has already started, subsequent sweeps have no in-memory state for pre-existing runs.

This fallback acts as a safety net: if the durable store still shows `runningAtMs` matching the task's execution start, the job is plausibly in-flight and should not be marked lost on this sweep. The 5-minute grace period ensures genuinely dead jobs are eventually reclaimed.

## Fix

Add `isCronJobInFlightFromStore()` that reads the on-disk cron store (`jobs-state.json`) and checks whether `job.state.runningAtMs` matches the task's execution start timestamp. When it does, `hasBackingSession()` returns `true`.

## Testing

Two tests added to `task-registry.maintenance.issue-60299.test.ts`:
- Keeps task alive when store confirms in-flight (`runningAtMs` matches)
- Marks task lost when store `runningAtMs` is stale (doesn't match)