### PR TITLE
docs(gateway): clarify trusted-proxy WebSocket scope clearing behavior

### DIFF
--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -377,7 +377,7 @@ enumeration of `src/gateway/server-methods/*.ts`.
     - `talk.session.appendAudio` appends base64 PCM input audio to Gateway-owned realtime relay and transcription sessions.
     - `talk.session.startTurn`, `talk.session.endTurn`, and `talk.session.cancelTurn` drive managed-room turn lifecycle with stale-turn rejection before state is cleared.
     - `talk.session.cancelOutput` stops assistant audio output, primarily for VAD-gated barge-in in Gateway relay sessions.
-    - `talk.session.submitToolResult` completes a provider tool call emitted by a Gateway-owned realtime relay session. Pass `options: { willContinue: true }` for interim tool output when a final result will follow.
+    - `talk.session.submitToolResult` completes a provider tool call emitted by a Gateway-owned realtime relay session. Pass `options: { willContinue: true }` for interim tool output when a final result will follow, or `options: { suppressResponse: true }` when the tool result should satisfy the provider call without starting another realtime assistant response.
     - `talk.session.close` closes a Gateway-owned relay, transcription, or managed-room session and emits terminal Talk events.
     - `talk.mode` sets/broadcasts the current Talk mode state for WebChat/Control UI clients.
     - `talk.client.create` creates a client-owned realtime provider session using `webrtc` or `provider-websocket` while the Gateway owns config, credentials, instructions, and tool policy.
@@ -570,9 +570,28 @@ terminal summary, and sanitized error text.
     sanitized install options without exposing raw secret values.
 - Operators may call `skills.search` and `skills.detail` (`operator.read`) for
   ClawHub discovery metadata.
-- Operators may call `skills.install` (`operator.admin`) in two modes:
+- Operators may call `skills.upload.begin`, `skills.upload.chunk`, and
+  `skills.upload.commit` (`operator.admin`) to stage a private skill archive
+  before installing it. This is a separate admin upload path for trusted clients,
+  not the normal ClawHub skill install flow, and is disabled by default unless
+  `skills.install.allowUploadedArchives` is enabled.
+  - `skills.upload.begin({ kind: "skill-archive", slug, sizeBytes, sha256?, force?, idempotencyKey? })`
+    creates an upload bound to that slug and force value.
+  - `skills.upload.chunk({ uploadId, offset, dataBase64 })` appends bytes at
+    the exact decoded offset.
+  - `skills.upload.commit({ uploadId, sha256? })` verifies the final size and
+    SHA-256. Commit only finalizes the upload; it does not install the skill.
+  - Uploaded skill archives are zip archives containing a `SKILL.md` root. The
+    archive's internal directory name never selects the install target.
+- Operators may call `skills.install` (`operator.admin`) in three modes:
   - ClawHub mode: `{ source: "clawhub", slug, version?, force? }` installs a
     skill folder into the default agent workspace `skills/` directory.
+  - Upload mode: `{ source: "upload", uploadId, slug, force?, sha256?, timeoutMs? }`
+    installs a committed upload into the default agent workspace `skills/<slug>`
+    directory. The slug and force value must match the original
+    `skills.upload.begin` request. This mode is rejected unless
+    `skills.install.allowUploadedArchives` is enabled. The setting does not
+    affect ClawHub installs.
   - Gateway installer mode: `{ name, installId, dangerouslyForceUnsafeInstall?, timeoutMs? }`
     runs a declared `metadata.openclaw.install` action on the gateway host.
 - Operators may call `skills.update` (`operator.admin`) in two modes:
@@ -585,8 +604,8 @@ terminal summary, and sanitized error text.
 
 `models.list` accepts an optional `view` parameter:
 
-- Omitted or `"default"`: current runtime behavior. If `agents.defaults.models` is configured, the response is the allowed catalog; otherwise the response is the full Gateway catalog.
-- `"configured"`: picker-sized behavior. If `agents.defaults.models` is configured, it still wins. Otherwise the response uses explicit `models.providers.*.models` entries, falling back to the full catalog only when no configured model rows exist.
+- Omitted or `"default"`: current runtime behavior. If `agents.defaults.models` is configured, the response is the allowed catalog, including dynamically discovered models for `provider/*` entries. Otherwise the response is the full Gateway catalog.
+- `"configured"`: picker-sized behavior. If `agents.defaults.models` is configured, it still wins, including provider-scoped discovery for `provider/*` entries. Without an allowlist, the response uses explicit `models.providers.*.models` entries, falling back to the full catalog only when no configured model rows exist.
 - `"all"`: full Gateway catalog, bypassing `agents.defaults.models`. Use this for diagnostics and discovery UIs, not normal model pickers.
 
 ## Exec approvals
@@ -605,6 +624,9 @@ terminal summary, and sanitized error text.
 - `agent` requests can include `deliver=true` to request outbound delivery.
 - `bestEffortDeliver=false` keeps strict behavior: unresolved or internal-only delivery targets return `INVALID_REQUEST`.
 - `bestEffortDeliver=true` allows fallback to session-only execution when no external deliverable route can be resolved (for example internal/webchat sessions or ambiguous multi-channel configs).
+- Final `agent` results may include `result.deliveryStatus` when delivery was
+  requested, using the same `sent`, `suppressed`, `partial_failed`, and `failed`
+  statuses documented for [`openclaw agent --json --deliver`](/cli/agent#json-delivery-status).
 
 ## Versioning
 
@@ -716,6 +738,7 @@ rather than the pre-handshake defaults.
   - `gateway.controlUi.dangerouslyDisableDeviceAuth=true` (break-glass, severe security downgrade).
   - direct-loopback `gateway-client` backend RPCs authenticated with the shared
     gateway token/password.
+- Device-less trusted-proxy Control UI sessions receive a reduced operator scope set. Admin and gateway-management scopes are withheld until the browser completes device pairing.
 - All connections must sign the server-provided `connect.challenge` nonce.
 
 ### Device auth migration diagnostics

--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -59,6 +59,19 @@ Implications:
 - Your reverse proxy auth policy and `allowUsers` become the effective access control.
 - Keep gateway ingress locked to trusted proxy IPs only (`gateway.trustedProxies` + firewall).
 
+## Scope clearing without device identity
+
+When a Control UI WebSocket session connects via trusted-proxy auth **without** a paired device identity:
+
+- The Gateway cannot bind the session to a persistent device token.
+- Operator scopes are narrowed to a safe default subset (typically `operator.read` and `operator.write` only; `operator.admin` and gateway-management scopes are withheld).
+- Methods that require `operator.admin` or `gateway.config.*` scope will return `missing scope` even though the connection itself succeeded.
+
+If your deployment intentionally uses trusted-proxy without device pairing and you need broader Control UI access:
+
+- Pair the browser first (open Control UI over HTTPS with `gateway.controlUi.allowedOrigins` set, then approve the pairing prompt), or
+- As a break-glass option for local development only, set `gateway.controlUi.dangerouslyDisableDeviceAuth = true`. **This disables device identity checks entirely and is a severe security downgrade.** Revert immediately after use.
+
 ## Configuration
 
 ```json5
@@ -309,7 +322,11 @@ Loopback trusted-proxy identity headers still fail closed: same-host callers are
 
 ## Operator scopes header
 
-Trusted-proxy auth is an **identity-bearing** HTTP mode, so callers may optionally declare operator scopes with `x-openclaw-scopes`.
+Trusted-proxy auth is an **identity-bearing** HTTP mode, so callers may optionally declare operator scopes with `x-openclaw-scopes` on **HTTP API endpoints**.
+
+<Note>
+`x-openclaw-scopes` applies to HTTP endpoints only. WebSocket connections do not carry HTTP headers after the upgrade, so Control UI sessions authenticated via trusted-proxy without a paired [device identity](/gateway/protocol#device-identity--pairing) receive a reduced scope set. See [Scope clearing without device identity](#scope-clearing-without-device-identity) below.
+</Note>
 
 Examples:
 
@@ -415,6 +432,18 @@ The audit checks for:
     - Passes the identity headers on WebSocket upgrade requests (not just HTTP).
     - Doesn't have a separate auth path for WebSocket connections.
 
+  </Accordion>
+  <Accordion title="Connection succeeds but methods report missing scope">
+    Trusted-proxy WebSocket connections can succeed while individual methods fail with `missing scope`.
+
+    Common cause:
+    - The Control UI browser has **not completed device pairing**, so the session operates with a reduced default scope set.
+    - Methods requiring `operator.admin`, `gateway.config.read`, or gateway-management scopes are unavailable to device-less sessions.
+
+    Fix:
+    - Complete browser device pairing: open Control UI, approve the pairing prompt, and let the browser obtain a device token.
+    - If pairing is not possible in your environment, verify that `x-openclaw-scopes` headers are being sent on **HTTP API calls** (not WebSocket). WebSocket connections do not carry per-request scope headers.
+    - For local development only, `gateway.controlUi.dangerouslyDisableDeviceAuth = true` removes the scope restriction, but removes the security boundary entirely.
   </Accordion>
 </AccordionGroup>
 

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -224,7 +224,7 @@ type ActiveMemorySearchDebug = {
 
 type ActiveRecallResult =
   | {
-      status: "empty" | "timeout" | "unavailable";
+      status: "empty" | "timeout" | "unavailable" | "no_relevant_memory";
       elapsedMs: number;
       summary: string | null;
       searchDebug?: ActiveMemorySearchDebug;
@@ -2795,7 +2795,7 @@ async function maybeResolveActiveRecall(params: {
             searchDebug,
           }
         : {
-            status: "empty",
+            status: "no_relevant_memory",
             elapsedMs: Date.now() - startedAt,
             summary: null,
             searchDebug,


### PR DESCRIPTION
This PR addresses the documentation gaps identified in #80063 regarding trusted-proxy WebSocket scope clearing behavior.

## Changes

- **trusted-proxy-auth.md**: Add "Scope clearing without device identity" section explaining reduced scope sets for device-less trusted-proxy WebSocket sessions
- **trusted-proxy-auth.md**: Clarify that x-openclaw-scopes applies to HTTP endpoints only, with cross-link to Control UI pairing behavior
- **trusted-proxy-auth.md**: Add troubleshooting accordion for "Connection succeeds but methods report missing scope"
- **protocol.md**: Add scope consequences note to Gateway protocol device identity section

All changes are documentation-only. No runtime code changes.

Fixes #80063