### PR TITLE
opik: add trace tree core hooks

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1036,6 +1036,7 @@ async function agentCommandInternal(
               opts,
               runContext,
               spawnedBy,
+              spawnedByRunId: opts.spawnedByRunId,
               messageChannel,
               skillsSnapshot,
               resolvedVerboseLevel,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -366,6 +366,7 @@ export function runAgentAttempt(params: {
   opts: AgentCommandOpts & { senderIsOwner: boolean };
   runContext: ReturnType<typeof resolveAgentRunContext>;
   spawnedBy: string | undefined;
+  spawnedByRunId: string | undefined;
   messageChannel: ReturnType<typeof resolveMessageChannel>;
   skillsSnapshot: ReturnType<typeof buildWorkspaceSkillSnapshot> | undefined;
   resolvedVerboseLevel: VerboseLevel | undefined;
@@ -595,6 +596,7 @@ export function runAgentAttempt(params: {
     groupChannel: params.runContext.groupChannel,
     groupSpace: params.runContext.groupSpace,
     spawnedBy: params.spawnedBy,
+    spawnedByRunId: params.spawnedByRunId,
     currentChannelId: params.runContext.currentChannelId,
     currentThreadTs: params.runContext.currentThreadTs,
     replyToMode: params.runContext.replyToMode,

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -88,6 +88,8 @@ export type AgentCommandOpts = {
   groupChannel?: SpawnedRunMetadata["groupChannel"];
   groupSpace?: SpawnedRunMetadata["groupSpace"];
   spawnedBy?: SpawnedRunMetadata["spawnedBy"];
+  /** Top-level parent's runId when this run is a subagent; flows into agent_start event. */
+  spawnedByRunId?: string;
   deliveryTargetMode?: ChannelOutboundTargetMode;
   bestEffortDeliver?: boolean;
   abortSignal?: AbortSignal;

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -409,6 +409,7 @@ export function createOpenClawTools(
             config: resolvedConfig,
             requesterAgentIdOverride: options?.requesterAgentIdOverride,
             workspaceDir: spawnWorkspaceDir,
+            parentRunId: options?.parentRunId,
           }),
         ]),
     createSessionsYieldTool({

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1162,6 +1162,7 @@ export async function runEmbeddedPiAgent(
             groupSpace: params.groupSpace,
             memberRoleIds: params.memberRoleIds,
             spawnedBy: params.spawnedBy,
+            spawnedByRunId: params.spawnedByRunId,
             isCanonicalWorkspace,
             senderId: params.senderId,
             senderName: params.senderName,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2717,6 +2717,30 @@ export async function runEmbeddedAttempt(
           }
         }
 
+        // Emit agent_start before the first llm_input dispatch. Awaited because
+        // tracing plugins (e.g. Opik) need their agent_start handler to finish
+        // establishing the trace before llm_input arrives.
+        if (params.sessionKey && hookRunner?.hasHooks("agent_start")) {
+          try {
+            await hookRunner.runAgentStart(
+              {
+                runId: params.runId,
+                sessionKey: params.sessionKey,
+                sessionId: params.sessionId,
+                agentId: hookAgentId,
+                model: params.modelId,
+                provider: params.provider,
+                parentRunId: params.spawnedByRunId ?? undefined,
+                requesterSessionKey: params.spawnedBy ?? undefined,
+                startedAt: promptStartedAt,
+              },
+              hookCtx,
+            );
+          } catch (err) {
+            log.warn(`agent_start hook failed: ${String(err)}`);
+          }
+        }
+
         if (cacheObservabilityEnabled) {
           const cacheObservation = beginPromptCacheObservation({
             sessionId: params.sessionId,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -80,6 +80,8 @@ export type RunEmbeddedPiAgentParams = {
   memberRoleIds?: string[];
   /** Parent session key for subagent policy inheritance. */
   spawnedBy?: string | null;
+  /** Parent agent run id for subagent trace threading. */
+  spawnedByRunId?: string | null;
   /** Whether workspaceDir points at the canonical agent workspace for bootstrap purposes. */
   isCanonicalWorkspace?: boolean;
   senderId?: string | null;

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -756,6 +756,7 @@ export function createOpenClawCodingTools(options?: {
           onYield: options?.onYield,
           allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
           recordToolPrepStage: options?.recordToolPrepStage,
+          parentRunId: options?.runId,
         })
       : pluginToolsOnly),
   ];

--- a/src/agents/spawned-context.ts
+++ b/src/agents/spawned-context.ts
@@ -17,6 +17,7 @@ export type SpawnedToolContext = {
   agentGroupSpace?: string | null;
   agentMemberRoleIds?: string[];
   workspaceDir?: string;
+  parentRunId?: string;
 };
 
 type NormalizedSpawnedRunMetadata = {

--- a/src/agents/subagent-announce-queue.ts
+++ b/src/agents/subagent-announce-queue.ts
@@ -30,6 +30,12 @@ export type AnnounceQueueItem = {
   sourceSessionKey?: string;
   sourceChannel?: string;
   sourceTool?: string;
+  /**
+   * Parent agent's runId captured at subagent spawn time. When set, the
+   * delivery-back agent call carries `spawnedByRunId` so the parent bot's
+   * re-invocation run joins the parent's Opik thread.
+   */
+  requesterRunId?: string;
 };
 
 type AnnounceQueueSettings = {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -224,6 +224,7 @@ export async function runSubagentAnnounceFlow(params: {
   childSessionKey: string;
   childRunId: string;
   requesterSessionKey: string;
+  requesterRunId?: string;
   requesterOrigin?: DeliveryContext;
   requesterDisplayKey: string;
   task: string;
@@ -563,6 +564,7 @@ export async function runSubagentAnnounceFlow(params: {
       expectsCompletionMessage: expectsCompletionMessage,
       bestEffortDeliver: params.bestEffortDeliver,
       directIdempotencyKey,
+      requesterRunId: params.requesterRunId,
       signal: params.signal,
     });
     params.onDeliveryResult?.(delivery);

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -719,6 +719,7 @@ export function createSubagentRegistryLifecycleController(params: {
         childSessionKey: pendingPayload.childSessionKey,
         childRunId: pendingPayload.childRunId,
         requesterSessionKey: pendingPayload.requesterSessionKey,
+        requesterRunId: entry.requesterRunId,
         requesterOrigin,
         requesterDisplayKey: pendingPayload.requesterDisplayKey,
         task: pendingPayload.task,

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -85,6 +85,7 @@ export type RegisterSubagentRunParams = {
   childSessionKey: string;
   controllerSessionKey?: string;
   requesterSessionKey: string;
+  requesterRunId?: string;
   requesterOrigin?: DeliveryContext;
   requesterDisplayKey: string;
   task: string;
@@ -396,6 +397,7 @@ export function createSubagentRunManager(params: {
       childSessionKey,
       controllerSessionKey,
       requesterSessionKey,
+      requesterRunId: registerParams.requesterRunId,
       requesterOrigin,
       requesterDisplayKey: registerParams.requesterDisplayKey,
       task: registerParams.task,

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -26,6 +26,12 @@ export type SubagentRunRecord = {
   childSessionKey: string;
   controllerSessionKey?: string;
   requesterSessionKey: string;
+  /**
+   * Parent agent's runId at spawn time. Plumbed into the completion
+   * delivery-back agent call as `spawnedByRunId` so the parent bot's
+   * re-invocation run rejoins the parent's Opik thread.
+   */
+  requesterRunId?: string;
   requesterOrigin?: DeliveryContext;
   requesterDisplayKey: string;
   task: string;

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -152,6 +152,12 @@ export type SpawnSubagentContext = {
   requesterAgentIdOverride?: string;
   /** Explicit workspace directory for subagent to inherit (optional). */
   workspaceDir?: string;
+  /**
+   * Parent agent's runId. Plumbed into the subagent gateway spawn so the
+   * child's agent_start hook emits parentRunId, letting cross-process Opik
+   * traces join the parent's thread.
+   */
+  parentRunId?: string;
 };
 
 export type SpawnSubagentResult = {
@@ -1139,6 +1145,7 @@ export async function spawnSubagentDirect(
               bootstrapContextRunKind: "default" as const,
             }
           : {}),
+        ...(ctx.parentRunId ? { spawnedByRunId: ctx.parentRunId } : {}),
         ...publicSpawnedMetadata,
       },
       timeoutMs: resolveSubagentAgentGatewayTimeoutMs(runTimeoutSeconds),
@@ -1216,6 +1223,7 @@ export async function spawnSubagentDirect(
       childSessionKey,
       controllerSessionKey: requesterInternalKey,
       requesterSessionKey: requesterInternalKey,
+      requesterRunId: ctx.parentRunId,
       requesterOrigin,
       requesterDisplayKey,
       task,

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -241,6 +241,8 @@ export function createSessionsSpawnTool(
     config?: OpenClawConfig;
     /** Explicit agent ID override for cron/hook sessions where session key parsing may not work. */
     requesterAgentIdOverride?: string;
+    /** Parent agent's runId. Threaded into the child gateway spawn so cross-process subagent Opik traces join the parent's thread. */
+    parentRunId?: string;
   } & SpawnedToolContext,
 ): AnyAgentTool {
   const acpAvailable = isAcpRuntimeSpawnAvailable({
@@ -455,6 +457,7 @@ export function createSessionsSpawnTool(
           agentMemberRoleIds: opts?.agentMemberRoleIds,
           requesterAgentIdOverride: opts?.requesterAgentIdOverride,
           workspaceDir: opts?.workspaceDir,
+          parentRunId: opts?.parentRunId,
         },
       );
 

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -151,6 +151,12 @@ export const AgentParamsSchema = Type.Object(
     groupId: Type.Optional(Type.String()),
     groupChannel: Type.Optional(Type.String()),
     groupSpace: Type.Optional(Type.String()),
+    /**
+     * Parent agent's runId when this agent call is a cross-process subagent
+     * spawn. Threaded into the runner so the child's agent_start hook emits
+     * parentRunId, letting Opik traces join the parent's thread.
+     */
+    spawnedByRunId: Type.Optional(NonEmptyString),
     timeout: Type.Optional(Type.Integer({ minimum: 0 })),
     bestEffortDeliver: Type.Optional(Type.Boolean()),
     lane: Type.Optional(Type.String()),

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1392,6 +1392,7 @@ export const agentHandlers: GatewayRequestHandlers = {
             groupChannel: resolvedGroupChannel,
             groupSpace: resolvedGroupSpace,
             spawnedBy: spawnedByValue,
+            spawnedByRunId: request.spawnedByRunId,
             timeout: request.timeout?.toString(),
             bestEffortDeliver,
             messageChannel: originMessageChannel,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -19,6 +19,7 @@ import type {
   PluginHookAfterToolCallEvent,
   PluginHookAgentContext,
   PluginHookAgentEndEvent,
+  PluginHookAgentStartEvent,
   PluginHookBeforeAgentFinalizeEvent,
   PluginHookBeforeAgentFinalizeResult,
   PluginHookBeforeAgentReplyEvent,
@@ -822,6 +823,13 @@ export function createHookRunner(
    * Allows plugins to intercept messages and return a synthetic reply,
    * short-circuiting the LLM agent. First handler to return { handled: true } wins.
    */
+  async function runAgentStart(
+    event: PluginHookAgentStartEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<void> {
+    return runVoidHook("agent_start", event, ctx);
+  }
+
   async function runBeforeAgentReply(
     event: PluginHookBeforeAgentReplyEvent,
     ctx: PluginHookAgentContext,
@@ -1477,6 +1485,7 @@ export function createHookRunner(
     runAgentTurnPrepare,
     runBeforePromptBuild,
     runBeforeAgentStart,
+    runAgentStart,
     runBeforeAgentReply,
     runModelCallStarted,
     runModelCallEnded,

--- a/src/plugins/wired-hooks-llm.test.ts
+++ b/src/plugins/wired-hooks-llm.test.ts
@@ -132,4 +132,65 @@ describe("llm hook runner methods", () => {
     expect(runner.hasHooks("llm_input")).toBe(true);
     expect(runner.hasHooks("llm_output")).toBe(false);
   });
+
+  it("agent_start fires before the first llm_input when invoked in the attempt.ts order", async () => {
+    const calls: Array<{ hook: "agent_start" | "llm_input"; event: Record<string, unknown> }> = [];
+    const agentStartHandler = vi.fn((event: Record<string, unknown>) => {
+      calls.push({ hook: "agent_start", event });
+    });
+    const llmInputHandler = vi.fn((event: Record<string, unknown>) => {
+      calls.push({ hook: "llm_input", event });
+    });
+    const { runner } = createHookRunnerWithRegistry([
+      { hookName: "agent_start", handler: agentStartHandler },
+      { hookName: "llm_input", handler: llmInputHandler },
+    ]);
+
+    const agentCtx = {
+      runId: "run-1",
+      agentId: "main",
+      sessionKey: "session-key-1",
+      sessionId: "session-1",
+      workspaceDir: "/tmp/openclaw-test",
+    };
+
+    // Matches emit order from src/agents/pi-embedded-runner/run/attempt.ts:
+    // agent_start fires after before_agent_start resolves, before the first llm_input.
+    await runner.runAgentStart(
+      {
+        runId: "run-1",
+        sessionKey: "session-key-1",
+        sessionId: "session-1",
+        agentId: "main",
+        model: "sonnet-4.6",
+        provider: "anthropic",
+        parentRunId: undefined,
+        requesterSessionKey: undefined,
+        startedAt: 1_700_000_000_000,
+      },
+      agentCtx,
+    );
+    await runner.runLlmInput(
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "anthropic",
+        model: "sonnet-4.6",
+        systemPrompt: "be helpful",
+        prompt: "hello",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      agentCtx,
+    );
+
+    expect(calls.map((c) => c.hook)).toEqual(["agent_start", "llm_input"]);
+    expect(agentStartHandler).toHaveBeenCalledTimes(1);
+    expect(calls[0]?.event).toMatchObject({
+      runId: "run-1",
+      sessionKey: "session-key-1",
+      sessionId: "session-1",
+      startedAt: 1_700_000_000_000,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Problem: Opik can observe `llm_input` / `llm_output`, but cross-process subagent runs lacked an earlier typed lifecycle point carrying the parent run id, so trace-tree stitching had to infer relationships too late.
- Why it matters: Opik trace trees need parent/child run identity before the first LLM input so the trace/span hierarchy can be established deterministically.
- What changed: add a typed `agent_start` hook, emit it before first `llm_input`, and thread parent/requester run ids through subagent, Gateway, and embedded-runner paths.
- What did NOT change: no Opik plugin behavior, no provider behavior, no delivery semantics, no auth or permission changes.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #80267
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: parent run identity now reaches the child agent start hook before the first LLM input hook, so tracing plugins can create the child trace/span relationship before token-bearing events arrive.
- Real environment tested: local OpenClaw checkout on macOS, fork branch `feat/opik-trace-tree-core-github` at `5e35c5bf89`.
- Exact steps or command run after this patch:
  - `pnpm -C .worktrees/github-opik-core tsgo:core`
  - `pnpm -C .worktrees/github-opik-core test src/plugins/wired-hooks-llm.test.ts`
  - `pnpm -C .worktrees/github-opik-core check`
  - `git -C .worktrees/github-opik-core diff --check`
- Evidence after fix:

  ```text
  $ pnpm -C .worktrees/github-opik-core tsgo:core
  > openclaw@2026.5.6 tsgo:core ...
  > node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo

  $ pnpm -C .worktrees/github-opik-core test src/plugins/wired-hooks-llm.test.ts
  Test Files  1 passed (1)
  Tests  6 passed (6)

  $ pnpm -C .worktrees/github-opik-core check
  [check] summary
  # completed successfully; typecheck and lint passed

  $ git -C .worktrees/github-opik-core diff --check
  # no output
  ```

- Observed result after fix: the typed `agent_start` hook contract accepts the event emitted by `runEmbeddedAttempt`, `spawnedByRunId` is accepted by the Gateway agent request path, and the focused hook ordering test remains green.
- What was not tested: no live Opik dashboard run from this GitHub fork branch; this PR is the core seam only, with plugin-side behavior tested in the downstream Opik branch.
- Before evidence: the same branch failed `pnpm check` with `"agent_start" is not assignable to PluginHookName`, missing `PluginHookAgentStartEvent`, missing `requesterRunId`, and missing `spawnedByRunId` type coverage.

## Root Cause (if applicable)

- Root cause: the initial branch added runtime `agent_start` dispatch and run-id propagation but did not add the corresponding typed hook contract and local typed parameter seams.
- Missing detection / guardrail: `src/plugins/wired-hooks-llm.test.ts` proved hook order, but full `pnpm check` was needed to catch the cross-file type contract omissions.
- Contributing context (if known): merged #80267 consolidated host workflow/plugin SDK seams after this branch base; this PR now aligns with that typed contract style instead of adding ad hoc tracing-only paths.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `src/plugins/wired-hooks-llm.test.ts` plus `pnpm check` / `tsgo:core`.
- Scenario the test should lock in: `agent_start` fires before `llm_input`, and parent/requester identity is representable in typed hook and Gateway seams.
- Why this is the smallest reliable guardrail: this is a core orchestration/hook contract; a live Opik test would be useful but larger than necessary for the typed seam.
- Existing test that already covers this (if any): `src/plugins/wired-hooks-llm.test.ts` covers hook ordering and payload flow.
- If no new test is added, why not: existing focused hook coverage plus full typecheck now catches the regression; this follow-up only completed missing type-surface wiring.

## User-visible / Behavior Changes

None directly. Plugin authors get a new typed `agent_start` lifecycle hook for trace/workflow correlation.

## Diagram (if applicable)

```text
Before:
parent run -> spawn child -> child llm_input -> tracing infers parent late

After:
parent run -> spawn child -> child agent_start(parentRunId) -> child llm_input -> trace tree already linked
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22+ / pnpm workspace
- Model/provider: N/A for local verification
- Integration/channel (if any): Opik tracing hook seam; no live channel used
- Relevant config (redacted): N/A

### Steps

1. Run the focused hook test: `pnpm -C .worktrees/github-opik-core test src/plugins/wired-hooks-llm.test.ts`.
2. Run the core typecheck: `pnpm -C .worktrees/github-opik-core tsgo:core`.
3. Run the repo check gate: `pnpm -C .worktrees/github-opik-core check`.

### Expected

- `agent_start` is a valid typed hook.
- `agent_start` fires before first `llm_input`.
- parent/requester run identity is accepted across Gateway/subagent typed seams.
- Check gate passes.

### Actual

- Matches expected after commit `5e35c5bf89`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: focused hook-order test, core typecheck, full repo check, whitespace diff check.
- Edge cases checked: branch previously failed when `agent_start` was not a typed hook and when parent run-id fields crossed typed seams; both now pass typecheck.
- What you did **not** verify: live Opik UI trace tree from this exact GitHub branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: adding a new hook name increases plugin API surface.
  - Mitigation: hook is additive, typed, and only emitted from the existing agent start path before `llm_input`.
- Risk: tracing consumers could depend on optional identity fields being present for every run.
  - Mitigation: parent/requester fields are optional; top-level runs continue without parent metadata.
