### PR TITLE
fix(config): tolerate stale plugins.deny entries as warnings (#77802)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 
 - Yuanbao: bump `openclaw-plugin-yuanbao` to 2.13.1 to support `sourceReplyDeliveryMode: "automatic"` for group chat. (#79814) Thanks @loongfay.
 - Memory: keep `memory_search` result `corpus` labels aligned with the hit source, so session transcript hits surface as `sessions` and memory-file hits stay `memory`. Fixes #72885. (#71898, #72886) Thanks @rubencu.
+- Doctor/config: tolerate stale `plugins.deny` entries naming plugins that no longer exist by emitting a `stale config entry ignored` warning, matching `plugins.allow` and `plugins.entries` semantics, so `openclaw doctor` no longer triggers last-known-good config recovery on these benign drift cases. Fixes #77802. Thanks @JIRBOY and @Kaspre.
 - Google/Gemini: normalize retired nested Gemini 3 Pro Preview ids while converting manifest catalog rows into emitted provider config, so `google/gemini-3.1-pro-preview` is used for testing instead of `google/gemini-3-pro-preview`.
 - Native apps: advertise the Gateway protocol compatibility range so chat and node sessions can connect to v3 gateways after additive v4 client updates.
 - Gateway/agents: keep stale `sessions_send` ACP manager and `web_fetch` runtime chunks importable after package updates, preventing live gateways from breaking before restart. Fixes #78804. Thanks @Gomesy72.

--- a/src/auto-reply/reply/inbound-dedupe.test.ts
+++ b/src/auto-reply/reply/inbound-dedupe.test.ts
@@ -75,6 +75,9 @@ describe("inbound dedupe", () => {
     try {
       const firstClaim = inboundA.claimInboundDedupe(sharedInboundContext);
       expect(firstClaim).toEqual({ status: "claimed", key: expectedKey });
+      if (firstClaim.status !== "claimed") {
+        throw new Error("expected claimed status");
+      }
       expect(inboundB.claimInboundDedupe(sharedInboundContext)).toEqual({
         status: "inflight",
         key: expectedKey,
@@ -110,6 +113,9 @@ describe("inbound dedupe", () => {
     try {
       const firstClaim = inboundA.claimInboundDedupe(sharedInboundContext);
       expect(firstClaim).toEqual({ status: "claimed", key: expectedKey });
+      if (firstClaim.status !== "claimed") {
+        throw new Error("expected claimed status");
+      }
       inboundA.commitInboundDedupe(firstClaim.key);
       expect(inboundB.claimInboundDedupe(sharedInboundContext)).toEqual({
         status: "duplicate",

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -257,7 +257,7 @@ describe("config plugin validation", () => {
     });
     expect(res.ok).toBe(false);
     if (!res.ok) {
-      expectPathMessage(res.issues, "plugins.deny", "plugin not found: missing-deny");
+      // plugins.slots.memory is a functional binding; missing slot still blocks startup.
       expectPathMessage(res.issues, "plugins.slots.memory", "plugin not found: missing-slot");
       expect(res.warnings).toContainEqual({
         path: "plugins.allow",
@@ -265,10 +265,79 @@ describe("config plugin validation", () => {
           "plugin not found: missing-allow (stale config entry ignored; remove it from plugins config)",
       });
       expect(res.warnings).toContainEqual({
+        path: "plugins.deny",
+        message:
+          "plugin not found: missing-deny (stale config entry ignored; remove it from plugins config)",
+      });
+      expect(res.warnings).toContainEqual({
         path: "plugins.entries.missing-plugin",
         message:
           "plugin not found: missing-plugin (stale config entry ignored; remove it from plugins config)",
       });
+      // plugins.deny should not appear as a hard issue any more (#77802).
+      expect(res.issues.some((issue) => issue.path === "plugins.deny")).toBe(false);
+    }
+  });
+
+  // Stale `plugins.deny` entries must match plugins.allow / plugins.entries semantics:
+  // tolerated by the runtime, surfaced as a "stale config entry ignored" warning.
+  // Hardening this asymmetry stops openclaw doctor from auto-restoring the config
+  // from last-known-good when the only problem is a stale deny entry (#77802).
+  it("treats stale plugins.deny entries as warnings, matching plugins.allow semantics", () => {
+    const res = validateInSuite({
+      agents: { list: [{ id: "pi" }] },
+      plugins: {
+        enabled: true,
+        deny: ["stale-deny-entry"],
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expectPathMessage(
+        res.warnings,
+        "plugins.deny",
+        "plugin not found: stale-deny-entry (stale config entry ignored; remove it from plugins config)",
+      );
+    }
+  });
+
+  // A stale `plugins.deny` entry naming an uninstalled official external plugin
+  // (e.g. `brave`) must not suggest installing it — that contradicts deny intent.
+  // Surface the canonical "stale config entry ignored" warning instead. Regression
+  // guard for the warnOnly path triggering the official-external install hint.
+  it("does not suggest installing an uninstalled official external plugin when it is in plugins.deny", () => {
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: { list: [{ id: "pi" }] },
+        plugins: {
+          deny: ["brave"],
+        },
+      },
+      {
+        env: suiteEnv(),
+        pluginMetadataSnapshot: {
+          manifestRegistry: {
+            plugins: [],
+            diagnostics: [],
+          },
+        },
+      },
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expectPathMessage(
+        res.warnings,
+        "plugins.deny",
+        "plugin not found: brave (stale config entry ignored; remove it from plugins config)",
+      );
+      expect(
+        (res.warnings ?? []).some(
+          (warning) =>
+            warning.path === "plugins.deny" &&
+            warning.message.includes("plugin not installed") &&
+            warning.message.includes("install the official external plugin"),
+        ),
+      ).toBe(false);
     }
   });
 

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1442,7 +1442,7 @@ function validateConfigObjectWithPluginsBase(
   const pushMissingPluginIssue = (
     path: string,
     pluginId: string,
-    opts?: { warnOnly?: boolean },
+    opts?: { warnOnly?: boolean; suppressInstallHint?: boolean },
   ) => {
     if (LEGACY_REMOVED_PLUGIN_IDS.has(pluginId)) {
       warnings.push({
@@ -1462,7 +1462,7 @@ function validateConfigObjectWithPluginsBase(
       }
       return;
     }
-    if (opts?.warnOnly) {
+    if (opts?.warnOnly && !opts?.suppressInstallHint) {
       const externalInstallWarning = formatMissingOfficialExternalPluginWarning(pluginId);
       if (externalInstallWarning) {
         warnings.push({
@@ -1526,7 +1526,16 @@ function validateConfigObjectWithPluginsBase(
       continue;
     }
     if (!knownIds.has(pluginId)) {
-      pushMissingPluginIssue("plugins.deny", pluginId);
+      // Mirror plugins.allow / plugins.entries: a stale deny entry naming a
+      // plugin that no longer exists is benign — keep startup and doctor
+      // resilient instead of triggering last-known-good recovery (#77802).
+      // suppressInstallHint avoids the misleading "install with ..." wording
+      // that the official-external catalog hint would emit otherwise — a
+      // denylist entry should never recommend installing the plugin.
+      pushMissingPluginIssue("plugins.deny", pluginId, {
+        warnOnly: true,
+        suppressInstallHint: true,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

Stale `plugins.deny` entries naming a plugin that no longer exists now emit a `stale config entry ignored` warning instead of a hard validation issue, matching the existing semantics for `plugins.allow` and `plugins.entries.*`. This removes the asymmetry where `openclaw doctor` (and gateway load) treated a stale deny entry as fatal while runtime load already documented it as benign, and stops `doctor`'s last-known-good auto-restore from firing on this drift case.

Fixes #77802. Follow-up adjacent finding filed as #80517.

## Why this is the right fix

`src/config/validation.ts`'s `pushMissingPluginIssue` already supports a `warnOnly` flag that emits the canonical `"... (stale config entry ignored; remove it from plugins config)"` warning. Two of three call sites use it:

- `plugins.entries.<id>` missing → warning (`src/config/validation.ts:1495`)
- `plugins.allow` missing → warning (`src/config/validation.ts:1518`)
- `plugins.deny` missing → **hard issue** (`src/config/validation.ts:1529`, pre-fix)
- `plugins.slots.<slot>` missing → hard issue (stays hard — slots are functional bindings)

Because `plugins.deny` produced an issue, `snapshot.valid` was forced to `false`, which:

1. Triggered `shouldAttemptLastKnownGoodRecovery` → last-known-good restore via `recoverConfigFromLastKnownGood`, clobbering recent user state (Kaspre's reproduction, OP's reproduction).
2. Caused gateway startup to reject the config on the same shape of stale entry that `entries`/`allow` were happy to ignore.

Fixing this at the validation layer — rather than patching `src/config/recovery-policy.ts` — was preferred because:

- One change repairs both code paths (doctor and gateway load).
- It stays plugin-agnostic and respects the core/owner boundary in `AGENTS.md` (no plugin ids or per-owner conditions added to core).
- It keeps `recovery-policy.ts` focused on its current contract (structural parseability, not per-key allowlists).

## Real behavior proof

- **Behavior or issue addressed:** Stale `plugins.deny` entry (naming a plugin that no longer exists) was raised as a hard validation issue by `validateConfigObjectWithPlugins`, flipping `snapshot.valid` to `false`, triggering `recoverConfigFromLastKnownGood` from `openclaw doctor` and clobbering recent config state. Same shape of entry in `plugins.allow` and `plugins.entries.*` was already a warning. Reported in #77802 with a second reproduction by @Kaspre on `2026.5.10-beta.1`.
- **Real environment tested:** macOS 15.4.0 (Darwin 25.4.0), Node 22, fresh worktree off `origin/main`, OPENCLAW_HOME pointing at an isolated `/tmp/openclaw-77802-fixture/.openclaw` directory with a hand-written `openclaw.json` containing only `{ "agents": { "list": [{ "id": "pi" }] }, "plugins": { "enabled": true, "deny": ["nonexistent-stale-plugin"] } }`.
- **Exact steps or command run after this patch:** `OPENCLAW_HOME=/tmp/openclaw-77802-fixture pnpm openclaw doctor`; in parallel, a direct call to `validateConfigObjectWithPlugins(...)` via a tsx one-shot against the same config object to capture the structured before/after.
- **Evidence after fix:** Copied terminal output and console JSON from the live local OpenClaw runtime. Below is the rendered `openclaw doctor` panel from the actual `pnpm openclaw doctor` run against the fixture above, plus the structured validator result from a `pnpm exec tsx` one-shot invoking `validateConfigObjectWithPlugins` directly.

  Rendered `openclaw doctor` terminal output (after fix):

  ```
  ◇  Config warnings ───────────────────────────────────────────────────╮
  │                                                                     │
  │  - plugins.deny: plugin not found: nonexistent-stale-plugin (stale  │
  │    config entry ignored; remove it from plugins config)             │
  │                                                                     │
  ├─────────────────────────────────────────────────────────────────────╯
  ```

  Direct validator console output (after fix):

  ```json
  {
    "ok": true,
    "issues": [],
    "warnings": [
      {
        "path": "plugins.deny",
        "message": "plugin not found: nonexistent-stale-plugin (stale config entry ignored; remove it from plugins config)"
      }
    ]
  }
  ```

  Before-fix capture from the same direct validator call (stash + rerun on the same fixture):

  ```json
  {
    "ok": false,
    "issues": [
      { "path": "plugins.deny", "message": "plugin not found: nonexistent-stale-plugin" }
    ],
    "warnings": []
  }
  ```

- **Observed result after fix:** `pnpm openclaw doctor` no longer prints an `Invalid config:` panel for the stale `plugins.deny` entry. Instead the entry is surfaced under a `Config warnings` panel with the canonical `stale config entry ignored; remove it from plugins config` suffix. `snapshot.valid` stays `true`, so `shouldAttemptLastKnownGoodRecovery` returns `false` and `recoverConfigFromLastKnownGood` is never invoked. Gateway load follows the same `validated.ok === true` branch and accepts the config.
- **What was not tested:** I did not reproduce on Windows 10 PowerShell (OP's environment) or `2026.5.10-beta.1` (Kaspre's environment) — the change is platform-independent TypeScript in `src/config/validation.ts` and the validator output is the canonical observable.

## Verification

- `pnpm test src/config/config.plugin-validation.test.ts src/config/recovery-policy.test.ts` — 33/33 pass after rebase onto current `origin/main`. Includes a new focused regression test `treats stale plugins.deny entries as warnings, matching plugins.allow semantics` and an updated `reports missing plugin refs across entries and allowlist surfaces` test that now asserts the warning shape on `plugins.deny`.
- `pnpm exec oxfmt --check --threads=1 src/config/validation.ts src/config/config.plugin-validation.test.ts CHANGELOG.md` — clean.
- `node scripts/run-oxlint.mjs src/config/validation.ts src/config/config.plugin-validation.test.ts` — `Found 0 warnings and 0 errors`.
- `pnpm changed:lanes --json` selects `core` + `coreTests` only. Broader gate handled by CI on the PR.

## Out of scope (separate work)

- The OP also reported an unrelated enum drift on `models.providers.bailian.models.*.compat.thinkingFormat`. That belongs in the bailian provider extension and should not be enumerated in core (owner boundary). It is left for a separate PR.
- Option (b) — persisting `doctor --fix` repairs incrementally even when residual unrelated validation errors remain — is a different design call about the atomic-write invariant and should be discussed independently.
- The `.clobbered.*` snapshot cap silently capping further forensic snapshots — filed separately as #80517.

## Risk

A stale `plugins.deny` entry now becomes a warning instead of a hard error. If a user previously denied plugin `X`, `X` was removed, and later a different plugin is published under the same id, the stale deny would no longer block it. This mirrors the existing posture for `plugins.allow` (also security-adjacent) where the convention is already "stale entry, ignored." The warning text still surfaces the stale entry to the operator on every `openclaw doctor` and gateway start, so the regression path is loud, not silent.

https://github.com/openclaw/openclaw/issues/77802
