### PR TITLE
refactor(agents): extract isOpenAIResponsesReasoningItemType helper

### DIFF
--- a/src/agents/openai-reasoning-compat.ts
+++ b/src/agents/openai-reasoning-compat.ts
@@ -58,3 +58,9 @@ export function mapOpenAIReasoningEffortForModel(params: {
     fallbackMap: resolveOpenAIReasoningEffortMap(params.model, params.fallbackMap),
   });
 }
+
+export function isOpenAIResponsesReasoningItemType(
+  value: unknown,
+): value is "reasoning" | `reasoning.${string}` {
+  return typeof value === "string" && (value === "reasoning" || value.startsWith("reasoning."));
+}

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -33,7 +33,10 @@ import {
   flattenCompletionMessagesToStringContent,
   stripCompletionMessagesToRoleContent,
 } from "./openai-completions-string-content.js";
-import { resolveOpenAIReasoningEffortMap } from "./openai-reasoning-compat.js";
+import {
+  isOpenAIResponsesReasoningItemType,
+  resolveOpenAIReasoningEffortMap,
+} from "./openai-reasoning-compat.js";
 import {
   isOpenAIGpt54MiniModel,
   normalizeOpenAIReasoningEffort,
@@ -465,7 +468,7 @@ async function processResponsesStream(
       output.responseId = stringifyUnknown((event.response as { id?: string } | undefined)?.id);
     } else if (type === "response.output_item.added") {
       const item = event.item as Record<string, unknown>;
-      if (item.type === "reasoning") {
+      if (isOpenAIResponsesReasoningItemType(item.type)) {
         currentItem = item;
         currentBlock = { type: "thinking", thinking: "" };
         output.content.push(currentBlock);
@@ -488,7 +491,10 @@ async function processResponsesStream(
         stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
       }
     } else if (type === "response.reasoning_summary_text.delta") {
-      if (currentItem?.type === "reasoning" && currentBlock?.type === "thinking") {
+      if (
+        isOpenAIResponsesReasoningItemType(currentItem?.type) &&
+        currentBlock?.type === "thinking"
+      ) {
         currentBlock.thinking = `${stringifyUnknown(currentBlock.thinking)}${stringifyUnknown(event.delta)}`;
         stream.push({
           type: "thinking_delta",
@@ -520,7 +526,7 @@ async function processResponsesStream(
       }
     } else if (type === "response.output_item.done") {
       const item = event.item as Record<string, unknown>;
-      if (item.type === "reasoning" && currentBlock?.type === "thinking") {
+      if (isOpenAIResponsesReasoningItemType(item.type) && currentBlock?.type === "thinking") {
         const summary = Array.isArray(item.summary)
           ? item.summary
               .map((part) => {

--- a/src/agents/pi-embedded-helpers/openai.ts
+++ b/src/agents/pi-embedded-helpers/openai.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { isOpenAIResponsesReasoningItemType } from "../openai-reasoning-compat.js";
 
 type OpenAIThinkingBlock = {
   type?: unknown;
@@ -46,7 +47,7 @@ function parseOpenAIReasoningSignature(value: unknown): OpenAIReasoningSignature
   if (!id.startsWith("rs_")) {
     return null;
   }
-  if (type === "reasoning" || type.startsWith("reasoning.")) {
+  if (isOpenAIResponsesReasoningItemType(type)) {
     return { id, type };
   }
   return null;


### PR DESCRIPTION
## Summary
This PR extracts the reasoning item type check (`item.type === "reasoning" || item.type.startsWith("reasoning.")`) into a shared `isOpenAIResponsesReasoningItemType` helper.

This refactoring ensures consistent compatibility checks for reasoning items across the OpenAI HTTP transport and embedded PI helpers, improving forward compatibility for new reasoning item type extensions.

## Verification
- Ran `pnpm check:changed` and it passed.