### PR TITLE
fix(codex): auto-approve plugin read tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Memory: keep `memory_search` result `corpus` labels aligned with the hit source, so session transcript hits surface as `sessions` and memory-file hits stay `memory`. Fixes #72885. (#71898, #72886) Thanks @rubencu.
+- Codex app-server: default native plugin app tool approvals to automatic so non-destructive read tools run when destructive actions are disabled.
 - Google/Gemini: normalize retired nested Gemini 3 Pro Preview ids while converting manifest catalog rows into emitted provider config, so `google/gemini-3.1-pro-preview` is used for testing instead of `google/gemini-3-pro-preview`.
 - Native apps: advertise the Gateway protocol compatibility range so chat and node sessions can connect to v3 gateways after additive v4 client updates.
 - Gateway/agents: keep stale `sessions_send` ACP manager and `web_fetch` runtime chunks importable after package updates, preventing live gateways from breaking before restart. Fixes #78804. Thanks @Gomesy72.

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -137,8 +137,9 @@ are emitted with `open_world_enabled: true`; OpenClaw does not expose a separate
 plugin open-world policy knob and does not maintain per-plugin destructive
 tool-name deny lists.
 
-Tool approval mode is prompted by default for plugin apps because OpenClaw does
-not have an interactive app-elicitation UI in this same-thread path.
+Tool approval mode is automatic by default for plugin apps so non-destructive
+read tools can run without a same-thread approval UI. Destructive tools remain
+controlled by each app's `destructive_enabled` policy.
 
 ## Destructive action policy
 

--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -64,7 +64,7 @@ describe("Codex plugin thread config", () => {
           enabled: true,
           destructive_enabled: true,
           open_world_enabled: true,
-          default_tools_approval_mode: "prompt",
+          default_tools_approval_mode: "auto",
         },
       },
     });
@@ -253,7 +253,7 @@ describe("Codex plugin thread config", () => {
           enabled: true,
           destructive_enabled: false,
           open_world_enabled: true,
-          default_tools_approval_mode: "prompt",
+          default_tools_approval_mode: "auto",
         },
       },
     });
@@ -577,7 +577,7 @@ describe("Codex plugin thread config", () => {
       enabled: true,
       destructive_enabled: false,
       open_world_enabled: true,
-      default_tools_approval_mode: "prompt",
+      default_tools_approval_mode: "auto",
     });
     expect(apps?.["github-app"]).not.toHaveProperty("tools");
   });

--- a/extensions/codex/src/app-server/plugin-thread-config.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.ts
@@ -196,7 +196,7 @@ export async function buildCodexPluginThreadConfig(
         enabled: true,
         destructive_enabled: record.policy.allowDestructiveActions,
         open_world_enabled: true,
-        default_tools_approval_mode: "prompt",
+        default_tools_approval_mode: "auto",
       };
       apps[app.id] = appConfig;
       policyApps[app.id] = {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -403,7 +403,7 @@ function createPluginAppConfigPatch() {
         enabled: true,
         destructive_enabled: true,
         open_world_enabled: true,
-        default_tools_approval_mode: "prompt",
+        default_tools_approval_mode: "auto",
       },
     },
   };
@@ -435,7 +435,7 @@ function createTwoPluginAppConfigPatch() {
         enabled: true,
         destructive_enabled: true,
         open_world_enabled: true,
-        default_tools_approval_mode: "prompt",
+        default_tools_approval_mode: "auto",
       },
     },
   };
@@ -469,7 +469,7 @@ function createTwoCalendarAppConfigPatch() {
         enabled: true,
         destructive_enabled: true,
         open_world_enabled: true,
-        default_tools_approval_mode: "prompt",
+        default_tools_approval_mode: "auto",
       },
     },
   };


### PR DESCRIPTION
## Summary
- Default enabled Codex native plugin app tool approvals to `auto` so non-destructive read tools can run without a same-thread approval UI.
- Keep destructive gating on each app's `destructive_enabled` policy and update app-server expectations.
- Document the new default and add the changelog entry.

## Real behavior proof
- **Behavior addressed:** Non-destructive Codex native plugin app reads should work when `allow_destructive_actions` is false, while destructive plugin app tools remain blocked when the effective destructive policy is false.
- **Real environment tested:** Local OpenClaw dev gateway profiles copied from the dev profile, foreground loopback gateways on ports `19231`-`19238`, Codex app-server backed by real native Google Calendar and GitHub plugin app tools. Run id `d19auto1283`.
- **Exact steps or command run after this patch:** `POLICY_MATRIX_USE_DIST_ENTRY=1 RUN_ID=d19auto1283 node .mem/main/proofs/demo-1-9-codex-plugin-policy-matrix/scripts/run-policy-matrix.mjs`
- **Evidence after fix:** Terminal output from the live policy matrix run:

```text
runId=d19auto1283
head=35a85bcfb50f919c458e2893d7a2d2f16bb9f727
PASS invalid-marketplace-startup: gateway_exit=1; invalid_marketplace_error_seen
PASS disabled-read: agent_exit=0; calendar_search_not_exposed
PASS disabled-plugin-enabled-read: agent_exit=0; calendar_search_not_exposed
PASS global-destructive-true-plugin-unset: agent_exit=0; calendar_search_succeeded; calendar_create_succeeded
PASS global-destructive-true-plugin-false: agent_exit=0; calendar_search_succeeded; calendar_create_failed_closed
PASS global-destructive-false-plugin-true: agent_exit=0; calendar_search_succeeded; calendar_create_succeeded
PASS global-destructive-false-plugin-unset: agent_exit=0; calendar_search_succeeded; calendar_create_failed_closed
PASS global-destructive-false-plugin-unset-yolo-read: agent_exit=0; calendar_search_succeeded
PASS manual-github-config-installs: agent_exit=0; github_tool_started; github_plugin_enabled_after_run
```

- **Observed result after fix:** The new YOLO/no-`auto_review` read scenario succeeded with `calendar_search_succeeded`; destructive deny coverage remained closed with `calendar_create_failed_closed` when `allow_destructive_actions` was false.
- **Not tested:** No known gaps for the changed Codex native plugin app approval behavior.

## Verification
- `corepack pnpm test extensions/codex/src/app-server/plugin-thread-config.test.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `corepack pnpm build`
- `corepack pnpm docs:check-mdx`
- `corepack pnpm check:changed`
- `node scripts/check-changelog-attributions.mjs`
- `git diff --check`
