### PR TITLE
Fix OpenAI Codex OAuth refresh reuse in app-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 - Auth/Claude CLI: persist fresher managed external CLI OAuth credentials back to `auth-profiles.json`, preventing stale `anthropic:claude-cli` profiles from repeatedly bootstrapping and flooding debug logs. Fixes #80129. Thanks @Caulderein.
 - Context: render `/context map` only from actual run context and persist Codex app-server run reports without counting deferred tool-search schemas as prompt-loaded tool schemas.
 - Codex app-server: report Codex-native tool execution to diagnostics so long-running native `bash`, web, file, and MCP tools no longer look like stale embedded runs to the watchdog. (#80217)
+- Codex app-server: reuse current OpenAI Codex OAuth access tokens for native app-server refresh requests instead of forcing a refresh that can trip `refresh_token_reused` after login.
 - Tasks: route group and channel task completions through the requester session so the parent agent can send the visible summary instead of stopping at a generic task-status line. Fixes #77251. (#77365) Thanks @funmerlin.
 - Telegram: preserve blank lines between manually indented bullet blocks and following numbered sections in rendered replies. Fixes #76998. Thanks @evgyur.
 - Slack: pass configured agent identity through draft preview sends so partial streaming replies keep custom username/avatar on the initial Slack message. Fixes #38235. (#38237) Thanks @lacymorrow.

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -909,7 +909,40 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
-  it("answers app-server ChatGPT token refresh requests from the bound profile", async () => {
+  it("answers app-server ChatGPT token refresh requests from a current bound profile", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    try {
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai-codex:work",
+        credential: {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "current-access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 24 * 60 * 60_000,
+          accountId: "account-123",
+          email: "codex@example.test",
+        },
+      });
+
+      await expect(
+        refreshCodexAppServerAuthTokens({
+          agentDir,
+          authProfileId: "openai-codex:work",
+        }),
+      ).resolves.toEqual({
+        accessToken: "current-access-token",
+        chatgptAccountId: "account-123",
+        chatgptPlanType: null,
+      });
+      expect(oauthMocks.refreshOpenAICodexToken).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("refreshes expired app-server ChatGPT token refresh requests from the bound profile", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
       access: "refreshed-access-token",
@@ -924,9 +957,9 @@ describe("bridgeCodexAppServerStartOptions", () => {
         credential: {
           type: "oauth",
           provider: "openai-codex",
-          access: "stale-access-token",
+          access: "expired-access-token",
           refresh: "refresh-token",
-          expires: Date.now() + 60_000,
+          expires: Date.now() - 60_000,
           accountId: "account-123",
           email: "codex@example.test",
         },
@@ -948,7 +981,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
-  it("refreshes inherited main Codex OAuth without cloning it into the child store", async () => {
+  it("refreshes expired inherited main Codex OAuth without cloning it into the child store", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const stateDir = path.join(root, "state");
     const childAgentDir = path.join(stateDir, "agents", "worker", "agent");
@@ -967,9 +1000,9 @@ describe("bridgeCodexAppServerStartOptions", () => {
         credential: {
           type: "oauth",
           provider: "openai-codex",
-          access: "main-current-access-token",
+          access: "main-expired-access-token",
           refresh: "main-refresh-token",
-          expires: Date.now() + 60_000,
+          expires: Date.now() - 60_000,
           accountId: "account-main",
           email: "main-codex@example.test",
         },
@@ -999,19 +1032,13 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
-  it("force-refreshes the owner credential instead of a stale child OAuth clone", async () => {
+  it("uses the owner credential instead of a stale child OAuth clone", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const stateDir = path.join(root, "state");
     const childAgentDir = path.join(stateDir, "agents", "worker", "agent");
     const childAuthPath = path.join(childAgentDir, "auth-profiles.json");
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
     vi.stubEnv("OPENCLAW_AGENT_DIR", "");
-    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
-      access: "main-refreshed-access-token",
-      refresh: "main-refreshed-refresh-token",
-      expires: Date.now() + 60_000,
-      accountId: "account-main-refreshed",
-    });
     try {
       upsertAuthProfile({
         profileId: "openai-codex:work",
@@ -1050,17 +1077,17 @@ describe("bridgeCodexAppServerStartOptions", () => {
           authProfileId: "openai-codex:work",
         }),
       ).resolves.toEqual({
-        accessToken: "main-refreshed-access-token",
-        chatgptAccountId: "account-main-refreshed",
+        accessToken: "main-current-access-token",
+        chatgptAccountId: "account-main",
         chatgptPlanType: null,
       });
 
-      expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("main-owner-refresh-token");
+      expect(oauthMocks.refreshOpenAICodexToken).not.toHaveBeenCalled();
       expect(loadAuthProfileStoreForSecretsRuntime().profiles["openai-codex:work"]).toMatchObject({
         type: "oauth",
         provider: "openai-codex",
-        access: "main-refreshed-access-token",
-        refresh: "main-refreshed-refresh-token",
+        access: "main-current-access-token",
+        refresh: "main-owner-refresh-token",
       });
       const child = JSON.parse(await fs.readFile(childAuthPath, "utf8")) as {
         profiles: Record<string, { access?: string; refresh?: string }>;
@@ -1091,7 +1118,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
           provider: "codex-cli",
           access: "stale-alias-access-token",
           refresh: "alias-refresh-token",
-          expires: Date.now() + 60_000,
+          expires: Date.now() - 60_000,
           accountId: "account-legacy",
           email: "legacy-codex@example.test",
         },

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -9,7 +9,6 @@ import {
   resolveApiKeyForProfile,
   resolveDefaultAgentDir,
   resolvePersistedAuthProfileOwnerAgentDir,
-  saveAuthProfileStore,
   type AuthProfileCredential,
   type AuthProfileStore,
   type OAuthCredential,
@@ -271,10 +270,7 @@ export async function refreshCodexAppServerAuthTokens(params: {
   authProfileId?: string;
   config?: AuthProfileOrderConfig;
 }): Promise<CodexChatgptAuthTokensRefreshResponse> {
-  const loginParams = await resolveCodexAppServerAuthProfileLoginParamsInternal({
-    ...params,
-    forceOAuthRefresh: true,
-  });
+  const loginParams = await resolveCodexAppServerAuthProfileLoginParamsInternal(params);
   if (!loginParams || loginParams.type !== "chatgptAuthTokens") {
     throw new Error("Codex app-server ChatGPT token refresh requires an OAuth auth profile.");
   }
@@ -288,7 +284,6 @@ export async function refreshCodexAppServerAuthTokens(params: {
 async function resolveCodexAppServerAuthProfileLoginParamsInternal(params: {
   agentDir: string;
   authProfileId?: string;
-  forceOAuthRefresh?: boolean;
   config?: AuthProfileOrderConfig;
 }): Promise<CodexLoginAccountParams | undefined> {
   const store = ensureAuthProfileStore(params.agentDir, { allowKeychainPrompt: false });
@@ -311,7 +306,6 @@ async function resolveCodexAppServerAuthProfileLoginParamsInternal(params: {
   }
   const loginParams = await resolveLoginParamsForCredential(profileId, credential, {
     agentDir: params.agentDir,
-    forceOAuthRefresh: params.forceOAuthRefresh === true,
     config: params.config,
   });
   if (!loginParams) {
@@ -342,7 +336,7 @@ async function resolveCodexAppServerEnvApiKeyLoginParams(params: {
 async function resolveLoginParamsForCredential(
   profileId: string,
   credential: AuthProfileCredential,
-  params: { agentDir: string; forceOAuthRefresh: boolean; config?: AuthProfileOrderConfig },
+  params: { agentDir: string; config?: AuthProfileOrderConfig },
 ): Promise<CodexLoginAccountParams | undefined> {
   if (credential.type === "api_key") {
     const resolved = await resolveApiKeyForProfile({
@@ -369,7 +363,6 @@ async function resolveLoginParamsForCredential(
   }
   const resolvedCredential = await resolveOAuthCredentialForCodexAppServer(profileId, credential, {
     agentDir: params.agentDir,
-    forceRefresh: params.forceOAuthRefresh,
     config: params.config,
   });
   const accessToken = resolvedCredential.access?.trim();
@@ -381,7 +374,7 @@ async function resolveLoginParamsForCredential(
 async function resolveOAuthCredentialForCodexAppServer(
   profileId: string,
   credential: OAuthCredential,
-  params: { agentDir: string; forceRefresh: boolean; config?: AuthProfileOrderConfig },
+  params: { agentDir: string; config?: AuthProfileOrderConfig },
 ): Promise<OAuthCredential> {
   const ownerAgentDir = resolvePersistedAuthProfileOwnerAgentDir({
     agentDir: params.agentDir,
@@ -394,10 +387,7 @@ async function resolveOAuthCredentialForCodexAppServer(
     isCodexAppServerAuthProvider(ownerCredential.provider, params.config)
       ? ownerCredential
       : credential;
-  if (params.forceRefresh) {
-    store.profiles[profileId] = { ...credentialForOwner, expires: 0 };
-    saveAuthProfileStore(store, ownerAgentDir);
-  }
+  store.profiles[profileId] = credentialForOwner;
   const resolved = await resolveApiKeyForProfile({
     store,
     profileId,


### PR DESCRIPTION
## Summary

- Reuse a current OpenAI Codex OAuth access token when the native Codex app-server asks OpenClaw to refresh ChatGPT auth tokens.
- Preserve the normal expired-token refresh path and owner-profile lookup for child agent stores.
- Add focused auth-bridge regression coverage plus a changelog entry.

## Root Cause

`refreshCodexAppServerAuthTokens` always requested `forceOAuthRefresh`, and the OAuth bridge handled that by writing `expires: 0` before resolving the profile. When the stored `openai-codex` profile was already fresh from a successful browser login, the next app-server token request still forced an OpenAI refresh. OpenAI can reject that reused refresh token with `401 refresh_token_reused`, which the gateway surfaced as the misleading "Model login expired" warning.

## Real behavior proof

Behavior fixed: native Codex app-server token refresh requests should use an already-current OpenAI Codex OAuth access token instead of forcing a refresh-token rotation immediately after login.

Real environment observed before the fix: local OpenClaw gateway on `2026.5.10-beta.1` after a successful `openclaw models auth login --provider openai-codex` and gateway restart.

Command used to inspect the real failure:

```bash
rg -n "refresh_token_reused|Codex agent harness failed" /tmp/openclaw/openclaw-2026-05-10.log
```

Copied result from the gateway log:

```text
Codex agent harness failed; not falling back to embedded PI backend
OAuth token refresh failed for openai-codex: OpenAI Codex token refresh failed (401)
"code": "refresh_token_reused"
model_fallback_decision ... "reason":"auth","status":401
```

Closest feasible after-fix proof: the new auth-bridge regression test drives the app-server refresh handler with a current bound `openai-codex` OAuth profile and asserts that it returns the current access token while `refreshOpenAICodexToken` is not called. The same test file also proves expired profiles still refresh.

Observed after-fix result:

```text
✓ answers app-server ChatGPT token refresh requests from a current bound profile
✓ refreshes expired app-server ChatGPT token refresh requests from the bound profile
Test Files  1 passed (1)
Tests  30 passed (30)
[test] passed 1 Vitest shard in 10.82s
```

Live proof blocked: I did not send a new live Telegram/Codex turn against the patched branch because that would require driving the operator's live OpenAI Codex account and channel session. The real pre-fix gateway log plus the focused bridge regression is the closest safe proof for this PR.

## Verification

- `oc-update --skip-codex` completed successfully before the patch: fast-forwarded `main`, applied open PR overlays, installed dependencies, built core/UI, linked the CLI, reinstalled the daemon, ran health check, and ran `openclaw security audit --deep` with `0 critical · 5 warn · 3 info` existing warnings.
- `pnpm test extensions/codex/src/app-server/auth-bridge.test.ts -- --reporter=verbose` passed: `Test Files 1 passed (1)`, `Tests 30 passed (30)`.
- `pnpm build` passed, including `OK: All 4 required plugin-sdk exports verified.`
- `git diff --check -- CHANGELOG.md extensions/codex/src/app-server/auth-bridge.ts extensions/codex/src/app-server/auth-bridge.test.ts` passed.

## What was not tested

- No live post-fix Codex app-server turn was sent with the operator's real OpenAI Codex account.
- `pnpm check:changed --staged` did not complete locally because this checkout has unrelated dirty overlay files; the extension-test typecheck lane reported existing errors in Discord/Matrix test files outside this PR. The staged PR diff itself is only `CHANGELOG.md`, `extensions/codex/src/app-server/auth-bridge.ts`, and `extensions/codex/src/app-server/auth-bridge.test.ts`.
