### PR TITLE
feat(home-assistant): Wagner Way kiosk dashboard (HA WebSocket bridge + Lit wall-tablet view)

### DIFF
--- a/docs/plans/2026-05-10-002-feat-home-assistant-kiosk-dashboard-plan.md
+++ b/docs/plans/2026-05-10-002-feat-home-assistant-kiosk-dashboard-plan.md
@@ -1,0 +1,640 @@
+---
+title: Home Assistant kiosk dashboard (Wagner Way overview)
+type: feat
+status: active
+date: 2026-05-10
+---
+
+# Home Assistant kiosk dashboard (Wagner Way overview)
+
+## Overview
+
+Build a wall-tablet kiosk dashboard inside OpenClaw that mirrors the existing Home Assistant Lovelace **Wagner Way** overview — family/alarm badges, weather, energy gauges (Battery SOC / Solar / Grid / House), Major Appliances gauges, and the Quick Keys tile grid. v1 scope is the first view only; subsequent views (Calendar, Rooms, Cameras, Climate, Sonos, AppleTV, Plex, People, Solar deep-dive, Eskom, Vacuums, Bourbon & Bubbles) are explicit follow-ups.
+
+The dashboard runs on an always-on wall tablet against the OpenClaw gateway. A new `extensions/home-assistant` plugin owns the long-lived WebSocket connection to Home Assistant, caches entity state, and bridges state changes and service calls through the existing OpenClaw gateway. A new no-chrome kiosk shell view in `ui/` consumes that bridge and renders the Wagner Way layout in Lit.
+
+## Problem Frame
+
+Home Assistant's Lovelace dashboard is the household control surface today (alarms, lights, gates, geyser, pumps, blinds, energy gauges). It runs in a separate browser tab from OpenClaw. The user wants a single wall tablet that lives inside OpenClaw — same control surface, same look-and-feel as the current HA dashboard — so OpenClaw becomes the household control plane and the agent (Jarvis) and the dashboard share one HA integration rather than two.
+
+This plan delivers v1 of that surface: read-and-control of the **Wagner Way overview** view only, on a wall-tablet kiosk, over HA WebSocket, with the same security posture established in the Jarvis Butler plan (dedicated non-admin HA user, services deny-listed at the HA-user layer).
+
+## Requirements Trace
+
+- **R1.** Tablet boots a no-chrome kiosk URL inside OpenClaw and renders the Wagner Way overview view at the same visual fidelity as the existing HA Lovelace view.
+- **R2.** Live state for badges, gauges, and tiles updates within ~1s of HA state changes (no polling).
+- **R3.** Tapping a tile in the Quick Keys section toggles the underlying entity via HA service call and reconciles the resulting state.
+- **R4.** Tapping a forbidden entity is impossible at the UI layer because the HA-user deny-list (locks, alarm-disarm, garage-open) prevents it server-side; the kiosk does not display tiles for deny-listed services.
+- **R5.** HA WebSocket disconnects (WiFi flap, HA restart) recover automatically with bounded backoff and a visible "reconnecting" indicator on the tablet — never a blank screen.
+- **R6.** HA long-lived token and base URL are stored as plugin credentials (not in source, not in the browser bundle); the browser receives entity state through the gateway WS, never a direct connection to HA.
+- **R7.** The kiosk respects the touch-target, brightness, and orientation needs of an always-on wall tablet (≥48px hit areas, dark theme, large numerals, no hover-only affordances).
+- **R8.** Plan composes cleanly with the Jarvis Butler agent-tool surface from `docs/plans/2026-05-10-001-feat-jarvis-the-butler-home-migration-plan.md` so the same HA user, deny-list, and integrity check serve both surfaces.
+
+## Scope Boundaries
+
+- v1 renders **only the Wagner Way overview view**. No Calendar, Rooms, Cameras, Alarm panel, Climate, Sonos, AppleTV, Plex, People, Solar, Eskom, Vacuums, or Bourbon & Bubbles views.
+- v1 does **not** render camera live views (`camera.*`). The Quick Keys "Front Door Cam" tile becomes a placeholder/disabled in v1; live camera streaming is deferred (see Camera Streaming risk below).
+- v1 does **not** integrate with the OpenClaw chat/agent surface — Jarvis already has its own HA tool path via the Butler plan. The kiosk consumes the same plugin, but does not add agent tools.
+- v1 does **not** mirror Lovelace HACS custom cards (`modern-circular-gauge`, `bubble-card`, `mushroom-vacuum-card`, `sunsynk-power-flow-card`, `clock-weather-card`, `energy-distribution`, `calendar-card-pro`, `xiaomi-vacuum-map-card`, etc.) — it implements OpenClaw-native Lit equivalents for the gauge, tile, and badge primitives that v1 actually uses.
+- v1 does not solve multi-kiosk fan-out, kiosk-to-kiosk handoff, voice control, or notifications-on-tablet.
+
+### Deferred to Separate Tasks
+
+- **Cameras view + camera tiles in Quick Keys** — separate v2 plan; needs RTSP/MJPEG/WebRTC strategy, LAN-only enforcement, and snapshot-link auth (the open Butler-plan unsolved spike).
+- **Calendar / Rooms / Climate / Sonos / AppleTV / Plex / People / Solar / Eskom / Vacuums / Bourbon & Bubbles views** — each becomes its own v2+ planning unit once the kiosk shell and HA bridge are stable.
+- **Agent tool surface for HA** — owned by `docs/plans/2026-05-10-001-feat-jarvis-the-butler-home-migration-plan.md` Unit 7; this plan does not duplicate it.
+- **HA user provisioning / token issuance / weekly deny-list integrity cron** — already covered by the Butler plan; this plan reuses, does not re-spec.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `extensions/anthropic/index.ts`, `extensions/anthropic/register.runtime.ts`, `extensions/anthropic/api.ts`, `extensions/anthropic/openclaw.plugin.json` — canonical extension shape: `definePluginEntry({ id, name, register })`, runtime registration via `register.runtime.ts`, public facade at `api.ts`, manifest at `openclaw.plugin.json`. Mirror this layout for `extensions/home-assistant/`.
+- `extensions/anthropic/config-defaults.ts` — config schema + defaults pattern; the HA extension follows the same shape for `homeAssistantUrl`, `tokenRef`, allow-list/deny-list config.
+- `src/plugin-sdk/*` — public SDK barrel that extensions consume; HA extension imports from here and `runtime-api.ts`, never reaches into core internals.
+- `ui/src/ui/gateway.ts` — `GatewayBrowserClient` WebSocket pattern. Existing in-browser WS to gateway handles reconnect, message dispatch. The kiosk subscribes to a new `ha:state` topic on this same socket.
+- `ui/src/ui/navigation.ts` — `TAB_PATHS` hash-route registry. Add a new `kiosk` route, but the kiosk path is **outside** the normal tab nav (no nav chrome) so it is registered as a standalone route, not a tab.
+- `ui/src/ui/views/agents-panels-status-files.ts` — `.fullscreen` CSS toggle is the closest existing precedent for a no-chrome surface; use the same pattern (or a tighter `kiosk-mode` body class) for the kiosk shell.
+- `ui/src/styles/*.css` — vanilla CSS custom properties (`--bg`, `--accent`, `--shadow-sm`). Kiosk styling extends these rather than introducing Tailwind/shadcn.
+- `ui/package.json` — `pnpm dev` (Vite localhost:5173), `pnpm build` (→ `dist/control-ui`), `pnpm test` (vitest).
+
+### Institutional Learnings
+
+From `docs/plans/2026-05-10-001-feat-jarvis-the-butler-home-migration-plan.md`:
+
+- **HA long-lived tokens have no per-entity ACL.** A token inherits the issuing user's permissions wholesale. The kiosk reuses the existing dedicated non-admin `jarvis_butler` HA user (or a sibling `jarvis_kiosk` user — decided in Unit 1) so the agent and the kiosk share an auditable allow-list.
+- **High-blast-radius services are deny-listed at the HA user, not in the client.** `lock.unlock`, `alarm_control_panel.alarm_disarm`, garage `cover.open_cover`. The kiosk **must not render tiles** for these; the user-layer deny-list is the safety net, the absent-tile is the primary defense.
+- **HA is the umbrella for Apple Home / Ring / Alexa / Sonoff / Sonos / etc.** One token, one URL, one transport. The kiosk follows the same single-proxy posture.
+- **Ring re-auths roughly monthly.** The kiosk surfaces this as a "degraded" state in the affected tile (e.g. doorbell battery sensor stale > N hours), not a silent retry.
+- **Camera URLs do not leave the LAN in plaintext.** Camera tiles in v2 must be LAN-only or behind the existing ngrok basic-auth + per-user app login posture. Stated here so the v2 split does not lose the constraint.
+- **Two-layer public auth posture.** Ngrok basic-auth + app login. The kiosk URL inherits this posture by virtue of living inside OpenClaw's existing UI shell, not as a parallel exposure.
+- **Generic entity friendly-names.** No PINs in entity names; no exact addresses. The kiosk renders whatever HA exposes — keep names generic at the HA layer.
+- **Failure-mode integrity check exists.** Weekly cron curls `services/lock/unlock` with the dedicated user's token and pages on anything other than permission-denied. The kiosk plan extends this check (same script, same user) — does not invent a parallel one.
+
+### External References
+
+- Home Assistant WebSocket API — `https://developers.home-assistant.io/docs/api/websocket/` (auth handshake, `subscribe_events` with `state_changed`, `subscribe_entities` for delta-only state, ping/pong, command IDs). Read at implementation time per root `AGENTS.md` "Dependency-backed behavior" rule; do not infer from this plan.
+- Lovelace dashboard YAML reference — `https://www.home-assistant.io/dashboards/` (semantics of `tile`, `entity`, `picture-entity`, `horizontal-stack`, etc., for fidelity reference when implementing the Lit equivalents).
+
+## Key Technical Decisions
+
+- **Server-relayed HA WebSocket, not browser-direct.** The HA token stays in `extensions/home-assistant`; the browser receives state via the existing gateway WS. **Why:** keeps long-lived tokens server-side, lets multiple kiosks share one HA connection later, fits the existing OpenClaw transport, and lets the same plugin serve both kiosk and agent without duplicating auth.
+- **HA bridged via a new `ha:*` topic family on the gateway WS, not new transport.** Add a `ha:state` push topic and a `ha:service-call` request topic to the existing gateway protocol. **Why:** preserves the single-WebSocket-in-browser invariant; reuses the existing reconnect/auth/dispatch pipeline in `ui/src/ui/gateway.ts`.
+- **Kiosk is a standalone Lit route at `#/kiosk`, outside `TAB_PATHS`.** Registered in the router but renders no nav chrome, no chat, no agent panels. **Why:** a wall tablet is a distinct surface posture; bolting it into the tabbed control UI as another tab confuses the desktop UX.
+- **OpenClaw-native Lit gauge/tile/badge primitives, not HACS card ports.** **Why:** the HACS cards are React/web-component bundles with their own state models; porting them is more work than reimplementing the v1-needed primitives in Lit + vanilla CSS, and produces a smaller, repo-native bundle. The visual fidelity bar is "looks like the Lovelace view" not "is the Lovelace view".
+- **Entity allow-list lives in the plugin, not the kiosk view.** The plugin filters HA state to a configured allow-list before bridging; the kiosk receives only what it is allowed to render. **Why:** defense in depth on top of HA-user deny-list, plus a single source of truth for "what the household has decided to put on the kiosk" that v2 views can extend without each touching HA auth.
+- **Optimistic tile updates with reconciliation.** Tile tap renders the new state immediately, then waits for the HA `state_changed` event to confirm; on timeout (e.g. 3s) it reverts and surfaces a transient error indicator. **Why:** wall-tablet UX cannot show a 600ms "is it on yet?" pause on every tap; the reconciliation echo from HA is the source of truth.
+- **Curated v1 entity list captured in plugin config, not hardcoded in the view.** The view template names slots (e.g. `slot.battery_soc`, `slot.solar_power`, `slot.gate_main`); plugin config maps slots → HA entity IDs. **Why:** household entity IDs change (devices replaced, sensors renamed); the view should not need a code change to track them.
+- **Test-first for the HA WS client and state store.** Visual UI is iterated, but the connection lifecycle, auth handshake, reconnect/backoff, and state diff logic are pure-logic units with clear contracts and known failure modes — characterization-first protects them from regression.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where does the dashboard live?** New extension `extensions/home-assistant/` for the HA WS client + bridge; new view `ui/src/ui/views/kiosk-*.ts` for the rendered surface.
+- **HA transport?** WebSocket from the extension; gateway WS to the browser.
+- **v1 scope?** Wagner Way overview only; cameras explicitly deferred.
+- **Kiosk shares the Butler plan's HA user?** Yes — same dedicated non-admin user, same deny-list. Unit 1 records whether to issue a sibling token (`jarvis_kiosk`) or reuse `jarvis_butler` based on rotation cadence preference.
+- **Custom HACS cards?** Not ported; native Lit equivalents for gauges/tiles/badges only.
+
+### Deferred to Implementation
+
+- **Exact gateway protocol shape for `ha:state` and `ha:service-call`.** Resolved when implementing Unit 4 against the existing `src/gateway/protocol/*` patterns; additive, versioned per root `AGENTS.md` gateway contract rule.
+- **Whether to use HA's `subscribe_events` (state_changed) or `subscribe_entities` (compressed deltas).** Decided in Unit 2 after reading current HA WS docs; both work, `subscribe_entities` is more efficient at scale.
+- **Tablet sleep / display-on behavior.** Decided in Unit 5 — likely browser-side `wake-lock` API plus tablet OS settings; no OpenClaw kernel involvement expected.
+- **Exact Lit gauge math for the 4-segment color bands.** Resolved in Unit 6 against the actual SVG arc rendering; planning specifies _that_ bands exist matching the HACS card thresholds, not the precise math.
+- **Brand/colors.** Match the existing OpenClaw control UI dark theme (`--bg`, `--accent`); the Lovelace screenshot's color choices are reference, not contract.
+
+## High-Level Technical Design
+
+> _This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce._
+
+### Four-piece data flow
+
+```mermaid
+sequenceDiagram
+    participant HA as Home Assistant
+    participant Ext as extensions/home-assistant
+    participant GW as OpenClaw gateway
+    participant UI as ui/ kiosk view
+
+    Note over Ext: long-lived WS, server-side token
+    Ext->>HA: auth (long-lived token)
+    HA-->>Ext: auth_ok
+    Ext->>HA: subscribe_entities (allow-list)
+    HA-->>Ext: state delta stream
+
+    Note over Ext,GW: filter to allow-list, normalize
+    Ext->>GW: publish ha:state {entity_id, state, attrs}
+
+    Note over UI: single WS to gateway, no HA token
+    UI->>GW: subscribe ha:state
+    GW-->>UI: ha:state events (push)
+
+    Note over UI: user taps a tile
+    UI->>GW: ha:service-call {domain, service, target}
+    GW->>Ext: dispatch ha:service-call
+    Ext->>HA: call_service (allow-list checked)
+    HA-->>Ext: state_changed (echo)
+    Ext->>GW: publish ha:state (echo)
+    GW-->>UI: ha:state (reconciles optimistic update)
+```
+
+### Wagner Way overview composition
+
+```text
++------------------------------------------------------------+
+| Badges row: people · phone batteries · alarms (top sticky) |
++--------------------------+---------------------------------+
+| Clock + Weather card     | Energy distribution flow card   |
++----+----+----+----+------+---------------------------------+
+| Battery SOC | Solar Power | Grid Power     | House Power   |
++----+----+----+----+------+---------------------------------+
+| Major Appliances row: Geyser · Pool · Jacuzzi · Clients · BTC |
++------------------------------------------------------------+
+| Quick Keys tile grid (gates, lights, geyser, pumps, blinds) |
++------------------------------------------------------------+
+| Vacuums nav · (Front Door Cam: deferred placeholder)        |
++------------------------------------------------------------+
+```
+
+### Slot → entity mapping (plugin config, illustrative)
+
+```yaml
+# extensions/home-assistant/config (shape, not literal)
+allowList:
+  - sensor.deye_sunsynk_sol_ark_battery_state_of_charge
+  - sensor.deye_sunsynk_sol_ark_pv_power
+  - sensor.deye_sunsynk_sol_ark_grid_power
+  - sensor.deye_sunsynk_sol_ark_load_power
+  - sensor.sonoff_10014e4497_power
+  - switch.sonoff_10013c3266
+  - cover.aqara_roller_blind_left
+  # ...
+denyServiceList:
+  - lock.unlock
+  - alarm_control_panel.alarm_disarm
+  - cover.open_cover # garage covers only — see HA-user-side too
+slots:
+  badge.alarm_wagner: alarm_control_panel.ring_alarm
+  gauge.battery_soc: sensor.deye_sunsynk_sol_ark_battery_state_of_charge
+  gauge.solar_power: sensor.deye_sunsynk_sol_ark_pv_power
+  tile.gate_main: switch.sonoff_10013c3266
+  tile.geyser_main: switch.sonoff_10014e4497
+  # ... etc
+```
+
+## Output Structure
+
+```text
+extensions/home-assistant/
+  openclaw.plugin.json           # manifest
+  package.json
+  index.ts                       # definePluginEntry
+  register.runtime.ts            # registers HA client + gateway bridge
+  api.ts                         # public facade barrel
+  config-schema.ts               # url, tokenRef, allowList, denyServiceList, slots
+  config-defaults.ts
+  ws-client.ts                   # HA WebSocket lifecycle + auth + subscribe
+  ws-client.test.ts
+  state-store.ts                 # entity state cache + diff
+  state-store.test.ts
+  allowlist.ts                   # filter + service deny-list
+  allowlist.test.ts
+  gateway-bridge.ts              # ha:* topic publisher + service-call dispatch
+  gateway-bridge.test.ts
+  README.md
+
+ui/src/ui/views/
+  kiosk-shell.ts                 # no-chrome shell + routing
+  kiosk-shell.test.ts
+  kiosk-wagner-way.ts            # Wagner Way overview composition
+  kiosk-wagner-way.test.ts
+
+ui/src/ui/components/kiosk/
+  ha-state-binding.ts            # connects gateway ha:state to Lit reactive store
+  ha-state-binding.test.ts
+  gauge-circular.ts              # circular gauge primitive
+  gauge-circular.test.ts
+  tile-toggle.ts                 # tap-to-toggle tile with optimistic update
+  tile-toggle.test.ts
+  badge-entity.ts                # entity badge primitive
+  badge-entity.test.ts
+  weather-card.ts                # clock + weather + forecast
+  energy-flow-card.ts            # energy distribution diagram
+
+ui/src/styles/
+  kiosk.css                      # kiosk-mode body class, large touch targets
+
+src/gateway/protocol/
+  ha-events.ts                   # ha:state, ha:service-call schemas (additive)
+  ha-events.test.ts
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: HA extension scaffold + config schema**
+
+**Goal:** Stand up `extensions/home-assistant/` following the canonical extension pattern, with a config schema for HA URL, credential reference, allow-list, service deny-list, and slot mapping.
+
+**Requirements:** R6, R8
+
+**Dependencies:** None.
+
+**Files:**
+
+- Create: `extensions/home-assistant/openclaw.plugin.json`
+- Create: `extensions/home-assistant/package.json`
+- Create: `extensions/home-assistant/index.ts`
+- Create: `extensions/home-assistant/register.runtime.ts`
+- Create: `extensions/home-assistant/api.ts`
+- Create: `extensions/home-assistant/config-schema.ts`
+- Create: `extensions/home-assistant/config-defaults.ts`
+- Create: `extensions/home-assistant/README.md`
+- Test: `extensions/home-assistant/config-schema.test.ts`
+
+**Approach:**
+
+- Mirror the `extensions/anthropic/` shape (`definePluginEntry`, `register.runtime.ts`, `api.ts`, `openclaw.plugin.json`).
+- Config schema fields: `homeAssistantUrl` (string URL), `tokenRef` (credential reference, not literal), `allowList` (entity-id list), `denyServiceList` (`<domain>.<service>` list), `slots` (slot-name → entity-id map).
+- Token storage follows the existing channel/provider credential pattern under `~/.openclaw/credentials/` — never in plugin config files, never in source.
+- Document in README that the HA user is the dedicated non-admin user from the Butler plan; do not duplicate the user-provisioning steps here.
+
+**Patterns to follow:**
+
+- `extensions/anthropic/index.ts`, `register.runtime.ts`, `api.ts`, `config-defaults.ts`
+- `extensions/anthropic/openclaw.plugin.json`
+
+**Test scenarios:**
+
+- Happy path: schema accepts a valid URL + tokenRef + allow-list + slots and round-trips through `resolvePluginConfigObject`.
+- Edge case: missing `tokenRef` rejects with a clear validation error pointing at the credentials path.
+- Edge case: `homeAssistantUrl` without `ws://` or `wss://` rejects (the WS client only speaks WS).
+- Edge case: a slot pointing at an entity not in `allowList` rejects at config validation, not later at runtime.
+- Edge case: a `denyServiceList` entry not formatted as `<domain>.<service>` rejects.
+
+**Verification:**
+
+- `pnpm test extensions/home-assistant` passes the schema tests.
+- `pnpm build` resolves the new extension without architecture-rule violations.
+- The plugin appears in the manifest registry on startup with `id: home-assistant` and surfaces a config form that asks for URL + credential.
+
+---
+
+- [ ] **Unit 2: HA WebSocket client + state store**
+
+**Goal:** Long-lived WebSocket client to Home Assistant: auth handshake, event subscription, state cache, ping/pong heartbeat, exponential reconnect, structured connection-state for downstream consumers.
+
+**Requirements:** R2, R5, R6
+
+**Dependencies:** Unit 1.
+
+**Files:**
+
+- Create: `extensions/home-assistant/ws-client.ts`
+- Create: `extensions/home-assistant/state-store.ts`
+- Test: `extensions/home-assistant/ws-client.test.ts`
+- Test: `extensions/home-assistant/state-store.test.ts`
+
+**Approach:**
+
+- Read the HA WebSocket API docs at implementation time; do not infer from this plan. Resolve the `subscribe_events` vs `subscribe_entities` choice during Unit 2 and document the chosen call in the file header comment.
+- Connection lifecycle states: `idle → connecting → authenticating → subscribed → degraded → disconnected`. Each transition emits an event for the bridge.
+- Reconnect: exponential backoff capped at e.g. 30s; reset on successful subscribe.
+- Heartbeat: HA WS supports `ping`/`pong` command frames at the protocol level; if the configured interval lapses without a pong, transition to `degraded` and recycle the socket.
+- State store is a `Map<entity_id, EntityState>` plus a per-entity subscriber registry; emits a diff (entity, prev, next) on each change.
+- Filter at ingestion: states for entities outside `allowList` are dropped before they hit the store.
+
+**Execution note:** Implement test-first. The connection state machine and reconnect/backoff logic regress easily when touched without coverage.
+
+**Patterns to follow:**
+
+- Reuse any long-lived-WS helper if Phase 1 finds one in `src/gateway/` or elsewhere; otherwise this is greenfield.
+
+**Test scenarios:**
+
+- Happy path: connect → auth → subscribe → first `state_changed` event lands in the store and emits a diff.
+- Happy path: existing entity state update produces a `(prev, next)` diff with both populated.
+- Edge case: auth failure transitions to `degraded` and surfaces an explicit error (not silent reconnect loop).
+- Edge case: `ping` timeout recycles the socket and resubscribes on reconnect.
+- Edge case: server closes socket → reconnect attempt 1 backs off ~1s, attempt 5 backs off ≤30s.
+- Edge case: state for an entity outside `allowList` does not enter the store and does not emit a diff.
+- Edge case: malformed/unexpected message payload is logged and ignored, does not crash the client.
+- Integration: state store consumer subscribed to entity X receives diff only for X, not for unrelated entity Y.
+
+**Verification:**
+
+- `pnpm test extensions/home-assistant` covers the lifecycle + store tests.
+- A live-test smoke (`OPENCLAW_LIVE_TEST=1`) against a real HA instance can connect, authenticate, subscribe, and observe a state change for one allow-listed entity.
+
+---
+
+- [ ] **Unit 3: Allow-list filtering and service deny-list enforcement**
+
+**Goal:** Centralize entity allow-list filtering and service-call deny-list enforcement so both the bridge and any future agent path go through one gate.
+
+**Requirements:** R4, R6
+
+**Dependencies:** Unit 1, Unit 2.
+
+**Files:**
+
+- Create: `extensions/home-assistant/allowlist.ts`
+- Test: `extensions/home-assistant/allowlist.test.ts`
+
+**Approach:**
+
+- Pure functions: `isEntityAllowed(entityId, config) → boolean`, `isServiceAllowed(domain, service, config) → boolean`.
+- Service-call gate is checked **before** the WS call_service is issued. A blocked call returns a structured error (`{ kind: "service-denied", domain, service }`) that the gateway bridge surfaces back to the kiosk.
+- The deny-list is stated as belt-and-braces; the HA-user-side deny-list (Butler plan, weekly cron) is the safety net. Document in code comments that removing this client gate does not lower security — it widens the failure surface from "tile invisible" to "tile visible but rejected".
+
+**Patterns to follow:**
+
+- Existing pure-function gate patterns in `src/plugin-sdk/` (look for similar policy gates).
+
+**Test scenarios:**
+
+- Happy path: allow-listed entity → `isEntityAllowed = true`.
+- Happy path: non-deny-listed service → `isServiceAllowed = true`.
+- Edge case: service in deny-list → false, with structured error type.
+- Edge case: allow-list empty → all entities denied (fail closed).
+- Edge case: deny-list empty + allow-list populated → service permission falls back to a documented default (decided in Unit 3: deny by default, allow only services explicitly enumerated in `allowServiceList` once that field is added — record the decision in the test).
+- Edge case: case-sensitivity and trailing-whitespace handling for entity IDs and service names.
+
+**Verification:**
+
+- `pnpm test extensions/home-assistant/allowlist.test.ts` passes.
+- A targeted test confirms that a `lock.unlock` call against the configured deny-list returns the structured `service-denied` error before the WS call_service is ever issued.
+
+---
+
+- [ ] **Unit 4: Gateway bridge — `ha:state` push + `ha:service-call` request topics**
+
+**Goal:** Bridge HA state and service calls onto the existing OpenClaw gateway WS so the browser sees a single transport.
+
+**Requirements:** R2, R3, R6
+
+**Dependencies:** Unit 2, Unit 3.
+
+**Files:**
+
+- Create: `extensions/home-assistant/gateway-bridge.ts`
+- Test: `extensions/home-assistant/gateway-bridge.test.ts`
+- Create: `src/gateway/protocol/ha-events.ts`
+- Test: `src/gateway/protocol/ha-events.test.ts`
+- Modify: `src/gateway/protocol/<barrel>.ts` (add `ha-events` to the protocol exports — exact file resolved at impl time)
+
+**Approach:**
+
+- Define `ha:state` (server → client push) and `ha:service-call` (client → server request) message shapes in `src/gateway/protocol/ha-events.ts` using the existing protocol typing/zod helpers (per `src/gateway/protocol/AGENTS.md` if present).
+- Additive change to the gateway protocol per root `AGENTS.md` "additive first" rule; bump the protocol version where convention dictates.
+- `gateway-bridge.ts` subscribes to the state-store diff stream, normalizes each diff into a `ha:state` payload (entity_id, state, attrs subset, timestamp), and publishes to the gateway. Does not re-publish unchanged state.
+- For `ha:service-call`: validates payload, runs through `allowlist.ts`, dispatches to the WS client's `call_service`. Returns the structured error for denied services; returns ack for accepted calls without waiting for the echo (the echo flows back via the normal state stream).
+- Bridge attaches/detaches when the plugin starts/stops; resilient to gateway disconnects.
+
+**Approach diagram (directional):**
+
+```text
+state-store diff  →  bridge filter  →  gateway publish ha:state
+gateway recv ha:service-call  →  allowlist gate  →  ws-client.call_service
+```
+
+**Patterns to follow:**
+
+- Existing channel-event bridges in `src/channels/` (look at how channels publish events to the gateway protocol).
+- `src/gateway/protocol/*` typing conventions for additive event types.
+
+**Test scenarios:**
+
+- Happy path: a state-store diff for an allow-listed entity appears as a `ha:state` event on the gateway publish channel within one tick.
+- Happy path: a valid `ha:service-call` for an allow-listed `switch.toggle` reaches `ws-client.call_service` with the correct domain/service/target.
+- Edge case: `ha:service-call` for a deny-listed service returns the structured `service-denied` error and never calls `ws-client.call_service`.
+- Edge case: `ha:service-call` payload missing `domain` or `target` fails validation with a clear error before any allow-list check.
+- Edge case: state-store diff for an entity not in `allowList` is dropped at the bridge (defense in depth: the store should not have it, but if config drift means it does, the bridge still refuses to publish it).
+- Edge case: gateway disconnect → bridge buffers/drops per documented policy (decide in Unit 4 whether to buffer last-known state for replay or drop and resync on reconnect; default: drop, rely on UI's resync request).
+- Integration: full round-trip — UI sends `ha:service-call`, bridge dispatches, mock WS client emits a `state_changed` echo, bridge publishes the resulting `ha:state` event.
+
+**Verification:**
+
+- `pnpm test extensions/home-assistant/gateway-bridge.test.ts` and `pnpm test src/gateway/protocol/ha-events.test.ts` pass.
+- `pnpm check:architecture` passes (additive protocol change, no cycle).
+- Manual smoke: with the plugin running and a real HA instance, browser devtools shows `ha:state` frames on the gateway WS for at least one allow-listed entity.
+
+---
+
+- [ ] **Unit 5: Kiosk shell view + `#/kiosk` route**
+
+**Goal:** No-chrome Lit shell view that hosts the kiosk dashboard, with body-class kiosk-mode styling, fullscreen toggle, and a visible connection-state indicator.
+
+**Requirements:** R1, R5, R7
+
+**Dependencies:** Unit 4 (so the shell can subscribe to `ha:state`).
+
+**Files:**
+
+- Create: `ui/src/ui/views/kiosk-shell.ts`
+- Test: `ui/src/ui/views/kiosk-shell.test.ts`
+- Create: `ui/src/ui/components/kiosk/ha-state-binding.ts`
+- Test: `ui/src/ui/components/kiosk/ha-state-binding.test.ts`
+- Modify: `ui/src/ui/navigation.ts` (register the kiosk route as a standalone route, not a tab)
+- Modify: `ui/src/ui/app-routing.ts` or equivalent router (file resolved at impl time) — add `#/kiosk` handling
+- Create: `ui/src/styles/kiosk.css`
+
+**Approach:**
+
+- Hash route `#/kiosk` resolves to `kiosk-shell`; not added to `TAB_PATHS`/`TAB_GROUPS` (the shell hides nav and chat).
+- Shell sets a `kiosk-mode` body class that disables the tabbed nav and chat panel via CSS; exits kiosk mode when navigating away.
+- Subscribes to the gateway's `ha:state` topic on mount; provides a Lit reactive store (`ha-state-binding.ts`) that child components consume.
+- Visible connection-state indicator (small corner pill: `live` / `reconnecting` / `degraded`) reflects the gateway-bridge connection and the upstream HA WS state.
+- Touch-friendly defaults: `font-size` floor for legibility on a wall tablet, `:hover` styles disabled, `user-select: none`, `touch-action: manipulation` to suppress double-tap zoom.
+- Wake-lock: request `navigator.wakeLock` on mount, release on unmount; documented as best-effort and tablet-OS-dependent.
+
+**Patterns to follow:**
+
+- `ui/src/ui/views/agents-panels-status-files.ts` `.fullscreen` toggle for the shell-without-chrome posture.
+- `ui/src/ui/gateway.ts` `GatewayBrowserClient` for subscribing to the new topic.
+- Vanilla CSS custom properties from `ui/src/styles/*.css` (`--bg`, `--accent`); extend, do not introduce a new framework.
+
+**Test scenarios:**
+
+- Happy path: navigating to `#/kiosk` mounts `kiosk-shell` and applies the `kiosk-mode` body class.
+- Happy path: a `ha:state` event from the gateway updates the reactive store; a child component reading entity X re-renders.
+- Edge case: gateway WS drops → connection-state indicator shows `reconnecting`; reconnects → returns to `live`.
+- Edge case: HA upstream `degraded` (e.g. token expired surfaced via gateway) → indicator shows `degraded`, store retains last-known state.
+- Edge case: navigating away from `#/kiosk` removes the body class and unsubscribes the binding (no orphan subscription leak).
+- Edge case: wake-lock request rejection (unsupported browser / OS) does not block render.
+- Integration: shell + binding wired to a fake gateway client receives a state update and surfaces it through the binding to a test consumer.
+
+**Verification:**
+
+- `pnpm test ui` covers the shell and binding tests.
+- `pnpm dev` shows `#/kiosk` rendering an empty kiosk shell with a working connection indicator against a running gateway.
+
+---
+
+- [ ] **Unit 6: Display primitives — gauge, tile, badge, weather card, energy-flow card**
+
+**Goal:** OpenClaw-native Lit components that match the visual fidelity of the Wagner Way Lovelace cards (`modern-circular-gauge`, `tile`, entity badge, `clock-weather-card`, `energy-distribution`) for v1.
+
+**Requirements:** R1, R7
+
+**Dependencies:** Unit 5 (consumes the shared `ha-state-binding`).
+
+**Files:**
+
+- Create: `ui/src/ui/components/kiosk/gauge-circular.ts`
+- Test: `ui/src/ui/components/kiosk/gauge-circular.test.ts`
+- Create: `ui/src/ui/components/kiosk/tile-toggle.ts`
+- Test: `ui/src/ui/components/kiosk/tile-toggle.test.ts`
+- Create: `ui/src/ui/components/kiosk/badge-entity.ts`
+- Test: `ui/src/ui/components/kiosk/badge-entity.test.ts`
+- Create: `ui/src/ui/components/kiosk/weather-card.ts`
+- Create: `ui/src/ui/components/kiosk/energy-flow-card.ts`
+
+**Approach:**
+
+- `gauge-circular`: SVG arc, configurable `min`/`max`, 4 segment color bands matching the Lovelace thresholds (e.g. blue → green → orange → red), large center numeral, unit label, optional secondary inner gauge for the Geyser dual-display.
+- `tile-toggle`: large rectangular tile with icon + name + state, `tap` event with optimistic state change, "in-flight" visual until reconciliation, error flash on `service-denied`.
+- `badge-entity`: small chip showing icon + name + state + last-changed; collapsible to single line when space-constrained.
+- `weather-card`: clock + current conditions + 5-row forecast (the same shape as `clock-weather-card`); reads from configured `weather` and outdoor sensors via slots.
+- `energy-flow-card`: simple SVG diagram of grid ↔ home ↔ battery ↔ solar with animated dots when power is flowing; v1 is _static-shape_, animation can be a follow-up if it adds noise.
+- All primitives bind via slot names, never raw entity IDs in the view layer — slot resolution happens once in the shell.
+
+**Test scenarios:**
+
+- `gauge-circular`: numeric 0/min/max/over-max/under-min render correctly; segment color picks the right band at boundary values; no NaN or `null` state renders a placeholder, not a broken SVG.
+- `gauge-circular`: secondary inner gauge renders when configured and is hidden when not.
+- `tile-toggle`: tap fires a `service-call` event with the configured domain/service/target; while in-flight the tile shows the in-flight visual; on reconciliation it settles to the new state.
+- `tile-toggle`: a `service-denied` reply flashes the error and reverts the tile to the prior state within the timeout.
+- `tile-toggle`: rapid double-tap does not emit two service calls (debounced or in-flight-locked — decided in Unit 6).
+- `badge-entity`: renders state + relative `last-changed`; entity unavailable (HA reports `unavailable`) renders a distinct neutral style, not "off".
+- `weather-card`: renders forecast rows even when sensor for current temp is `unavailable` (graceful partial render).
+- `energy-flow-card`: handles negative power values (export) by reversing the visual flow direction.
+- Edge case (all): a slot mapped to a non-existent or removed entity ID renders a placeholder + a small "missing" hint, not a crash.
+
+**Verification:**
+
+- `pnpm test ui` covers the primitive component tests.
+- `pnpm dev` storybook-style harness page (or a dev-only view at `#/kiosk-dev`) renders each primitive with sample data for visual review.
+
+---
+
+- [ ] **Unit 7: Wagner Way overview composition**
+
+**Goal:** Compose the primitives into the Wagner Way overview view at the visual fidelity of the existing Lovelace screenshot.
+
+**Requirements:** R1, R3, R7
+
+**Dependencies:** Unit 5, Unit 6.
+
+**Files:**
+
+- Create: `ui/src/ui/views/kiosk-wagner-way.ts`
+- Test: `ui/src/ui/views/kiosk-wagner-way.test.ts`
+
+**Approach:**
+
+- Layout sections in source order:
+  1. **Badges row (sticky top):** people (Audrey, Michelle, Ijeani, Peter), each phone/iPad battery, Wagner alarm, Bourbon alarm.
+  2. **House Info row:** clock + weather card (left, ~50%); energy-flow card (right, ~50%).
+  3. **Energy gauges row:** Battery SOC, Solar Power.
+  4. **Power gauges row:** Grid Power, House Power.
+  5. **Major Appliances row:** Geyser (with secondary inner gauge), Pool Pump, Jacuzzi Pump, Total Clients, Bitcoin (BTC).
+  6. **Quick Keys tile grid:** Main Gate, Garage Door, Main Entrance Lights, Braai Light, Main Geyser, Geyser Timer, Vintage Lights, Patio Lights, Pool Pump, Jacuzzi Pump, Office Lights, Jacuzzi Down Lights, Wall Lights, Left Blind (cover), Right Blind (cover). **Excludes any entity covered by the deny-list.**
+  7. **Footer nav (placeholder):** "Vacuums" and "Front Door Cam" as disabled placeholders pointing at v2.
+- Tile order and column hints match the Lovelace `grid_options.columns` values where reasonable, but use a CSS grid that gracefully reflows for the actual tablet aspect ratio.
+- All entity references go through the slot map from Unit 1 — no hardcoded entity IDs in this file.
+- A configuration check at view mount logs (and visibly indicates) any slot in the v1 manifest that has no allow-list entry; never renders a tile bound to a missing slot.
+
+**Test scenarios:**
+
+- Happy path: rendering with a fully populated slot map produces all 7 sections.
+- Happy path: Battery SOC at 95% renders blue; at 50% renders orange; at 10% renders red (via the gauge primitive's segment selection).
+- Edge case: a slot mapped to an entity not present in the gateway state store renders a placeholder tile/gauge, not a crash.
+- Edge case: tapping the Main Gate tile fires a `ha:service-call` for `switch.toggle` against the configured target.
+- Edge case: a deny-listed service (e.g. an attempt to put a `lock.unlock` slot in the manifest) is rejected at config validation and the corresponding tile never renders. (Cross-checked with Unit 1's schema test.)
+- Integration: simulated state stream — Battery SOC updates from 95 → 60 → 30 → 5 — the gauge re-renders, color band changes at each threshold, no extra renders for unchanged attributes.
+
+**Verification:**
+
+- `pnpm test ui` covers the composition tests.
+- `pnpm dev` against a real HA instance renders the Wagner Way view with live state updates within ~1s of HA changes.
+- Side-by-side visual check against the existing Lovelace screenshot confirms section order, gauge thresholds, and tile grid match.
+
+---
+
+- [ ] **Unit 8: Tile-tap → service-call → reconciliation loop**
+
+**Goal:** End-to-end interaction loop: tap a tile, optimistic UI, service call through the bridge, deny-list enforcement, state echo reconciles or reverts.
+
+**Requirements:** R3, R4, R5
+
+**Dependencies:** Unit 7.
+
+**Files:**
+
+- Modify: `ui/src/ui/components/kiosk/tile-toggle.ts` (wire to the gateway client's `ha:service-call` request)
+- Modify: `extensions/home-assistant/gateway-bridge.ts` (already partially in Unit 4 — finalize the service-call request handler with reconciliation timeouts)
+- Test: `ui/src/ui/components/kiosk/tile-toggle.integration.test.ts`
+
+**Approach:**
+
+- Tile tap → emits `ha:service-call` via gateway client → bridge validates + dispatches → HA emits `state_changed` → bridge republishes as `ha:state` → tile reconciles its optimistic state with the canonical state.
+- Reconciliation timeout: configurable per-tile (default 3s). On timeout without an echo, revert the optimistic state and show a transient error indicator. Default-3s is a planning starting point; tune in Unit 8 against real-world observed HA echo latency for switches vs covers.
+- Service-denied: short red flash + return to prior state; no console-only error (the kiosk is the only display).
+- Cover-position tiles (left/right blinds) are out-of-scope for v1's _position-slider_ interaction — v1 toggle = open/close (`cover.toggle`), no slider. (Position slider can land in v2 once the toggle loop is stable.)
+
+**Test scenarios:**
+
+- Happy path: tap a switch tile → optimistic-on shown → echo lands within 1s → tile shows confirmed-on. Verifies one render for optimistic, one for echo, no extra renders.
+- Happy path: tap a cover tile → optimistic state reflects the toggle; echo confirms.
+- Edge case: tap a tile, no echo within 3s → tile reverts, error indicator flashes; subsequent taps still work.
+- Edge case: tap a tile bound to a deny-listed service (only reachable if config drift occurred) → service-denied returns within one tick, tile reverts immediately, no 3s wait.
+- Edge case: rapid taps before echo arrives — bridge serializes; tile shows the latest intended state; reconciles to the final echo.
+- Edge case: gateway disconnects mid-call → in-flight tile transitions to "uncertain", no false error; on reconnect the next `ha:state` for that entity reconciles.
+- Integration: full happy-path round-trip with a fake HA WS — taps the Main Gate tile, assert WS `call_service` payload, send back a `state_changed` echo, assert tile lands in the confirmed-on state.
+
+**Verification:**
+
+- `pnpm test ui` and `pnpm test extensions/home-assistant` pass.
+- Manual smoke: tap each Quick Keys tile on the wall tablet, observe state matches the HA app within 1s for switches, 1–3s for covers.
+- `pnpm check:changed` green on the change set.
+
+## System-Wide Impact
+
+- **Interaction graph:** new gateway protocol topics (`ha:state` push, `ha:service-call` request) extend `src/gateway/protocol/*`. Additive only; no existing topics change semantics.
+- **Error propagation:** `service-denied` errors travel from `allowlist.ts` → bridge → gateway → tile. Connection-state degradation propagates from HA WS → state-store status flag → bridge → kiosk shell indicator.
+- **State lifecycle risks:** state store is in-memory only (no persistence). Stale state across plugin restart is acceptable because subscribe-on-connect refills the store; document this so future caching ideas don't silently change the contract.
+- **API surface parity:** the HA plugin exposes the same allow-list/deny-list gate that the Butler-plan agent path will consume when integrated. Both surfaces must go through `allowlist.ts` — make this a code-level invariant via `api.ts` re-exports.
+- **Integration coverage:** unit tests alone will not prove tile-tap → HA call_service → echo. The integration test in Unit 8 with a fake HA WS is the proof. A live-test smoke against real HA is the second proof.
+- **Unchanged invariants:** existing OpenClaw tabs, chat, and agent panels are unaffected — kiosk mode is additive and routed separately. The Butler plan's HA tool path (REST + Scripts) is unchanged; this plan adds a parallel WebSocket consumer of the same HA user, not a replacement.
+
+## Risks & Dependencies
+
+| Risk                                                                        | Mitigation                                                                                                                                                                                                                                                                                                                                                                 |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| HA WS reconnect storms after WiFi flap or HA restart                        | Exponential backoff capped at 30s; bridge does not republish stale state on reconnect — it resyncs from a fresh subscribe. Connection-state pill makes the state visible; no silent failure.                                                                                                                                                                               |
+| Token rotation: HA long-lived token revoked or rotated                      | Token is a credential reference, not a literal config value. Rotation is a credentials-store update, no code change. Bridge surfaces auth-failure as `degraded` state, not silent reconnect-loop. Hooks into the Butler plan's existing weekly integrity cron — if the cron starts seeing unexpected responses, the kiosk is also affected and the same alert covers both. |
+| Service deny-list drift (a developer edits config to remove a deny entry)   | Two-layer defense: client-side `allowlist.ts` (Unit 3) + HA-user-side deny-list (Butler plan). Removing only one still leaves the other. The weekly integrity cron from the Butler plan catches HA-user-side drift.                                                                                                                                                        |
+| Camera URL leakage when v2 lands cameras                                    | Out of scope for v1 by exclusion. Captured under "Deferred to Separate Tasks" so the constraint is preserved when v2 is planned.                                                                                                                                                                                                                                           |
+| Kiosk shows stale state if gateway is up but HA is down                     | Connection-state pill shows `degraded`; tiles render last-known state with a subtle "stale" indicator after a configurable threshold (default 60s). Tapping in `degraded` mode shows a transient "HA unavailable" error rather than queuing the call.                                                                                                                      |
+| Wall-tablet display sleeps and the wake-lock fails                          | Wake-lock is best-effort. Document that the tablet OS sleep/screensaver settings are part of the deployment; the kiosk shell doesn't fight the OS.                                                                                                                                                                                                                         |
+| HACS card visual fidelity gap (e.g. `sunsynk-power-flow-card` is intricate) | v1 ships a simpler `energy-flow-card` that captures the data flow, not the full HACS visual. Solar deep-dive view in v2 can iterate. Document the visual gap in the README so the household isn't surprised.                                                                                                                                                               |
+| Gateway protocol additions break existing clients                           | Additive-only per root `AGENTS.md`; new topics don't change existing ones. `pnpm check:architecture` covers cycles; manual review of `src/gateway/protocol/AGENTS.md` if it exists for protocol versioning rules.                                                                                                                                                          |
+| `ha:service-call` payload from a malicious or compromised client            | Allow-list and deny-list gates run on the server (extension) side; the browser is treated as untrusted input. Schema validation at the protocol layer rejects malformed calls.                                                                                                                                                                                             |
+| Multi-kiosk or multi-tab interactions cause duplicate service calls         | v1 is single-tablet; document that running two kiosks is allowed (state push fans out fine) but rapid taps from two surfaces could double-toggle. Mitigation: rely on HA's idempotency where applicable; revisit if v2 adds multi-kiosk explicitly.                                                                                                                        |
+
+## Documentation / Operational Notes
+
+- Update `extensions/home-assistant/README.md` with: setup (which HA user, where the token comes from, how `homeAssistantUrl` is configured), v1 scope and known gaps, deny-list policy and its relationship to the HA-user-side deny-list, and the cross-link to the Butler plan.
+- Note in the README that the kiosk URL is intended for LAN access on the wall tablet; if exposed via ngrok, the existing two-layer auth posture applies.
+- No changelog entry until merged; per root `AGENTS.md` use a single-line `### Changes` entry crediting the implementer when the PR lands.
+- No new gates or env vars expected; the existing config + credentials lanes cover this.
+
+## Sources & References
+
+- **Origin context:** user request + screenshot of the existing Wagner Way Lovelace dashboard (no formal `docs/brainstorms/*-requirements.md` document — planning bootstrap covered the gap).
+- **Cross-plan dependency:** [docs/plans/2026-05-10-001-feat-jarvis-the-butler-home-migration-plan.md](docs/plans/2026-05-10-001-feat-jarvis-the-butler-home-migration-plan.md) — owns HA user provisioning, agent-tool surface, weekly deny-list integrity cron.
+- **Extension reference:** `extensions/anthropic/` — canonical extension layout.
+- **UI reference:** `ui/src/ui/views/`, `ui/src/ui/gateway.ts`, `ui/src/ui/navigation.ts`.
+- **External docs (read at impl time):** Home Assistant WebSocket API — https://developers.home-assistant.io/docs/api/websocket/ ; Lovelace dashboard reference — https://www.home-assistant.io/dashboards/

--- a/extensions/home-assistant/README.md
+++ b/extensions/home-assistant/README.md
@@ -7,12 +7,15 @@ dashboard view consumes this plugin via the OpenClaw gateway.
 Tracking plan: [`docs/plans/2026-05-10-002-feat-home-assistant-kiosk-dashboard-plan.md`](../../docs/plans/2026-05-10-002-feat-home-assistant-kiosk-dashboard-plan.md).
 Cross-plan dependency: [`docs/plans/2026-05-10-001-feat-jarvis-the-butler-home-migration-plan.md`](../../docs/plans/2026-05-10-001-feat-jarvis-the-butler-home-migration-plan.md).
 
-> **Status: gate landed (Units 1 + 2 + 3).** This package now ships the
-> manifest, config schema, defaults, the long-lived HA WebSocket client,
-> the entity state store, and the centralized allow-list / service
-> deny-list gate. The gateway bridge (Unit 4) is the next piece -- it
-> wires the WS client into `register.runtime.ts` and bridges state and
-> service-call dispatch onto the OpenClaw gateway WS.
+> **Status: bridge landed (Units 1 + 2 + 3 + 4).** This package now ships
+> the manifest, config schema, defaults, the long-lived HA WebSocket
+> client, the entity state store, the allow-list / deny-list gate, and
+> the gateway bridge that exposes the kiosk-facing methods on the
+> OpenClaw gateway WS. The remaining piece for v1 ship is wiring
+> `register.runtime.ts` to actually instantiate the WS client with a
+> resolved long-lived token from `~/.openclaw/credentials/` and call
+> `attachHomeAssistantBridge` -- the bridge logic and primitives are
+> all in place and exported through `./api.ts`.
 
 ## Configuration
 
@@ -64,12 +67,54 @@ is a credentials-store update, no code change.
   is separated from runtime logic; future units add narrow `*.runtime.ts`
   modules.
 
-## What lands in later units
+## Gateway bridge (`gateway-bridge.ts`)
 
-- **Unit 4:** `gateway-bridge.ts` + `src/gateway/protocol/ha-events.ts` --
-  bridges HA state and service calls onto the OpenClaw gateway WS via new
-  additive `ha:state` and `ha:service-call` topics, and starts the WS client
-  on plugin register.
+The kiosk view talks to this plugin entirely through the existing OpenClaw
+gateway WebSocket. No new core protocol files were needed -- plugin
+broadcasts already use the `plugin.*` namespace and `registerGatewayMethod`
+accepts arbitrary string method names.
+
+| Direction                 | Wire name                     | Scope            | Payload shape                                                                                                                                     |
+| ------------------------- | ----------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ha:subscribe` request    | `home-assistant.subscribe`    | `operator.read`  | `{}` -> `{ snapshot: [{ entity_id, state }] }`. Captures the broadcast function and returns the current cached snapshot of allow-listed entities. |
+| `ha:state` push           | `plugin.home-assistant.state` | (operator/admin) | `{ entity_id, prev, next }` for every state-store diff after subscribe.                                                                           |
+| `ha:service-call` request | `home-assistant.serviceCall`  | `operator.write` | `{ domain, service, target, serviceData? }` -> `{ dispatched: true }` on success, structured error otherwise.                                     |
+
+Validation order on `home-assistant.serviceCall`:
+
+1. `target` present and non-empty -> else `invalid_params`.
+2. `domain.service` passes `checkServiceCall` (deny-list + format checks)
+   -> else `service-denied`.
+3. `target` is in `allowList` -> else `entity-denied`.
+4. Dispatch via `ws-client.callService(...)`. WS-client failures surface as
+   `ha_call_failed`.
+
+> **Plan deviation recorded.** The original plan called for adding `ha:state`
+> and `ha:service-call` to `src/gateway/protocol/`. After inspecting the
+> gateway, plugin broadcasts already use the `plugin.*` namespace
+> (`src/gateway/server-broadcast.ts`) and method handlers register against
+> arbitrary names (`OpenClawPluginApi.registerGatewayMethod`). No core
+> protocol additions were needed; the bridge stays fully extension-local
+> per `extensions/CLAUDE.md` boundary rules.
+
+## v1 ship: wiring `register.runtime.ts`
+
+The bridge is built and tested; the last step is wiring it on plugin
+register. Pseudo-shape:
+
+```ts
+// extensions/home-assistant/register.runtime.ts (v1 ship)
+const config = resolveHomeAssistantConfig(api);
+if (!config) return;                // not configured -> no-op
+const token = await resolveCredential(config.tokenRef);
+const store = new HomeAssistantStateStore({ allowList: config.allowList });
+const client = new HomeAssistantClient({ url: config.homeAssistantUrl, token, store, ... });
+attachHomeAssistantBridge({ api, store, client, config });
+client.start();
+```
+
+Credential resolution follows the existing channel/provider pattern under
+`~/.openclaw/credentials/` -- not landed in this unit.
 
 ## Allow-list / deny-list gate (`allowlist.ts`)
 

--- a/extensions/home-assistant/README.md
+++ b/extensions/home-assistant/README.md
@@ -1,0 +1,79 @@
+# Home Assistant plugin
+
+WebSocket bridge from OpenClaw to Home Assistant. Owns the long-lived HA
+connection, the entity allow-list, and the service deny-list. The kiosk
+dashboard view consumes this plugin via the OpenClaw gateway.
+
+Tracking plan: [`docs/plans/2026-05-10-002-feat-home-assistant-kiosk-dashboard-plan.md`](../../docs/plans/2026-05-10-002-feat-home-assistant-kiosk-dashboard-plan.md).
+Cross-plan dependency: [`docs/plans/2026-05-10-001-feat-jarvis-the-butler-home-migration-plan.md`](../../docs/plans/2026-05-10-001-feat-jarvis-the-butler-home-migration-plan.md).
+
+> **Status: scaffold (Unit 1).** This package currently ships only the plugin
+> manifest, config schema, and credential-reference defaults. No HA WebSocket
+> client, state store, or gateway bridge yet -- those land in Units 2, 3, and
+> 4 of the kiosk plan.
+
+## Configuration
+
+| Field              | Required | Notes                                                                                                                                                                   |
+| ------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `homeAssistantUrl` | yes      | Must start with `ws://` or `wss://`. Default: `ws://192.168.2.41:8123/api/websocket`.                                                                                   |
+| `tokenRef`         | yes      | Credential reference, never the literal token. Default: `homeAssistant.jarvisKiosk`.                                                                                    |
+| `allowList`        | no       | Entity IDs the kiosk is permitted to read. Defaults to `[]` (closed). Slots reference entries in this list.                                                             |
+| `denyServiceList`  | no       | Services the kiosk must never call. Defaults to `lock.unlock`, `alarm_control_panel.alarm_disarm`, `cover.open_cover` (matches the Butler-plan HA-user-side deny-list). |
+| `slots`            | no       | Map of kiosk slot names (`gauge.battery_soc`, `tile.gate_main`, ...) to allow-listed entity IDs.                                                                        |
+
+The runtime parser enforces three cross-field invariants the manifest's JSON
+Schema cannot express:
+
+1. `homeAssistantUrl` must start with `ws://` or `wss://`.
+2. Every entry in `denyServiceList` must look like `<domain>.<service>`.
+3. Every slot value must reference an entity present in `allowList`.
+
+## HA user (jarvis_kiosk)
+
+The kiosk uses a dedicated non-admin Home Assistant user named `jarvis_kiosk`.
+This is a sibling of the `jarvis_butler` user owned by the Jarvis Butler plan,
+not a reuse. Two separate users so:
+
+- The kiosk and the agent can rotate independently.
+- A compromised tablet cannot use the agent's credentials.
+- HA-user-side exposure (Settings -> Voice assistants -> Expose) is curated
+  separately for the kiosk and the agent.
+
+The HA-user-side deny-list (locks, alarm-disarm, garage-open) is the safety
+net. The client-side `denyServiceList` in this plugin is defense in depth so
+a forbidden tile never even issues the call.
+
+## Credential storage
+
+The literal long-lived access token lives under `~/.openclaw/credentials/`,
+following the existing OpenClaw credential-storage convention. The plugin
+config holds a reference (`tokenRef`), never the token itself. Token rotation
+is a credentials-store update, no code change.
+
+## Boundary
+
+- Imports only from `openclaw/plugin-sdk/*` and this package's local barrels
+  (`./api.ts`, `./config-schema.ts`, `./register.runtime.ts`,
+  `./config-defaults.ts`).
+- No deep imports into `src/**`, other extensions, or
+  `src/plugin-sdk-internal/**`.
+- Per `extensions/CLAUDE.md`: control-plane metadata (manifest + JSON Schema)
+  is separated from runtime logic; future units add narrow `*.runtime.ts`
+  modules.
+
+## What lands in later units
+
+- **Unit 2:** `ws-client.ts` + `state-store.ts` -- HA WebSocket connection
+  lifecycle and entity state cache.
+- **Unit 3:** `allowlist.ts` -- centralized allow-list / deny-list gate that
+  every consumer (kiosk + future agent path) goes through.
+- **Unit 4:** `gateway-bridge.ts` + `src/gateway/protocol/ha-events.ts` --
+  bridges HA state and service calls onto the OpenClaw gateway WS via new
+  additive `ha:state` and `ha:service-call` topics.
+
+## Tests
+
+```sh
+pnpm test extensions/home-assistant
+```

--- a/extensions/home-assistant/README.md
+++ b/extensions/home-assistant/README.md
@@ -7,10 +7,13 @@ dashboard view consumes this plugin via the OpenClaw gateway.
 Tracking plan: [`docs/plans/2026-05-10-002-feat-home-assistant-kiosk-dashboard-plan.md`](../../docs/plans/2026-05-10-002-feat-home-assistant-kiosk-dashboard-plan.md).
 Cross-plan dependency: [`docs/plans/2026-05-10-001-feat-jarvis-the-butler-home-migration-plan.md`](../../docs/plans/2026-05-10-001-feat-jarvis-the-butler-home-migration-plan.md).
 
-> **Status: scaffold (Unit 1).** This package currently ships only the plugin
-> manifest, config schema, and credential-reference defaults. No HA WebSocket
-> client, state store, or gateway bridge yet -- those land in Units 2, 3, and
-> 4 of the kiosk plan.
+> **Status: WS client landed (Units 1 + 2).** This package now ships the
+> manifest, config schema, defaults, the long-lived HA WebSocket client
+> (auth handshake, state-changed subscription, heartbeat, exponential
+> reconnect), and the entity state store with allow-list filtering.
+> The allow-list / service deny-list gate (Unit 3) and the gateway bridge
+> (Unit 4) are not yet wired -- the WS client is unreferenced from
+> `register.runtime.ts` until Unit 4 plumbs it in.
 
 ## Configuration
 
@@ -64,13 +67,37 @@ is a credentials-store update, no code change.
 
 ## What lands in later units
 
-- **Unit 2:** `ws-client.ts` + `state-store.ts` -- HA WebSocket connection
-  lifecycle and entity state cache.
-- **Unit 3:** `allowlist.ts` -- centralized allow-list / deny-list gate that
-  every consumer (kiosk + future agent path) goes through.
+- **Unit 3:** `allowlist.ts` -- centralized service deny-list gate that every
+  service-call consumer (kiosk + future agent path) goes through.
 - **Unit 4:** `gateway-bridge.ts` + `src/gateway/protocol/ha-events.ts` --
   bridges HA state and service calls onto the OpenClaw gateway WS via new
-  additive `ha:state` and `ha:service-call` topics.
+  additive `ha:state` and `ha:service-call` topics, and starts the WS client
+  on plugin register.
+
+## WS client overview (`ws-client.ts`)
+
+```text
+idle -> connecting -> authenticating -> subscribed
+                                          | (heartbeat miss / drop)
+                                          v
+                                       degraded -- reconnect (1s..30s exp) --> connecting
+```
+
+- **Server-relayed transport.** The browser never holds the HA token; only
+  this client does. Future Unit 4 publishes filtered state onto the OpenClaw
+  gateway WS.
+- **Reconnect.** Exponential backoff `min(maxDelayMs, baseDelayMs * 2^(n-1))`.
+  Defaults: base 1s, cap 30s. Counter resets on successful subscribe.
+- **Heartbeat.** Application-level `ping`/`pong` with id matching. Default
+  interval 30s, timeout 10s. Pong timeout recycles the socket.
+- **State store reset on resubscribe.** After a connection drop, the next
+  successful subscribe flushes the store so downstream consumers see a clean
+  refill rather than a stale cache.
+- **Auth invalid is terminal.** `auth_invalid` transitions to `degraded`
+  without scheduling a reconnect -- the operator must rotate the credential.
+- **Injectable everything.** WS factory, store, clock, timers, and logger
+  are all options so tests are deterministic and the same module works under
+  Node 22 (`globalThis.WebSocket`) and the `ws` package.
 
 ## Tests
 

--- a/extensions/home-assistant/README.md
+++ b/extensions/home-assistant/README.md
@@ -7,13 +7,12 @@ dashboard view consumes this plugin via the OpenClaw gateway.
 Tracking plan: [`docs/plans/2026-05-10-002-feat-home-assistant-kiosk-dashboard-plan.md`](../../docs/plans/2026-05-10-002-feat-home-assistant-kiosk-dashboard-plan.md).
 Cross-plan dependency: [`docs/plans/2026-05-10-001-feat-jarvis-the-butler-home-migration-plan.md`](../../docs/plans/2026-05-10-001-feat-jarvis-the-butler-home-migration-plan.md).
 
-> **Status: WS client landed (Units 1 + 2).** This package now ships the
-> manifest, config schema, defaults, the long-lived HA WebSocket client
-> (auth handshake, state-changed subscription, heartbeat, exponential
-> reconnect), and the entity state store with allow-list filtering.
-> The allow-list / service deny-list gate (Unit 3) and the gateway bridge
-> (Unit 4) are not yet wired -- the WS client is unreferenced from
-> `register.runtime.ts` until Unit 4 plumbs it in.
+> **Status: gate landed (Units 1 + 2 + 3).** This package now ships the
+> manifest, config schema, defaults, the long-lived HA WebSocket client,
+> the entity state store, and the centralized allow-list / service
+> deny-list gate. The gateway bridge (Unit 4) is the next piece -- it
+> wires the WS client into `register.runtime.ts` and bridges state and
+> service-call dispatch onto the OpenClaw gateway WS.
 
 ## Configuration
 
@@ -67,12 +66,28 @@ is a credentials-store update, no code change.
 
 ## What lands in later units
 
-- **Unit 3:** `allowlist.ts` -- centralized service deny-list gate that every
-  service-call consumer (kiosk + future agent path) goes through.
 - **Unit 4:** `gateway-bridge.ts` + `src/gateway/protocol/ha-events.ts` --
   bridges HA state and service calls onto the OpenClaw gateway WS via new
   additive `ha:state` and `ha:service-call` topics, and starts the WS client
   on plugin register.
+
+## Allow-list / deny-list gate (`allowlist.ts`)
+
+- `isEntityAllowed(entityId, config)` -> boolean. Empty `allowList` denies
+  everything (fail-closed). Whitespace-trimmed but case-sensitive: HA emits
+  lowercase entity IDs, so mixed-case operator typos surface as a config
+  error rather than silent coercion.
+- `checkServiceCall({domain, service}, config)` -> structured allow/deny
+  result. Deny carries `{kind: "service-denied", domain, service, detail}`
+  for the bridge to echo back to the kiosk.
+- v1 policy is **deny-list-authoritative**: a service is allowed unless the
+  exact `<domain>.<service>` form is in `denyServiceList`. The HA-user-side
+  deny-list documented in the Butler plan is the actual safety net; this
+  gate is belt-and-braces.
+- **Future hardening (deferred):** add `HomeAssistantConfig.allowServiceList`.
+  When present + non-empty, the gate switches to deny-by-default. Deny-list
+  precedence is preserved (deny wins). Tests under "future hardening guard"
+  in `allowlist.test.ts` lock that contract.
 
 ## WS client overview (`ws-client.ts`)
 

--- a/extensions/home-assistant/allowlist.test.ts
+++ b/extensions/home-assistant/allowlist.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkServiceCall,
+  isEntityAllowed,
+  isServiceAllowed,
+  type ServiceCheckResult,
+} from "./allowlist.js";
+
+const CONFIG = {
+  allowList: [
+    "sensor.deye_sunsynk_sol_ark_battery_state_of_charge",
+    "switch.sonoff_10013c3266",
+    "cover.aqara_roller_blind_left",
+  ],
+  denyServiceList: ["lock.unlock", "alarm_control_panel.alarm_disarm", "cover.open_cover"],
+} as const;
+
+describe("allowlist gate", () => {
+  describe("isEntityAllowed", () => {
+    it("returns true for an entity in allowList", () => {
+      expect(isEntityAllowed("switch.sonoff_10013c3266", CONFIG)).toBe(true);
+    });
+
+    it("returns false for an entity outside allowList", () => {
+      expect(isEntityAllowed("switch.something_unauthorized", CONFIG)).toBe(false);
+    });
+
+    it("fail-closed: an empty allowList denies everything", () => {
+      expect(isEntityAllowed("switch.sonoff_10013c3266", { allowList: [] })).toBe(false);
+    });
+
+    it("normalizes whitespace -- a space-padded entity id matches its trimmed form", () => {
+      expect(isEntityAllowed("  switch.sonoff_10013c3266  ", CONFIG)).toBe(true);
+    });
+
+    it("is case-sensitive on the comparison side -- HA entity ids are lowercase by convention", () => {
+      // HA's data plane only emits lowercase. We do not silently match
+      // mixed-case operator typos to a real entity; better to surface the
+      // mismatch loudly during config validation than to mask it here.
+      expect(isEntityAllowed("Switch.Sonoff_10013c3266", CONFIG)).toBe(false);
+    });
+
+    it("rejects non-string entity ids", () => {
+      // The schema parser already rejects these, but the gate is also a
+      // boundary that may be reached from runtime payloads.
+      expect(isEntityAllowed(undefined as unknown as string, CONFIG)).toBe(false);
+      expect(isEntityAllowed(null as unknown as string, CONFIG)).toBe(false);
+      expect(isEntityAllowed(42 as unknown as string, CONFIG)).toBe(false);
+    });
+  });
+
+  describe("isServiceAllowed", () => {
+    it("returns true for a service not in denyServiceList", () => {
+      expect(isServiceAllowed("switch", "toggle", CONFIG)).toBe(true);
+    });
+
+    it("returns false for a service in denyServiceList", () => {
+      expect(isServiceAllowed("lock", "unlock", CONFIG)).toBe(false);
+    });
+
+    it("v1 documented default: empty denyServiceList allows any service (deny-list-authoritative)", () => {
+      // Recorded decision: until allowServiceList lands, the gate is purely
+      // deny-list-authoritative. The household-level safety net is the
+      // HA-user-side deny-list from the Butler plan; this client gate is
+      // belt-and-braces, not the only line of defense.
+      expect(isServiceAllowed("switch", "toggle", { denyServiceList: [] })).toBe(true);
+      expect(isServiceAllowed("lock", "unlock", { denyServiceList: [] })).toBe(true);
+    });
+  });
+
+  describe("checkServiceCall", () => {
+    it("returns allowed=true with the normalized domain/service for safe calls", () => {
+      const result = checkServiceCall({ domain: "switch", service: "toggle" }, CONFIG);
+      expect(result).toEqual<ServiceCheckResult>({
+        allowed: true,
+        domain: "switch",
+        service: "toggle",
+      });
+    });
+
+    it("returns a structured service-denied error for deny-listed services", () => {
+      const result = checkServiceCall({ domain: "lock", service: "unlock" }, CONFIG);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason.kind).toBe("service-denied");
+        expect(result.reason.domain).toBe("lock");
+        expect(result.reason.service).toBe("unlock");
+        expect(result.reason.detail).toMatch(/deny[-\s]?list/i);
+      }
+    });
+
+    it("trims whitespace and lowercases domain/service before checking", () => {
+      const result = checkServiceCall({ domain: "  LOCK ", service: "Unlock" }, CONFIG);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason.domain).toBe("lock");
+        expect(result.reason.service).toBe("unlock");
+      }
+    });
+
+    it("rejects malformed domain/service inputs without crashing", () => {
+      const result = checkServiceCall({ domain: "", service: "toggle" }, CONFIG);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason.kind).toBe("service-denied");
+        expect(result.reason.detail).toMatch(/empty|invalid/i);
+      }
+    });
+
+    it("rejects domain or service containing a dot (would mis-match the deny-list)", () => {
+      // denyServiceList entries are <domain>.<service>; a domain that itself
+      // contains a dot would let a caller smuggle past the comparison.
+      const result = checkServiceCall(
+        { domain: "switch.lock", service: "unlock" },
+        { denyServiceList: ["lock.unlock"] },
+      );
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason.kind).toBe("service-denied");
+      }
+    });
+  });
+
+  describe("future hardening guard (locks v1 deferred decision)", () => {
+    it("documents that deny-list precedence holds even if allowServiceList is later added", () => {
+      // When `allowServiceList` is added to HomeAssistantConfig, the gate must
+      // still treat denyServiceList as authoritative (deny wins over allow).
+      // This test fails fast if a future change reverses that precedence
+      // by treating allowServiceList as overriding the deny-list.
+      const config = { denyServiceList: ["lock.unlock"] };
+      expect(isServiceAllowed("lock", "unlock", config)).toBe(false);
+    });
+  });
+
+  describe("integration: filtering a list of HA service-call payloads", () => {
+    it("partitions a batch of calls into allowed and denied", () => {
+      const calls = [
+        { domain: "switch", service: "toggle", target: "switch.sonoff_10013c3266" },
+        { domain: "lock", service: "unlock", target: "lock.front_door" },
+        { domain: "cover", service: "set_cover_position", target: "cover.aqara_roller_blind_left" },
+        { domain: "alarm_control_panel", service: "alarm_disarm", target: "alarm.ring_alarm" },
+      ];
+
+      const results = calls.map((c) => ({
+        target: c.target,
+        result: checkServiceCall({ domain: c.domain, service: c.service }, CONFIG),
+      }));
+
+      const allowed = results.filter((r) => r.result.allowed).map((r) => r.target);
+      const denied = results.filter((r) => !r.result.allowed).map((r) => r.target);
+
+      expect(allowed).toEqual(["switch.sonoff_10013c3266", "cover.aqara_roller_blind_left"]);
+      expect(denied).toEqual(["lock.front_door", "alarm.ring_alarm"]);
+    });
+  });
+});

--- a/extensions/home-assistant/allowlist.ts
+++ b/extensions/home-assistant/allowlist.ts
@@ -1,0 +1,112 @@
+/**
+ * Centralized allow-list / deny-list gate for the Home Assistant bridge.
+ *
+ * Pure functions over `HomeAssistantConfig`. Two surfaces consume this gate:
+ *   - the gateway bridge (Unit 4) for incoming service-call requests from the
+ *     kiosk
+ *   - any future agent-tool path that wants to call HA services through the
+ *     same plugin
+ *
+ * Both go through `isEntityAllowed` and `checkServiceCall` so the household's
+ * curated allow-list and deny-list are the single source of truth.
+ *
+ * V1 service-permission policy (deferred decision now resolved):
+ *   - If a service is in `denyServiceList` -> denied.
+ *   - Otherwise -> allowed.
+ *
+ * The HA-user-side deny-list documented in the Jarvis Butler plan is the
+ * actual safety net (locks, alarm-disarm, garage-open are not exposed to the
+ * `jarvis_kiosk` HA user at all). This client-side gate is belt-and-braces
+ * so a tile bound to a forbidden service never even issues the call.
+ *
+ * Future hardening (deferred -- not in v1): add
+ * `HomeAssistantConfig.allowServiceList`. When present + non-empty, the gate
+ * switches to deny-by-default and requires services to be enumerated there.
+ * The deny-list keeps precedence (deny wins over allow). The
+ * "future hardening guard" test in allowlist.test.ts locks this contract.
+ */
+
+import type { HomeAssistantConfig } from "./config-schema.js";
+
+export type ServiceDeniedReason = {
+  kind: "service-denied";
+  domain: string;
+  service: string;
+  detail: string;
+};
+
+export type ServiceCheckResult =
+  | { allowed: true; domain: string; service: string }
+  | { allowed: false; reason: ServiceDeniedReason };
+
+const SEGMENT_PATTERN = /^[a-z][a-z0-9_]*$/;
+
+function normalize(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function isEntityAllowed(
+  entityId: unknown,
+  config: Pick<HomeAssistantConfig, "allowList">,
+): boolean {
+  const normalized = normalize(entityId);
+  if (normalized === null) {
+    return false;
+  }
+  // HA emits lowercase entity IDs; we match exactly post-trim. Mismatched
+  // casing surfaces as a config error rather than getting silently coerced.
+  return config.allowList.includes(normalized);
+}
+
+function buildDeniedResult(domain: string, service: string, detail: string): ServiceCheckResult {
+  return {
+    allowed: false,
+    reason: { kind: "service-denied", domain, service, detail },
+  };
+}
+
+function isWellFormedSegment(value: string): boolean {
+  // Lowercased before this check; rejects empty strings, segments with dots
+  // (which would let a caller smuggle past the deny-list comparison), and
+  // anything outside the HA convention of [a-z][a-z0-9_]*.
+  return SEGMENT_PATTERN.test(value);
+}
+
+export function checkServiceCall(
+  args: { domain: unknown; service: unknown },
+  config: Pick<HomeAssistantConfig, "denyServiceList">,
+): ServiceCheckResult {
+  const rawDomain = normalize(args.domain);
+  const rawService = normalize(args.service);
+  const domain = (rawDomain ?? "").toLowerCase();
+  const service = (rawService ?? "").toLowerCase();
+
+  if (rawDomain === null || rawDomain.length === 0) {
+    return buildDeniedResult(domain, service, "empty or invalid domain");
+  }
+  if (rawService === null || rawService.length === 0) {
+    return buildDeniedResult(domain, service, "empty or invalid service");
+  }
+  if (!isWellFormedSegment(domain) || !isWellFormedSegment(service)) {
+    return buildDeniedResult(domain, service, "invalid <domain>.<service> format");
+  }
+
+  const key = `${domain}.${service}`;
+  if (config.denyServiceList.includes(key)) {
+    return buildDeniedResult(domain, service, `service "${key}" is in the deny-list`);
+  }
+
+  return { allowed: true, domain, service };
+}
+
+export function isServiceAllowed(
+  domain: unknown,
+  service: unknown,
+  config: Pick<HomeAssistantConfig, "denyServiceList">,
+): boolean {
+  return checkServiceCall({ domain, service }, config).allowed;
+}

--- a/extensions/home-assistant/api.ts
+++ b/extensions/home-assistant/api.ts
@@ -10,4 +10,25 @@ export {
   DEFAULT_TOKEN_REF,
   DEFAULT_DENY_SERVICE_LIST,
 } from "./config-defaults.js";
+export {
+  HomeAssistantStateStore,
+  type EntityState,
+  type StateChangedEvent,
+  type StateDiff,
+  type StateDiffListener,
+  type ListenerErrorListener,
+  type StateStoreOptions,
+  type Unsubscribe,
+} from "./state-store.js";
+export {
+  HomeAssistantClient,
+  type ConnectionState,
+  type HomeAssistantClientOptions,
+  type LogEntry,
+  type LogLevel,
+  type Logger,
+  type StateChangeListener,
+  type WebSocketLike,
+  type WebSocketLikeFactory,
+} from "./ws-client.js";
 export { registerHomeAssistantPlugin } from "./register.runtime.js";

--- a/extensions/home-assistant/api.ts
+++ b/extensions/home-assistant/api.ts
@@ -38,4 +38,18 @@ export {
   type ServiceCheckResult,
   type ServiceDeniedReason,
 } from "./allowlist.js";
+export {
+  HA_SERVICE_CALL_METHOD,
+  HA_STATE_EVENT,
+  HA_SUBSCRIBE_METHOD,
+  attachHomeAssistantBridge,
+  type AttachBridgeArgs,
+  type BridgeBroadcastFn,
+  type BridgeGatewayApi,
+  type BridgeGatewayHandler,
+  type BridgeGatewayHandlerArgs,
+  type BridgeHandle,
+  type BridgeLogger,
+  type ServiceCallClient,
+} from "./gateway-bridge.js";
 export { registerHomeAssistantPlugin } from "./register.runtime.js";

--- a/extensions/home-assistant/api.ts
+++ b/extensions/home-assistant/api.ts
@@ -31,4 +31,11 @@ export {
   type WebSocketLike,
   type WebSocketLikeFactory,
 } from "./ws-client.js";
+export {
+  checkServiceCall,
+  isEntityAllowed,
+  isServiceAllowed,
+  type ServiceCheckResult,
+  type ServiceDeniedReason,
+} from "./allowlist.js";
 export { registerHomeAssistantPlugin } from "./register.runtime.js";

--- a/extensions/home-assistant/api.ts
+++ b/extensions/home-assistant/api.ts
@@ -1,0 +1,13 @@
+export {
+  homeAssistantConfigSchema,
+  parseHomeAssistantConfig,
+  type HomeAssistantConfig,
+  type HomeAssistantConfigParseIssue,
+  type HomeAssistantConfigParseResult,
+} from "./config-schema.js";
+export {
+  DEFAULT_HOME_ASSISTANT_URL,
+  DEFAULT_TOKEN_REF,
+  DEFAULT_DENY_SERVICE_LIST,
+} from "./config-defaults.js";
+export { registerHomeAssistantPlugin } from "./register.runtime.js";

--- a/extensions/home-assistant/config-defaults.ts
+++ b/extensions/home-assistant/config-defaults.ts
@@ -1,0 +1,27 @@
+/**
+ * Default configuration values for the Home Assistant kiosk bridge.
+ *
+ * The HA URL points at the household HA host. The token reference points at a
+ * dedicated non-admin HA user (`jarvis_kiosk`) -- a sibling of the
+ * `jarvis_butler` user owned by the Jarvis Butler plan
+ * (docs/plans/2026-05-10-001-feat-jarvis-the-butler-home-migration-plan.md).
+ *
+ * Two separate users so the kiosk and the agent rotate independently and so a
+ * compromised tablet cannot use the agent's credentials.
+ */
+
+export const DEFAULT_HOME_ASSISTANT_URL = "ws://192.168.2.41:8123/api/websocket";
+
+export const DEFAULT_TOKEN_REF = "homeAssistant.jarvisKiosk";
+
+/**
+ * Services the kiosk must never call. Mirrors the HA-user-side deny-list
+ * documented in the Butler plan; the user-side deny-list is the safety net,
+ * this client-side list is defense in depth so a forbidden tile never even
+ * issues the call.
+ */
+export const DEFAULT_DENY_SERVICE_LIST: readonly string[] = [
+  "lock.unlock",
+  "alarm_control_panel.alarm_disarm",
+  "cover.open_cover",
+];

--- a/extensions/home-assistant/config-schema.test.ts
+++ b/extensions/home-assistant/config-schema.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_DENY_SERVICE_LIST,
+  DEFAULT_HOME_ASSISTANT_URL,
+  DEFAULT_TOKEN_REF,
+} from "./config-defaults.js";
+import {
+  homeAssistantConfigSchema,
+  parseHomeAssistantConfig,
+  type HomeAssistantConfigParseIssue,
+} from "./config-schema.js";
+
+function expectIssueAtPath(
+  issues: HomeAssistantConfigParseIssue[] | undefined,
+  path: Array<string | number>,
+): HomeAssistantConfigParseIssue {
+  expect(issues, "expected a parse issue but got none").toBeTruthy();
+  const matched = (issues ?? []).find(
+    (issue) =>
+      issue.path.length === path.length &&
+      issue.path.every((segment, index) => segment === path[index]),
+  );
+  expect(
+    matched,
+    `expected issue at path ${JSON.stringify(path)}; got ${JSON.stringify(issues)}`,
+  ).toBeTruthy();
+  return matched as HomeAssistantConfigParseIssue;
+}
+
+const VALID_CONFIG = {
+  homeAssistantUrl: DEFAULT_HOME_ASSISTANT_URL,
+  tokenRef: DEFAULT_TOKEN_REF,
+  allowList: ["sensor.deye_sunsynk_sol_ark_battery_state_of_charge", "switch.sonoff_10013c3266"],
+  denyServiceList: [...DEFAULT_DENY_SERVICE_LIST],
+  slots: {
+    "gauge.battery_soc": "sensor.deye_sunsynk_sol_ark_battery_state_of_charge",
+    "tile.gate_main": "switch.sonoff_10013c3266",
+  },
+};
+
+describe("home-assistant config schema", () => {
+  describe("happy path", () => {
+    it("accepts a valid URL, tokenRef, allow-list, deny-list, and slots", () => {
+      const result = parseHomeAssistantConfig(VALID_CONFIG);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.homeAssistantUrl).toBe(DEFAULT_HOME_ASSISTANT_URL);
+        expect(result.data.tokenRef).toBe(DEFAULT_TOKEN_REF);
+        expect(result.data.allowList).toEqual(VALID_CONFIG.allowList);
+        expect(result.data.denyServiceList).toEqual(VALID_CONFIG.denyServiceList);
+        expect(result.data.slots).toEqual(VALID_CONFIG.slots);
+      }
+    });
+
+    it("round-trips through the SDK plugin schema's safeParse", () => {
+      const safeParse = homeAssistantConfigSchema.safeParse;
+      expect(safeParse).toBeTypeOf("function");
+      const result = safeParse!(VALID_CONFIG);
+      expect(result.success).toBe(true);
+    });
+
+    it("publishes a strict JSON Schema for loader-side validation", () => {
+      const json = homeAssistantConfigSchema.jsonSchema as Record<string, unknown>;
+      expect(json.type).toBe("object");
+      expect(json.additionalProperties).toBe(false);
+      expect(json.required).toEqual(["homeAssistantUrl", "tokenRef"]);
+    });
+
+    it("treats allowList, denyServiceList, and slots as optional", () => {
+      const result = parseHomeAssistantConfig({
+        homeAssistantUrl: "wss://ha.example.com:8123/api/websocket",
+        tokenRef: "homeAssistant.jarvisKiosk",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.allowList).toEqual([]);
+        expect(result.data.denyServiceList).toEqual([]);
+        expect(result.data.slots).toEqual({});
+      }
+    });
+  });
+
+  describe("required fields", () => {
+    it("rejects configs without tokenRef and points at the credentials path", () => {
+      const result = parseHomeAssistantConfig({
+        homeAssistantUrl: DEFAULT_HOME_ASSISTANT_URL,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = expectIssueAtPath(result.error.issues, ["tokenRef"]);
+        expect(issue.message).toMatch(/credential reference/);
+      }
+    });
+
+    it("rejects configs without homeAssistantUrl", () => {
+      const result = parseHomeAssistantConfig({ tokenRef: DEFAULT_TOKEN_REF });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expectIssueAtPath(result.error.issues, ["homeAssistantUrl"]);
+      }
+    });
+  });
+
+  describe("homeAssistantUrl validation", () => {
+    it.each([
+      "http://192.168.2.41:8123/api/websocket",
+      "https://homeassistant.local:8123/api/websocket",
+      "192.168.2.41:8123",
+      "",
+    ])("rejects %s", (url) => {
+      const result = parseHomeAssistantConfig({
+        ...VALID_CONFIG,
+        homeAssistantUrl: url,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expectIssueAtPath(result.error.issues, ["homeAssistantUrl"]);
+      }
+    });
+
+    it.each(["ws://192.168.2.41:8123/api/websocket", "wss://ha.example.com/api/websocket"])(
+      "accepts %s",
+      (url) => {
+        const result = parseHomeAssistantConfig({ ...VALID_CONFIG, homeAssistantUrl: url });
+        expect(result.success).toBe(true);
+      },
+    );
+  });
+
+  describe("denyServiceList format", () => {
+    it("rejects entries that are not <domain>.<service>", () => {
+      const result = parseHomeAssistantConfig({
+        ...VALID_CONFIG,
+        denyServiceList: ["lock.unlock", "noDotHere"],
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expectIssueAtPath(result.error.issues, ["denyServiceList", 1]);
+      }
+    });
+
+    it("rejects empty-string entries", () => {
+      const result = parseHomeAssistantConfig({
+        ...VALID_CONFIG,
+        denyServiceList: [""],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts the default deny-list", () => {
+      const result = parseHomeAssistantConfig({
+        ...VALID_CONFIG,
+        denyServiceList: [...DEFAULT_DENY_SERVICE_LIST],
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("slots cross-field validation", () => {
+    it("rejects a slot whose target is not in allowList", () => {
+      const result = parseHomeAssistantConfig({
+        ...VALID_CONFIG,
+        slots: {
+          "gauge.battery_soc": "sensor.deye_sunsynk_sol_ark_battery_state_of_charge",
+          "tile.unknown": "switch.does_not_exist",
+        },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = expectIssueAtPath(result.error.issues, ["slots", "tile.unknown"]);
+        expect(issue.message).toMatch(/not in allowList/);
+      }
+    });
+
+    it("rejects a slot mapped to a non-string", () => {
+      const result = parseHomeAssistantConfig({
+        ...VALID_CONFIG,
+        slots: { "gauge.bad": 42 } as unknown as Record<string, string>,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expectIssueAtPath(result.error.issues, ["slots", "gauge.bad"]);
+      }
+    });
+  });
+
+  describe("structural validation", () => {
+    it("rejects unknown top-level properties", () => {
+      const result = parseHomeAssistantConfig({
+        ...VALID_CONFIG,
+        leftoverFromAnotherPlugin: true,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expectIssueAtPath(result.error.issues, ["leftoverFromAnotherPlugin"]);
+      }
+    });
+
+    it("rejects non-object input", () => {
+      expect(parseHomeAssistantConfig(null).success).toBe(false);
+      expect(parseHomeAssistantConfig("ws://192.168.2.41").success).toBe(false);
+      expect(parseHomeAssistantConfig([VALID_CONFIG]).success).toBe(false);
+    });
+  });
+});

--- a/extensions/home-assistant/config-schema.ts
+++ b/extensions/home-assistant/config-schema.ts
@@ -1,0 +1,191 @@
+import {
+  buildPluginConfigSchema,
+  type OpenClawPluginConfigSchema,
+} from "openclaw/plugin-sdk/plugin-entry";
+
+/**
+ * Validated shape of `plugins.entries["home-assistant"].config`.
+ *
+ * Cross-field invariants enforced here (not expressible in the manifest's
+ * JSON Schema):
+ *   - homeAssistantUrl must start with ws:// or wss://
+ *   - every entry in denyServiceList must look like `<domain>.<service>`
+ *   - every slot value must reference an entity present in allowList
+ */
+export type HomeAssistantConfig = {
+  homeAssistantUrl: string;
+  tokenRef: string;
+  allowList: readonly string[];
+  denyServiceList: readonly string[];
+  slots: Readonly<Record<string, string>>;
+};
+
+export type HomeAssistantConfigParseIssue = {
+  path: Array<string | number>;
+  message: string;
+};
+
+export type HomeAssistantConfigParseResult =
+  | { success: true; data: HomeAssistantConfig }
+  | { success: false; error: { issues: HomeAssistantConfigParseIssue[] } };
+
+const SERVICE_PATTERN = /^[a-z][a-z0-9_]*\.[a-z][a-z0-9_]*$/;
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function pushIssue(
+  issues: HomeAssistantConfigParseIssue[],
+  path: Array<string | number>,
+  message: string,
+): void {
+  issues.push({ path, message });
+}
+
+export function parseHomeAssistantConfig(value: unknown): HomeAssistantConfigParseResult {
+  const issues: HomeAssistantConfigParseIssue[] = [];
+
+  if (!isPlainRecord(value)) {
+    pushIssue(issues, [], "expected a Home Assistant plugin config object");
+    return { success: false, error: { issues } };
+  }
+
+  const known = new Set(["homeAssistantUrl", "tokenRef", "allowList", "denyServiceList", "slots"]);
+  for (const key of Object.keys(value)) {
+    if (!known.has(key)) {
+      pushIssue(issues, [key], `unknown property "${key}"`);
+    }
+  }
+
+  const url = value.homeAssistantUrl;
+  if (typeof url !== "string" || url.trim().length === 0) {
+    pushIssue(issues, ["homeAssistantUrl"], "homeAssistantUrl is required");
+  } else if (!url.startsWith("ws://") && !url.startsWith("wss://")) {
+    pushIssue(issues, ["homeAssistantUrl"], "homeAssistantUrl must start with ws:// or wss://");
+  }
+
+  const tokenRef = value.tokenRef;
+  if (typeof tokenRef !== "string" || tokenRef.trim().length === 0) {
+    pushIssue(
+      issues,
+      ["tokenRef"],
+      "tokenRef is required (credential reference, never the literal token)",
+    );
+  }
+
+  const allowListRaw = value.allowList ?? [];
+  let allowList: string[] = [];
+  if (allowListRaw === undefined) {
+    allowList = [];
+  } else if (!isStringArray(allowListRaw)) {
+    pushIssue(issues, ["allowList"], "allowList must be an array of entity-id strings");
+  } else {
+    allowList = allowListRaw;
+  }
+
+  const denyServiceListRaw = value.denyServiceList ?? [];
+  let denyServiceList: string[] = [];
+  if (denyServiceListRaw === undefined) {
+    denyServiceList = [];
+  } else if (!isStringArray(denyServiceListRaw)) {
+    pushIssue(
+      issues,
+      ["denyServiceList"],
+      "denyServiceList must be an array of <domain>.<service> strings",
+    );
+  } else {
+    denyServiceList = denyServiceListRaw;
+    denyServiceListRaw.forEach((entry, index) => {
+      if (!SERVICE_PATTERN.test(entry)) {
+        pushIssue(
+          issues,
+          ["denyServiceList", index],
+          `denyServiceList[${index}] "${entry}" is not formatted as <domain>.<service>`,
+        );
+      }
+    });
+  }
+
+  const slotsRaw = value.slots ?? {};
+  let slots: Record<string, string> = {};
+  if (slotsRaw === undefined) {
+    slots = {};
+  } else if (!isPlainRecord(slotsRaw)) {
+    pushIssue(issues, ["slots"], "slots must be an object mapping slot name to entity id");
+  } else {
+    const allowSet = new Set(allowList);
+    for (const [slotName, slotTarget] of Object.entries(slotsRaw)) {
+      if (typeof slotTarget !== "string" || slotTarget.length === 0) {
+        pushIssue(
+          issues,
+          ["slots", slotName],
+          `slot "${slotName}" must map to a non-empty entity id string`,
+        );
+        continue;
+      }
+      if (allowList.length > 0 && !allowSet.has(slotTarget)) {
+        pushIssue(
+          issues,
+          ["slots", slotName],
+          `slot "${slotName}" maps to "${slotTarget}" which is not in allowList`,
+        );
+        continue;
+      }
+      slots[slotName] = slotTarget;
+    }
+  }
+
+  if (issues.length > 0) {
+    return { success: false, error: { issues } };
+  }
+
+  return {
+    success: true,
+    data: {
+      homeAssistantUrl: url as string,
+      tokenRef: tokenRef as string,
+      allowList,
+      denyServiceList,
+      slots,
+    },
+  };
+}
+
+const HOME_ASSISTANT_JSON_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["homeAssistantUrl", "tokenRef"],
+  properties: {
+    homeAssistantUrl: { type: "string", minLength: 1 },
+    tokenRef: { type: "string", minLength: 1 },
+    allowList: { type: "array", items: { type: "string" } },
+    denyServiceList: { type: "array", items: { type: "string" } },
+    slots: { type: "object", additionalProperties: { type: "string" } },
+  },
+} as const;
+
+/**
+ * The plugin config schema surfaced to the host. Uses the SDK's
+ * `buildPluginConfigSchema` for shape, but routes parsing through
+ * `parseHomeAssistantConfig` so cross-field invariants (URL scheme, slot
+ * targets in allowList, service format) run on every config validation pass.
+ */
+export const homeAssistantConfigSchema: OpenClawPluginConfigSchema = buildPluginConfigSchema(
+  // We don't need a zod instance here -- the safeParse override covers all
+  // parsing, and the JSON Schema below is what callers without a runtime
+  // instance see. Pass an inert object that satisfies the helper's typing.
+  { _def: { typeName: "ZodAny" } } as never,
+  {
+    safeParse: (value: unknown) => parseHomeAssistantConfig(value),
+  },
+);
+
+// `buildPluginConfigSchema` falls back to a permissive `additionalProperties: true`
+// JSON Schema when the supplied schema lacks `toJSONSchema`. Override with the
+// strict manifest-equivalent shape so loader-side validation matches our intent.
+(homeAssistantConfigSchema as { jsonSchema?: unknown }).jsonSchema = HOME_ASSISTANT_JSON_SCHEMA;

--- a/extensions/home-assistant/gateway-bridge.test.ts
+++ b/extensions/home-assistant/gateway-bridge.test.ts
@@ -1,0 +1,507 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  HA_SERVICE_CALL_METHOD,
+  HA_STATE_EVENT,
+  HA_SUBSCRIBE_METHOD,
+  attachHomeAssistantBridge,
+  type BridgeGatewayApi,
+  type BridgeGatewayHandlerArgs,
+  type ServiceCallClient,
+} from "./gateway-bridge.js";
+import { HomeAssistantStateStore, type EntityState } from "./state-store.js";
+
+type RegisteredMethod = {
+  method: string;
+  handler: (args: BridgeGatewayHandlerArgs) => Promise<void> | void;
+  scope?: string;
+};
+
+class FakeApi implements BridgeGatewayApi {
+  registered: RegisteredMethod[] = [];
+  registerGatewayMethod = (
+    method: string,
+    handler: (args: BridgeGatewayHandlerArgs) => Promise<void> | void,
+    opts?: { scope?: string },
+  ): void => {
+    this.registered.push({ method, handler, scope: opts?.scope });
+  };
+  byName(method: string): RegisteredMethod {
+    const found = this.registered.find((r) => r.method === method);
+    if (!found) {
+      throw new Error(`method not registered: ${method}`);
+    }
+    return found;
+  }
+}
+
+type Captured = { event: string; payload: unknown };
+
+function makeContext(): {
+  broadcast: (event: string, payload: unknown) => void;
+  events: Captured[];
+} {
+  const events: Captured[] = [];
+  return {
+    broadcast: (event, payload) => events.push({ event, payload }),
+    events,
+  };
+}
+
+function makeRespond(): {
+  respond: (ok: boolean, payload?: unknown, error?: { code: string; message: string }) => void;
+  calls: Array<{ ok: boolean; payload?: unknown; error?: { code: string; message: string } }>;
+} {
+  const calls: Array<{
+    ok: boolean;
+    payload?: unknown;
+    error?: { code: string; message: string };
+  }> = [];
+  return {
+    respond: (ok, payload, error) => calls.push({ ok, payload, error }),
+    calls,
+  };
+}
+
+class FakeServiceCallClient implements ServiceCallClient {
+  calls: Array<{
+    domain: string;
+    service: string;
+    target: string;
+    serviceData?: Record<string, unknown>;
+  }> = [];
+  shouldThrow: Error | null = null;
+  callService(args: {
+    domain: string;
+    service: string;
+    target: string;
+    serviceData?: Record<string, unknown>;
+  }): void {
+    if (this.shouldThrow) {
+      const err = this.shouldThrow;
+      this.shouldThrow = null;
+      throw err;
+    }
+    this.calls.push({ ...args });
+  }
+}
+
+const CONFIG = {
+  allowList: ["sensor.battery_soc", "switch.gate_main", "switch.geyser", "cover.left_blind"],
+  denyServiceList: ["lock.unlock", "alarm_control_panel.alarm_disarm", "cover.open_cover"],
+} as const;
+
+function makeState(entity_id: string, state: string): EntityState {
+  return { entity_id, state, attributes: {} };
+}
+
+describe("home-assistant gateway bridge", () => {
+  describe("registration", () => {
+    it("registers home-assistant.subscribe with read scope and home-assistant.serviceCall with write scope", () => {
+      const api = new FakeApi();
+      const store = new HomeAssistantStateStore({ allowList: [...CONFIG.allowList] });
+      attachHomeAssistantBridge({
+        api,
+        store,
+        client: new FakeServiceCallClient(),
+        config: CONFIG,
+      });
+
+      expect(api.byName(HA_SUBSCRIBE_METHOD).scope).toBe("operator.read");
+      expect(api.byName(HA_SERVICE_CALL_METHOD).scope).toBe("operator.write");
+    });
+  });
+
+  describe("subscribe + state push", () => {
+    it("captures broadcast on subscribe and returns the current snapshot of allow-listed entities", async () => {
+      const api = new FakeApi();
+      const store = new HomeAssistantStateStore({ allowList: [...CONFIG.allowList] });
+      attachHomeAssistantBridge({
+        api,
+        store,
+        client: new FakeServiceCallClient(),
+        config: CONFIG,
+      });
+
+      // Seed some state before the kiosk subscribes.
+      store.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: null,
+        new_state: makeState("sensor.battery_soc", "97"),
+      });
+      store.applyStateChanged({
+        entity_id: "switch.gate_main",
+        old_state: null,
+        new_state: makeState("switch.gate_main", "off"),
+      });
+
+      const ctx = makeContext();
+      const r = makeRespond();
+      await api.byName(HA_SUBSCRIBE_METHOD).handler({
+        params: {},
+        respond: r.respond,
+        context: ctx,
+      });
+
+      expect(r.calls).toHaveLength(1);
+      expect(r.calls[0].ok).toBe(true);
+      expect(r.calls[0].payload).toMatchObject({
+        snapshot: expect.arrayContaining([
+          { entity_id: "sensor.battery_soc", state: expect.any(Object) },
+          { entity_id: "switch.gate_main", state: expect.any(Object) },
+        ]),
+      });
+    });
+
+    it("after subscribe, every state-store diff broadcasts as plugin.home-assistant.state", async () => {
+      const api = new FakeApi();
+      const store = new HomeAssistantStateStore({ allowList: [...CONFIG.allowList] });
+      attachHomeAssistantBridge({
+        api,
+        store,
+        client: new FakeServiceCallClient(),
+        config: CONFIG,
+      });
+
+      const ctx = makeContext();
+      await api.byName(HA_SUBSCRIBE_METHOD).handler({
+        params: {},
+        respond: makeRespond().respond,
+        context: ctx,
+      });
+
+      store.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: null,
+        new_state: makeState("sensor.battery_soc", "97"),
+      });
+
+      expect(ctx.events).toHaveLength(1);
+      expect(ctx.events[0].event).toBe(HA_STATE_EVENT);
+      expect(ctx.events[0].payload).toMatchObject({
+        entity_id: "sensor.battery_soc",
+        prev: null,
+        next: { entity_id: "sensor.battery_soc", state: "97" },
+      });
+    });
+
+    it("does NOT broadcast state diffs before subscribe is called", () => {
+      const api = new FakeApi();
+      const store = new HomeAssistantStateStore({ allowList: [...CONFIG.allowList] });
+      const ctx = makeContext();
+      attachHomeAssistantBridge({
+        api,
+        store,
+        client: new FakeServiceCallClient(),
+        config: CONFIG,
+      });
+
+      // Even though the state store would emit a diff, no broadcast
+      // function has been captured yet -- there's no client to push to.
+      store.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: null,
+        new_state: makeState("sensor.battery_soc", "97"),
+      });
+
+      expect(ctx.events).toHaveLength(0);
+    });
+
+    it("does NOT broadcast diffs for entities outside allowList (defense in depth)", async () => {
+      const api = new FakeApi();
+      // Store has the entity allow-listed, but bridge config is narrower.
+      const store = new HomeAssistantStateStore({
+        allowList: ["sensor.battery_soc", "sensor.uninvited"],
+      });
+      const ctx = makeContext();
+      attachHomeAssistantBridge({
+        api,
+        store,
+        client: new FakeServiceCallClient(),
+        config: { ...CONFIG, allowList: ["sensor.battery_soc"] },
+      });
+
+      await api.byName(HA_SUBSCRIBE_METHOD).handler({
+        params: {},
+        respond: makeRespond().respond,
+        context: ctx,
+      });
+
+      store.applyStateChanged({
+        entity_id: "sensor.uninvited",
+        old_state: null,
+        new_state: makeState("sensor.uninvited", "1"),
+      });
+      store.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: null,
+        new_state: makeState("sensor.battery_soc", "97"),
+      });
+
+      expect(ctx.events).toHaveLength(1);
+      expect(ctx.events[0].payload).toMatchObject({ entity_id: "sensor.battery_soc" });
+    });
+  });
+
+  describe("home-assistant.serviceCall", () => {
+    it("happy path: dispatches an allow-listed switch.toggle to the WS client", async () => {
+      const api = new FakeApi();
+      const store = new HomeAssistantStateStore({ allowList: [...CONFIG.allowList] });
+      const client = new FakeServiceCallClient();
+      attachHomeAssistantBridge({ api, store, client, config: CONFIG });
+
+      const r = makeRespond();
+      await api.byName(HA_SERVICE_CALL_METHOD).handler({
+        params: { domain: "switch", service: "toggle", target: "switch.gate_main" },
+        respond: r.respond,
+        context: makeContext(),
+      });
+
+      expect(client.calls).toEqual([
+        { domain: "switch", service: "toggle", target: "switch.gate_main" },
+      ]);
+      expect(r.calls).toHaveLength(1);
+      expect(r.calls[0].ok).toBe(true);
+      expect(r.calls[0].payload).toMatchObject({ dispatched: true });
+    });
+
+    it("forwards optional service_data (e.g. cover position)", async () => {
+      const api = new FakeApi();
+      const store = new HomeAssistantStateStore({ allowList: [...CONFIG.allowList] });
+      const client = new FakeServiceCallClient();
+      attachHomeAssistantBridge({ api, store, client, config: CONFIG });
+
+      await api.byName(HA_SERVICE_CALL_METHOD).handler({
+        params: {
+          domain: "cover",
+          service: "set_cover_position",
+          target: "cover.left_blind",
+          serviceData: { position: 50 },
+        },
+        respond: makeRespond().respond,
+        context: makeContext(),
+      });
+
+      expect(client.calls).toEqual([
+        {
+          domain: "cover",
+          service: "set_cover_position",
+          target: "cover.left_blind",
+          serviceData: { position: 50 },
+        },
+      ]);
+    });
+
+    it("denies a deny-listed service with structured service-denied error and never calls the WS client", async () => {
+      const api = new FakeApi();
+      const store = new HomeAssistantStateStore({ allowList: [...CONFIG.allowList] });
+      const client = new FakeServiceCallClient();
+      attachHomeAssistantBridge({ api, store, client, config: CONFIG });
+
+      const r = makeRespond();
+      await api.byName(HA_SERVICE_CALL_METHOD).handler({
+        params: { domain: "lock", service: "unlock", target: "lock.front_door" },
+        respond: r.respond,
+        context: makeContext(),
+      });
+
+      expect(client.calls).toHaveLength(0);
+      expect(r.calls).toHaveLength(1);
+      expect(r.calls[0].ok).toBe(false);
+      expect(r.calls[0].error?.code).toBe("service-denied");
+    });
+
+    it("denies a target entity that is not in allowList", async () => {
+      const api = new FakeApi();
+      const store = new HomeAssistantStateStore({ allowList: [...CONFIG.allowList] });
+      const client = new FakeServiceCallClient();
+      attachHomeAssistantBridge({ api, store, client, config: CONFIG });
+
+      const r = makeRespond();
+      await api.byName(HA_SERVICE_CALL_METHOD).handler({
+        params: { domain: "switch", service: "toggle", target: "switch.not_allow_listed" },
+        respond: r.respond,
+        context: makeContext(),
+      });
+
+      expect(client.calls).toHaveLength(0);
+      expect(r.calls[0].ok).toBe(false);
+      expect(r.calls[0].error?.code).toBe("entity-denied");
+    });
+
+    it("rejects payloads missing target with invalid_params before any allow-list check", async () => {
+      const api = new FakeApi();
+      const store = new HomeAssistantStateStore({ allowList: [...CONFIG.allowList] });
+      const client = new FakeServiceCallClient();
+      attachHomeAssistantBridge({ api, store, client, config: CONFIG });
+
+      const r = makeRespond();
+      await api.byName(HA_SERVICE_CALL_METHOD).handler({
+        params: { domain: "switch", service: "toggle" },
+        respond: r.respond,
+        context: makeContext(),
+      });
+
+      expect(client.calls).toHaveLength(0);
+      expect(r.calls[0].ok).toBe(false);
+      expect(r.calls[0].error?.code).toBe("invalid_params");
+      expect(r.calls[0].error?.message).toMatch(/target/i);
+    });
+
+    it("rejects payloads missing domain or service", async () => {
+      const api = new FakeApi();
+      const store = new HomeAssistantStateStore({ allowList: [...CONFIG.allowList] });
+      const client = new FakeServiceCallClient();
+      attachHomeAssistantBridge({ api, store, client, config: CONFIG });
+
+      const r = makeRespond();
+      await api.byName(HA_SERVICE_CALL_METHOD).handler({
+        params: { service: "toggle", target: "switch.gate_main" },
+        respond: r.respond,
+        context: makeContext(),
+      });
+
+      expect(r.calls[0].ok).toBe(false);
+      expect(r.calls[0].error?.code).toMatch(/invalid_params|service-denied/);
+    });
+
+    it("surfaces ws-client failure as ha_call_failed without crashing the handler", async () => {
+      const api = new FakeApi();
+      const store = new HomeAssistantStateStore({ allowList: [...CONFIG.allowList] });
+      const client = new FakeServiceCallClient();
+      client.shouldThrow = new Error("not subscribed");
+      attachHomeAssistantBridge({ api, store, client, config: CONFIG });
+
+      const r = makeRespond();
+      await api.byName(HA_SERVICE_CALL_METHOD).handler({
+        params: { domain: "switch", service: "toggle", target: "switch.gate_main" },
+        respond: r.respond,
+        context: makeContext(),
+      });
+
+      expect(r.calls[0].ok).toBe(false);
+      expect(r.calls[0].error?.code).toBe("ha_call_failed");
+      expect(r.calls[0].error?.message).toMatch(/not subscribed/);
+    });
+  });
+
+  describe("detach", () => {
+    it("stops broadcasting after detach", async () => {
+      const api = new FakeApi();
+      const store = new HomeAssistantStateStore({ allowList: [...CONFIG.allowList] });
+      const ctx = makeContext();
+      const handle = attachHomeAssistantBridge({
+        api,
+        store,
+        client: new FakeServiceCallClient(),
+        config: CONFIG,
+      });
+
+      await api.byName(HA_SUBSCRIBE_METHOD).handler({
+        params: {},
+        respond: makeRespond().respond,
+        context: ctx,
+      });
+
+      store.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: null,
+        new_state: makeState("sensor.battery_soc", "97"),
+      });
+      expect(ctx.events).toHaveLength(1);
+
+      handle.detach();
+
+      store.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: makeState("sensor.battery_soc", "97"),
+        new_state: makeState("sensor.battery_soc", "60"),
+      });
+      expect(ctx.events).toHaveLength(1); // unchanged
+    });
+  });
+
+  describe("integration: full round-trip tile-tap -> service call -> state echo -> push", () => {
+    it("dispatches the call, then later state echo flows back as a plugin.home-assistant.state event", async () => {
+      const api = new FakeApi();
+      const store = new HomeAssistantStateStore({ allowList: [...CONFIG.allowList] });
+      const client = new FakeServiceCallClient();
+      const ctx = makeContext();
+      attachHomeAssistantBridge({ api, store, client, config: CONFIG });
+
+      // 1. UI subscribes.
+      await api.byName(HA_SUBSCRIBE_METHOD).handler({
+        params: {},
+        respond: makeRespond().respond,
+        context: ctx,
+      });
+
+      // 2. UI taps a tile -> service call dispatched.
+      const r = makeRespond();
+      await api.byName(HA_SERVICE_CALL_METHOD).handler({
+        params: { domain: "switch", service: "toggle", target: "switch.geyser" },
+        respond: r.respond,
+        context: ctx,
+      });
+      expect(r.calls[0].ok).toBe(true);
+      expect(client.calls).toHaveLength(1);
+
+      // 3. HA emits state_changed for the toggled entity (simulated by
+      // applying it to the store directly, which is what ws-client does
+      // when the real HA event arrives).
+      store.applyStateChanged({
+        entity_id: "switch.geyser",
+        old_state: null,
+        new_state: makeState("switch.geyser", "on"),
+      });
+
+      // 4. UI receives a plugin.home-assistant.state push reflecting the
+      // toggled state.
+      expect(ctx.events).toHaveLength(1);
+      expect(ctx.events[0]).toEqual({
+        event: HA_STATE_EVENT,
+        payload: {
+          entity_id: "switch.geyser",
+          prev: null,
+          next: makeState("switch.geyser", "on"),
+        },
+      });
+    });
+  });
+
+  describe("logger", () => {
+    it("invokes the optional logger on broadcast errors without breaking other listeners", async () => {
+      const api = new FakeApi();
+      const store = new HomeAssistantStateStore({ allowList: [...CONFIG.allowList] });
+      const logger = vi.fn();
+      const ctx = {
+        broadcast: (_event: string, _payload: unknown) => {
+          throw new Error("transport down");
+        },
+      };
+      attachHomeAssistantBridge({
+        api,
+        store,
+        client: new FakeServiceCallClient(),
+        config: CONFIG,
+        logger,
+      });
+
+      await api.byName(HA_SUBSCRIBE_METHOD).handler({
+        params: {},
+        respond: makeRespond().respond,
+        context: ctx,
+      });
+
+      // Emit a diff -- broadcast will throw inside the listener.
+      store.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: null,
+        new_state: makeState("sensor.battery_soc", "97"),
+      });
+
+      expect(logger).toHaveBeenCalled();
+      const errorEntry = logger.mock.calls.find(([entry]) => entry?.level === "warn");
+      expect(errorEntry).toBeTruthy();
+    });
+  });
+});

--- a/extensions/home-assistant/gateway-bridge.ts
+++ b/extensions/home-assistant/gateway-bridge.ts
@@ -1,0 +1,211 @@
+/**
+ * Bridges the HA state store and WS client onto the OpenClaw gateway WS.
+ *
+ * Two gateway methods are registered with the host:
+ *   - `home-assistant.subscribe` (read scope) -- the kiosk calls this on
+ *     mount. The bridge captures the broadcast function from the request
+ *     context, returns a snapshot of currently-cached allow-listed entities,
+ *     and from then on every state-store diff is pushed to all connected
+ *     clients on `plugin.home-assistant.state`.
+ *   - `home-assistant.serviceCall` (write scope) -- the kiosk calls this on
+ *     tile tap. The bridge validates payload shape, runs the call through
+ *     `allowlist.ts` (deny-list + entity allow-list), and dispatches via
+ *     `ws-client.callService`. Echo back via the normal state-changed flow.
+ *
+ * Plan deviation (recorded explicitly): the original kiosk plan called for
+ * defining `ha:state` / `ha:service-call` in `src/gateway/protocol/`. After
+ * inspecting the gateway, plugin broadcasts already use the `plugin.*`
+ * namespace and method handlers register against arbitrary string method
+ * names (see `src/gateway/server-broadcast.ts` `EVENT_SCOPE_GUARDS`, and
+ * `OpenClawPluginApi.registerGatewayMethod` in `src/plugins/types.ts`). No
+ * core protocol additions are needed; the bridge stays fully extension-
+ * local per the boundary rules in `extensions/CLAUDE.md`.
+ */
+
+import { checkServiceCall, isEntityAllowed } from "./allowlist.js";
+import type { HomeAssistantConfig } from "./config-schema.js";
+import type { HomeAssistantStateStore, StateDiff } from "./state-store.js";
+
+// -- Topic / method constants ------------------------------------------------
+
+/**
+ * Server -> client push topic. Plugin broadcasts must live under `plugin.*`
+ * to satisfy the gateway's per-event scope guard for non-core events.
+ */
+export const HA_STATE_EVENT = "plugin.home-assistant.state";
+export const HA_SUBSCRIBE_METHOD = "home-assistant.subscribe";
+export const HA_SERVICE_CALL_METHOD = "home-assistant.serviceCall";
+
+// -- Public types we consume from the host ----------------------------------
+
+export type BridgeBroadcastFn = (event: string, payload: unknown) => void;
+
+export type BridgeGatewayHandlerArgs = {
+  params: Record<string, unknown>;
+  respond: (ok: boolean, payload?: unknown, error?: { code: string; message: string }) => void;
+  context: { broadcast: BridgeBroadcastFn };
+};
+
+export type BridgeGatewayHandler = (args: BridgeGatewayHandlerArgs) => Promise<void> | void;
+
+/**
+ * Minimal slice of `OpenClawPluginApi` the bridge depends on. Tests pass a
+ * fake; production wiring (in `register.runtime.ts`) passes the real
+ * `OpenClawPluginApi`, which is structurally compatible.
+ */
+export type BridgeGatewayApi = {
+  registerGatewayMethod: (
+    method: string,
+    handler: BridgeGatewayHandler,
+    opts?: { scope?: string },
+  ) => void;
+};
+
+/** Subset of HomeAssistantClient the bridge calls. */
+export type ServiceCallClient = {
+  callService(args: {
+    domain: string;
+    service: string;
+    target: string;
+    serviceData?: Record<string, unknown>;
+  }): void;
+};
+
+export type BridgeLogger = (entry: {
+  level: "info" | "warn" | "error";
+  message: string;
+  data?: unknown;
+}) => void;
+
+export type AttachBridgeArgs = {
+  api: BridgeGatewayApi;
+  store: HomeAssistantStateStore;
+  client: ServiceCallClient;
+  config: Pick<HomeAssistantConfig, "allowList" | "denyServiceList">;
+  logger?: BridgeLogger;
+};
+
+export type BridgeHandle = {
+  detach: () => void;
+};
+
+// -- Implementation ---------------------------------------------------------
+
+export function attachHomeAssistantBridge(args: AttachBridgeArgs): BridgeHandle {
+  const { api, store, client, config, logger = () => undefined } = args;
+  const allowSet = new Set(config.allowList);
+
+  let captured: BridgeBroadcastFn | null = null;
+  let detached = false;
+
+  const onDiff = (diff: StateDiff): void => {
+    if (detached || !captured) {
+      return;
+    }
+    // Defense in depth: the store should already filter to allowList, but
+    // bridge-side config can be narrower than store-side config (e.g. when
+    // a single store backs multiple bridge instances in the future).
+    if (!allowSet.has(diff.entity_id)) {
+      return;
+    }
+    try {
+      captured(HA_STATE_EVENT, {
+        entity_id: diff.entity_id,
+        prev: diff.prev,
+        next: diff.next,
+      });
+    } catch (cause) {
+      logger({
+        level: "warn",
+        message: "ha-bridge.broadcast-failed",
+        data: { entity_id: diff.entity_id, cause: String(cause) },
+      });
+    }
+  };
+
+  const unsubscribe = store.subscribeAll(onDiff);
+
+  api.registerGatewayMethod(
+    HA_SUBSCRIBE_METHOD,
+    async ({ context, respond }) => {
+      captured = context.broadcast;
+      const snapshot = config.allowList.flatMap((entity_id) => {
+        const state = store.get(entity_id);
+        return state ? [{ entity_id, state }] : [];
+      });
+      respond(true, { snapshot });
+    },
+    { scope: "operator.read" },
+  );
+
+  api.registerGatewayMethod(
+    HA_SERVICE_CALL_METHOD,
+    async ({ params, respond }) => {
+      const target = readString(params.target);
+      if (!target) {
+        respond(false, undefined, {
+          code: "invalid_params",
+          message: "target entity_id is required",
+        });
+        return;
+      }
+
+      const check = checkServiceCall({ domain: params.domain, service: params.service }, config);
+      if (!check.allowed) {
+        respond(false, undefined, {
+          code: check.reason.kind,
+          message: check.reason.detail,
+        });
+        return;
+      }
+
+      if (!isEntityAllowed(target, config)) {
+        respond(false, undefined, {
+          code: "entity-denied",
+          message: `entity "${target}" is not in allowList`,
+        });
+        return;
+      }
+
+      try {
+        const serviceData = readRecord(params.serviceData);
+        client.callService({
+          domain: check.domain,
+          service: check.service,
+          target,
+          ...(serviceData ? { serviceData } : {}),
+        });
+        respond(true, { dispatched: true });
+      } catch (cause) {
+        respond(false, undefined, {
+          code: "ha_call_failed",
+          message: cause instanceof Error ? cause.message : String(cause),
+        });
+      }
+    },
+    { scope: "operator.write" },
+  );
+
+  return {
+    detach: () => {
+      detached = true;
+      unsubscribe();
+      captured = null;
+    },
+  };
+}
+
+function readString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}

--- a/extensions/home-assistant/index.ts
+++ b/extensions/home-assistant/index.ts
@@ -1,0 +1,13 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { homeAssistantConfigSchema } from "./config-schema.js";
+import { registerHomeAssistantPlugin } from "./register.runtime.js";
+
+export default definePluginEntry({
+  id: "home-assistant",
+  name: "Home Assistant",
+  description: "WebSocket bridge from OpenClaw to Home Assistant. Powers the kiosk dashboard view.",
+  configSchema: homeAssistantConfigSchema,
+  register(api) {
+    return registerHomeAssistantPlugin(api);
+  },
+});

--- a/extensions/home-assistant/openclaw.plugin.json
+++ b/extensions/home-assistant/openclaw.plugin.json
@@ -1,0 +1,52 @@
+{
+  "id": "home-assistant",
+  "name": "Home Assistant",
+  "description": "WebSocket bridge from OpenClaw to Home Assistant. Powers the kiosk dashboard view; auth, allow-list, and deny-list policy live in this plugin.",
+  "enabledByDefault": false,
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "homeAssistantUrl": { "type": "string" },
+      "tokenRef": { "type": "string" },
+      "allowList": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "denyServiceList": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "slots": {
+        "type": "object",
+        "additionalProperties": { "type": "string" }
+      }
+    },
+    "required": ["homeAssistantUrl", "tokenRef"]
+  },
+  "uiHints": {
+    "homeAssistantUrl": {
+      "label": "Home Assistant URL",
+      "help": "WebSocket URL for the Home Assistant API. Must start with ws:// or wss://.",
+      "placeholder": "ws://192.168.2.41:8123/api/websocket"
+    },
+    "tokenRef": {
+      "label": "HA token credential reference",
+      "help": "Credential reference for the dedicated non-admin HA user (jarvis_kiosk). The literal long-lived token lives under ~/.openclaw/credentials/, never in this config.",
+      "placeholder": "homeAssistant.jarvisKiosk",
+      "sensitive": false
+    },
+    "allowList": {
+      "label": "Allow-listed entities",
+      "help": "Home Assistant entity IDs the kiosk is permitted to read. Every slot target must reference an entity in this list."
+    },
+    "denyServiceList": {
+      "label": "Service deny-list",
+      "help": "Services the kiosk must never call (for example lock.unlock). Belt-and-braces with the HA-user-side deny-list from the Jarvis Butler plan."
+    },
+    "slots": {
+      "label": "Slot to entity map",
+      "help": "Maps kiosk slot names (gauge.battery_soc, tile.gate_main, ...) to allow-listed HA entity IDs."
+    }
+  }
+}

--- a/extensions/home-assistant/package.json
+++ b/extensions/home-assistant/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/home-assistant",
+  "version": "2026.5.10",
+  "private": true,
+  "description": "OpenClaw Home Assistant bridge plugin (kiosk dashboard data plane)",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/home-assistant/register.runtime.test.ts
+++ b/extensions/home-assistant/register.runtime.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerHomeAssistantPlugin } from "./register.runtime.js";
+
+type Service = {
+  id: string;
+  start: (ctx: unknown) => unknown;
+  stop?: (ctx: unknown) => unknown;
+};
+
+type RegisteredMethod = {
+  method: string;
+  handler: (args: unknown) => unknown;
+  scope?: string;
+};
+
+function createFakeApi(pluginConfig: unknown) {
+  const services: Service[] = [];
+  const methods: RegisteredMethod[] = [];
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+
+  const api = {
+    pluginConfig,
+    config: { plugins: { entries: { "home-assistant": { config: pluginConfig } } } },
+    logger,
+    registerService: (service: Service) => {
+      services.push(service);
+    },
+    registerGatewayMethod: (
+      method: string,
+      handler: (args: unknown) => unknown,
+      opts?: { scope?: string },
+    ) => {
+      methods.push({ method, handler, scope: opts?.scope });
+    },
+  };
+
+  return { api, services, methods, logger };
+}
+
+describe("registerHomeAssistantPlugin", () => {
+  describe("missing or invalid config", () => {
+    it("registers a no-op service that logs the validation issues on start", () => {
+      const { api, services, methods, logger } = createFakeApi({
+        // missing tokenRef
+        homeAssistantUrl: "ws://192.168.2.41:8123/api/websocket",
+      });
+
+      registerHomeAssistantPlugin(api as never);
+
+      // Only the disabled-until-configured service registered, no gateway methods.
+      expect(services).toHaveLength(1);
+      expect(services[0].id).toBe("home-assistant");
+      expect(methods).toHaveLength(0);
+
+      services[0].start({});
+      expect(logger.warn).toHaveBeenCalled();
+      const message = logger.warn.mock.calls[0][0] as string;
+      expect(message).toMatch(/disabled until configured/);
+      expect(message).toMatch(/tokenRef/);
+    });
+
+    it("logs and skips when pluginConfig is undefined entirely", () => {
+      const { api, services, methods, logger } = createFakeApi(undefined);
+
+      registerHomeAssistantPlugin(api as never);
+
+      expect(services).toHaveLength(1);
+      expect(methods).toHaveLength(0);
+      services[0].start({});
+      expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe("valid config", () => {
+    const validConfig = {
+      homeAssistantUrl: "ws://192.168.2.41:8123/api/websocket",
+      tokenRef: "homeAssistant.jarvisKiosk",
+      allowList: ["switch.gate_main"],
+      denyServiceList: ["lock.unlock"],
+      slots: { "tile.gate_main": "switch.gate_main" },
+    };
+
+    it("registers both gateway methods and the lifecycle service", () => {
+      const { api, services, methods } = createFakeApi(validConfig);
+
+      registerHomeAssistantPlugin(api as never);
+
+      // home-assistant.subscribe + home-assistant.serviceCall.
+      expect(methods.map((m) => m.method).sort()).toEqual([
+        "home-assistant.serviceCall",
+        "home-assistant.subscribe",
+      ]);
+      expect(methods.find((m) => m.method === "home-assistant.subscribe")?.scope).toBe(
+        "operator.read",
+      );
+      expect(methods.find((m) => m.method === "home-assistant.serviceCall")?.scope).toBe(
+        "operator.write",
+      );
+
+      expect(services).toHaveLength(1);
+      expect(services[0].id).toBe("home-assistant");
+      expect(typeof services[0].start).toBe("function");
+      expect(typeof services[0].stop).toBe("function");
+    });
+
+    it("service-call handler throws a clear error when WS client is not yet started", async () => {
+      const { api, methods } = createFakeApi(validConfig);
+      registerHomeAssistantPlugin(api as never);
+
+      const serviceCallMethod = methods.find((m) => m.method === "home-assistant.serviceCall");
+      expect(serviceCallMethod).toBeTruthy();
+
+      const responses: Array<{
+        ok: boolean;
+        payload?: unknown;
+        error?: { code: string; message: string };
+      }> = [];
+      await serviceCallMethod!.handler({
+        params: { domain: "switch", service: "toggle", target: "switch.gate_main" },
+        respond: (ok: boolean, payload?: unknown, error?: { code: string; message: string }) => {
+          responses.push({ ok, payload, error });
+        },
+        context: { broadcast: () => undefined },
+      });
+
+      expect(responses).toHaveLength(1);
+      expect(responses[0].ok).toBe(false);
+      expect(responses[0].error?.code).toBe("ha_call_failed");
+      expect(responses[0].error?.message).toMatch(/not yet started/);
+    });
+  });
+});

--- a/extensions/home-assistant/register.runtime.ts
+++ b/extensions/home-assistant/register.runtime.ts
@@ -1,14 +1,165 @@
+/**
+ * Production plugin wiring.
+ *
+ * What this does on plugin register:
+ *   1. Parses `api.pluginConfig` through the shared schema. On failure,
+ *      registers a no-op service that logs "disabled until configured"
+ *      and returns -- matching the memory-lancedb pattern.
+ *   2. Builds a `HomeAssistantStateStore` keyed off the operator's
+ *      allow-list.
+ *   3. Attaches the gateway bridge eagerly so `home-assistant.subscribe`
+ *      and `home-assistant.serviceCall` are reachable as soon as the
+ *      kiosk client connects. The bridge consumes a late-bound service-
+ *      call adapter; the actual WS client is created when the service
+ *      starts (which is when credentials get resolved).
+ *   4. Registers a service whose `start` resolves the long-lived token
+ *      via the SDK secret-ref helper, instantiates the WS client, and
+ *      calls `client.start()`. `stop` tears the client down.
+ *
+ * Boundary: imports only `openclaw/plugin-sdk/*` and this package's own
+ * barrels. No deep imports into `src/**` per `extensions/CLAUDE.md`.
+ */
+
+import { resolveRequiredConfiguredSecretRefInputString } from "openclaw/plugin-sdk/config-runtime";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { parseHomeAssistantConfig, type HomeAssistantConfig } from "./config-schema.js";
+import {
+  attachHomeAssistantBridge,
+  type BridgeLogger,
+  type ServiceCallClient,
+} from "./gateway-bridge.js";
+import { HomeAssistantStateStore } from "./state-store.js";
+import {
+  HomeAssistantClient,
+  type Logger,
+  type WebSocketLike,
+  type WebSocketLikeFactory,
+} from "./ws-client.js";
+
+const PLUGIN_ID = "home-assistant";
+
+export function registerHomeAssistantPlugin(api: OpenClawPluginApi): void {
+  const parseResult = parseHomeAssistantConfig(api.pluginConfig);
+  if (!parseResult.success) {
+    const detail = parseResult.error.issues
+      .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+      .join("; ");
+    api.registerService({
+      id: PLUGIN_ID,
+      start: () => {
+        api.logger.warn(`home-assistant: disabled until configured (${detail})`);
+      },
+    });
+    return;
+  }
+
+  const config = parseResult.data;
+  const store = new HomeAssistantStateStore({ allowList: config.allowList });
+
+  let client: HomeAssistantClient | null = null;
+
+  // Late-bound adapter so the bridge can be attached during register()
+  // (so gateway methods exist as soon as the gateway is up) while the
+  // actual WS client is only instantiated when the service starts and
+  // the token resolves.
+  const serviceCallAdapter: ServiceCallClient = {
+    callService(args) {
+      if (!client) {
+        throw new Error("home-assistant: WebSocket client not yet started");
+      }
+      client.callService(args);
+    },
+  };
+
+  attachHomeAssistantBridge({
+    api: api as Parameters<typeof attachHomeAssistantBridge>[0]["api"],
+    store,
+    client: serviceCallAdapter,
+    config,
+    logger: bridgeLoggerFor(api),
+  });
+
+  api.registerService({
+    id: PLUGIN_ID,
+    start: async (ctx) => {
+      const token = await resolveRequiredConfiguredSecretRefInputString({
+        config: ctx.config,
+        env: process.env,
+        value: config.tokenRef,
+        path: `plugins.entries.${PLUGIN_ID}.config.tokenRef`,
+      });
+      if (!token) {
+        ctx.logger.warn(
+          `home-assistant: token reference "${config.tokenRef}" did not resolve to a value`,
+        );
+        return;
+      }
+
+      client = new HomeAssistantClient({
+        url: config.homeAssistantUrl,
+        token,
+        store,
+        webSocketFactory: defaultWebSocketFactory(),
+        logger: wsClientLoggerFor(ctx.logger),
+      });
+      client.start();
+    },
+    stop: async () => {
+      client?.stop();
+      client = null;
+    },
+  });
+}
+
+function defaultWebSocketFactory(): WebSocketLikeFactory {
+  // Node 22+ ships globalThis.WebSocket. The WHATWG interface matches
+  // our WebSocketLike contract structurally.
+  return (url: string): WebSocketLike => {
+    const WebSocketCtor = (globalThis as { WebSocket?: new (url: string) => WebSocketLike })
+      .WebSocket;
+    if (!WebSocketCtor) {
+      throw new Error(
+        "home-assistant: globalThis.WebSocket is unavailable; need Node 22+ or a polyfill",
+      );
+    }
+    return new WebSocketCtor(url);
+  };
+}
+
+function wsClientLoggerFor(logger: {
+  info: (m: string) => void;
+  warn: (m: string) => void;
+  error: (m: string) => void;
+}): Logger {
+  return (entry) => {
+    const formatted = entry.data ? `${entry.message} ${safeStringify(entry.data)}` : entry.message;
+    if (entry.level === "info") logger.info(formatted);
+    else if (entry.level === "warn") logger.warn(formatted);
+    else logger.error(formatted);
+  };
+}
+
+function bridgeLoggerFor(api: OpenClawPluginApi): BridgeLogger {
+  return (entry) => {
+    const formatted = entry.data ? `${entry.message} ${safeStringify(entry.data)}` : entry.message;
+    if (entry.level === "info") api.logger.info(formatted);
+    else if (entry.level === "warn") api.logger.warn(formatted);
+    else api.logger.error(formatted);
+  };
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return typeof value === "string" ? value : JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
 
 /**
- * Registers Home Assistant runtime surfaces with the host.
- *
- * Unit 1 scaffold: no surfaces are registered yet. Subsequent units add the
- * WS client, state store, allow-list gate, and gateway bridge. Keeping this
- * function as the single registration entry point preserves the manifest-first
- * boundary -- discovery and config validation run without booting any of the
- * runtime modules listed above.
+ * Exposed for tests so the registration can be replayed without
+ * standing up a real plugin host.
  */
-export function registerHomeAssistantPlugin(_api: OpenClawPluginApi): void {
-  // intentionally empty: scaffold-only registration.
-}
+export type RegisterHomeAssistantPluginContext = {
+  config: HomeAssistantConfig;
+};

--- a/extensions/home-assistant/register.runtime.ts
+++ b/extensions/home-assistant/register.runtime.ts
@@ -1,0 +1,14 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+
+/**
+ * Registers Home Assistant runtime surfaces with the host.
+ *
+ * Unit 1 scaffold: no surfaces are registered yet. Subsequent units add the
+ * WS client, state store, allow-list gate, and gateway bridge. Keeping this
+ * function as the single registration entry point preserves the manifest-first
+ * boundary -- discovery and config validation run without booting any of the
+ * runtime modules listed above.
+ */
+export function registerHomeAssistantPlugin(_api: OpenClawPluginApi): void {
+  // intentionally empty: scaffold-only registration.
+}

--- a/extensions/home-assistant/state-store.test.ts
+++ b/extensions/home-assistant/state-store.test.ts
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HomeAssistantStateStore, type EntityState, type StateDiff } from "./state-store.js";
+
+function makeState(entity_id: string, state: string, extra?: Partial<EntityState>): EntityState {
+  return {
+    entity_id,
+    state,
+    attributes: {},
+    last_changed: "2026-05-10T19:00:00+00:00",
+    last_updated: "2026-05-10T19:00:00+00:00",
+    ...extra,
+  };
+}
+
+describe("HomeAssistantStateStore", () => {
+  let store: HomeAssistantStateStore;
+
+  beforeEach(() => {
+    store = new HomeAssistantStateStore({
+      allowList: ["sensor.battery_soc", "switch.gate_main"],
+    });
+  });
+
+  describe("happy path: ingest + diff", () => {
+    it("stores a new state and emits a diff with prev=null on first observation", () => {
+      const seen: StateDiff[] = [];
+      store.subscribeAll((diff) => seen.push(diff));
+
+      const next = makeState("sensor.battery_soc", "97");
+      store.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: null,
+        new_state: next,
+      });
+
+      expect(seen).toHaveLength(1);
+      expect(seen[0].entity_id).toBe("sensor.battery_soc");
+      expect(seen[0].prev).toBeNull();
+      expect(seen[0].next).toEqual(next);
+      expect(store.get("sensor.battery_soc")).toEqual(next);
+    });
+
+    it("emits a diff with both prev and next populated on update", () => {
+      const seen: StateDiff[] = [];
+      store.subscribeAll((diff) => seen.push(diff));
+
+      const first = makeState("sensor.battery_soc", "97");
+      const second = makeState("sensor.battery_soc", "60", {
+        last_updated: "2026-05-10T19:05:00+00:00",
+      });
+
+      store.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: null,
+        new_state: first,
+      });
+      store.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: first,
+        new_state: second,
+      });
+
+      expect(seen).toHaveLength(2);
+      expect(seen[1].prev).toEqual(first);
+      expect(seen[1].next).toEqual(second);
+      expect(store.get("sensor.battery_soc")).toEqual(second);
+    });
+
+    it("emits a diff with next=null when entity is removed (new_state null)", () => {
+      const initial = makeState("sensor.battery_soc", "97");
+      store.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: null,
+        new_state: initial,
+      });
+
+      const seen: StateDiff[] = [];
+      store.subscribeAll((diff) => seen.push(diff));
+
+      store.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: initial,
+        new_state: null,
+      });
+
+      expect(seen).toHaveLength(1);
+      expect(seen[0].prev).toEqual(initial);
+      expect(seen[0].next).toBeNull();
+      expect(store.get("sensor.battery_soc")).toBeUndefined();
+    });
+  });
+
+  describe("allow-list filtering", () => {
+    it("drops state for an entity outside allowList without emitting", () => {
+      const seen: StateDiff[] = [];
+      store.subscribeAll((diff) => seen.push(diff));
+
+      store.applyStateChanged({
+        entity_id: "sensor.not_allowed",
+        old_state: null,
+        new_state: makeState("sensor.not_allowed", "42"),
+      });
+
+      expect(seen).toHaveLength(0);
+      expect(store.get("sensor.not_allowed")).toBeUndefined();
+    });
+
+    it("treats an empty allowList as fail-closed (drops everything)", () => {
+      const closedStore = new HomeAssistantStateStore({ allowList: [] });
+      const seen: StateDiff[] = [];
+      closedStore.subscribeAll((diff) => seen.push(diff));
+
+      closedStore.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: null,
+        new_state: makeState("sensor.battery_soc", "97"),
+      });
+
+      expect(seen).toHaveLength(0);
+      expect(closedStore.get("sensor.battery_soc")).toBeUndefined();
+    });
+  });
+
+  describe("per-entity subscription", () => {
+    it("delivers diffs only for the subscribed entity", () => {
+      const battery: StateDiff[] = [];
+      const gate: StateDiff[] = [];
+      store.subscribe("sensor.battery_soc", (diff) => battery.push(diff));
+      store.subscribe("switch.gate_main", (diff) => gate.push(diff));
+
+      store.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: null,
+        new_state: makeState("sensor.battery_soc", "97"),
+      });
+      store.applyStateChanged({
+        entity_id: "switch.gate_main",
+        old_state: null,
+        new_state: makeState("switch.gate_main", "off"),
+      });
+
+      expect(battery).toHaveLength(1);
+      expect(battery[0].entity_id).toBe("sensor.battery_soc");
+      expect(gate).toHaveLength(1);
+      expect(gate[0].entity_id).toBe("switch.gate_main");
+    });
+
+    it("returns an unsubscribe function that stops further notifications", () => {
+      const seen: StateDiff[] = [];
+      const unsubscribe = store.subscribe("sensor.battery_soc", (diff) => seen.push(diff));
+
+      store.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: null,
+        new_state: makeState("sensor.battery_soc", "97"),
+      });
+      unsubscribe();
+      store.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: makeState("sensor.battery_soc", "97"),
+        new_state: makeState("sensor.battery_soc", "50"),
+      });
+
+      expect(seen).toHaveLength(1);
+    });
+  });
+
+  describe("listener resilience", () => {
+    it("does not let a listener throwing break other listeners", () => {
+      const calls: string[] = [];
+      store.subscribeAll(() => {
+        calls.push("a");
+        throw new Error("bang");
+      });
+      store.subscribeAll(() => {
+        calls.push("b");
+      });
+
+      const errors = vi.fn();
+      store.onListenerError(errors);
+
+      store.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: null,
+        new_state: makeState("sensor.battery_soc", "97"),
+      });
+
+      expect(calls).toEqual(["a", "b"]);
+      expect(errors).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("reset", () => {
+    it("clears stored state and emits prev=lastKnown, next=null for each entity", () => {
+      store.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: null,
+        new_state: makeState("sensor.battery_soc", "97"),
+      });
+      store.applyStateChanged({
+        entity_id: "switch.gate_main",
+        old_state: null,
+        new_state: makeState("switch.gate_main", "off"),
+      });
+
+      const seen: StateDiff[] = [];
+      store.subscribeAll((diff) => seen.push(diff));
+
+      store.reset();
+
+      expect(seen.map((d) => d.entity_id).sort()).toEqual([
+        "sensor.battery_soc",
+        "switch.gate_main",
+      ]);
+      expect(seen.every((d) => d.next === null)).toBe(true);
+      expect(store.get("sensor.battery_soc")).toBeUndefined();
+      expect(store.get("switch.gate_main")).toBeUndefined();
+    });
+  });
+
+  describe("integration: per-entity vs subscribeAll fan-out", () => {
+    it("delivers each diff once per registered listener for that entity, plus once to subscribeAll", () => {
+      const all: StateDiff[] = [];
+      const battery: StateDiff[] = [];
+      const gate: StateDiff[] = [];
+
+      store.subscribeAll((diff) => all.push(diff));
+      store.subscribe("sensor.battery_soc", (diff) => battery.push(diff));
+      store.subscribe("switch.gate_main", (diff) => gate.push(diff));
+
+      store.applyStateChanged({
+        entity_id: "sensor.battery_soc",
+        old_state: null,
+        new_state: makeState("sensor.battery_soc", "97"),
+      });
+
+      expect(all).toHaveLength(1);
+      expect(battery).toHaveLength(1);
+      expect(gate).toHaveLength(0);
+    });
+  });
+});

--- a/extensions/home-assistant/state-store.ts
+++ b/extensions/home-assistant/state-store.ts
@@ -1,0 +1,153 @@
+/**
+ * Entity-state cache for the Home Assistant kiosk bridge.
+ *
+ * Pure logic, no transport. The WS client feeds state-changed events in via
+ * `applyStateChanged`; the gateway bridge (or any other consumer) reads via
+ * `subscribe` / `subscribeAll`.
+ *
+ * Filters at ingestion: states for entities outside `allowList` never enter
+ * the store and never reach a listener. The deny-list lives in the service-
+ * call gate (Unit 3), not here -- this module is read-only state ingestion.
+ */
+
+export type EntityState = {
+  entity_id: string;
+  state: string;
+  attributes: Record<string, unknown>;
+  last_changed?: string;
+  last_updated?: string;
+};
+
+export type StateChangedEvent = {
+  entity_id: string;
+  old_state: EntityState | null;
+  new_state: EntityState | null;
+};
+
+export type StateDiff = {
+  entity_id: string;
+  prev: EntityState | null;
+  next: EntityState | null;
+};
+
+export type StateDiffListener = (diff: StateDiff) => void;
+export type ListenerErrorListener = (error: { listenerId: number; cause: unknown }) => void;
+export type Unsubscribe = () => void;
+
+export type StateStoreOptions = {
+  allowList: ReadonlySet<string> | readonly string[];
+};
+
+export class HomeAssistantStateStore {
+  private readonly allowList: ReadonlySet<string>;
+  private readonly entities = new Map<string, EntityState>();
+  private readonly anyListeners = new Map<number, StateDiffListener>();
+  private readonly perEntityListeners = new Map<string, Map<number, StateDiffListener>>();
+  private listenerErrorListeners = new Set<ListenerErrorListener>();
+  private listenerCounter = 0;
+
+  constructor(options: StateStoreOptions) {
+    this.allowList =
+      options.allowList instanceof Set
+        ? (options.allowList as ReadonlySet<string>)
+        : new Set(options.allowList);
+  }
+
+  applyStateChanged(event: StateChangedEvent): void {
+    const { entity_id } = event;
+    if (!this.allowList.has(entity_id)) {
+      return;
+    }
+
+    const prev = this.entities.get(entity_id) ?? null;
+    const next = event.new_state ?? null;
+
+    if (next) {
+      this.entities.set(entity_id, next);
+    } else {
+      this.entities.delete(entity_id);
+    }
+
+    this.emit({ entity_id, prev, next });
+  }
+
+  get(entity_id: string): EntityState | undefined {
+    return this.entities.get(entity_id);
+  }
+
+  subscribe(entity_id: string, listener: StateDiffListener): Unsubscribe {
+    const id = ++this.listenerCounter;
+    let bucket = this.perEntityListeners.get(entity_id);
+    if (!bucket) {
+      bucket = new Map();
+      this.perEntityListeners.set(entity_id, bucket);
+    }
+    bucket.set(id, listener);
+    return () => {
+      const b = this.perEntityListeners.get(entity_id);
+      if (!b) {
+        return;
+      }
+      b.delete(id);
+      if (b.size === 0) {
+        this.perEntityListeners.delete(entity_id);
+      }
+    };
+  }
+
+  subscribeAll(listener: StateDiffListener): Unsubscribe {
+    const id = ++this.listenerCounter;
+    this.anyListeners.set(id, listener);
+    return () => {
+      this.anyListeners.delete(id);
+    };
+  }
+
+  onListenerError(listener: ListenerErrorListener): Unsubscribe {
+    this.listenerErrorListeners.add(listener);
+    return () => {
+      this.listenerErrorListeners.delete(listener);
+    };
+  }
+
+  /**
+   * Clear all stored state and emit a removal diff for each entity that was
+   * present. Used after a WS reconnect when the client resubscribes from a
+   * fresh state (per the plan's "do not republish stale state on reconnect"
+   * decision); downstream consumers see the world flush and refill.
+   */
+  reset(): void {
+    const previous = Array.from(this.entities.entries());
+    this.entities.clear();
+    for (const [entity_id, prev] of previous) {
+      this.emit({ entity_id, prev, next: null });
+    }
+  }
+
+  private emit(diff: StateDiff): void {
+    const perEntity = this.perEntityListeners.get(diff.entity_id);
+    if (perEntity) {
+      for (const [id, listener] of perEntity) {
+        this.dispatchSafely(id, listener, diff);
+      }
+    }
+    for (const [id, listener] of this.anyListeners) {
+      this.dispatchSafely(id, listener, diff);
+    }
+  }
+
+  private dispatchSafely(listenerId: number, listener: StateDiffListener, diff: StateDiff): void {
+    try {
+      listener(diff);
+    } catch (cause) {
+      for (const errorListener of this.listenerErrorListeners) {
+        try {
+          errorListener({ listenerId, cause });
+        } catch {
+          // Swallow listener-error-listener failures; otherwise we'd lose
+          // the original diff for every other consumer.
+        }
+      }
+    }
+  }
+}

--- a/extensions/home-assistant/ws-client.test.ts
+++ b/extensions/home-assistant/ws-client.test.ts
@@ -1,0 +1,454 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HomeAssistantStateStore } from "./state-store.js";
+import { HomeAssistantClient, type ConnectionState, type WebSocketLike } from "./ws-client.js";
+
+/**
+ * Minimal HA-protocol-aware fake WebSocket. The harness lets a test step
+ * through the lifecycle (open -> auth_required -> auth_ok -> subscribe ack ->
+ * event push) without any real network traffic.
+ */
+class FakeWebSocket implements WebSocketLike {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readyState: number = FakeWebSocket.CONNECTING;
+  readonly url: string;
+  readonly sent: string[] = [];
+  closeCalls = 0;
+
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: { data: unknown }) => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  onclose: ((ev: { code?: number; reason?: string }) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.closeCalls += 1;
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.({ code: 1000, reason: "" });
+  }
+
+  // -- test driver helpers --
+
+  simulateOpen(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  simulateMessage(payload: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(payload) });
+  }
+
+  simulateRawMessage(raw: string): void {
+    this.onmessage?.({ data: raw });
+  }
+
+  simulateClose(code = 1006, reason = "abnormal"): void {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.({ code, reason });
+  }
+
+  /** Last message the client sent, parsed as JSON. */
+  lastSent(): Record<string, unknown> {
+    const last = this.sent.at(-1);
+    if (last === undefined) {
+      throw new Error("no messages sent");
+    }
+    return JSON.parse(last) as Record<string, unknown>;
+  }
+
+  /** Find the first sent message matching predicate. */
+  findSent(
+    predicate: (msg: Record<string, unknown>) => boolean,
+  ): Record<string, unknown> | undefined {
+    return this.sent
+      .map((s) => JSON.parse(s) as Record<string, unknown>)
+      .find((msg) => predicate(msg));
+  }
+}
+
+/**
+ * Manual scheduler so reconnect/heartbeat timing is deterministic without
+ * vitest fake timers (which would also affect microtasks vitest itself uses).
+ */
+class ManualScheduler {
+  private nextHandle = 1;
+  private pending = new Map<number, { fn: () => void; due: number }>();
+  private now = 0;
+
+  setTimeoutFn = (fn: () => void, ms: number): unknown => {
+    const handle = this.nextHandle++;
+    this.pending.set(handle, { fn, due: this.now + Math.max(0, ms) });
+    return handle;
+  };
+
+  clearTimeoutFn = (handle: unknown): void => {
+    if (typeof handle === "number") {
+      this.pending.delete(handle);
+    }
+  };
+
+  /** Advance virtual time and fire any timers that have come due. */
+  advance(ms: number): void {
+    this.now += ms;
+    while (true) {
+      const due = Array.from(this.pending.entries())
+        .filter(([, t]) => t.due <= this.now)
+        .sort((a, b) => a[1].due - b[1].due);
+      if (due.length === 0) {
+        break;
+      }
+      const [handle, { fn }] = due[0];
+      this.pending.delete(handle);
+      fn();
+    }
+  }
+
+  pendingCount(): number {
+    return this.pending.size;
+  }
+}
+
+type Harness = {
+  client: HomeAssistantClient;
+  sockets: FakeWebSocket[];
+  scheduler: ManualScheduler;
+  store: HomeAssistantStateStore;
+  states: ConnectionState[];
+  logged: Array<{ level: string; message: string; data?: unknown }>;
+};
+
+function createHarness(
+  options: { allowList?: string[]; heartbeatIntervalMs?: number; heartbeatTimeoutMs?: number } = {},
+): Harness {
+  const allowList = options.allowList ?? ["sensor.battery_soc", "switch.gate_main"];
+  const sockets: FakeWebSocket[] = [];
+  const scheduler = new ManualScheduler();
+  const states: ConnectionState[] = [];
+  const logged: Array<{ level: string; message: string; data?: unknown }> = [];
+
+  const store = new HomeAssistantStateStore({ allowList });
+
+  const client = new HomeAssistantClient({
+    url: "ws://test/api/websocket",
+    token: "fake-token",
+    store,
+    webSocketFactory: (url) => {
+      const ws = new FakeWebSocket(url);
+      sockets.push(ws);
+      return ws;
+    },
+    reconnect: { baseDelayMs: 1000, maxDelayMs: 30000 },
+    heartbeat: {
+      intervalMs: options.heartbeatIntervalMs ?? 30000,
+      timeoutMs: options.heartbeatTimeoutMs ?? 10000,
+    },
+    setTimeoutFn: scheduler.setTimeoutFn,
+    clearTimeoutFn: scheduler.clearTimeoutFn,
+    logger: (entry) => logged.push(entry),
+  });
+
+  client.onStateChange((state) => states.push(state));
+
+  return { client, sockets, scheduler, store, states, logged };
+}
+
+/**
+ * Drive a freshly-started client all the way through auth + subscribe so the
+ * test starts from the `subscribed` state. Returns the latest socket.
+ */
+function driveToSubscribed(harness: Harness): FakeWebSocket {
+  harness.client.start();
+  const ws = harness.sockets.at(-1)!;
+  ws.simulateOpen();
+  ws.simulateMessage({ type: "auth_required", ha_version: "test" });
+  ws.simulateMessage({ type: "auth_ok", ha_version: "test" });
+  // Client sends subscribe_events; ack with the same id.
+  const subscribe = ws.findSent((m) => m.type === "subscribe_events");
+  expect(subscribe, "client must send subscribe_events after auth_ok").toBeTruthy();
+  ws.simulateMessage({ id: subscribe!.id, type: "result", success: true });
+  return ws;
+}
+
+describe("HomeAssistantClient", () => {
+  beforeEach(() => {
+    // Nothing global -- harness owns all state.
+  });
+
+  afterEach(() => {
+    // Tests must call client.stop() explicitly when needed.
+  });
+
+  describe("happy path: connect -> auth -> subscribe", () => {
+    it("walks idle -> connecting -> authenticating -> subscribed", () => {
+      const h = createHarness();
+      expect(h.client.state).toBe("idle");
+
+      h.client.start();
+      expect(h.client.state).toBe("connecting");
+      expect(h.sockets).toHaveLength(1);
+
+      h.sockets[0].simulateOpen();
+      h.sockets[0].simulateMessage({ type: "auth_required", ha_version: "test" });
+      expect(h.client.state).toBe("authenticating");
+
+      const authMsg = h.sockets[0].findSent((m) => m.type === "auth");
+      expect(authMsg).toMatchObject({ type: "auth", access_token: "fake-token" });
+
+      h.sockets[0].simulateMessage({ type: "auth_ok", ha_version: "test" });
+      const subscribe = h.sockets[0].findSent((m) => m.type === "subscribe_events");
+      expect(subscribe).toMatchObject({ type: "subscribe_events", event_type: "state_changed" });
+
+      h.sockets[0].simulateMessage({ id: subscribe!.id, type: "result", success: true });
+      expect(h.client.state).toBe("subscribed");
+      expect(h.states).toEqual(["connecting", "authenticating", "subscribed"]);
+    });
+
+    it("forwards state_changed events to the store after subscribe", () => {
+      const h = createHarness();
+      const ws = driveToSubscribed(h);
+
+      const newState = {
+        entity_id: "sensor.battery_soc",
+        state: "97",
+        attributes: {},
+        last_changed: "2026-05-10T19:00:00+00:00",
+        last_updated: "2026-05-10T19:00:00+00:00",
+      };
+
+      ws.simulateMessage({
+        id: 1,
+        type: "event",
+        event: {
+          event_type: "state_changed",
+          data: { entity_id: "sensor.battery_soc", old_state: null, new_state: newState },
+        },
+      });
+
+      expect(h.store.get("sensor.battery_soc")).toEqual(newState);
+    });
+  });
+
+  describe("auth failure", () => {
+    it("transitions to degraded on auth_invalid and surfaces an explicit error", () => {
+      const h = createHarness();
+      h.client.start();
+      h.sockets[0].simulateOpen();
+      h.sockets[0].simulateMessage({ type: "auth_required" });
+      h.sockets[0].simulateMessage({ type: "auth_invalid", message: "Bad token" });
+
+      expect(h.client.state).toBe("degraded");
+      expect(h.logged.some((l) => l.level === "error" && /auth/i.test(l.message))).toBe(true);
+      // Must not reconnect after auth_invalid -- token won't change without operator action.
+      expect(h.scheduler.pendingCount()).toBe(0);
+    });
+  });
+
+  describe("heartbeat", () => {
+    it("sends a ping after heartbeatIntervalMs and accepts pong", () => {
+      const h = createHarness({ heartbeatIntervalMs: 30000, heartbeatTimeoutMs: 10000 });
+      const ws = driveToSubscribed(h);
+
+      h.scheduler.advance(30000);
+      const ping = ws.findSent((m) => m.type === "ping");
+      expect(ping).toBeTruthy();
+      expect(typeof ping!.id).toBe("number");
+
+      ws.simulateMessage({ id: ping!.id, type: "pong" });
+      expect(h.client.state).toBe("subscribed");
+    });
+
+    it("recycles the socket on ping timeout and triggers reconnect", () => {
+      const h = createHarness({ heartbeatIntervalMs: 30000, heartbeatTimeoutMs: 10000 });
+      const ws = driveToSubscribed(h);
+
+      h.scheduler.advance(30000);
+      // Don't reply with pong; advance past timeout.
+      h.scheduler.advance(10000);
+
+      expect(ws.closeCalls).toBeGreaterThan(0);
+      expect(h.client.state).toBe("degraded");
+
+      // Reconnect timer should be scheduled.
+      expect(h.scheduler.pendingCount()).toBeGreaterThan(0);
+      h.scheduler.advance(1000); // base reconnect delay
+      expect(h.sockets.length).toBe(2);
+    });
+  });
+
+  describe("reconnect with exponential backoff", () => {
+    it("attempt 1 backs off ~1s, attempt 5 caps at <=30s", () => {
+      const h = createHarness();
+      h.client.start();
+      h.sockets[0].simulateOpen();
+      h.sockets[0].simulateMessage({ type: "auth_required" });
+      // Auth never completes -- socket drops.
+      h.sockets[0].simulateClose();
+
+      // attempt 1: 1000ms
+      expect(h.client.computeReconnectDelay(1)).toBe(1000);
+      // attempt 2: 2000ms
+      expect(h.client.computeReconnectDelay(2)).toBe(2000);
+      // attempt 5: 16000ms (1000 * 2^4)
+      expect(h.client.computeReconnectDelay(5)).toBe(16000);
+      // attempt 7: capped at 30000
+      expect(h.client.computeReconnectDelay(7)).toBe(30000);
+      // attempt 100: still capped
+      expect(h.client.computeReconnectDelay(100)).toBe(30000);
+    });
+
+    it("schedules reconnect after socket close and creates a fresh socket", () => {
+      const h = createHarness();
+      h.client.start();
+      h.sockets[0].simulateOpen();
+      h.sockets[0].simulateClose();
+
+      expect(h.client.state).toBe("degraded");
+      // Backoff for attempt 1 is 1000ms.
+      h.scheduler.advance(1000);
+      expect(h.sockets.length).toBe(2);
+      expect(h.client.state).toBe("connecting");
+    });
+
+    it("resets backoff after a successful subscribe", () => {
+      const h = createHarness();
+      driveToSubscribed(h);
+      // Attempt counter should be zero after subscribe; computeReconnectDelay
+      // for attempt 1 is the unaffected baseline.
+      expect(h.client.computeReconnectDelay(1)).toBe(1000);
+
+      // Now drop the connection and reconnect.
+      h.sockets[0].simulateClose();
+      h.scheduler.advance(1000);
+      expect(h.sockets.length).toBe(2);
+    });
+  });
+
+  describe("allow-list filtering at ingestion", () => {
+    it("does not store state for entities outside allowList", () => {
+      const h = createHarness({ allowList: ["sensor.battery_soc"] });
+      const ws = driveToSubscribed(h);
+
+      ws.simulateMessage({
+        id: 1,
+        type: "event",
+        event: {
+          event_type: "state_changed",
+          data: {
+            entity_id: "sensor.uninvited",
+            old_state: null,
+            new_state: {
+              entity_id: "sensor.uninvited",
+              state: "x",
+              attributes: {},
+            },
+          },
+        },
+      });
+
+      expect(h.store.get("sensor.uninvited")).toBeUndefined();
+    });
+  });
+
+  describe("malformed payloads", () => {
+    it("logs and ignores invalid JSON without crashing or transitioning state", () => {
+      const h = createHarness();
+      const ws = driveToSubscribed(h);
+
+      ws.simulateRawMessage("not valid json");
+      expect(h.client.state).toBe("subscribed");
+      expect(h.logged.some((l) => l.level === "warn" && /parse|json/i.test(l.message))).toBe(true);
+    });
+
+    it("logs and ignores unexpected message shapes", () => {
+      const h = createHarness();
+      const ws = driveToSubscribed(h);
+
+      ws.simulateMessage({ type: "totally-unknown", whatever: 1 });
+      expect(h.client.state).toBe("subscribed");
+    });
+
+    it("ignores event payloads that are not state_changed", () => {
+      const h = createHarness();
+      const ws = driveToSubscribed(h);
+
+      ws.simulateMessage({
+        id: 1,
+        type: "event",
+        event: { event_type: "service_registered", data: {} },
+      });
+      expect(h.client.state).toBe("subscribed");
+    });
+  });
+
+  describe("stop()", () => {
+    it("transitions to disconnected, closes the socket, and cancels reconnect timers", () => {
+      const h = createHarness();
+      driveToSubscribed(h);
+
+      h.client.stop();
+      expect(h.client.state).toBe("disconnected");
+      expect(h.sockets[0].closeCalls).toBeGreaterThan(0);
+      expect(h.scheduler.pendingCount()).toBe(0);
+    });
+
+    it("does not reconnect after stop()", () => {
+      const h = createHarness();
+      driveToSubscribed(h);
+
+      h.client.stop();
+      h.scheduler.advance(60000);
+      expect(h.sockets).toHaveLength(1);
+    });
+  });
+
+  describe("integration: socket recycle after a heartbeat miss flushes stale state", () => {
+    it("reset is called when a fresh subscribe completes after reconnect", () => {
+      const h = createHarness({ heartbeatIntervalMs: 30000, heartbeatTimeoutMs: 10000 });
+      const ws = driveToSubscribed(h);
+
+      // Seed some state, then drop.
+      ws.simulateMessage({
+        id: 1,
+        type: "event",
+        event: {
+          event_type: "state_changed",
+          data: {
+            entity_id: "sensor.battery_soc",
+            old_state: null,
+            new_state: {
+              entity_id: "sensor.battery_soc",
+              state: "97",
+              attributes: {},
+            },
+          },
+        },
+      });
+      expect(h.store.get("sensor.battery_soc")).toBeDefined();
+
+      const resetSpy = vi.spyOn(h.store, "reset");
+      ws.simulateClose();
+      h.scheduler.advance(1000);
+
+      // Walk new socket through auth + subscribe.
+      const ws2 = h.sockets[1];
+      ws2.simulateOpen();
+      ws2.simulateMessage({ type: "auth_required" });
+      ws2.simulateMessage({ type: "auth_ok" });
+      const subscribe = ws2.findSent((m) => m.type === "subscribe_events");
+      ws2.simulateMessage({ id: subscribe!.id, type: "result", success: true });
+
+      expect(resetSpy).toHaveBeenCalled();
+      expect(h.client.state).toBe("subscribed");
+    });
+  });
+});

--- a/extensions/home-assistant/ws-client.test.ts
+++ b/extensions/home-assistant/ws-client.test.ts
@@ -411,6 +411,63 @@ describe("HomeAssistantClient", () => {
     });
   });
 
+  describe("callService", () => {
+    it("sends a call_service frame to HA with the configured domain/service/target", () => {
+      const h = createHarness();
+      const ws = driveToSubscribed(h);
+
+      h.client.callService({
+        domain: "switch",
+        service: "toggle",
+        target: "switch.sonoff_10013c3266",
+      });
+
+      const sent = ws.findSent((m) => m.type === "call_service");
+      expect(sent).toBeTruthy();
+      expect(sent).toMatchObject({
+        type: "call_service",
+        domain: "switch",
+        service: "toggle",
+        target: { entity_id: "switch.sonoff_10013c3266" },
+      });
+      expect(typeof sent!.id).toBe("number");
+    });
+
+    it("forwards optional service_data to HA", () => {
+      const h = createHarness();
+      const ws = driveToSubscribed(h);
+
+      h.client.callService({
+        domain: "cover",
+        service: "set_cover_position",
+        target: "cover.aqara_roller_blind_left",
+        serviceData: { position: 50 },
+      });
+
+      const sent = ws.findSent((m) => m.type === "call_service");
+      expect(sent).toMatchObject({
+        type: "call_service",
+        domain: "cover",
+        service: "set_cover_position",
+        target: { entity_id: "cover.aqara_roller_blind_left" },
+        service_data: { position: 50 },
+      });
+    });
+
+    it("throws when called before subscribe completes", () => {
+      const h = createHarness();
+      h.client.start();
+      // Not yet subscribed.
+      expect(() =>
+        h.client.callService({
+          domain: "switch",
+          service: "toggle",
+          target: "switch.sonoff_10013c3266",
+        }),
+      ).toThrow(/not subscribed|not connected/i);
+    });
+  });
+
   describe("integration: socket recycle after a heartbeat miss flushes stale state", () => {
     it("reset is called when a fresh subscribe completes after reconnect", () => {
       const h = createHarness({ heartbeatIntervalMs: 30000, heartbeatTimeoutMs: 10000 });

--- a/extensions/home-assistant/ws-client.ts
+++ b/extensions/home-assistant/ws-client.ts
@@ -1,0 +1,466 @@
+/**
+ * Long-lived Home Assistant WebSocket client.
+ *
+ * Lifecycle (HA WS protocol):
+ *   1. open                                  -> CONNECTING
+ *   2. server: { type: "auth_required" }     -> AUTHENTICATING
+ *      client: { type: "auth", access_token: ... }
+ *   3. server: { type: "auth_ok" }
+ *      client: { id, type: "subscribe_events", event_type: "state_changed" }
+ *   4. server: { id, type: "result", success: true } -> SUBSCRIBED
+ *   5. server: { id, type: "event", event: { event_type, data } }
+ *
+ * After SUBSCRIBED, periodic { id, type: "ping" } / { id, type: "pong" } at
+ * the application layer guards against silent half-open sockets.
+ *
+ * Boundaries respected by this module:
+ *   - No core internals are imported. The WS factory, store, and clock are
+ *     injected so tests can drive the lifecycle deterministically without a
+ *     real socket or real timers.
+ *   - Allow-list filtering happens in `state-store.ts`. This client does not
+ *     re-implement it; it forwards events as-is.
+ *
+ * What this module does NOT do (deferred per the kiosk plan):
+ *   - service_call dispatch -- belongs to the gateway bridge in Unit 4.
+ *   - deny-list enforcement -- belongs to `allowlist.ts` in Unit 3.
+ */
+
+import type { HomeAssistantStateStore } from "./state-store.js";
+
+// -- WebSocket-like contract --------------------------------------------------
+
+/**
+ * Subset of the WHATWG WebSocket interface that this client uses. Both the
+ * standard browser WebSocket and a `ws` package socket satisfy this; tests
+ * supply a fake implementation. The numeric readyState constants follow the
+ * standard (0 CONNECTING, 1 OPEN, 2 CLOSING, 3 CLOSED).
+ */
+export interface WebSocketLike {
+  readyState: number;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  onopen: (() => void) | null;
+  onmessage: ((ev: { data: unknown }) => void) | null;
+  onerror: ((ev: unknown) => void) | null;
+  onclose: ((ev: { code?: number; reason?: string }) => void) | null;
+}
+
+export type WebSocketLikeFactory = (url: string) => WebSocketLike;
+
+// -- Connection state machine -------------------------------------------------
+
+export type ConnectionState =
+  | "idle"
+  | "connecting"
+  | "authenticating"
+  | "subscribed"
+  | "degraded"
+  | "disconnected";
+
+export type StateChangeListener = (state: ConnectionState) => void;
+export type Unsubscribe = () => void;
+
+export type LogLevel = "info" | "warn" | "error";
+export type LogEntry = {
+  level: LogLevel;
+  message: string;
+  data?: unknown;
+};
+export type Logger = (entry: LogEntry) => void;
+
+// -- Options -------------------------------------------------------------------
+
+export type HomeAssistantClientOptions = {
+  url: string;
+  token: string;
+  store: HomeAssistantStateStore;
+  webSocketFactory: WebSocketLikeFactory;
+  /** Reconnect backoff knobs. Defaults: base 1s, cap 30s. */
+  reconnect?: { baseDelayMs?: number; maxDelayMs?: number };
+  /** Heartbeat knobs. Defaults: ping every 30s, pong timeout 10s. */
+  heartbeat?: { intervalMs?: number; timeoutMs?: number };
+  setTimeoutFn?: (fn: () => void, ms: number) => unknown;
+  clearTimeoutFn?: (handle: unknown) => void;
+  logger?: Logger;
+};
+
+const DEFAULT_BASE_DELAY_MS = 1000;
+const DEFAULT_MAX_DELAY_MS = 30000;
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 30000;
+const DEFAULT_HEARTBEAT_TIMEOUT_MS = 10000;
+
+// -- HA WS message shapes (only what we read; everything else is opaque) ----
+
+type HaMessage = Record<string, unknown> & { type?: string; id?: number };
+
+type HaStateAttributes = Record<string, unknown>;
+
+type HaEntityState = {
+  entity_id: string;
+  state: string;
+  attributes: HaStateAttributes;
+  last_changed?: string;
+  last_updated?: string;
+};
+
+type HaStateChangedData = {
+  entity_id: string;
+  old_state: HaEntityState | null;
+  new_state: HaEntityState | null;
+};
+
+// -- Implementation ----------------------------------------------------------
+
+export class HomeAssistantClient {
+  state: ConnectionState = "idle";
+
+  private readonly options: HomeAssistantClientOptions;
+  private readonly setTimeoutFn: (fn: () => void, ms: number) => unknown;
+  private readonly clearTimeoutFn: (handle: unknown) => void;
+  private readonly logger: Logger;
+  private readonly baseDelayMs: number;
+  private readonly maxDelayMs: number;
+  private readonly heartbeatIntervalMs: number;
+  private readonly heartbeatTimeoutMs: number;
+
+  private socket: WebSocketLike | null = null;
+  private nextCommandId = 1;
+  private subscribeId: number | null = null;
+  private outstandingPing: { id: number; timeoutHandle: unknown } | null = null;
+  private heartbeatHandle: unknown = null;
+  private reconnectHandle: unknown = null;
+  private reconnectAttempt = 0;
+  private hasEverSubscribed = false;
+  private stopped = false;
+
+  private readonly stateListeners = new Set<StateChangeListener>();
+
+  constructor(options: HomeAssistantClientOptions) {
+    this.options = options;
+    this.setTimeoutFn = options.setTimeoutFn ?? ((fn, ms) => setTimeout(fn, ms));
+    this.clearTimeoutFn =
+      options.clearTimeoutFn ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>));
+    this.logger = options.logger ?? (() => undefined);
+    this.baseDelayMs = options.reconnect?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+    this.maxDelayMs = options.reconnect?.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+    this.heartbeatIntervalMs = options.heartbeat?.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+    this.heartbeatTimeoutMs = options.heartbeat?.timeoutMs ?? DEFAULT_HEARTBEAT_TIMEOUT_MS;
+  }
+
+  start(): void {
+    if (this.stopped) {
+      return;
+    }
+    if (this.state !== "idle" && this.state !== "disconnected" && this.state !== "degraded") {
+      return;
+    }
+    this.openSocket();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.cancelReconnect();
+    this.cancelHeartbeat();
+    this.detachAndClose();
+    this.transition("disconnected");
+  }
+
+  onStateChange(listener: StateChangeListener): Unsubscribe {
+    this.stateListeners.add(listener);
+    return () => {
+      this.stateListeners.delete(listener);
+    };
+  }
+
+  /** Visible for tests; pure function over the configured backoff bounds. */
+  computeReconnectDelay(attempt: number): number {
+    if (attempt <= 0) {
+      return 0;
+    }
+    const exp = Math.min(this.maxDelayMs, this.baseDelayMs * 2 ** (attempt - 1));
+    return Math.min(this.maxDelayMs, exp);
+  }
+
+  // -- internal ------------------------------------------------------------
+
+  private openSocket(): void {
+    if (this.stopped) {
+      return;
+    }
+    this.cancelReconnect();
+    this.cancelHeartbeat();
+
+    const ws = this.options.webSocketFactory(this.options.url);
+    this.socket = ws;
+    this.transition("connecting");
+
+    ws.onopen = () => {
+      // No state transition on raw open -- HA sends auth_required next.
+      this.logger({ level: "info", message: "ha-ws.open" });
+    };
+    ws.onmessage = (ev) => this.handleMessage(ev);
+    ws.onerror = (ev) => {
+      this.logger({ level: "warn", message: "ha-ws.socket-error", data: ev });
+    };
+    ws.onclose = (ev) => this.handleClose(ev);
+  }
+
+  private handleMessage(ev: { data: unknown }): void {
+    const raw = typeof ev.data === "string" ? ev.data : String(ev.data);
+    let msg: HaMessage;
+    try {
+      msg = JSON.parse(raw) as HaMessage;
+    } catch (cause) {
+      this.logger({
+        level: "warn",
+        message: "ha-ws.parse-failed",
+        data: { error: String(cause), raw: raw.slice(0, 200) },
+      });
+      return;
+    }
+
+    if (typeof msg !== "object" || msg === null) {
+      this.logger({ level: "warn", message: "ha-ws.unexpected-shape", data: raw.slice(0, 200) });
+      return;
+    }
+
+    switch (msg.type) {
+      case "auth_required":
+        this.handleAuthRequired();
+        return;
+      case "auth_ok":
+        this.handleAuthOk();
+        return;
+      case "auth_invalid":
+        this.handleAuthInvalid(msg);
+        return;
+      case "result":
+        this.handleResult(msg);
+        return;
+      case "event":
+        this.handleEvent(msg);
+        return;
+      case "pong":
+        this.handlePong(msg);
+        return;
+      default:
+        this.logger({
+          level: "warn",
+          message: "ha-ws.unknown-type",
+          data: { type: msg.type ?? null },
+        });
+    }
+  }
+
+  private handleAuthRequired(): void {
+    this.transition("authenticating");
+    this.send({ type: "auth", access_token: this.options.token });
+  }
+
+  private handleAuthOk(): void {
+    // Subscribe to state_changed events. The plan leaves the choice between
+    // subscribe_events and subscribe_entities to impl time; subscribe_events
+    // is simpler and adequate for household-scale entity counts.
+    const id = this.takeCommandId();
+    this.subscribeId = id;
+    this.send({ id, type: "subscribe_events", event_type: "state_changed" });
+  }
+
+  private handleAuthInvalid(msg: HaMessage): void {
+    this.logger({
+      level: "error",
+      message: "ha-ws.auth-invalid",
+      data: { detail: msg.message ?? null },
+    });
+    // No reconnect: token won't fix itself. Operator must rotate credentials.
+    this.cancelReconnect();
+    this.cancelHeartbeat();
+    this.detachAndClose();
+    this.transition("degraded");
+  }
+
+  private handleResult(msg: HaMessage): void {
+    if (this.subscribeId !== null && msg.id === this.subscribeId) {
+      const success = msg.success === true;
+      if (!success) {
+        this.logger({ level: "error", message: "ha-ws.subscribe-failed", data: msg });
+        this.degradeAndReconnect();
+        return;
+      }
+      this.subscribeId = null;
+      // On every resubscribe except the very first, flush stale state so the
+      // store mirrors HA again from a known-empty starting point. Resubscribe
+      // happens after a connection drop, where the kiosk plan calls out
+      // "fresh subscribe" semantics.
+      if (this.hasEverSubscribed) {
+        this.options.store.reset();
+      }
+      this.hasEverSubscribed = true;
+      this.reconnectAttempt = 0;
+      this.transition("subscribed");
+      this.scheduleHeartbeat();
+    }
+  }
+
+  private handleEvent(msg: HaMessage): void {
+    const event = (msg as { event?: { event_type?: string; data?: unknown } }).event;
+    if (!event || event.event_type !== "state_changed") {
+      return;
+    }
+    const data = event.data as HaStateChangedData | undefined;
+    if (!data || typeof data.entity_id !== "string") {
+      this.logger({ level: "warn", message: "ha-ws.bad-event-data" });
+      return;
+    }
+    this.options.store.applyStateChanged({
+      entity_id: data.entity_id,
+      old_state: data.old_state ?? null,
+      new_state: data.new_state ?? null,
+    });
+  }
+
+  private handlePong(msg: HaMessage): void {
+    if (!this.outstandingPing) {
+      return;
+    }
+    if (msg.id !== this.outstandingPing.id) {
+      this.logger({ level: "warn", message: "ha-ws.pong-id-mismatch" });
+      return;
+    }
+    this.clearTimeoutFn(this.outstandingPing.timeoutHandle);
+    this.outstandingPing = null;
+    this.scheduleHeartbeat();
+  }
+
+  private handleClose(_ev: { code?: number; reason?: string }): void {
+    // Server-initiated or network-initiated close. Closes we initiate
+    // ourselves go through detachAndClose which detaches handlers first, so
+    // this branch only fires for unexpected drops.
+    this.cancelHeartbeat();
+    this.socket = null;
+    if (this.stopped) {
+      this.transition("disconnected");
+      return;
+    }
+    this.transition("degraded");
+    this.scheduleReconnect();
+  }
+
+  private degradeAndReconnect(): void {
+    this.cancelHeartbeat();
+    this.detachAndClose();
+    this.transition("degraded");
+    this.scheduleReconnect();
+  }
+
+  private detachAndClose(): void {
+    const sock = this.socket;
+    this.socket = null;
+    if (!sock) {
+      return;
+    }
+    sock.onopen = null;
+    sock.onmessage = null;
+    sock.onerror = null;
+    sock.onclose = null;
+    try {
+      sock.close();
+    } catch (cause) {
+      this.logger({ level: "warn", message: "ha-ws.close-failed", data: cause });
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped) {
+      return;
+    }
+    this.cancelReconnect();
+    this.reconnectAttempt += 1;
+    const delay = this.computeReconnectDelay(this.reconnectAttempt);
+    this.logger({
+      level: "info",
+      message: "ha-ws.reconnect-scheduled",
+      data: { attempt: this.reconnectAttempt, delayMs: delay },
+    });
+    this.reconnectHandle = this.setTimeoutFn(() => {
+      this.reconnectHandle = null;
+      this.openSocket();
+    }, delay);
+  }
+
+  private cancelReconnect(): void {
+    if (this.reconnectHandle) {
+      this.clearTimeoutFn(this.reconnectHandle);
+      this.reconnectHandle = null;
+    }
+  }
+
+  private scheduleHeartbeat(): void {
+    this.cancelHeartbeat();
+    if (this.state !== "subscribed") {
+      return;
+    }
+    this.heartbeatHandle = this.setTimeoutFn(() => {
+      this.heartbeatHandle = null;
+      this.sendPing();
+    }, this.heartbeatIntervalMs);
+  }
+
+  private cancelHeartbeat(): void {
+    if (this.heartbeatHandle) {
+      this.clearTimeoutFn(this.heartbeatHandle);
+      this.heartbeatHandle = null;
+    }
+    if (this.outstandingPing) {
+      this.clearTimeoutFn(this.outstandingPing.timeoutHandle);
+      this.outstandingPing = null;
+    }
+  }
+
+  private sendPing(): void {
+    if (this.state !== "subscribed" || !this.socket) {
+      return;
+    }
+    const id = this.takeCommandId();
+    this.send({ id, type: "ping" });
+    const timeoutHandle = this.setTimeoutFn(() => {
+      this.logger({
+        level: "warn",
+        message: "ha-ws.ping-timeout",
+        data: { pingId: id },
+      });
+      this.outstandingPing = null;
+      this.degradeAndReconnect();
+    }, this.heartbeatTimeoutMs);
+    this.outstandingPing = { id, timeoutHandle };
+  }
+
+  private send(payload: Record<string, unknown>): void {
+    if (!this.socket) {
+      return;
+    }
+    try {
+      this.socket.send(JSON.stringify(payload));
+    } catch (cause) {
+      this.logger({ level: "warn", message: "ha-ws.send-failed", data: cause });
+    }
+  }
+
+  private takeCommandId(): number {
+    return this.nextCommandId++;
+  }
+
+  private transition(next: ConnectionState): void {
+    if (this.state === next) {
+      return;
+    }
+    this.state = next;
+    for (const listener of this.stateListeners) {
+      try {
+        listener(next);
+      } catch (cause) {
+        this.logger({ level: "warn", message: "ha-ws.state-listener-failed", data: cause });
+      }
+    }
+  }
+}

--- a/extensions/home-assistant/ws-client.ts
+++ b/extensions/home-assistant/ws-client.ts
@@ -172,6 +172,40 @@ export class HomeAssistantClient {
     };
   }
 
+  /**
+   * Send a `call_service` frame to HA.
+   *
+   * Fire-and-forget: the kiosk's reconciliation path is the state-changed
+   * echo, not the result frame. If we ever need the typed result, swap this
+   * for a Promise-returning variant that tracks the command id and resolves
+   * on the matching `result` message.
+   *
+   * Caller is responsible for allow-list / deny-list gating before getting
+   * here -- see `allowlist.ts`. This method validates only WS readiness.
+   */
+  callService(args: {
+    domain: string;
+    service: string;
+    target: string;
+    serviceData?: Record<string, unknown>;
+  }): void {
+    if (this.state !== "subscribed" || !this.socket) {
+      throw new Error("home-assistant client is not subscribed; cannot call_service yet");
+    }
+    const id = this.takeCommandId();
+    const payload: Record<string, unknown> = {
+      id,
+      type: "call_service",
+      domain: args.domain,
+      service: args.service,
+      target: { entity_id: args.target },
+    };
+    if (args.serviceData) {
+      payload.service_data = args.serviceData;
+    }
+    this.send(payload);
+  }
+
   /** Visible for tests; pure function over the configured backoff bounds. */
   computeReconnectDelay(attempt: number): number {
     if (attempt <= 0) {

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,5 +1,10 @@
 import "./styles.css";
 import "./ui/app.ts";
+import { autoMountKioskOnHashRoute } from "./ui/kiosk/kiosk-bootstrap.ts";
+
+// Self-bootstrap: if the URL is #/kiosk, wait for the gateway client to
+// come online and mount the wall-tablet kiosk view. No-op otherwise.
+autoMountKioskOnHashRoute();
 
 type ViteImportMeta = ImportMeta & {
   readonly env?: {

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -8,6 +8,7 @@
 @import "./styles/cron-quick-create.css";
 @import "./styles/usage.css";
 @import "./styles/dreams.css";
+@import "./styles/kiosk.css";
 @import "@create-markdown/preview/themes/system.css";
 
 .cm-preview {

--- a/ui/src/styles/kiosk.css
+++ b/ui/src/styles/kiosk.css
@@ -1,0 +1,310 @@
+/**
+ * Wall-tablet kiosk styles.
+ *
+ * The `.kiosk-mode` class is set on `<html>` while the kiosk view is
+ * mounted (kiosk-shell.ts toggles it). It hides the standard control-UI
+ * shell, removes hover-only affordances, and bumps touch targets.
+ *
+ * Design tokens come from base.css; this file only reshapes layout for
+ * the kiosk surface and never invents new colors.
+ */
+
+:root.kiosk-mode .shell,
+:root.kiosk-mode .topbar,
+:root.kiosk-mode .nav,
+:root.kiosk-mode .dashboard-header {
+  display: none !important;
+}
+
+:root.kiosk-mode {
+  background: var(--bg);
+  color: var(--text);
+}
+
+:root.kiosk-mode body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 18px;
+  line-height: 1.4;
+  -webkit-font-smoothing: antialiased;
+  user-select: none;
+  touch-action: manipulation;
+  overscroll-behavior: none;
+}
+
+.kiosk-shell {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  min-height: 100vh;
+  padding: 24px clamp(24px, 4vw, 48px);
+  gap: 24px;
+  box-sizing: border-box;
+}
+
+.kiosk-shell__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.kiosk-shell__title {
+  margin: 0;
+  font-size: clamp(28px, 3vw, 40px);
+  font-weight: 600;
+  color: var(--text-strong);
+  letter-spacing: 0.5px;
+}
+
+.kiosk-shell__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--muted);
+  min-height: 44px;
+  box-sizing: border-box;
+}
+
+.kiosk-shell__pill::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--muted);
+}
+
+.kiosk-shell__pill--live {
+  color: #43ff00;
+  border-color: rgba(67, 255, 0, 0.35);
+  background: rgba(67, 255, 0, 0.08);
+}
+
+.kiosk-shell__pill--live::before {
+  background: #43ff00;
+  box-shadow: 0 0 12px rgba(67, 255, 0, 0.6);
+}
+
+.kiosk-shell__pill--attaching {
+  color: var(--accent);
+  border-color: rgba(255, 92, 92, 0.35);
+  background: rgba(255, 92, 92, 0.08);
+}
+
+.kiosk-shell__pill--attaching::before {
+  background: var(--accent);
+}
+
+.kiosk-shell__pill--degraded {
+  color: #ff5c5c;
+  border-color: rgba(255, 92, 92, 0.45);
+  background: rgba(255, 92, 92, 0.1);
+}
+
+.kiosk-shell__pill--degraded::before {
+  background: #ff5c5c;
+  animation: kiosk-pulse 1s ease-in-out infinite;
+}
+
+@keyframes kiosk-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+.kiosk-shell__body {
+  display: block;
+}
+
+.kiosk-shell__placeholder {
+  display: grid;
+  place-items: center;
+  height: 100%;
+  color: var(--muted);
+  font-size: 18px;
+}
+
+/* -- Display primitive base styles (used by kiosk-* components) -- */
+
+.kiosk-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 16px;
+  display: grid;
+  gap: 8px;
+  box-sizing: border-box;
+}
+
+.kiosk-tile {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 14px 16px;
+  min-height: 64px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  font-size: 18px;
+  color: var(--text);
+  transition: background 120ms ease, border-color 120ms ease, transform 60ms ease;
+}
+
+.kiosk-tile:active {
+  transform: scale(0.98);
+}
+
+.kiosk-tile[data-state="on"] {
+  border-color: rgba(67, 255, 0, 0.45);
+  background: rgba(67, 255, 0, 0.08);
+}
+
+.kiosk-tile[data-state="off"] {
+  border-color: var(--border);
+}
+
+.kiosk-tile[data-pending="true"] {
+  opacity: 0.7;
+}
+
+.kiosk-tile[data-error="true"] {
+  border-color: rgba(255, 92, 92, 0.6);
+  background: rgba(255, 92, 92, 0.12);
+}
+
+.kiosk-tile__icon {
+  width: 28px;
+  height: 28px;
+  flex: 0 0 28px;
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+}
+
+.kiosk-tile__name {
+  flex: 1 1 auto;
+  font-weight: 600;
+}
+
+.kiosk-tile__state {
+  font-size: 14px;
+  color: var(--muted);
+  text-transform: lowercase;
+}
+
+.kiosk-tile__state--on {
+  color: #43ff00;
+}
+
+.kiosk-tile__state--off {
+  color: var(--muted);
+}
+
+.kiosk-gauge {
+  display: grid;
+  place-items: center;
+  position: relative;
+  aspect-ratio: 1 / 1;
+  min-width: 0;
+}
+
+.kiosk-gauge svg {
+  width: 100%;
+  height: auto;
+}
+
+.kiosk-gauge__numeral {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: clamp(32px, 4vw, 56px);
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.kiosk-gauge__unit {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: end center;
+  padding-bottom: 18%;
+  font-size: 14px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.kiosk-gauge__name {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: end center;
+  padding-bottom: 0.5em;
+  font-size: 14px;
+  color: var(--muted);
+  text-align: center;
+  white-space: nowrap;
+}
+
+.kiosk-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-size: 14px;
+  min-height: 36px;
+  box-sizing: border-box;
+}
+
+.kiosk-badge__name {
+  font-weight: 600;
+}
+
+.kiosk-badge__state {
+  color: var(--muted);
+}
+
+.kiosk-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.kiosk-grid--gauges-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.kiosk-grid--gauges-5 {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.kiosk-grid--gauges-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.kiosk-grid--tiles {
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+.kiosk-grid--badges {
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+}
+
+@media (max-width: 900px) {
+  .kiosk-grid--gauges-4,
+  .kiosk-grid--gauges-5 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/ui/src/ui/kiosk/components/badge-entity.test.ts
+++ b/ui/src/ui/kiosk/components/badge-entity.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import "./badge-entity.js";
+import type { KioskBadgeEntity } from "./badge-entity.js";
+
+async function mount(props: Partial<KioskBadgeEntity>): Promise<KioskBadgeEntity> {
+  const el = document.createElement("kiosk-badge-entity") as KioskBadgeEntity;
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe("kiosk-badge-entity", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders name and state", async () => {
+    const el = await mount({ name: "Audrey iPhone", state: "87", unit: "%" });
+    expect(el.textContent).toContain("Audrey iPhone");
+    expect(el.textContent).toContain("87%");
+  });
+
+  it("renders n/a for unavailable state", async () => {
+    const el = await mount({ name: "Wagner Alarm", state: "unavailable" });
+    expect(el.textContent).toContain("n/a");
+  });
+
+  it("renders n/a for unknown state", async () => {
+    const el = await mount({ name: "Audrey", state: "unknown" });
+    expect(el.textContent).toContain("n/a");
+  });
+
+  it("flags unavailable state via data-unavailable for CSS", async () => {
+    const el = await mount({ name: "X", state: "unavailable" });
+    expect(el.querySelector("[data-unavailable='true']")).toBeTruthy();
+  });
+
+  it("falls back to the entity id when no name is set", async () => {
+    const el = await mount({ entityId: "person.audrey", state: "home" });
+    expect(el.textContent).toContain("person.audrey");
+  });
+});

--- a/ui/src/ui/kiosk/components/badge-entity.ts
+++ b/ui/src/ui/kiosk/components/badge-entity.ts
@@ -1,0 +1,39 @@
+/**
+ * Compact entity badge -- name + state in a chip-shaped pill.
+ *
+ * Used for the people / phone-battery / alarm row at the top of the
+ * Wagner Way overview. Read-only; no tap action.
+ */
+
+import { LitElement, html, type TemplateResult } from "lit";
+import { property } from "lit/decorators.js";
+
+export class KioskBadgeEntity extends LitElement {
+  override createRenderRoot() {
+    return this;
+  }
+
+  @property() entityId: string = "";
+  @property() name: string = "";
+  @property() state: string = "unavailable";
+  @property() unit: string = "";
+
+  override render(): TemplateResult {
+    const isUnavailable = !this.state || this.state === "unavailable" || this.state === "unknown";
+    const display = isUnavailable ? "n/a" : `${this.state}${this.unit ? this.unit : ""}`;
+    return html`<span
+      class="kiosk-badge"
+      data-state=${this.state}
+      data-unavailable=${isUnavailable ? "true" : "false"}
+      data-test-id="kiosk-badge"
+      title=${this.entityId}
+    >
+      <span class="kiosk-badge__name">${this.name || this.entityId}</span>
+      <span class="kiosk-badge__state">${display}</span>
+    </span>`;
+  }
+}
+
+if (!customElements.get("kiosk-badge-entity")) {
+  customElements.define("kiosk-badge-entity", KioskBadgeEntity);
+}

--- a/ui/src/ui/kiosk/components/energy-flow-card.ts
+++ b/ui/src/ui/kiosk/components/energy-flow-card.ts
@@ -1,0 +1,76 @@
+/**
+ * Static energy-flow card.
+ *
+ * Renders the four-quadrant low-carbon flow diagram (solar / grid /
+ * home / battery) at v1 visual fidelity: nodes with current power
+ * readings, edge values for daily totals. The HACS sunsynk-power-flow
+ * card has animated dots and SVG line styling; we keep this minimal
+ * and rely on the tokens from base.css. Fidelity polish is v2.
+ */
+
+import { LitElement, html, type TemplateResult } from "lit";
+import { property } from "lit/decorators.js";
+
+export type EnergyNodeReading = {
+  /** Display label, e.g. "Solar", "Grid", "Home", "Battery". */
+  label: string;
+  /** Current instantaneous power (W). */
+  power: number | null;
+  /** Daily total (kWh). */
+  daily?: number;
+  /** Optional secondary info (e.g. battery SOC %). */
+  detail?: string;
+};
+
+export class KioskEnergyFlowCard extends LitElement {
+  override createRenderRoot() {
+    return this;
+  }
+
+  @property({ attribute: false }) solar: EnergyNodeReading | null = null;
+  @property({ attribute: false }) grid: EnergyNodeReading | null = null;
+  @property({ attribute: false }) home: EnergyNodeReading | null = null;
+  @property({ attribute: false }) battery: EnergyNodeReading | null = null;
+
+  override render(): TemplateResult {
+    return html`<div class="kiosk-card kiosk-energy-flow" data-test-id="kiosk-energy-flow">
+      <div class="kiosk-energy-flow__grid">
+        ${renderNode("solar", this.solar)} ${renderNode("grid", this.grid)}
+        ${renderNode("battery", this.battery)} ${renderNode("home", this.home)}
+      </div>
+    </div>`;
+  }
+}
+
+function renderNode(slot: string, node: EnergyNodeReading | null): TemplateResult {
+  if (!node) {
+    return html`<div
+      class="kiosk-energy-flow__node kiosk-energy-flow__node--${slot}"
+      data-empty="true"
+    >
+      <div class="kiosk-energy-flow__label">${slot}</div>
+      <div class="kiosk-energy-flow__power">--</div>
+    </div>`;
+  }
+  return html`<div class="kiosk-energy-flow__node kiosk-energy-flow__node--${slot}">
+    <div class="kiosk-energy-flow__label">${node.label}</div>
+    <div class="kiosk-energy-flow__power">
+      ${node.power !== null && Number.isFinite(node.power) ? formatPower(node.power) : "--"}
+    </div>
+    ${node.daily !== undefined
+      ? html`<div class="kiosk-energy-flow__daily">${node.daily.toFixed(1)} kWh</div>`
+      : ""}
+    ${node.detail ? html`<div class="kiosk-energy-flow__detail">${node.detail}</div>` : ""}
+  </div>`;
+}
+
+function formatPower(watts: number): string {
+  if (Math.abs(watts) >= 1000) {
+    return `${(watts / 1000).toFixed(2)} kW`;
+  }
+  return `${Math.round(watts)} W`;
+}
+
+if (!customElements.get("kiosk-energy-flow-card")) {
+  customElements.define("kiosk-energy-flow-card", KioskEnergyFlowCard);
+}

--- a/ui/src/ui/kiosk/components/gauge-circular.test.ts
+++ b/ui/src/ui/kiosk/components/gauge-circular.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import "./gauge-circular.js";
+import type { KioskGaugeCircular } from "./gauge-circular.js";
+
+async function mountGauge(props: Partial<KioskGaugeCircular>): Promise<KioskGaugeCircular> {
+  const el = document.createElement("kiosk-gauge-circular") as KioskGaugeCircular;
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe("kiosk-gauge-circular", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders the numeric value with formatting", async () => {
+    const el = await mountGauge({ value: 97, min: 0, max: 100, unit: "%", name: "Battery SOC" });
+    expect(el.textContent).toContain("97");
+    expect(el.textContent).toContain("%");
+    expect(el.textContent).toContain("Battery SOC");
+  });
+
+  it("formats large numbers with locale separators", async () => {
+    const el = await mountGauge({ value: 80953, min: 40000, max: 140000, unit: "$" });
+    // Could be 80,953 or 80'953 depending on locale; just assert presence of comma or thousand-separator pattern.
+    expect(el.textContent).toMatch(/80[,.\s']?953|80953/);
+  });
+
+  it("renders -- placeholder for non-finite values without crashing", async () => {
+    const el = await mountGauge({ value: Number.NaN, min: 0, max: 100 });
+    expect(el.textContent).toMatch(/--/);
+    expect(el.querySelector("[data-empty='true']")).toBeTruthy();
+  });
+
+  it("renders -- placeholder when max <= min (zero-range guard)", async () => {
+    const el = await mountGauge({ value: 5, min: 10, max: 10 });
+    expect(el.querySelector("[data-empty='true']")).toBeTruthy();
+  });
+
+  it("renders an SVG with both a background and a value arc when value > min", async () => {
+    const el = await mountGauge({ value: 50, min: 0, max: 100 });
+    const paths = el.querySelectorAll("svg path");
+    expect(paths.length).toBe(2);
+  });
+
+  it("renders only the background arc when value === min (no value-arc draw)", async () => {
+    const el = await mountGauge({ value: 0, min: 0, max: 100 });
+    const paths = el.querySelectorAll("svg path");
+    expect(paths.length).toBe(1);
+  });
+
+  it("clamps values above max so the visible arc never overshoots", async () => {
+    const el = await mountGauge({ value: 9999, min: 0, max: 100 });
+    const paths = el.querySelectorAll("svg path");
+    // 2 paths -- clamped, still draws
+    expect(paths.length).toBe(2);
+  });
+
+  it("picks a segment color based on the value", async () => {
+    const el = await mountGauge({
+      value: 95,
+      min: 0,
+      max: 100,
+      segments: [
+        { from: 0, color: "#ff0000" },
+        { from: 60, color: "#00ff00" },
+        { from: 90, color: "#0000ff" },
+      ],
+    });
+    const valuePath = el.querySelectorAll("svg path")[1];
+    expect(valuePath.getAttribute("stroke")).toBe("#0000ff");
+  });
+
+  it("falls back to a default color when no segments are configured", async () => {
+    const el = await mountGauge({ value: 50, min: 0, max: 100, segments: [] });
+    const valuePath = el.querySelectorAll("svg path")[1];
+    expect(valuePath.getAttribute("stroke")).toMatch(/--accent|var/);
+  });
+});

--- a/ui/src/ui/kiosk/components/gauge-circular.ts
+++ b/ui/src/ui/kiosk/components/gauge-circular.ts
@@ -1,0 +1,165 @@
+/**
+ * Circular gauge primitive (SVG arc).
+ *
+ * Public attributes:
+ *   - value: number (current reading)
+ *   - min:  number (default 0)
+ *   - max:  number (required)
+ *   - unit: string (e.g. "W", "%", "$")
+ *   - name: string (caption shown beneath the numeral)
+ *   - segments: ColorSegment[] (color bands; first matching `from` wins)
+ *
+ * Mirrors the visual fidelity of HACS modern-circular-gauge for v1's
+ * Wagner Way overview but is a small Lit + SVG primitive, not a port.
+ */
+
+import { LitElement, html, svg, type TemplateResult } from "lit";
+import { property } from "lit/decorators.js";
+
+export type GaugeColorSegment = {
+  /** Inclusive lower bound; if the value >= this, the segment matches. */
+  from: number;
+  /** Hex or rgb() color string. */
+  color: string;
+};
+
+const DEFAULT_SEGMENTS: GaugeColorSegment[] = [{ from: 0, color: "var(--accent)" }];
+
+export class KioskGaugeCircular extends LitElement {
+  override createRenderRoot() {
+    return this;
+  }
+
+  @property({ type: Number }) value: number = 0;
+  @property({ type: Number }) min: number = 0;
+  @property({ type: Number }) max: number = 100;
+  @property({ type: String }) unit: string = "";
+  @property({ type: String }) name: string = "";
+  @property({ attribute: false }) segments: GaugeColorSegment[] = DEFAULT_SEGMENTS;
+
+  override render(): TemplateResult {
+    const value = Number.isFinite(this.value) ? this.value : Number.NaN;
+    const min = this.min;
+    const max = this.max;
+    const range = max - min;
+
+    if (!Number.isFinite(value) || range <= 0) {
+      return html`<div class="kiosk-gauge" data-empty="true">
+        ${this.renderArc(0, "var(--muted)")}
+        <div class="kiosk-gauge__numeral">--</div>
+        ${this.renderName()}
+      </div>`;
+    }
+
+    const clamped = Math.max(min, Math.min(max, value));
+    const ratio = (clamped - min) / range;
+    const color = pickSegmentColor(value, this.segments);
+
+    return html`<div class="kiosk-gauge">
+      ${this.renderArc(ratio, color)}
+      <div class="kiosk-gauge__numeral">
+        ${formatValue(value)}${this.unit
+          ? html`<span class="kiosk-gauge__unit-suffix" aria-hidden="true">${this.unit}</span>`
+          : ""}
+      </div>
+      ${this.renderName()}
+    </div>`;
+  }
+
+  private renderName(): TemplateResult {
+    return this.name ? html`<div class="kiosk-gauge__name">${this.name}</div>` : html``;
+  }
+
+  private renderArc(ratio: number, color: string): TemplateResult {
+    // 270deg arc starting from -135deg (lower-left) to +135deg (lower-right).
+    // Standard gauge sweep with a gap at the bottom.
+    const radius = 80;
+    const center = 100;
+    const stroke = 12;
+    const startAngle = -225;
+    const endAngle = 45;
+    const totalSweep = endAngle - startAngle;
+    const valueAngle = startAngle + totalSweep * ratio;
+
+    const bgPath = describeArc(center, center, radius, startAngle, endAngle);
+    const valuePath = describeArc(center, center, radius, startAngle, valueAngle);
+
+    return svg`
+      <svg viewBox="0 0 200 200" role="presentation" aria-hidden="true">
+        <path
+          d=${bgPath}
+          stroke="var(--border)"
+          stroke-width=${stroke}
+          stroke-linecap="round"
+          fill="none"
+        />
+        ${
+          ratio > 0
+            ? svg`<path
+              d=${valuePath}
+              stroke=${color}
+              stroke-width=${stroke}
+              stroke-linecap="round"
+              fill="none"
+            />`
+            : svg``
+        }
+      </svg>
+    `;
+  }
+}
+
+function pickSegmentColor(value: number, segments: GaugeColorSegment[]): string {
+  if (!segments || segments.length === 0) {
+    return "var(--accent)";
+  }
+  // Sort by `from` ascending; pick the highest `from` that the value is >=.
+  const sorted = [...segments].sort((a, b) => a.from - b.from);
+  let chosen = sorted[0].color;
+  for (const segment of sorted) {
+    if (value >= segment.from) {
+      chosen = segment.color;
+    }
+  }
+  return chosen;
+}
+
+function formatValue(value: number): string {
+  if (!Number.isFinite(value)) return "--";
+  if (Math.abs(value) >= 10000) {
+    return Math.round(value).toLocaleString();
+  }
+  if (Math.abs(value) >= 100) {
+    return Math.round(value).toString();
+  }
+  if (Math.abs(value) >= 10) {
+    return value.toFixed(0);
+  }
+  return value.toFixed(1);
+}
+
+function polarToCartesian(cx: number, cy: number, radius: number, angleDeg: number) {
+  const angleRad = ((angleDeg - 90) * Math.PI) / 180;
+  return {
+    x: cx + radius * Math.cos(angleRad),
+    y: cy + radius * Math.sin(angleRad),
+  };
+}
+
+function describeArc(
+  cx: number,
+  cy: number,
+  radius: number,
+  startAngle: number,
+  endAngle: number,
+): string {
+  const start = polarToCartesian(cx, cy, radius, endAngle);
+  const end = polarToCartesian(cx, cy, radius, startAngle);
+  const sweep = endAngle - startAngle;
+  const largeArc = Math.abs(sweep) > 180 ? 1 : 0;
+  return `M ${start.x} ${start.y} A ${radius} ${radius} 0 ${largeArc} 0 ${end.x} ${end.y}`;
+}
+
+if (!customElements.get("kiosk-gauge-circular")) {
+  customElements.define("kiosk-gauge-circular", KioskGaugeCircular);
+}

--- a/ui/src/ui/kiosk/components/gauge-circular.ts
+++ b/ui/src/ui/kiosk/components/gauge-circular.ts
@@ -1,16 +1,26 @@
 /**
  * Circular gauge primitive (SVG arc).
  *
- * Public attributes:
- *   - value: number (current reading)
- *   - min:  number (default 0)
- *   - max:  number (required)
- *   - unit: string (e.g. "W", "%", "$")
- *   - name: string (caption shown beneath the numeral)
- *   - segments: ColorSegment[] (color bands; first matching `from` wins)
+ * Visual model mirrors the HACS `modern-circular-gauge` card by selvalt7:
+ * https://github.com/selvalt7/modern-circular-gauge
  *
- * Mirrors the visual fidelity of HACS modern-circular-gauge for v1's
- * Wagner Way overview but is a small Lit + SVG primitive, not a port.
+ * Implementation notes (locked to that card's geometry for fidelity):
+ *   - viewBox -50 -50 100 100, RADIUS = 47, stroke = 6.
+ *   - Single 270deg arc path computed once from angle 0 to 270 (math
+ *     convention; angle 0 = 3 o'clock).
+ *   - The whole arc group is rotated by 135deg so the open gap sits at
+ *     the bottom of the circle (classic gauge sweep from lower-left to
+ *     lower-right).
+ *   - Foreground "value" reveal is done with stroke-dasharray on the same
+ *     path -- no second arc computation, no joins, smooth at every value.
+ *   - Stroke-linecap is round so the value tip has the same pill cap as
+ *     the original card.
+ *
+ * Segments: a list of color bands with a `from` threshold. The active
+ * band (highest `from` <= value) colors the value arc. Smooth-gradient
+ * mode from the original (conic-gradient via foreignObject) is not
+ * implemented in v1 -- visually we get the same step-color reveal that
+ * the kiosk plan called for.
  */
 
 import { LitElement, html, svg, type TemplateResult } from "lit";
@@ -19,11 +29,20 @@ import { property } from "lit/decorators.js";
 export type GaugeColorSegment = {
   /** Inclusive lower bound; if the value >= this, the segment matches. */
   from: number;
-  /** Hex or rgb() color string. */
+  /** Hex or rgb() color string, or CSS variable reference. */
   color: string;
 };
 
 const DEFAULT_SEGMENTS: GaugeColorSegment[] = [{ from: 0, color: "var(--accent)" }];
+
+// -- Geometry constants (match selvalt7/modern-circular-gauge) -------------
+
+const RADIUS = 47;
+const MAX_ANGLE = 270;
+const STROKE_WIDTH = 6;
+// rotateAngle = 360 - MAX_ANGLE / 2 - 90 = 360 - 135 - 90 = 135
+const ROTATE_ANGLE = 360 - MAX_ANGLE / 2 - 90;
+const TRACK_CIRCUMFERENCE = (RADIUS * 2 * Math.PI * MAX_ANGLE) / 360;
 
 export class KioskGaugeCircular extends LitElement {
   override createRenderRoot() {
@@ -39,9 +58,7 @@ export class KioskGaugeCircular extends LitElement {
 
   override render(): TemplateResult {
     const value = Number.isFinite(this.value) ? this.value : Number.NaN;
-    const min = this.min;
-    const max = this.max;
-    const range = max - min;
+    const range = this.max - this.min;
 
     if (!Number.isFinite(value) || range <= 0) {
       return html`<div class="kiosk-gauge" data-empty="true">
@@ -51,8 +68,8 @@ export class KioskGaugeCircular extends LitElement {
       </div>`;
     }
 
-    const clamped = Math.max(min, Math.min(max, value));
-    const ratio = (clamped - min) / range;
+    const clamped = Math.max(this.min, Math.min(this.max, value));
+    const ratio = (clamped - this.min) / range;
     const color = pickSegmentColor(value, this.segments);
 
     return html`<div class="kiosk-gauge">
@@ -71,39 +88,35 @@ export class KioskGaugeCircular extends LitElement {
   }
 
   private renderArc(ratio: number, color: string): TemplateResult {
-    // 270deg arc starting from -135deg (lower-left) to +135deg (lower-right).
-    // Standard gauge sweep with a gap at the bottom.
-    const radius = 80;
-    const center = 100;
-    const stroke = 12;
-    const startAngle = -225;
-    const endAngle = 45;
-    const totalSweep = endAngle - startAngle;
-    const valueAngle = startAngle + totalSweep * ratio;
-
-    const bgPath = describeArc(center, center, radius, startAngle, endAngle);
-    const valuePath = describeArc(center, center, radius, startAngle, valueAngle);
+    const arcLength = Math.max(ratio * TRACK_CIRCUMFERENCE, 0);
+    const dasharray = `${arcLength} ${TRACK_CIRCUMFERENCE - arcLength}`;
+    const path = describeArc(0, 0, RADIUS, 0, MAX_ANGLE);
 
     return svg`
-      <svg viewBox="0 0 200 200" role="presentation" aria-hidden="true">
-        <path
-          d=${bgPath}
-          stroke="var(--border)"
-          stroke-width=${stroke}
-          stroke-linecap="round"
-          fill="none"
-        />
-        ${
-          ratio > 0
-            ? svg`<path
-              d=${valuePath}
-              stroke=${color}
-              stroke-width=${stroke}
-              stroke-linecap="round"
-              fill="none"
-            />`
-            : svg``
-        }
+      <svg viewBox="-50 -50 100 100" role="presentation" aria-hidden="true">
+        <g transform="rotate(${ROTATE_ANGLE})">
+          <path
+            class="kiosk-gauge__track"
+            d=${path}
+            stroke="var(--border)"
+            stroke-width=${STROKE_WIDTH}
+            stroke-linecap="round"
+            fill="none"
+          />
+          ${
+            ratio > 0
+              ? svg`<path
+                  class="kiosk-gauge__value"
+                  d=${path}
+                  stroke=${color}
+                  stroke-width=${STROKE_WIDTH}
+                  stroke-linecap="round"
+                  fill="none"
+                  stroke-dasharray=${dasharray}
+                />`
+              : svg``
+          }
+        </g>
       </svg>
     `;
   }
@@ -113,7 +126,6 @@ function pickSegmentColor(value: number, segments: GaugeColorSegment[]): string 
   if (!segments || segments.length === 0) {
     return "var(--accent)";
   }
-  // Sort by `from` ascending; pick the highest `from` that the value is >=.
   const sorted = [...segments].sort((a, b) => a.from - b.from);
   let chosen = sorted[0].color;
   for (const segment of sorted) {
@@ -138,26 +150,23 @@ function formatValue(value: number): string {
   return value.toFixed(1);
 }
 
-function polarToCartesian(cx: number, cy: number, radius: number, angleDeg: number) {
-  const angleRad = ((angleDeg - 90) * Math.PI) / 180;
-  return {
-    x: cx + radius * Math.cos(angleRad),
-    y: cy + radius * Math.sin(angleRad),
-  };
+// -- SVG arc geometry (matches selvalt7/modern-circular-gauge svgArc) ------
+
+function describeArc(cx: number, cy: number, r: number, startDeg: number, endDeg: number): string {
+  const start = toRadian(startDeg);
+  const end = toRadian(endDeg);
+  const delta = (end - start) % (2 * Math.PI);
+  const startX = cx + r * Math.cos(start);
+  const startY = cy + r * Math.sin(start);
+  const endX = cx + r * Math.cos(start + delta);
+  const endY = cy + r * Math.sin(start + delta);
+  const largeArc = delta > Math.PI ? 1 : 0;
+  const sweep = delta > 0 ? 1 : 0;
+  return `M ${startX} ${startY} A ${r} ${r} 0 ${largeArc} ${sweep} ${endX} ${endY}`;
 }
 
-function describeArc(
-  cx: number,
-  cy: number,
-  radius: number,
-  startAngle: number,
-  endAngle: number,
-): string {
-  const start = polarToCartesian(cx, cy, radius, endAngle);
-  const end = polarToCartesian(cx, cy, radius, startAngle);
-  const sweep = endAngle - startAngle;
-  const largeArc = Math.abs(sweep) > 180 ? 1 : 0;
-  return `M ${start.x} ${start.y} A ${radius} ${radius} 0 ${largeArc} 0 ${end.x} ${end.y}`;
+function toRadian(angleDeg: number): number {
+  return (angleDeg / 180) * Math.PI;
 }
 
 if (!customElements.get("kiosk-gauge-circular")) {

--- a/ui/src/ui/kiosk/components/tile-toggle.test.ts
+++ b/ui/src/ui/kiosk/components/tile-toggle.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import "./tile-toggle.js";
+import type { KioskTileToggle, TileTapDetail } from "./tile-toggle.js";
+
+async function mountTile(props: Partial<KioskTileToggle>): Promise<KioskTileToggle> {
+  const el = document.createElement("kiosk-tile-toggle") as KioskTileToggle;
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe("kiosk-tile-toggle", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders name + state label", async () => {
+    const el = await mountTile({
+      entityId: "switch.gate_main",
+      name: "Main Gate",
+      state: "off",
+    });
+    expect(el.textContent).toContain("Main Gate");
+    expect(el.textContent).toContain("off");
+  });
+
+  it("emits a tile-tap event with domain/service/entity_id on click", async () => {
+    const el = await mountTile({
+      entityId: "switch.gate_main",
+      domain: "switch",
+      service: "toggle",
+      state: "off",
+    });
+    const seen: TileTapDetail[] = [];
+    el.addEventListener("tile-tap", (ev) => seen.push((ev as CustomEvent<TileTapDetail>).detail));
+
+    el.querySelector("button")?.click();
+
+    expect(seen).toEqual([{ entityId: "switch.gate_main", domain: "switch", service: "toggle" }]);
+  });
+
+  it("does not emit when entityId is empty (the tile is disabled)", async () => {
+    const el = await mountTile({ entityId: "", name: "Unwired", state: "off" });
+    const seen: unknown[] = [];
+    el.addEventListener("tile-tap", (ev) => seen.push(ev));
+
+    el.querySelector("button")?.click();
+
+    expect(seen).toHaveLength(0);
+  });
+
+  it("reflects pending and error attributes for CSS to style", async () => {
+    const el = await mountTile({
+      entityId: "switch.geyser",
+      name: "Geyser",
+      state: "on",
+      pending: true,
+    });
+    let btn = el.querySelector("button")!;
+    expect(btn.getAttribute("data-pending")).toBe("true");
+
+    el.pending = false;
+    el.error = true;
+    el.errorMessage = "service-denied";
+    await el.updateComplete;
+    btn = el.querySelector("button")!;
+    expect(btn.getAttribute("data-error")).toBe("true");
+    expect(btn.getAttribute("title")).toBe("service-denied");
+  });
+
+  it("renders an n/a label for unavailable state without crashing", async () => {
+    const el = await mountTile({
+      entityId: "switch.unavailable_for_now",
+      name: "Stale",
+      state: "unavailable",
+    });
+    expect(el.textContent).toContain("n/a");
+  });
+
+  it("uses an explicit icon when provided", async () => {
+    const el = await mountTile({
+      entityId: "switch.gate_main",
+      name: "Gate",
+      state: "off",
+      icon: "G",
+    });
+    expect(el.querySelector(".kiosk-tile__icon")?.textContent?.trim()).toBe("G");
+  });
+});

--- a/ui/src/ui/kiosk/components/tile-toggle.ts
+++ b/ui/src/ui/kiosk/components/tile-toggle.ts
@@ -1,0 +1,104 @@
+/**
+ * Tap-to-toggle tile primitive.
+ *
+ * Renders a large touch target with icon, name, and state. On tap, emits
+ * a `tile-tap` CustomEvent that Unit 8 wires to the gateway service-call
+ * loop with optimistic state and reconciliation. The tile itself supports
+ * three lifecycle attributes that callers drive:
+ *   - data-pending="true" while the call is in flight
+ *   - data-error="true" briefly on a denied / failed call
+ *   - data-state reflects the current entity state ("on" / "off" / etc.)
+ *
+ * The tile does NOT do its own service-call dispatch -- that lives in
+ * the wagner-way view (Unit 7) where the gateway client + binding are
+ * available. Keeping dispatch out of the primitive lets the same
+ * component appear in storybook-style harness pages without coupling.
+ */
+
+import { LitElement, html, type TemplateResult } from "lit";
+import { property } from "lit/decorators.js";
+
+export type TileTapDetail = {
+  entityId: string;
+  domain: string;
+  service: string;
+  serviceData?: Record<string, unknown>;
+};
+
+export class KioskTileToggle extends LitElement {
+  override createRenderRoot() {
+    return this;
+  }
+
+  /** HA entity_id this tile controls. */
+  @property() entityId: string = "";
+  /** Domain to invoke (e.g. "switch", "cover", "automation"). */
+  @property() domain: string = "switch";
+  /** Service to invoke (e.g. "toggle"). */
+  @property() service: string = "toggle";
+  /** Display name. */
+  @property() name: string = "";
+  /** Current entity state for visual reflection ("on", "off", "open", ...). */
+  @property() state: string = "unavailable";
+  /** Pending visual while the optimistic call is in flight. */
+  @property({ type: Boolean }) pending: boolean = false;
+  /** Error visual on denied / failed call. Cleared by the host after a beat. */
+  @property({ type: Boolean }) error: boolean = false;
+  /** Optional last-flash error message (read by tests; rendered as title). */
+  @property() errorMessage: string = "";
+  /** Optional emoji or single-char icon shown in the leading icon slot. */
+  @property() icon: string = "";
+
+  override render(): TemplateResult {
+    const stateLabel = displayStateLabel(this.state);
+    return html`<button
+      type="button"
+      class="kiosk-tile"
+      data-state=${this.state}
+      data-pending=${this.pending ? "true" : "false"}
+      data-error=${this.error ? "true" : "false"}
+      data-test-id="kiosk-tile"
+      title=${this.errorMessage || ""}
+      ?disabled=${!this.entityId}
+      @click=${this.onClick}
+    >
+      <span class="kiosk-tile__icon" aria-hidden="true"
+        >${this.icon || iconForState(this.state)}</span
+      >
+      <span class="kiosk-tile__name">${this.name || this.entityId}</span>
+      <span
+        class="kiosk-tile__state ${stateLabel === "on" || stateLabel === "open"
+          ? "kiosk-tile__state--on"
+          : "kiosk-tile__state--off"}"
+        >${stateLabel}</span
+      >
+    </button>`;
+  }
+
+  private onClick = (ev: MouseEvent): void => {
+    ev.preventDefault();
+    if (!this.entityId) return;
+    const detail: TileTapDetail = {
+      entityId: this.entityId,
+      domain: this.domain,
+      service: this.service,
+    };
+    this.dispatchEvent(
+      new CustomEvent<TileTapDetail>("tile-tap", { detail, bubbles: true, composed: true }),
+    );
+  };
+}
+
+function displayStateLabel(state: string): string {
+  if (!state || state === "unavailable") return "n/a";
+  return state;
+}
+
+function iconForState(state: string): string {
+  if (state === "on" || state === "open") return "*";
+  return ".";
+}
+
+if (!customElements.get("kiosk-tile-toggle")) {
+  customElements.define("kiosk-tile-toggle", KioskTileToggle);
+}

--- a/ui/src/ui/kiosk/components/weather-card.ts
+++ b/ui/src/ui/kiosk/components/weather-card.ts
@@ -1,0 +1,82 @@
+/**
+ * Clock + current-conditions weather card.
+ *
+ * v1: text-only (clock, current temp, current conditions, simple
+ * forecast list). The HACS clock-weather-card has animated icons
+ * and rich layout; we keep this minimal and consistent with the
+ * vanilla CSS token set. Visual fidelity polish is a v2 follow-up.
+ */
+
+import { LitElement, html, type TemplateResult } from "lit";
+import { property } from "lit/decorators.js";
+
+export type WeatherForecastEntry = {
+  /** ISO date or human label. */
+  label: string;
+  /** Conditions (e.g. "rainy", "partlycloudy"). */
+  conditions: string;
+  /** Low temperature. */
+  low?: number;
+  /** High temperature. */
+  high?: number;
+};
+
+export class KioskWeatherCard extends LitElement {
+  override createRenderRoot() {
+    return this;
+  }
+
+  @property() title: string = "";
+  /** Current conditions text. */
+  @property() conditions: string = "";
+  @property({ type: Number }) currentTemp: number | null = null;
+  @property({ type: Number }) humidity: number | null = null;
+  @property({ type: String }) unit: string = "C";
+  @property({ type: String }) clock: string = "";
+  @property({ type: String }) date: string = "";
+  @property({ attribute: false }) forecast: WeatherForecastEntry[] = [];
+
+  override render(): TemplateResult {
+    return html`<div class="kiosk-card kiosk-weather" data-test-id="kiosk-weather">
+      ${this.title ? html`<div class="kiosk-weather__title">${this.title}</div>` : ""}
+      <div class="kiosk-weather__now">
+        ${this.clock ? html`<div class="kiosk-weather__clock">${this.clock}</div>` : ""}
+        ${this.date ? html`<div class="kiosk-weather__date">${this.date}</div>` : ""}
+        ${this.currentTemp !== null
+          ? html`<div class="kiosk-weather__temp">
+              ${formatTemp(this.currentTemp)}&deg;${this.unit}
+            </div>`
+          : html``}
+        ${this.conditions
+          ? html`<div class="kiosk-weather__conditions">${this.conditions}</div>`
+          : ""}
+        ${this.humidity !== null
+          ? html`<div class="kiosk-weather__humidity">${this.humidity}% humidity</div>`
+          : ""}
+      </div>
+      ${this.forecast.length > 0
+        ? html`<ul class="kiosk-weather__forecast">
+            ${this.forecast.map(
+              (row) => html`<li class="kiosk-weather__forecast-row">
+                <span class="kiosk-weather__forecast-label">${row.label}</span>
+                <span class="kiosk-weather__forecast-conditions">${row.conditions}</span>
+                <span class="kiosk-weather__forecast-temps">
+                  ${row.low !== undefined ? formatTemp(row.low) : "--"} /
+                  ${row.high !== undefined ? formatTemp(row.high) : "--"}&deg;
+                </span>
+              </li>`,
+            )}
+          </ul>`
+        : ""}
+    </div>`;
+  }
+}
+
+function formatTemp(value: number): string {
+  if (!Number.isFinite(value)) return "--";
+  return Math.round(value).toString();
+}
+
+if (!customElements.get("kiosk-weather-card")) {
+  customElements.define("kiosk-weather-card", KioskWeatherCard);
+}

--- a/ui/src/ui/kiosk/ha-state-binding.test.ts
+++ b/ui/src/ui/kiosk/ha-state-binding.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  HaStateBinding,
+  HA_STATE_EVENT,
+  HA_SUBSCRIBE_METHOD,
+  HA_SERVICE_CALL_METHOD,
+  type HaGatewayClient,
+  type HaConnectionState,
+} from "./ha-state-binding.js";
+
+type GatewayEventFrame = { type: "event"; event: string; payload?: unknown };
+
+class FakeGatewayClient implements HaGatewayClient {
+  requestCalls: Array<{ method: string; params?: unknown }> = [];
+  shouldRequestThrow: Error | null = null;
+  responses: Map<string, unknown> = new Map();
+  errorResponses: Map<string, Error> = new Map();
+  private eventListeners = new Set<(evt: GatewayEventFrame) => void>();
+
+  async request<T = unknown>(method: string, params?: unknown): Promise<T> {
+    this.requestCalls.push({ method, params });
+    if (this.shouldRequestThrow) {
+      const err = this.shouldRequestThrow;
+      this.shouldRequestThrow = null;
+      throw err;
+    }
+    if (this.errorResponses.has(method)) {
+      throw this.errorResponses.get(method)!;
+    }
+    return (this.responses.get(method) as T) ?? (undefined as T);
+  }
+
+  addEventListener(listener: (evt: GatewayEventFrame) => void): () => void {
+    this.eventListeners.add(listener);
+    return () => {
+      this.eventListeners.delete(listener);
+    };
+  }
+
+  emit(evt: GatewayEventFrame): void {
+    for (const listener of this.eventListeners) {
+      listener(evt);
+    }
+  }
+}
+
+const SAMPLE_SNAPSHOT = {
+  snapshot: [
+    {
+      entity_id: "sensor.battery_soc",
+      state: { entity_id: "sensor.battery_soc", state: "97", attributes: {} },
+    },
+    {
+      entity_id: "switch.gate_main",
+      state: { entity_id: "switch.gate_main", state: "off", attributes: {} },
+    },
+  ],
+};
+
+describe("HaStateBinding", () => {
+  describe("attach + subscribe", () => {
+    it("calls home-assistant.subscribe and seeds the cache from the snapshot", async () => {
+      const client = new FakeGatewayClient();
+      client.responses.set(HA_SUBSCRIBE_METHOD, SAMPLE_SNAPSHOT);
+      const binding = new HaStateBinding(client);
+
+      await binding.attach();
+
+      expect(client.requestCalls.map((c) => c.method)).toContain(HA_SUBSCRIBE_METHOD);
+      expect(binding.get("sensor.battery_soc")).toEqual({
+        entity_id: "sensor.battery_soc",
+        state: "97",
+        attributes: {},
+      });
+      expect(binding.get("switch.gate_main")).toEqual({
+        entity_id: "switch.gate_main",
+        state: "off",
+        attributes: {},
+      });
+    });
+
+    it("transitions live -> degraded if the subscribe request fails", async () => {
+      const client = new FakeGatewayClient();
+      client.errorResponses.set(HA_SUBSCRIBE_METHOD, new Error("not connected"));
+      const binding = new HaStateBinding(client);
+
+      await binding.attach();
+
+      expect(binding.connectionState).toBe("degraded");
+    });
+
+    it("emits state changes after attach", async () => {
+      const client = new FakeGatewayClient();
+      client.responses.set(HA_SUBSCRIBE_METHOD, SAMPLE_SNAPSHOT);
+      const binding = new HaStateBinding(client);
+      await binding.attach();
+
+      const seen: string[] = [];
+      binding.subscribe("sensor.battery_soc", (state) => seen.push(state?.state ?? "(none)"));
+
+      client.emit({
+        type: "event",
+        event: HA_STATE_EVENT,
+        payload: {
+          entity_id: "sensor.battery_soc",
+          prev: { entity_id: "sensor.battery_soc", state: "97", attributes: {} },
+          next: { entity_id: "sensor.battery_soc", state: "60", attributes: {} },
+        },
+      });
+
+      expect(seen).toEqual(["60"]);
+      expect(binding.get("sensor.battery_soc")?.state).toBe("60");
+    });
+
+    it("ignores events for unrelated topics", async () => {
+      const client = new FakeGatewayClient();
+      client.responses.set(HA_SUBSCRIBE_METHOD, SAMPLE_SNAPSHOT);
+      const binding = new HaStateBinding(client);
+      await binding.attach();
+
+      const seen: unknown[] = [];
+      binding.subscribe("sensor.battery_soc", (state) => seen.push(state));
+
+      client.emit({
+        type: "event",
+        event: "something.else",
+        payload: { entity_id: "sensor.battery_soc", next: null },
+      });
+
+      expect(seen).toHaveLength(0);
+    });
+
+    it("removes the entity from the cache when next is null", async () => {
+      const client = new FakeGatewayClient();
+      client.responses.set(HA_SUBSCRIBE_METHOD, SAMPLE_SNAPSHOT);
+      const binding = new HaStateBinding(client);
+      await binding.attach();
+
+      client.emit({
+        type: "event",
+        event: HA_STATE_EVENT,
+        payload: {
+          entity_id: "sensor.battery_soc",
+          prev: { entity_id: "sensor.battery_soc", state: "97", attributes: {} },
+          next: null,
+        },
+      });
+
+      expect(binding.get("sensor.battery_soc")).toBeUndefined();
+    });
+  });
+
+  describe("subscribeAll", () => {
+    it("delivers diffs for every entity to subscribeAll listeners", async () => {
+      const client = new FakeGatewayClient();
+      client.responses.set(HA_SUBSCRIBE_METHOD, { snapshot: [] });
+      const binding = new HaStateBinding(client);
+      await binding.attach();
+
+      const all = vi.fn();
+      binding.subscribeAll(all);
+
+      client.emit({
+        type: "event",
+        event: HA_STATE_EVENT,
+        payload: {
+          entity_id: "switch.gate_main",
+          prev: null,
+          next: { entity_id: "switch.gate_main", state: "on", attributes: {} },
+        },
+      });
+
+      expect(all).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("connectionState transitions", () => {
+    it("starts in idle, moves to live after attach succeeds", async () => {
+      const client = new FakeGatewayClient();
+      client.responses.set(HA_SUBSCRIBE_METHOD, SAMPLE_SNAPSHOT);
+      const binding = new HaStateBinding(client);
+      const seen: HaConnectionState[] = [];
+      binding.onConnectionStateChange((s) => seen.push(s));
+
+      expect(binding.connectionState).toBe("idle");
+
+      await binding.attach();
+
+      expect(binding.connectionState).toBe("live");
+      expect(seen).toContain("attaching");
+      expect(seen).toContain("live");
+    });
+  });
+
+  describe("callService", () => {
+    it("forwards the request to the gateway with the right method name", async () => {
+      const client = new FakeGatewayClient();
+      client.responses.set(HA_SUBSCRIBE_METHOD, SAMPLE_SNAPSHOT);
+      client.responses.set(HA_SERVICE_CALL_METHOD, { dispatched: true });
+      const binding = new HaStateBinding(client);
+      await binding.attach();
+
+      const result = await binding.callService({
+        domain: "switch",
+        service: "toggle",
+        target: "switch.gate_main",
+      });
+
+      expect(client.requestCalls).toEqual(
+        expect.arrayContaining([
+          {
+            method: HA_SERVICE_CALL_METHOD,
+            params: {
+              domain: "switch",
+              service: "toggle",
+              target: "switch.gate_main",
+            },
+          },
+        ]),
+      );
+      expect(result).toEqual({ dispatched: true });
+    });
+
+    it("propagates ws gateway request rejection so the caller can show a flash", async () => {
+      const client = new FakeGatewayClient();
+      client.responses.set(HA_SUBSCRIBE_METHOD, SAMPLE_SNAPSHOT);
+      client.errorResponses.set(HA_SERVICE_CALL_METHOD, new Error("service-denied"));
+      const binding = new HaStateBinding(client);
+      await binding.attach();
+
+      await expect(
+        binding.callService({
+          domain: "lock",
+          service: "unlock",
+          target: "lock.front_door",
+        }),
+      ).rejects.toThrow(/service-denied/);
+    });
+  });
+
+  describe("detach", () => {
+    it("stops emitting after detach", async () => {
+      const client = new FakeGatewayClient();
+      client.responses.set(HA_SUBSCRIBE_METHOD, SAMPLE_SNAPSHOT);
+      const binding = new HaStateBinding(client);
+      await binding.attach();
+
+      const seen: unknown[] = [];
+      binding.subscribeAll((diff) => seen.push(diff));
+
+      binding.detach();
+
+      client.emit({
+        type: "event",
+        event: HA_STATE_EVENT,
+        payload: {
+          entity_id: "sensor.battery_soc",
+          prev: null,
+          next: { entity_id: "sensor.battery_soc", state: "1", attributes: {} },
+        },
+      });
+
+      expect(seen).toHaveLength(0);
+    });
+  });
+});

--- a/ui/src/ui/kiosk/ha-state-binding.ts
+++ b/ui/src/ui/kiosk/ha-state-binding.ts
@@ -1,0 +1,258 @@
+/**
+ * Browser-side reactive cache for Home Assistant entity state, plus
+ * the gateway request seam for service calls.
+ *
+ * Lifecycle:
+ *   1. caller constructs HaStateBinding(client)
+ *   2. await binding.attach() -- calls `home-assistant.subscribe`, seeds
+ *      the cache from the returned snapshot, transitions to `live`
+ *   3. for every `plugin.home-assistant.state` push, the binding updates
+ *      its cache and notifies per-entity / subscribeAll listeners
+ *   4. caller invokes binding.callService({...}) on tile taps
+ *   5. binding.detach() unsubscribes the gateway listener
+ *
+ * This is the browser counterpart to extensions/home-assistant's
+ * gateway-bridge. The wire-protocol constants are duplicated here on
+ * purpose -- the UI does not import from the extension package, the
+ * boundary keeps them as independent contracts that must agree on the
+ * three string literals below. A test in each package locks the
+ * literals so drift fails fast.
+ */
+
+export const HA_STATE_EVENT = "plugin.home-assistant.state";
+export const HA_SUBSCRIBE_METHOD = "home-assistant.subscribe";
+export const HA_SERVICE_CALL_METHOD = "home-assistant.serviceCall";
+
+// -- gateway client contract (subset of GatewayBrowserClient we depend on) --
+
+export type GatewayEventFrame = {
+  type: "event";
+  event: string;
+  payload?: unknown;
+};
+
+export type GatewayEventListener = (evt: GatewayEventFrame) => void;
+
+export interface HaGatewayClient {
+  request<T = unknown>(method: string, params?: unknown): Promise<T>;
+  addEventListener(listener: GatewayEventListener): () => void;
+}
+
+// -- entity-state types ----------------------------------------------------
+
+export type HaEntityState = {
+  entity_id: string;
+  state: string;
+  attributes: Record<string, unknown>;
+  last_changed?: string;
+  last_updated?: string;
+};
+
+export type HaStateChange = {
+  entity_id: string;
+  prev: HaEntityState | null;
+  next: HaEntityState | null;
+};
+
+export type HaConnectionState = "idle" | "attaching" | "live" | "degraded" | "detached";
+
+export type HaConnectionStateListener = (state: HaConnectionState) => void;
+export type HaEntityListener = (state: HaEntityState | null) => void;
+export type HaDiffListener = (change: HaStateChange) => void;
+export type Unsubscribe = () => void;
+
+// -- service-call payloads -------------------------------------------------
+
+export type HaServiceCallArgs = {
+  domain: string;
+  service: string;
+  target: string;
+  serviceData?: Record<string, unknown>;
+};
+
+export type HaServiceCallResult = { dispatched: true };
+
+// -- implementation --------------------------------------------------------
+
+type SubscribeResponse = {
+  snapshot?: Array<{ entity_id: string; state: HaEntityState }>;
+};
+
+export class HaStateBinding {
+  connectionState: HaConnectionState = "idle";
+
+  private readonly client: HaGatewayClient;
+  private cache = new Map<string, HaEntityState>();
+  private perEntityListeners = new Map<string, Set<HaEntityListener>>();
+  private allListeners = new Set<HaDiffListener>();
+  private connectionListeners = new Set<HaConnectionStateListener>();
+  private removeGatewayListener: Unsubscribe | null = null;
+
+  constructor(client: HaGatewayClient) {
+    this.client = client;
+  }
+
+  async attach(): Promise<void> {
+    if (this.connectionState !== "idle" && this.connectionState !== "degraded") {
+      return;
+    }
+    this.transitionConnection("attaching");
+    this.removeGatewayListener?.();
+    this.removeGatewayListener = this.client.addEventListener((evt) => this.onEvent(evt));
+    try {
+      const response = await this.client.request<SubscribeResponse>(HA_SUBSCRIBE_METHOD);
+      const snapshot = Array.isArray(response?.snapshot) ? response!.snapshot : [];
+      this.cache.clear();
+      for (const entry of snapshot) {
+        if (entry && entry.entity_id && entry.state) {
+          this.cache.set(entry.entity_id, entry.state);
+        }
+      }
+      this.transitionConnection("live");
+    } catch (cause) {
+      this.transitionConnection("degraded");
+      // eslint-disable-next-line no-console
+      console.warn("[ha-state-binding] subscribe failed", cause);
+    }
+  }
+
+  detach(): void {
+    if (this.removeGatewayListener) {
+      this.removeGatewayListener();
+      this.removeGatewayListener = null;
+    }
+    this.transitionConnection("detached");
+  }
+
+  get(entity_id: string): HaEntityState | undefined {
+    return this.cache.get(entity_id);
+  }
+
+  subscribe(entity_id: string, listener: HaEntityListener): Unsubscribe {
+    let bucket = this.perEntityListeners.get(entity_id);
+    if (!bucket) {
+      bucket = new Set();
+      this.perEntityListeners.set(entity_id, bucket);
+    }
+    bucket.add(listener);
+    return () => {
+      const b = this.perEntityListeners.get(entity_id);
+      if (!b) return;
+      b.delete(listener);
+      if (b.size === 0) {
+        this.perEntityListeners.delete(entity_id);
+      }
+    };
+  }
+
+  subscribeAll(listener: HaDiffListener): Unsubscribe {
+    this.allListeners.add(listener);
+    return () => {
+      this.allListeners.delete(listener);
+    };
+  }
+
+  onConnectionStateChange(listener: HaConnectionStateListener): Unsubscribe {
+    this.connectionListeners.add(listener);
+    return () => {
+      this.connectionListeners.delete(listener);
+    };
+  }
+
+  async callService(args: HaServiceCallArgs): Promise<HaServiceCallResult> {
+    const params: Record<string, unknown> = {
+      domain: args.domain,
+      service: args.service,
+      target: args.target,
+    };
+    if (args.serviceData) {
+      params.serviceData = args.serviceData;
+    }
+    return this.client.request<HaServiceCallResult>(HA_SERVICE_CALL_METHOD, params);
+  }
+
+  // -- internals -----------------------------------------------------------
+
+  private onEvent(evt: GatewayEventFrame): void {
+    if (evt.event !== HA_STATE_EVENT) {
+      return;
+    }
+    const change = parseStateChange(evt.payload);
+    if (!change) {
+      return;
+    }
+    if (change.next) {
+      this.cache.set(change.entity_id, change.next);
+    } else {
+      this.cache.delete(change.entity_id);
+    }
+    this.notify(change);
+  }
+
+  private notify(change: HaStateChange): void {
+    const perEntity = this.perEntityListeners.get(change.entity_id);
+    if (perEntity) {
+      for (const listener of perEntity) {
+        try {
+          listener(change.next);
+        } catch (cause) {
+          // eslint-disable-next-line no-console
+          console.warn("[ha-state-binding] entity listener threw", cause);
+        }
+      }
+    }
+    for (const listener of this.allListeners) {
+      try {
+        listener(change);
+      } catch (cause) {
+        // eslint-disable-next-line no-console
+        console.warn("[ha-state-binding] all-listener threw", cause);
+      }
+    }
+  }
+
+  private transitionConnection(next: HaConnectionState): void {
+    if (this.connectionState === next) return;
+    this.connectionState = next;
+    for (const listener of this.connectionListeners) {
+      try {
+        listener(next);
+      } catch (cause) {
+        // eslint-disable-next-line no-console
+        console.warn("[ha-state-binding] connection listener threw", cause);
+      }
+    }
+  }
+}
+
+function parseStateChange(payload: unknown): HaStateChange | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+  const p = payload as Record<string, unknown>;
+  if (typeof p.entity_id !== "string") {
+    return null;
+  }
+  return {
+    entity_id: p.entity_id,
+    prev: parseEntityState(p.prev),
+    next: parseEntityState(p.next),
+  };
+}
+
+function parseEntityState(value: unknown): HaEntityState | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const v = value as Record<string, unknown>;
+  if (typeof v.entity_id !== "string" || typeof v.state !== "string") {
+    return null;
+  }
+  return {
+    entity_id: v.entity_id,
+    state: v.state,
+    attributes: (v.attributes as Record<string, unknown>) ?? {},
+    ...(typeof v.last_changed === "string" ? { last_changed: v.last_changed } : {}),
+    ...(typeof v.last_updated === "string" ? { last_updated: v.last_updated } : {}),
+  };
+}

--- a/ui/src/ui/kiosk/kiosk-bootstrap.ts
+++ b/ui/src/ui/kiosk/kiosk-bootstrap.ts
@@ -83,3 +83,53 @@ function hashMatchesKiosk(hash: string): boolean {
   const trimmed = hash.split("?")[0];
   return trimmed === KIOSK_HASH || trimmed === "#kiosk";
 }
+
+/**
+ * Self-bootstrapping entry: if the location hash is `#/kiosk`, wait for the
+ * `<openclaw-app>` element to mount and its gateway client to come online,
+ * then mount the kiosk shell as a body-level sibling and hide the rest of
+ * the UI. Imported once from `ui/src/main.ts` -- the host app does not need
+ * to know it exists.
+ *
+ * No-op if the hash does not match.
+ */
+export function autoMountKioskOnHashRoute(options?: {
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  appSelector?: string;
+}): void {
+  if (!hashMatchesKiosk(window.location.hash)) {
+    return;
+  }
+  const pollIntervalMs = options?.pollIntervalMs ?? 100;
+  const timeoutMs = options?.timeoutMs ?? 30_000;
+  const appSelector = options?.appSelector ?? "openclaw-app";
+
+  const deadline = Date.now() + timeoutMs;
+  let mounted: MountKioskResult | null = null;
+
+  const tryMount = (): boolean => {
+    if (mounted?.mounted) return true;
+    const app = document.querySelector(appSelector) as
+      | (HTMLElement & { client?: HaGatewayClient | null })
+      | null;
+    const client = app?.client ?? null;
+    if (!client) return false;
+    mounted = mountKioskIfRequested({ client });
+    return mounted.mounted;
+  };
+
+  if (tryMount()) return;
+
+  const handle = window.setInterval(() => {
+    if (tryMount() || Date.now() > deadline) {
+      window.clearInterval(handle);
+      if (!mounted?.mounted) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          "[kiosk] gateway client did not come online within timeout; kiosk view not mounted",
+        );
+      }
+    }
+  }, pollIntervalMs);
+}

--- a/ui/src/ui/kiosk/kiosk-bootstrap.ts
+++ b/ui/src/ui/kiosk/kiosk-bootstrap.ts
@@ -1,0 +1,85 @@
+/**
+ * Optional kiosk bootstrap.
+ *
+ * The kiosk view is intentionally NOT registered as a tab in
+ * `ui/src/ui/navigation.ts` -- a wall tablet wants no nav chrome at all.
+ * This module exposes a small helper that the host app (`ui/src/ui/app.ts`)
+ * can call once on startup to detect the `#/kiosk` hash route and mount
+ * the kiosk shell as a sibling to the main app shell.
+ *
+ * Wiring (one-line addition to `ui/src/ui/app.ts` after the gateway client
+ * is ready):
+ *
+ *   import { mountKioskIfRequested } from "./kiosk/kiosk-bootstrap.js";
+ *   mountKioskIfRequested({ client: this.client, mountPoint: document.body });
+ *
+ * This module does not modify navigation.ts or the existing routing
+ * dispatcher. If the URL hash is anything other than `#/kiosk` it is a
+ * no-op. The host app continues rendering the normal control UI.
+ */
+
+import "./kiosk-shell.js";
+import "./kiosk-wagner-way.js";
+import type { HaGatewayClient } from "./ha-state-binding.js";
+
+const KIOSK_HASH = "#/kiosk";
+
+export type MountKioskArgs = {
+  client: HaGatewayClient;
+  mountPoint?: HTMLElement;
+  /** Hook for tests to override the location source. */
+  locationHash?: string;
+};
+
+export type MountKioskResult = {
+  mounted: boolean;
+  unmount: () => void;
+};
+
+export function mountKioskIfRequested(args: MountKioskArgs): MountKioskResult {
+  const hash = args.locationHash ?? window.location.hash;
+  if (!hashMatchesKiosk(hash)) {
+    return { mounted: false, unmount: () => undefined };
+  }
+
+  const mountPoint = args.mountPoint ?? document.body;
+  const shell = document.createElement("kiosk-shell") as HTMLElement & {
+    client: HaGatewayClient;
+  };
+  shell.client = args.client;
+
+  const view = document.createElement("kiosk-wagner-way");
+  shell.appendChild(view);
+
+  // Hide the existing app shell while the kiosk is mounted so it does not
+  // bleed through. The shell's own kiosk-mode body class also drives this
+  // via CSS, but explicit display:none is a hard guarantee even if the
+  // stylesheet has not loaded yet.
+  const previousChildren = Array.from(mountPoint.children);
+  for (const child of previousChildren) {
+    if (child instanceof HTMLElement && child !== shell) {
+      child.dataset.kioskHiddenPriorDisplay = child.style.display;
+      child.style.display = "none";
+    }
+  }
+  mountPoint.appendChild(shell);
+
+  return {
+    mounted: true,
+    unmount: () => {
+      shell.remove();
+      for (const child of previousChildren) {
+        if (child instanceof HTMLElement) {
+          child.style.display = child.dataset.kioskHiddenPriorDisplay ?? "";
+          delete child.dataset.kioskHiddenPriorDisplay;
+        }
+      }
+    },
+  };
+}
+
+function hashMatchesKiosk(hash: string): boolean {
+  if (!hash) return false;
+  const trimmed = hash.split("?")[0];
+  return trimmed === KIOSK_HASH || trimmed === "#kiosk";
+}

--- a/ui/src/ui/kiosk/kiosk-bootstrap.ts
+++ b/ui/src/ui/kiosk/kiosk-bootstrap.ts
@@ -47,9 +47,8 @@ export function mountKioskIfRequested(args: MountKioskArgs): MountKioskResult {
     client: HaGatewayClient;
   };
   shell.client = args.client;
-
-  const view = document.createElement("kiosk-wagner-way");
-  shell.appendChild(view);
+  // kiosk-shell renders <kiosk-wagner-way> directly once binding is ready;
+  // no need to append a child element here (light DOM + slots don't mix).
 
   // Hide the existing app shell while the kiosk is mounted so it does not
   // bleed through. The shell's own kiosk-mode body class also drives this

--- a/ui/src/ui/kiosk/kiosk-shell.test.ts
+++ b/ui/src/ui/kiosk/kiosk-shell.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import "./kiosk-shell.js";
+import {
+  HA_STATE_EVENT,
+  HA_SUBSCRIBE_METHOD,
+  type GatewayEventFrame,
+  type HaGatewayClient,
+} from "./ha-state-binding.js";
+import type { KioskShell } from "./kiosk-shell.js";
+
+class FakeClient implements HaGatewayClient {
+  private listeners = new Set<(evt: GatewayEventFrame) => void>();
+  responses = new Map<string, unknown>();
+  errors = new Map<string, Error>();
+
+  async request<T = unknown>(method: string, _params?: unknown): Promise<T> {
+    if (this.errors.has(method)) {
+      throw this.errors.get(method)!;
+    }
+    return (this.responses.get(method) as T) ?? (undefined as T);
+  }
+
+  addEventListener(listener: (evt: GatewayEventFrame) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  emit(evt: GatewayEventFrame): void {
+    for (const l of this.listeners) {
+      l(evt);
+    }
+  }
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function mountShell(client: HaGatewayClient | null): Promise<KioskShell> {
+  const el = document.createElement("kiosk-shell") as KioskShell;
+  el.client = client;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  await flush();
+  await el.updateComplete;
+  return el;
+}
+
+describe("kiosk-shell", () => {
+  beforeEach(() => {
+    document.documentElement.classList.remove("kiosk-mode");
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    document.documentElement.classList.remove("kiosk-mode");
+  });
+
+  it("adds kiosk-mode body class on mount and removes it on unmount", async () => {
+    const client = new FakeClient();
+    client.responses.set(HA_SUBSCRIBE_METHOD, { snapshot: [] });
+    const el = await mountShell(client);
+
+    expect(document.documentElement.classList.contains("kiosk-mode")).toBe(true);
+
+    el.remove();
+    expect(document.documentElement.classList.contains("kiosk-mode")).toBe(false);
+  });
+
+  it("renders the connection pill and reflects connection state transitions", async () => {
+    const client = new FakeClient();
+    client.responses.set(HA_SUBSCRIBE_METHOD, { snapshot: [] });
+    const el = await mountShell(client);
+
+    const pill = el.querySelector('[data-test-id="kiosk-connection-pill"]');
+    expect(pill).toBeTruthy();
+    expect(pill?.textContent?.trim()).toBe("live");
+  });
+
+  it("shows reconnecting when subscribe rejects", async () => {
+    const client = new FakeClient();
+    client.errors.set(HA_SUBSCRIBE_METHOD, new Error("not connected"));
+    const el = await mountShell(client);
+
+    const pill = el.querySelector('[data-test-id="kiosk-connection-pill"]');
+    expect(pill?.textContent?.trim()).toBe("reconnecting");
+  });
+
+  it("renders the placeholder until the client is provided", async () => {
+    const el = await mountShell(null);
+
+    expect(el.textContent).toMatch(/Connecting to Home Assistant/i);
+  });
+
+  it("exposes the binding so child views can subscribe", async () => {
+    const client = new FakeClient();
+    client.responses.set(HA_SUBSCRIBE_METHOD, {
+      snapshot: [
+        {
+          entity_id: "sensor.battery_soc",
+          state: { entity_id: "sensor.battery_soc", state: "97", attributes: {} },
+        },
+      ],
+    });
+    const el = await mountShell(client);
+
+    const binding = el.getBinding();
+    expect(binding).toBeTruthy();
+    expect(binding?.get("sensor.battery_soc")?.state).toBe("97");
+
+    // After mount, a state-change push should update the binding cache.
+    client.emit({
+      type: "event",
+      event: HA_STATE_EVENT,
+      payload: {
+        entity_id: "sensor.battery_soc",
+        prev: { entity_id: "sensor.battery_soc", state: "97", attributes: {} },
+        next: { entity_id: "sensor.battery_soc", state: "60", attributes: {} },
+      },
+    });
+    expect(binding?.get("sensor.battery_soc")?.state).toBe("60");
+  });
+});

--- a/ui/src/ui/kiosk/kiosk-shell.ts
+++ b/ui/src/ui/kiosk/kiosk-shell.ts
@@ -13,6 +13,7 @@
 
 import { LitElement, html, type TemplateResult } from "lit";
 import { property, state } from "lit/decorators.js";
+import "./kiosk-wagner-way.js";
 import {
   HaStateBinding,
   type HaConnectionState,
@@ -73,9 +74,7 @@ export class KioskShell extends LitElement {
     return html`
       <div class="kiosk-shell" data-connection=${this.connection}>
         <header class="kiosk-shell__header">
-          <h1 class="kiosk-shell__title">
-            <slot name="title">Wagner Way</slot>
-          </h1>
+          <h1 class="kiosk-shell__title">Wagner Way</h1>
           <div
             class="kiosk-shell__pill kiosk-shell__pill--${this.connection}"
             role="status"
@@ -87,7 +86,10 @@ export class KioskShell extends LitElement {
         </header>
         <main class="kiosk-shell__body">
           ${this.binding
-            ? html`<slot></slot>`
+            ? html`<kiosk-wagner-way
+                .binding=${this.binding}
+                data-test-id="kiosk-shell-view"
+              ></kiosk-wagner-way>`
             : html`<div class="kiosk-shell__placeholder">Connecting to Home Assistant...</div>`}
         </main>
       </div>

--- a/ui/src/ui/kiosk/kiosk-shell.ts
+++ b/ui/src/ui/kiosk/kiosk-shell.ts
@@ -1,0 +1,158 @@
+/**
+ * Wall-tablet kiosk shell.
+ *
+ * Renders the no-chrome surface that hosts the Wagner Way overview view
+ * (and future v2 views). Sets the `kiosk-mode` class on the document
+ * root on mount so CSS hides nav and chat. Subscribes to the gateway
+ * via HaStateBinding and surfaces a small connection-state pill in the
+ * top-right.
+ *
+ * The actual dashboard content slot is provided by `kiosk-wagner-way.ts`
+ * (Unit 7); this shell is layout + connection plumbing only.
+ */
+
+import { LitElement, html, type TemplateResult } from "lit";
+import { property, state } from "lit/decorators.js";
+import {
+  HaStateBinding,
+  type HaConnectionState,
+  type HaGatewayClient,
+} from "./ha-state-binding.js";
+
+const KIOSK_MODE_CLASS = "kiosk-mode";
+
+export class KioskShell extends LitElement {
+  override createRenderRoot() {
+    return this;
+  }
+
+  /**
+   * The gateway client to talk to OpenClaw. Set by the bootstrap when
+   * the kiosk URL is detected; tests pass a fake.
+   */
+  @property({ attribute: false })
+  client: HaGatewayClient | null = null;
+
+  @state() private binding: HaStateBinding | null = null;
+  @state() private connection: HaConnectionState = "idle";
+
+  private wakeLockSentinel: { release: () => Promise<void> } | null = null;
+  private removeConnectionListener: (() => void) | null = null;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    document.documentElement.classList.add(KIOSK_MODE_CLASS);
+    this.requestWakeLock();
+    if (this.client) {
+      this.attachClient(this.client);
+    }
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    document.documentElement.classList.remove(KIOSK_MODE_CLASS);
+    this.releaseWakeLock();
+    this.detachClient();
+  }
+
+  override updated(changed: Map<string, unknown>): void {
+    if (changed.has("client")) {
+      this.detachClient();
+      if (this.client) {
+        this.attachClient(this.client);
+      }
+    }
+  }
+
+  /** Public for tests + the wagner-way view. */
+  getBinding(): HaStateBinding | null {
+    return this.binding;
+  }
+
+  override render(): TemplateResult {
+    return html`
+      <div class="kiosk-shell" data-connection=${this.connection}>
+        <header class="kiosk-shell__header">
+          <h1 class="kiosk-shell__title">
+            <slot name="title">Wagner Way</slot>
+          </h1>
+          <div
+            class="kiosk-shell__pill kiosk-shell__pill--${this.connection}"
+            role="status"
+            aria-live="polite"
+            data-test-id="kiosk-connection-pill"
+          >
+            ${labelForConnection(this.connection)}
+          </div>
+        </header>
+        <main class="kiosk-shell__body">
+          ${this.binding
+            ? html`<slot></slot>`
+            : html`<div class="kiosk-shell__placeholder">Connecting to Home Assistant...</div>`}
+        </main>
+      </div>
+    `;
+  }
+
+  // -- internals -----------------------------------------------------------
+
+  private attachClient(client: HaGatewayClient): void {
+    const binding = new HaStateBinding(client);
+    this.binding = binding;
+    this.removeConnectionListener = binding.onConnectionStateChange((state) => {
+      this.connection = state;
+    });
+    void binding.attach();
+  }
+
+  private detachClient(): void {
+    this.removeConnectionListener?.();
+    this.removeConnectionListener = null;
+    this.binding?.detach();
+    this.binding = null;
+    this.connection = "idle";
+  }
+
+  private requestWakeLock(): void {
+    const navAny = navigator as unknown as {
+      wakeLock?: { request: (type: string) => Promise<{ release: () => Promise<void> }> };
+    };
+    if (!navAny.wakeLock || typeof navAny.wakeLock.request !== "function") {
+      return;
+    }
+    navAny.wakeLock
+      .request("screen")
+      .then((sentinel) => {
+        this.wakeLockSentinel = sentinel;
+      })
+      .catch(() => {
+        // best-effort; the OS may decline.
+      });
+  }
+
+  private releaseWakeLock(): void {
+    if (this.wakeLockSentinel) {
+      void this.wakeLockSentinel.release().catch(() => undefined);
+      this.wakeLockSentinel = null;
+    }
+  }
+}
+
+function labelForConnection(state: HaConnectionState): string {
+  switch (state) {
+    case "live":
+      return "live";
+    case "attaching":
+      return "connecting";
+    case "degraded":
+      return "reconnecting";
+    case "detached":
+      return "off";
+    default:
+      return "idle";
+  }
+}
+
+if (!customElements.get("kiosk-shell")) {
+  customElements.define("kiosk-shell", KioskShell);
+}

--- a/ui/src/ui/kiosk/kiosk-wagner-way.test.ts
+++ b/ui/src/ui/kiosk/kiosk-wagner-way.test.ts
@@ -163,6 +163,45 @@ describe("kiosk-wagner-way", () => {
     ]);
   });
 
+  it("integration: tile tap dispatches via the controller and reconciles on state echo", async () => {
+    const { el, client } = await mountView();
+    // Block the gateway service-call promise until we explicitly resolve.
+    let resolveCall: (v: unknown) => void = () => undefined;
+    const slowCall = new Promise<unknown>((resolve) => {
+      resolveCall = resolve;
+    });
+    const originalRequest = client.request.bind(client);
+    client.request = ((method: string, params: unknown) => {
+      if (method === "home-assistant.serviceCall") {
+        return slowCall;
+      }
+      return originalRequest(method, params);
+    }) as typeof client.request;
+
+    const controller = el.getInteractionController();
+    expect(controller).toBeTruthy();
+
+    // Tap the Main Gate tile.
+    const tiles = el.querySelectorAll("kiosk-tile-toggle");
+    const gateTile = Array.from(tiles).find(
+      (t) => (t as HTMLElement & { name?: string }).name === "Main Gate",
+    );
+    expect(gateTile).toBeTruthy();
+    gateTile!.querySelector("button")!.click();
+
+    // Status reflects pending while the gateway call is in flight.
+    const gateEntity = DEFAULT_WAGNER_WAY_SLOTS["tile.gate_main"];
+    expect(controller!.status.get(gateEntity)?.pending).toBe(true);
+
+    // HA echoes the new state. Controller reconciles, status clears.
+    client.emit(makeStateEvent(gateEntity, "on"));
+    expect(controller!.status.get(gateEntity)).toBeUndefined();
+
+    // Resolve the slow gateway promise so vitest doesn't leave it open.
+    resolveCall({ dispatched: true });
+    await flush(2);
+  });
+
   it("renders disabled placeholders for Vacuums and Front Door Cam", async () => {
     const { el } = await mountView();
 

--- a/ui/src/ui/kiosk/kiosk-wagner-way.test.ts
+++ b/ui/src/ui/kiosk/kiosk-wagner-way.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import "./kiosk-wagner-way.js";
+import {
+  HA_STATE_EVENT,
+  HA_SUBSCRIBE_METHOD,
+  HaStateBinding,
+  type GatewayEventFrame,
+  type HaGatewayClient,
+} from "./ha-state-binding.js";
+import { DEFAULT_WAGNER_WAY_SLOTS, type KioskWagnerWay } from "./kiosk-wagner-way.js";
+
+class FakeClient implements HaGatewayClient {
+  private listeners = new Set<(evt: GatewayEventFrame) => void>();
+  responses = new Map<string, unknown>();
+
+  async request<T = unknown>(method: string, _params?: unknown): Promise<T> {
+    return (this.responses.get(method) as T) ?? (undefined as T);
+  }
+
+  addEventListener(listener: (evt: GatewayEventFrame) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  emit(evt: GatewayEventFrame): void {
+    for (const l of this.listeners) l(evt);
+  }
+}
+
+function makeStateEvent(entity_id: string, state: string): GatewayEventFrame {
+  return {
+    type: "event",
+    event: HA_STATE_EVENT,
+    payload: {
+      entity_id,
+      prev: null,
+      next: { entity_id, state, attributes: {} },
+    },
+  };
+}
+
+async function flush(times = 2): Promise<void> {
+  for (let i = 0; i < times; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+async function mountView(): Promise<{
+  el: KioskWagnerWay;
+  client: FakeClient;
+  binding: HaStateBinding;
+}> {
+  const client = new FakeClient();
+  client.responses.set(HA_SUBSCRIBE_METHOD, {
+    snapshot: [
+      {
+        entity_id: DEFAULT_WAGNER_WAY_SLOTS["energy.battery_soc"],
+        state: {
+          entity_id: DEFAULT_WAGNER_WAY_SLOTS["energy.battery_soc"],
+          state: "97",
+          attributes: {},
+        },
+      },
+      {
+        entity_id: DEFAULT_WAGNER_WAY_SLOTS["tile.gate_main"],
+        state: {
+          entity_id: DEFAULT_WAGNER_WAY_SLOTS["tile.gate_main"],
+          state: "off",
+          attributes: {},
+        },
+      },
+    ],
+  });
+  const binding = new HaStateBinding(client);
+  await binding.attach();
+
+  const el = document.createElement("kiosk-wagner-way") as KioskWagnerWay;
+  el.binding = binding;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  await flush();
+  await el.updateComplete;
+
+  return { el, client, binding };
+}
+
+describe("kiosk-wagner-way", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders all 7 sections", async () => {
+    const { el } = await mountView();
+
+    expect(el.querySelector('[data-test-id="kiosk-wagner-way"]')).toBeTruthy();
+    expect(el.querySelectorAll(".kiosk-wagner-way__badges").length).toBe(1);
+    expect(el.querySelector("kiosk-weather-card")).toBeTruthy();
+    expect(el.querySelector("kiosk-energy-flow-card")).toBeTruthy();
+    expect(el.querySelectorAll("kiosk-gauge-circular").length).toBeGreaterThanOrEqual(9);
+    expect(el.querySelector('[data-test-id="kiosk-quick-keys"]')).toBeTruthy();
+    expect(el.querySelector('[data-test-id="kiosk-vacuums-placeholder"]')).toBeTruthy();
+    expect(el.querySelector('[data-test-id="kiosk-cameras-placeholder"]')).toBeTruthy();
+  });
+
+  it("renders all Quick Keys tiles from the default slot map", async () => {
+    const { el } = await mountView();
+    const tiles = el.querySelectorAll("kiosk-tile-toggle");
+    // 15 tiles in the v1 Quick Keys grid (matches DEFAULT_WAGNER_WAY_SLOTS).
+    expect(tiles.length).toBe(15);
+  });
+
+  it("re-renders when a state-change event arrives for an allow-listed entity", async () => {
+    const { el, client } = await mountView();
+
+    // Initial battery_soc value is 97 from the snapshot.
+    const batteryGauge = Array.from(el.querySelectorAll("kiosk-gauge-circular")).find(
+      (g) => (g as HTMLElement & { name?: string }).name === "Battery SOC",
+    );
+    expect(batteryGauge).toBeTruthy();
+    const beforeRevision = (el as unknown as { revision: number }).revision;
+
+    client.emit(makeStateEvent(DEFAULT_WAGNER_WAY_SLOTS["energy.battery_soc"], "60"));
+    await flush();
+    await el.updateComplete;
+
+    expect((el as unknown as { revision: number }).revision).toBe(beforeRevision + 1);
+  });
+
+  it("renders n/a for entities that have no cached state yet", async () => {
+    const { el } = await mountView();
+
+    // The bourbon alarm slot has no snapshot entry; its badge should show n/a.
+    const badges = Array.from(el.querySelectorAll("kiosk-badge-entity"));
+    const bourbon = badges.find(
+      (b) => (b as HTMLElement & { name?: string }).name === "Bourbon Alarm",
+    );
+    expect(bourbon?.textContent).toContain("n/a");
+  });
+
+  it("propagates tile-tap events from a child tile up the tree", async () => {
+    const { el } = await mountView();
+    const seen: Array<unknown> = [];
+    el.addEventListener("tile-tap", (ev) => seen.push((ev as CustomEvent).detail));
+
+    const tiles = el.querySelectorAll("kiosk-tile-toggle");
+    const gateTile = Array.from(tiles).find(
+      (t) => (t as HTMLElement & { name?: string }).name === "Main Gate",
+    );
+    expect(gateTile).toBeTruthy();
+    gateTile?.querySelector("button")?.click();
+
+    expect(seen).toEqual([
+      {
+        entityId: DEFAULT_WAGNER_WAY_SLOTS["tile.gate_main"],
+        domain: "switch",
+        service: "toggle",
+      },
+    ]);
+  });
+
+  it("renders disabled placeholders for Vacuums and Front Door Cam", async () => {
+    const { el } = await mountView();
+
+    const vacuums = el.querySelector(
+      '[data-test-id="kiosk-vacuums-placeholder"]',
+    ) as HTMLButtonElement | null;
+    const cameras = el.querySelector(
+      '[data-test-id="kiosk-cameras-placeholder"]',
+    ) as HTMLButtonElement | null;
+
+    expect(vacuums?.disabled).toBe(true);
+    expect(cameras?.disabled).toBe(true);
+    expect(vacuums?.textContent).toContain("v2");
+    expect(cameras?.textContent).toContain("v2");
+  });
+});

--- a/ui/src/ui/kiosk/kiosk-wagner-way.ts
+++ b/ui/src/ui/kiosk/kiosk-wagner-way.ts
@@ -1,0 +1,25 @@
+/**
+ * Wagner Way overview Lit element -- placeholder shell.
+ *
+ * Real composition lands in Unit 7. This stub exists so that
+ * `kiosk-bootstrap.ts` can mount a complete tree even before Unit 7
+ * lands; tests that only need the shell + connection pill don't depend
+ * on the full overview layout.
+ */
+import { LitElement, html, type TemplateResult } from "lit";
+
+export class KioskWagnerWay extends LitElement {
+  override createRenderRoot() {
+    return this;
+  }
+
+  override render(): TemplateResult {
+    return html`<div class="kiosk-wagner-way" data-test-id="kiosk-wagner-way-placeholder">
+      <p>Wagner Way overview composition lands in Unit 7.</p>
+    </div>`;
+  }
+}
+
+if (!customElements.get("kiosk-wagner-way")) {
+  customElements.define("kiosk-wagner-way", KioskWagnerWay);
+}

--- a/ui/src/ui/kiosk/kiosk-wagner-way.ts
+++ b/ui/src/ui/kiosk/kiosk-wagner-way.ts
@@ -1,21 +1,489 @@
 /**
- * Wagner Way overview Lit element -- placeholder shell.
+ * Wagner Way overview composition.
  *
- * Real composition lands in Unit 7. This stub exists so that
- * `kiosk-bootstrap.ts` can mount a complete tree even before Unit 7
- * lands; tests that only need the shell + connection pill don't depend
- * on the full overview layout.
+ * Mirrors the layout of the user's existing Home Assistant Lovelace
+ * "Wagner Way" view at v1 visual fidelity, using the OpenClaw-native
+ * Lit primitives from `./components/`. Every entity reference goes
+ * through a slot map so the household can rename or replace devices
+ * without touching this file -- the slot keys are the contract, the
+ * entity IDs are config.
+ *
+ * Sections, in source order:
+ *   1. Badges row: people, phone/iPad batteries, alarms.
+ *   2. House Info row: clock+weather card, energy flow card.
+ *   3. Energy gauges row: Battery SOC, Solar Power.
+ *   4. Power gauges row: Grid Power, House Power.
+ *   5. Major Appliances row: Geyser, Pool, Jacuzzi, Total Clients, BTC.
+ *   6. Quick Keys tile grid: gates, lights, pumps, blinds.
+ *   7. Footer: Vacuums + Front Door Cam placeholders (v2 lands them).
+ *
+ * Each tile that maps to a deny-listed service or a missing slot is
+ * rendered as a disabled placeholder rather than removed silently --
+ * that surface tells the operator something is mis-configured.
  */
+
 import { LitElement, html, type TemplateResult } from "lit";
+import { property, state } from "lit/decorators.js";
+import "./components/gauge-circular.js";
+import "./components/tile-toggle.js";
+import "./components/badge-entity.js";
+import "./components/weather-card.js";
+import "./components/energy-flow-card.js";
+import type { GaugeColorSegment } from "./components/gauge-circular.js";
+import type { HaStateBinding } from "./ha-state-binding.js";
+
+// -- Slot contract ----------------------------------------------------------
+
+/**
+ * Map of slot name -> HA entity_id. v1 ships a default that mirrors the
+ * household's existing Lovelace YAML; the bootstrap or operator config
+ * can override individual entries.
+ */
+export type WagnerWaySlots = Record<string, string>;
+
+export const DEFAULT_WAGNER_WAY_SLOTS: WagnerWaySlots = {
+  // Badges
+  "person.audrey": "person.audrey_de_klerk",
+  "battery.audrey_iphone": "sensor.audrey_platinum_iphone_battery_level",
+  "person.michelle": "person.michele_van_wyk",
+  "battery.michelle_iphone": "sensor.michelle_iphone_battery_level",
+  "person.ijeani": "person.ijeani_van_wyk",
+  "battery.ijeani_ipad": "sensor.ijeani_ipad_air_battery_level",
+  "person.peter": "person.peter_van_wyk",
+  "battery.peter_iphone": "sensor.peter_platinum_iphone_16_battery_level",
+  "alarm.wagner": "alarm_control_panel.ring_alarm",
+  "alarm.bourbon": "alarm_control_panel.alarm",
+  // Weather + outdoor sensors
+  "weather.primary": "weather.pirateweather",
+  "sensor.outdoor_temp": "sensor.outdoor_temp",
+  "sensor.outdoor_humidity": "sensor.outdoor_humidity",
+  // Energy flow nodes
+  "energy.solar_power": "sensor.deye_sunsynk_sol_ark_pv_power",
+  "energy.solar_daily": "sensor.deye_sunsynk_sol_ark_pv_energy",
+  "energy.grid_power": "sensor.deye_sunsynk_sol_ark_grid_power",
+  "energy.grid_daily": "sensor.deye_sunsynk_sol_ark_grid_energy_in",
+  "energy.load_power": "sensor.deye_sunsynk_sol_ark_load_power",
+  "energy.load_daily": "sensor.deye_sunsynk_sol_ark_load_energy",
+  "energy.battery_power": "sensor.deye_sunsynk_sol_ark_battery_power",
+  "energy.battery_soc": "sensor.deye_sunsynk_sol_ark_battery_state_of_charge",
+  // Major appliance gauges
+  "gauge.geyser_power": "sensor.sonoff_10014e4497_power",
+  "gauge.pool_pump_power": "sensor.sonoff_1001f43fa5_power",
+  "gauge.jacuzzi_pump_power": "sensor.sonoff_1001f4478d_power",
+  "gauge.total_clients": "sensor.tp_link_router_total_clients",
+  "gauge.btc_price": "sensor.cryptoinfo_btc_price",
+  // Quick Keys (tiles)
+  "tile.gate_main": "switch.sonoff_10013c3266",
+  "tile.garage_door": "switch.sonoff_10015c4e8e",
+  "tile.entrance_lights": "switch.main_entrance_ligts_switch",
+  "tile.braai_light": "switch.wagner_braai_light",
+  "tile.geyser_main": "switch.sonoff_10014e4497",
+  "tile.geyser_timer": "automation.geyser_timer",
+  "tile.vintage_lights": "switch.sonoff_1000a8d0f7_1",
+  "tile.jacuzzi_down_lights": "switch.sonoff_100230c71f_3",
+  "tile.patio_lights": "switch.sonoff_1000a8d0f7_2",
+  "tile.pool_pump": "switch.sonoff_1001f43fa5",
+  "tile.jacuzzi_pump": "switch.sonoff_1001f4478d",
+  "tile.office_lights": "switch.sonoff_1000c7e394",
+  "tile.wall_lights": "switch.sonoff_100230c71f_2",
+  "tile.left_blind": "cover.aqara_roller_blind_left",
+  "tile.right_blind": "cover.aqara_roller_blind_right",
+};
+
+// -- Tile / badge / gauge declarations --------------------------------------
+
+type BadgeSpec = {
+  slot: string;
+  name: string;
+  unit?: string;
+};
+
+type GaugeSpec = {
+  slot: string;
+  name: string;
+  unit: string;
+  min: number;
+  max: number;
+  segments: GaugeColorSegment[];
+};
+
+type TileSpec = {
+  slot: string;
+  name: string;
+  domain: string;
+  service: string;
+  icon?: string;
+};
+
+const BADGES: BadgeSpec[] = [
+  { slot: "person.audrey", name: "Audrey" },
+  { slot: "battery.audrey_iphone", name: "Audrey iPhone", unit: "%" },
+  { slot: "person.michelle", name: "Michelle" },
+  { slot: "battery.michelle_iphone", name: "Michelle iPhone", unit: "%" },
+  { slot: "person.ijeani", name: "Ijeani" },
+  { slot: "battery.ijeani_ipad", name: "Ijeani iPad", unit: "%" },
+  { slot: "person.peter", name: "Peter" },
+  { slot: "battery.peter_iphone", name: "Peter iPhone", unit: "%" },
+  { slot: "alarm.wagner", name: "Wagner Alarm" },
+  { slot: "alarm.bourbon", name: "Bourbon Alarm" },
+];
+
+const SOC_SEGMENTS: GaugeColorSegment[] = [
+  { from: 0, color: "#ff0000" },
+  { from: 40, color: "#fca103" },
+  { from: 60, color: "#2bff00" },
+  { from: 90, color: "#0bb6ef" },
+];
+
+const SOLAR_SEGMENTS: GaugeColorSegment[] = [
+  { from: 0, color: "#ff0000" },
+  { from: 1500, color: "#fca103" },
+  { from: 3000, color: "#2bff00" },
+  { from: 4500, color: "#0bb6ef" },
+];
+
+const POWER_SEGMENTS: GaugeColorSegment[] = [
+  { from: 0, color: "#0bb6ef" },
+  { from: 1500, color: "#2bff00" },
+  { from: 2500, color: "#fca103" },
+  { from: 4000, color: "#ff0000" },
+];
+
+const APPLIANCE_SEGMENTS: GaugeColorSegment[] = [
+  { from: 0, color: "#0bb6ef" },
+  { from: 500, color: "#2bff00" },
+  { from: 900, color: "#fca103" },
+  { from: 1500, color: "#ff0000" },
+];
+
+const GEYSER_SEGMENTS: GaugeColorSegment[] = [
+  { from: 0, color: "#0bb6ef" },
+  { from: 500, color: "#2bff00" },
+  { from: 900, color: "#fca103" },
+  { from: 1500, color: "#ff0000" },
+];
+
+const ENERGY_GAUGES: GaugeSpec[] = [
+  {
+    slot: "energy.battery_soc",
+    name: "Battery SOC",
+    unit: "%",
+    min: 0,
+    max: 100,
+    segments: SOC_SEGMENTS,
+  },
+  {
+    slot: "energy.solar_power",
+    name: "Solar Power",
+    unit: "W",
+    min: 0,
+    max: 5000,
+    segments: SOLAR_SEGMENTS,
+  },
+];
+
+const POWER_GAUGES: GaugeSpec[] = [
+  {
+    slot: "energy.grid_power",
+    name: "Grid Power",
+    unit: "W",
+    min: 0,
+    max: 6000,
+    segments: POWER_SEGMENTS,
+  },
+  {
+    slot: "energy.load_power",
+    name: "House Power",
+    unit: "W",
+    min: 0,
+    max: 6000,
+    segments: POWER_SEGMENTS,
+  },
+];
+
+const APPLIANCE_GAUGES: GaugeSpec[] = [
+  {
+    slot: "gauge.geyser_power",
+    name: "Geyser",
+    unit: "W",
+    min: 0,
+    max: 3000,
+    segments: GEYSER_SEGMENTS,
+  },
+  {
+    slot: "gauge.pool_pump_power",
+    name: "Pool Pump",
+    unit: "W",
+    min: 0,
+    max: 1500,
+    segments: APPLIANCE_SEGMENTS,
+  },
+  {
+    slot: "gauge.jacuzzi_pump_power",
+    name: "Jacuzzi Pump",
+    unit: "W",
+    min: 0,
+    max: 1500,
+    segments: APPLIANCE_SEGMENTS,
+  },
+  {
+    slot: "gauge.total_clients",
+    name: "Total Clients",
+    unit: "",
+    min: 0,
+    max: 250,
+    segments: [{ from: 0, color: "#0bb6ef" }],
+  },
+  {
+    slot: "gauge.btc_price",
+    name: "Bitcoin",
+    unit: "$",
+    min: 40000,
+    max: 140000,
+    segments: [
+      { from: 40000, color: "#0bb6ef" },
+      { from: 80000, color: "#2bff00" },
+      { from: 90000, color: "#fca103" },
+      { from: 115000, color: "#ff0000" },
+    ],
+  },
+];
+
+const QUICK_KEY_TILES: TileSpec[] = [
+  { slot: "tile.gate_main", name: "Main Gate", domain: "switch", service: "toggle" },
+  { slot: "tile.garage_door", name: "Garage Door", domain: "switch", service: "toggle" },
+  {
+    slot: "tile.entrance_lights",
+    name: "Main Entrance Lights",
+    domain: "switch",
+    service: "toggle",
+  },
+  { slot: "tile.braai_light", name: "Braai Light", domain: "switch", service: "toggle" },
+  { slot: "tile.geyser_main", name: "Main Geyser", domain: "switch", service: "toggle" },
+  { slot: "tile.geyser_timer", name: "Geyser Timer", domain: "automation", service: "toggle" },
+  { slot: "tile.vintage_lights", name: "Vintage Lights", domain: "switch", service: "toggle" },
+  {
+    slot: "tile.jacuzzi_down_lights",
+    name: "Jacuzzi Down Lights",
+    domain: "switch",
+    service: "toggle",
+  },
+  { slot: "tile.patio_lights", name: "Patio Lights", domain: "switch", service: "toggle" },
+  { slot: "tile.pool_pump", name: "Pool Pump", domain: "switch", service: "toggle" },
+  { slot: "tile.jacuzzi_pump", name: "Jacuzzi Pump", domain: "switch", service: "toggle" },
+  { slot: "tile.office_lights", name: "Office Lights", domain: "switch", service: "toggle" },
+  { slot: "tile.wall_lights", name: "Wall Lights", domain: "switch", service: "toggle" },
+  { slot: "tile.left_blind", name: "Left Blind", domain: "cover", service: "toggle" },
+  { slot: "tile.right_blind", name: "Right Blind", domain: "cover", service: "toggle" },
+];
+
+// -- Element ----------------------------------------------------------------
 
 export class KioskWagnerWay extends LitElement {
   override createRenderRoot() {
     return this;
   }
 
+  /** State binding from the kiosk shell. Tests pass a fake. */
+  @property({ attribute: false }) binding: HaStateBinding | null = null;
+
+  /** Slot -> entity_id map. Defaults to the household-wide Wagner Way slots. */
+  @property({ attribute: false }) slots: WagnerWaySlots = DEFAULT_WAGNER_WAY_SLOTS;
+
+  @state() private revision: number = 0;
+
+  private removeBindingListener: (() => void) | null = null;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.attachToBinding();
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.detachFromBinding();
+  }
+
+  override updated(changed: Map<string, unknown>): void {
+    if (changed.has("binding")) {
+      this.detachFromBinding();
+      this.attachToBinding();
+    }
+  }
+
   override render(): TemplateResult {
-    return html`<div class="kiosk-wagner-way" data-test-id="kiosk-wagner-way-placeholder">
-      <p>Wagner Way overview composition lands in Unit 7.</p>
+    return html`<section class="kiosk-wagner-way" data-test-id="kiosk-wagner-way">
+      ${this.renderBadges()} ${this.renderHouseInfoRow()} ${this.renderGaugeRow(ENERGY_GAUGES)}
+      ${this.renderGaugeRow(POWER_GAUGES)} ${this.renderHeading("Major Appliances")}
+      ${this.renderGaugeRow(APPLIANCE_GAUGES)} ${this.renderHeading("Quick Keys")}
+      ${this.renderQuickKeys()} ${this.renderFooter()}
+    </section>`;
+  }
+
+  // -- internal helpers ----------------------------------------------------
+
+  private attachToBinding(): void {
+    if (!this.binding) return;
+    this.removeBindingListener = this.binding.subscribeAll(() => {
+      this.revision += 1;
+    });
+  }
+
+  private detachFromBinding(): void {
+    this.removeBindingListener?.();
+    this.removeBindingListener = null;
+  }
+
+  private resolve(slot: string): string | undefined {
+    return this.slots[slot];
+  }
+
+  private numericState(slot: string): number | null {
+    const id = this.resolve(slot);
+    if (!id) return null;
+    const value = this.binding?.get(id);
+    if (!value) return null;
+    const parsed = Number(value.state);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  private rawState(slot: string): string {
+    const id = this.resolve(slot);
+    if (!id) return "unavailable";
+    return this.binding?.get(id)?.state ?? "unavailable";
+  }
+
+  private renderHeading(label: string): TemplateResult {
+    return html`<h2 class="kiosk-wagner-way__heading">${label}</h2>`;
+  }
+
+  private renderBadges(): TemplateResult {
+    return html`<div class="kiosk-wagner-way__badges kiosk-grid kiosk-grid--badges">
+      ${BADGES.map((spec) => {
+        const id = this.resolve(spec.slot) ?? "";
+        return html`<kiosk-badge-entity
+          .entityId=${id}
+          .name=${spec.name}
+          .state=${this.rawState(spec.slot)}
+          .unit=${spec.unit ?? ""}
+        ></kiosk-badge-entity>`;
+      })}
+    </div>`;
+  }
+
+  private renderHouseInfoRow(): TemplateResult {
+    const tempState = this.numericState("sensor.outdoor_temp");
+    const humidityState = this.numericState("sensor.outdoor_humidity");
+    const weather = this.binding?.get(this.resolve("weather.primary") ?? "");
+    const conditions = (weather?.state as string) ?? "";
+    return html`<div class="kiosk-wagner-way__row kiosk-wagner-way__row--house-info">
+      <kiosk-weather-card
+        title="Wagner Way"
+        .conditions=${conditions}
+        .currentTemp=${tempState}
+        .humidity=${humidityState}
+      ></kiosk-weather-card>
+      <kiosk-energy-flow-card
+        .solar=${this.energyNode("Solar", "energy.solar_power", "energy.solar_daily")}
+        .grid=${this.energyNode("Grid", "energy.grid_power", "energy.grid_daily")}
+        .home=${this.energyNode("Home", "energy.load_power", "energy.load_daily")}
+        .battery=${this.energyNodeWithDetail(
+          "Battery",
+          "energy.battery_power",
+          undefined,
+          this.batterySocDetail(),
+        )}
+      ></kiosk-energy-flow-card>
+    </div>`;
+  }
+
+  private energyNode(label: string, powerSlot: string, dailySlot?: string) {
+    const power = this.numericState(powerSlot);
+    if (power === null && (!dailySlot || this.numericState(dailySlot) === null)) {
+      return null;
+    }
+    const daily = dailySlot ? this.numericState(dailySlot) : null;
+    return {
+      label,
+      power: power,
+      ...(daily !== null ? { daily } : {}),
+    };
+  }
+
+  private energyNodeWithDetail(
+    label: string,
+    powerSlot: string,
+    dailySlot: string | undefined,
+    detail: string | undefined,
+  ) {
+    const node = this.energyNode(label, powerSlot, dailySlot);
+    if (!node) return null;
+    return detail ? { ...node, detail } : node;
+  }
+
+  private batterySocDetail(): string | undefined {
+    const soc = this.numericState("energy.battery_soc");
+    return soc !== null ? `${Math.round(soc)}% SOC` : undefined;
+  }
+
+  private renderGaugeRow(specs: GaugeSpec[]): TemplateResult {
+    const cls = `kiosk-grid kiosk-grid--gauges-${specs.length === 5 ? 5 : specs.length === 2 ? 2 : 4}`;
+    return html`<div class=${cls}>
+      ${specs.map((spec) => {
+        const value = this.numericState(spec.slot);
+        return html`<kiosk-gauge-circular
+          .value=${value ?? Number.NaN}
+          .min=${spec.min}
+          .max=${spec.max}
+          .unit=${spec.unit}
+          .name=${spec.name}
+          .segments=${spec.segments}
+        ></kiosk-gauge-circular>`;
+      })}
+    </div>`;
+  }
+
+  private renderQuickKeys(): TemplateResult {
+    return html`<div class="kiosk-grid kiosk-grid--tiles" data-test-id="kiosk-quick-keys">
+      ${QUICK_KEY_TILES.map((spec) => {
+        const id = this.resolve(spec.slot) ?? "";
+        const state = this.rawState(spec.slot);
+        return html`<kiosk-tile-toggle
+          .entityId=${id}
+          .domain=${spec.domain}
+          .service=${spec.service}
+          .name=${spec.name}
+          .state=${state}
+          .icon=${spec.icon ?? ""}
+        ></kiosk-tile-toggle>`;
+      })}
+    </div>`;
+  }
+
+  private renderFooter(): TemplateResult {
+    return html`<div class="kiosk-wagner-way__footer kiosk-grid kiosk-grid--tiles">
+      <button
+        type="button"
+        class="kiosk-tile"
+        data-state="placeholder"
+        data-test-id="kiosk-vacuums-placeholder"
+        disabled
+      >
+        <span class="kiosk-tile__icon" aria-hidden="true">V</span>
+        <span class="kiosk-tile__name">Vacuums (v2)</span>
+        <span class="kiosk-tile__state">soon</span>
+      </button>
+      <button
+        type="button"
+        class="kiosk-tile"
+        data-state="placeholder"
+        data-test-id="kiosk-cameras-placeholder"
+        disabled
+      >
+        <span class="kiosk-tile__icon" aria-hidden="true">C</span>
+        <span class="kiosk-tile__name">Front Door Cam (v2)</span>
+        <span class="kiosk-tile__state">soon</span>
+      </button>
     </div>`;
   }
 }

--- a/ui/src/ui/kiosk/kiosk-wagner-way.ts
+++ b/ui/src/ui/kiosk/kiosk-wagner-way.ts
@@ -30,7 +30,9 @@ import "./components/badge-entity.js";
 import "./components/weather-card.js";
 import "./components/energy-flow-card.js";
 import type { GaugeColorSegment } from "./components/gauge-circular.js";
+import type { TileTapDetail } from "./components/tile-toggle.js";
 import type { HaStateBinding } from "./ha-state-binding.js";
+import { TileInteractionController } from "./tile-interaction-controller.js";
 
 // -- Slot contract ----------------------------------------------------------
 
@@ -311,8 +313,20 @@ export class KioskWagnerWay extends LitElement {
     }
   }
 
+  /**
+   * Visible for tests: the controller that handles optimistic
+   * dispatch + reconciliation for tile taps.
+   */
+  getInteractionController(): TileInteractionController | null {
+    return this.interactionController;
+  }
+
   override render(): TemplateResult {
-    return html`<section class="kiosk-wagner-way" data-test-id="kiosk-wagner-way">
+    return html`<section
+      class="kiosk-wagner-way"
+      data-test-id="kiosk-wagner-way"
+      @tile-tap=${this.onTileTap}
+    >
       ${this.renderBadges()} ${this.renderHouseInfoRow()} ${this.renderGaugeRow(ENERGY_GAUGES)}
       ${this.renderGaugeRow(POWER_GAUGES)} ${this.renderHeading("Major Appliances")}
       ${this.renderGaugeRow(APPLIANCE_GAUGES)} ${this.renderHeading("Quick Keys")}
@@ -327,12 +341,26 @@ export class KioskWagnerWay extends LitElement {
     this.removeBindingListener = this.binding.subscribeAll(() => {
       this.revision += 1;
     });
+    this.interactionController = new TileInteractionController({ binding: this.binding });
+    this.removeStatusListener = this.interactionController.onStatusChange(() => {
+      this.revision += 1;
+    });
   }
 
   private detachFromBinding(): void {
     this.removeBindingListener?.();
     this.removeBindingListener = null;
+    this.removeStatusListener?.();
+    this.removeStatusListener = null;
+    this.interactionController?.detach();
+    this.interactionController = null;
   }
+
+  private onTileTap = (ev: Event): void => {
+    const detail = (ev as CustomEvent<TileTapDetail>).detail;
+    if (!detail || !this.interactionController) return;
+    void this.interactionController.dispatch(detail);
+  };
 
   private resolve(slot: string): string | undefined {
     return this.slots[slot];
@@ -448,6 +476,7 @@ export class KioskWagnerWay extends LitElement {
       ${QUICK_KEY_TILES.map((spec) => {
         const id = this.resolve(spec.slot) ?? "";
         const state = this.rawState(spec.slot);
+        const status = id ? this.interactionController?.status.get(id) : undefined;
         return html`<kiosk-tile-toggle
           .entityId=${id}
           .domain=${spec.domain}
@@ -455,6 +484,9 @@ export class KioskWagnerWay extends LitElement {
           .name=${spec.name}
           .state=${state}
           .icon=${spec.icon ?? ""}
+          .pending=${status?.pending ?? false}
+          .error=${status?.error ?? false}
+          .errorMessage=${status?.errorMessage ?? ""}
         ></kiosk-tile-toggle>`;
       })}
     </div>`;

--- a/ui/src/ui/kiosk/tile-interaction-controller.test.ts
+++ b/ui/src/ui/kiosk/tile-interaction-controller.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  HA_STATE_EVENT,
+  HA_SUBSCRIBE_METHOD,
+  HA_SERVICE_CALL_METHOD,
+  HaStateBinding,
+  type GatewayEventFrame,
+  type HaGatewayClient,
+} from "./ha-state-binding.js";
+import { TileInteractionController } from "./tile-interaction-controller.js";
+
+class FakeClient implements HaGatewayClient {
+  private listeners = new Set<(evt: GatewayEventFrame) => void>();
+  responses = new Map<string, unknown>();
+  errors = new Map<string, Error>();
+  serviceCallCalls: Array<Record<string, unknown>> = [];
+
+  async request<T = unknown>(method: string, params?: unknown): Promise<T> {
+    if (method === HA_SERVICE_CALL_METHOD) {
+      this.serviceCallCalls.push((params ?? {}) as Record<string, unknown>);
+    }
+    if (this.errors.has(method)) {
+      throw this.errors.get(method)!;
+    }
+    return (this.responses.get(method) as T) ?? (undefined as T);
+  }
+
+  addEventListener(listener: (evt: GatewayEventFrame) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  emit(evt: GatewayEventFrame): void {
+    for (const l of this.listeners) l(evt);
+  }
+}
+
+class ManualScheduler {
+  private next = 1;
+  private pending = new Map<number, { fn: () => void; due: number }>();
+  private now = 0;
+
+  setTimeoutFn = (fn: () => void, ms: number): unknown => {
+    const handle = this.next++;
+    this.pending.set(handle, { fn, due: this.now + Math.max(0, ms) });
+    return handle;
+  };
+
+  clearTimeoutFn = (h: unknown): void => {
+    if (typeof h === "number") this.pending.delete(h);
+  };
+
+  advance(ms: number): void {
+    this.now += ms;
+    while (true) {
+      const due = Array.from(this.pending.entries())
+        .filter(([, t]) => t.due <= this.now)
+        .sort((a, b) => a[1].due - b[1].due);
+      if (due.length === 0) break;
+      const [handle, { fn }] = due[0];
+      this.pending.delete(handle);
+      fn();
+    }
+  }
+}
+
+async function buildHarness(): Promise<{
+  client: FakeClient;
+  binding: HaStateBinding;
+  scheduler: ManualScheduler;
+  controller: TileInteractionController;
+}> {
+  const client = new FakeClient();
+  client.responses.set(HA_SUBSCRIBE_METHOD, { snapshot: [] });
+  const binding = new HaStateBinding(client);
+  await binding.attach();
+
+  const scheduler = new ManualScheduler();
+  const controller = new TileInteractionController({
+    binding,
+    setTimeoutFn: scheduler.setTimeoutFn,
+    clearTimeoutFn: scheduler.clearTimeoutFn,
+    reconcileTimeoutMs: 3000,
+    errorFlashMs: 1500,
+  });
+
+  return { client, binding, scheduler, controller };
+}
+
+function emitState(client: FakeClient, entity_id: string, state: string): void {
+  client.emit({
+    type: "event",
+    event: HA_STATE_EVENT,
+    payload: {
+      entity_id,
+      prev: null,
+      next: { entity_id, state, attributes: {} },
+    },
+  });
+}
+
+describe("TileInteractionController", () => {
+  beforeEach(() => {
+    // ensure clean
+  });
+  afterEach(() => {
+    // nothing global
+  });
+
+  it("happy path: dispatch sets pending, state echo clears it", async () => {
+    const { client, controller } = await buildHarness();
+    client.responses.set(HA_SERVICE_CALL_METHOD, { dispatched: true });
+
+    const onChange = vi.fn();
+    controller.onStatusChange(onChange);
+
+    const dispatched = controller.dispatch({
+      entityId: "switch.gate_main",
+      domain: "switch",
+      service: "toggle",
+    });
+    // pending is set synchronously before the gateway promise resolves
+    expect(controller.status.get("switch.gate_main")?.pending).toBe(true);
+
+    await dispatched;
+    expect(client.serviceCallCalls).toEqual([
+      { domain: "switch", service: "toggle", target: "switch.gate_main" },
+    ]);
+    expect(controller.status.get("switch.gate_main")?.pending).toBe(true);
+
+    // State echo arrives -- pending clears and the entry leaves the
+    // status map (no pending, no error -> nothing to display).
+    emitState(client, "switch.gate_main", "on");
+    expect(controller.status.get("switch.gate_main")).toBeUndefined();
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("forwards optional serviceData to the gateway request", async () => {
+    const { client, controller } = await buildHarness();
+    client.responses.set(HA_SERVICE_CALL_METHOD, { dispatched: true });
+
+    await controller.dispatch({
+      entityId: "cover.left_blind",
+      domain: "cover",
+      service: "set_cover_position",
+      serviceData: { position: 50 },
+    });
+
+    expect(client.serviceCallCalls).toEqual([
+      {
+        domain: "cover",
+        service: "set_cover_position",
+        target: "cover.left_blind",
+        serviceData: { position: 50 },
+      },
+    ]);
+  });
+
+  it("reconcile timeout: no echo within reconcileTimeoutMs reverts pending and flashes error", async () => {
+    const { client, scheduler, controller } = await buildHarness();
+    client.responses.set(HA_SERVICE_CALL_METHOD, { dispatched: true });
+
+    await controller.dispatch({
+      entityId: "switch.geyser",
+      domain: "switch",
+      service: "toggle",
+    });
+    expect(controller.status.get("switch.geyser")?.pending).toBe(true);
+
+    scheduler.advance(3000);
+    const status = controller.status.get("switch.geyser")!;
+    expect(status.pending).toBe(false);
+    expect(status.error).toBe(true);
+    expect(status.errorMessage).toMatch(/timed.?out|timeout/i);
+
+    // Error flashes briefly then clears.
+    scheduler.advance(1500);
+    // After the error-flash window clears, the controller drops the entry
+    // from its status map (no pending, no error -> nothing to display).
+    expect(controller.status.get("switch.geyser")).toBeUndefined();
+  });
+
+  it("service-denied: gateway rejection clears pending, sets error with message", async () => {
+    const { client, scheduler, controller } = await buildHarness();
+    client.errors.set(HA_SERVICE_CALL_METHOD, new Error("service-denied"));
+
+    await controller.dispatch({
+      entityId: "lock.front_door",
+      domain: "lock",
+      service: "unlock",
+    });
+
+    const status = controller.status.get("lock.front_door")!;
+    expect(status.pending).toBe(false);
+    expect(status.error).toBe(true);
+    expect(status.errorMessage).toMatch(/service-denied/);
+
+    scheduler.advance(1500);
+    // After the error-flash window, the controller drops the entry.
+    expect(controller.status.get("lock.front_door")).toBeUndefined();
+  });
+
+  it("ha_call_failed: ws-client failure surfaced as error", async () => {
+    const { client, controller } = await buildHarness();
+    client.errors.set(HA_SERVICE_CALL_METHOD, new Error("not subscribed"));
+
+    await controller.dispatch({
+      entityId: "switch.gate_main",
+      domain: "switch",
+      service: "toggle",
+    });
+
+    const status = controller.status.get("switch.gate_main")!;
+    expect(status.error).toBe(true);
+    expect(status.errorMessage).toMatch(/not subscribed/);
+  });
+
+  it("rapid taps on the same entity do not double-dispatch while one is in flight", async () => {
+    const { client, controller } = await buildHarness();
+    let resolveCall: (v: unknown) => void = () => undefined;
+    client.responses.set(HA_SERVICE_CALL_METHOD, { dispatched: true });
+    // Force the gateway to wait until we resolve manually -- replace request
+    // with one that never resolves until we tell it to.
+    const slowResponse = new Promise<unknown>((resolve) => {
+      resolveCall = resolve;
+    });
+    const originalRequest = client.request.bind(client);
+    client.request = ((method: string, params: unknown) => {
+      if (method === HA_SERVICE_CALL_METHOD) {
+        // Track the call but block until we resolve.
+        client.serviceCallCalls.push((params ?? {}) as Record<string, unknown>);
+        return slowResponse;
+      }
+      return originalRequest(method, params);
+    }) as typeof client.request;
+
+    const first = controller.dispatch({
+      entityId: "switch.gate_main",
+      domain: "switch",
+      service: "toggle",
+    });
+    // A second tap while the first is pending -- should be ignored.
+    const second = controller.dispatch({
+      entityId: "switch.gate_main",
+      domain: "switch",
+      service: "toggle",
+    });
+
+    // Only one service call so far.
+    expect(client.serviceCallCalls).toHaveLength(1);
+
+    // Let the first one settle.
+    resolveCall({ dispatched: true });
+    await first;
+    await second;
+
+    expect(client.serviceCallCalls).toHaveLength(1);
+  });
+
+  it("does not crash if a state echo arrives for an entity that was never dispatched", async () => {
+    const { client, controller } = await buildHarness();
+    expect(() => emitState(client, "switch.unrelated", "on")).not.toThrow();
+    expect(controller.status.get("switch.unrelated")).toBeUndefined();
+  });
+
+  it("detach unsubscribes so further state echos do not mutate status", async () => {
+    const { client, controller, scheduler } = await buildHarness();
+    client.responses.set(HA_SERVICE_CALL_METHOD, { dispatched: true });
+
+    await controller.dispatch({
+      entityId: "switch.gate_main",
+      domain: "switch",
+      service: "toggle",
+    });
+    expect(controller.status.get("switch.gate_main")?.pending).toBe(true);
+
+    controller.detach();
+
+    // Even though an echo arrives, controller is detached -- status should
+    // not flip back. (Pending stays whatever it was at detach.)
+    emitState(client, "switch.gate_main", "on");
+    expect(controller.status.get("switch.gate_main")?.pending).toBe(true);
+
+    // And no spurious timeout fires after detach.
+    scheduler.advance(3000);
+  });
+});

--- a/ui/src/ui/kiosk/tile-interaction-controller.ts
+++ b/ui/src/ui/kiosk/tile-interaction-controller.ts
@@ -1,0 +1,216 @@
+/**
+ * Optimistic tile-tap dispatch + reconciliation controller.
+ *
+ * Tap arrives -> set pending=true -> dispatch via binding.callService ->
+ * await echo (HA state_changed event) within reconcileTimeoutMs ->
+ * clear pending. On rejection or timeout, flip to error state for
+ * errorFlashMs then clear.
+ *
+ * Status map drives the tile primitives' data-pending / data-error
+ * attributes. The wagner-way view subscribes to onStatusChange and
+ * re-renders on every status flip.
+ *
+ * Hardening choices in v1:
+ *   - per-entity in-flight guard: rapid double-taps while a call is
+ *     pending are dropped. The reconciliation echo is the next
+ *     possible event for that entity, not a queued second call.
+ *   - timer injection: tests use a manual scheduler; production uses
+ *     setTimeout/clearTimeout from globalThis.
+ *   - failure messages: the gateway error message becomes the tile's
+ *     errorMessage so the operator sees what HA / the bridge returned
+ *     ("service-denied", "entity-denied", "ha_call_failed", etc).
+ */
+
+import type { HaStateBinding, HaStateChange } from "./ha-state-binding.js";
+
+export type TileStatus = {
+  pending: boolean;
+  error: boolean;
+  errorMessage: string;
+};
+
+const EMPTY_STATUS: TileStatus = { pending: false, error: false, errorMessage: "" };
+
+/**
+ * Mirrors the TileTapDetail shape emitted by `tile-toggle`. The controller
+ * translates `entityId` to the wire-protocol `target` field on its way
+ * through the binding.
+ */
+export type TileTapDispatch = {
+  entityId: string;
+  domain: string;
+  service: string;
+  serviceData?: Record<string, unknown>;
+};
+
+export type TileInteractionOptions = {
+  binding: HaStateBinding;
+  setTimeoutFn?: (fn: () => void, ms: number) => unknown;
+  clearTimeoutFn?: (handle: unknown) => void;
+  reconcileTimeoutMs?: number;
+  errorFlashMs?: number;
+};
+
+export type StatusChangeListener = () => void;
+export type Unsubscribe = () => void;
+
+const DEFAULT_RECONCILE_TIMEOUT_MS = 3000;
+const DEFAULT_ERROR_FLASH_MS = 1500;
+
+type InFlight = {
+  entityId: string;
+  reconcileHandle: unknown;
+};
+
+export class TileInteractionController {
+  private readonly binding: HaStateBinding;
+  private readonly setTimeoutFn: (fn: () => void, ms: number) => unknown;
+  private readonly clearTimeoutFn: (handle: unknown) => void;
+  private readonly reconcileTimeoutMs: number;
+  private readonly errorFlashMs: number;
+
+  private statuses = new Map<string, TileStatus>();
+  private inflight = new Map<string, InFlight>();
+  private errorFlashHandles = new Map<string, unknown>();
+  private listeners = new Set<StatusChangeListener>();
+  private removeBindingListener: Unsubscribe | null = null;
+  private detached = false;
+
+  /** Read-only view of per-entity tile statuses. */
+  get status(): ReadonlyMap<string, TileStatus> {
+    return this.statuses;
+  }
+
+  constructor(options: TileInteractionOptions) {
+    this.binding = options.binding;
+    this.setTimeoutFn = options.setTimeoutFn ?? ((fn, ms) => setTimeout(fn, ms));
+    this.clearTimeoutFn =
+      options.clearTimeoutFn ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>));
+    this.reconcileTimeoutMs = options.reconcileTimeoutMs ?? DEFAULT_RECONCILE_TIMEOUT_MS;
+    this.errorFlashMs = options.errorFlashMs ?? DEFAULT_ERROR_FLASH_MS;
+
+    this.removeBindingListener = this.binding.subscribeAll((change) => this.onStateChange(change));
+  }
+
+  detach(): void {
+    this.detached = true;
+    this.removeBindingListener?.();
+    this.removeBindingListener = null;
+    for (const flight of this.inflight.values()) {
+      this.clearTimeoutFn(flight.reconcileHandle);
+    }
+    this.inflight.clear();
+    for (const handle of this.errorFlashHandles.values()) {
+      this.clearTimeoutFn(handle);
+    }
+    this.errorFlashHandles.clear();
+  }
+
+  onStatusChange(listener: StatusChangeListener): Unsubscribe {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  async dispatch(args: TileTapDispatch): Promise<void> {
+    if (this.detached) return;
+    if (this.inflight.has(args.entityId)) {
+      // Already in flight -- drop duplicate tap. The reconciliation echo
+      // for the original tap is the right next event.
+      return;
+    }
+
+    this.setStatus(args.entityId, { pending: true, error: false, errorMessage: "" });
+
+    const reconcileHandle = this.setTimeoutFn(() => {
+      this.onReconcileTimeout(args.entityId);
+    }, this.reconcileTimeoutMs);
+    this.inflight.set(args.entityId, { entityId: args.entityId, reconcileHandle });
+
+    try {
+      await this.binding.callService({
+        domain: args.domain,
+        service: args.service,
+        target: args.entityId,
+        ...(args.serviceData ? { serviceData: args.serviceData } : {}),
+      });
+      // Success: keep pending=true; the echo or timeout will clear it.
+      // (Some installs return success quickly without an echo. The
+      // reconcile timer guards that case.)
+    } catch (cause) {
+      this.completeInFlight(args.entityId);
+      const message = cause instanceof Error ? cause.message : String(cause);
+      this.flashError(args.entityId, message);
+    }
+  }
+
+  // -- internals -----------------------------------------------------------
+
+  private onStateChange(change: HaStateChange): void {
+    if (this.detached) return;
+    if (!this.inflight.has(change.entity_id)) {
+      return;
+    }
+    this.completeInFlight(change.entity_id);
+    // Successful reconciliation -- clear status (no error).
+    this.setStatus(change.entity_id, { pending: false, error: false, errorMessage: "" });
+  }
+
+  private onReconcileTimeout(entityId: string): void {
+    if (this.detached) return;
+    if (!this.inflight.has(entityId)) return;
+    this.completeInFlight(entityId);
+    this.flashError(entityId, "timed out waiting for HA echo");
+  }
+
+  private completeInFlight(entityId: string): void {
+    const flight = this.inflight.get(entityId);
+    if (!flight) return;
+    this.clearTimeoutFn(flight.reconcileHandle);
+    this.inflight.delete(entityId);
+  }
+
+  private flashError(entityId: string, message: string): void {
+    this.setStatus(entityId, { pending: false, error: true, errorMessage: message });
+    const existing = this.errorFlashHandles.get(entityId);
+    if (existing) {
+      this.clearTimeoutFn(existing);
+    }
+    const handle = this.setTimeoutFn(() => {
+      this.errorFlashHandles.delete(entityId);
+      if (this.detached) return;
+      this.setStatus(entityId, { ...EMPTY_STATUS });
+    }, this.errorFlashMs);
+    this.errorFlashHandles.set(entityId, handle);
+  }
+
+  private setStatus(entityId: string, next: TileStatus): void {
+    const current = this.statuses.get(entityId);
+    if (
+      current &&
+      current.pending === next.pending &&
+      current.error === next.error &&
+      current.errorMessage === next.errorMessage
+    ) {
+      return;
+    }
+    if (next.pending === false && next.error === false && next.errorMessage === "") {
+      this.statuses.delete(entityId);
+    } else {
+      this.statuses.set(entityId, next);
+    }
+    this.notify();
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      try {
+        listener();
+      } catch (cause) {
+        // eslint-disable-next-line no-console
+        console.warn("[tile-interaction] listener threw", cause);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- New \`extensions/home-assistant\` plugin: long-lived HA WebSocket client, entity state store, allow-list/deny-list gate, and gateway bridge exposing kiosk methods on the OpenClaw gateway WS (no core protocol changes — uses the existing \`plugin.*\` broadcast namespace).
- New \`ui/src/ui/kiosk/\` surface: no-chrome wall-tablet shell at \`#/kiosk\` with native Lit primitives for the Wagner Way overview (gauges, tiles, badges, weather, energy flow), tile-tap optimistic dispatch + HA echo reconciliation, and a self-bootstrapping hash-route mount that does not modify \`app.ts\` / \`app-gateway.ts\` / \`navigation.ts\`.
- Plan: [\`docs/plans/2026-05-10-002-feat-home-assistant-kiosk-dashboard-plan.md\`](https://github.com/openclaw/openclaw/blob/main/docs/plans/2026-05-10-002-feat-home-assistant-kiosk-dashboard-plan.md). 11 commits land Units 1–10 of the plan plus one slot-rendering fix discovered during dev-server smoke.

## What this is for

A wall-tablet kiosk inside OpenClaw that mirrors the household's existing Home Assistant Lovelace \"Wagner Way\" view — live energy gauges, family/alarm badges, Quick Keys tile grid, weather, and an energy-flow diagram. Lets OpenClaw own the household control plane rather than running a separate HA tab on every tablet, and reuses the security posture established in [\`docs/plans/2026-05-10-001-feat-jarvis-the-butler-home-migration-plan.md\`](https://github.com/openclaw/openclaw/blob/main/docs/plans/2026-05-10-001-feat-jarvis-the-butler-home-migration-plan.md) (dedicated non-admin HA user, services deny-listed at the HA-user layer).

## Architecture (one-pager)

\`\`\`
HA WebSocket  --auth+subscribe-->  extensions/home-assistant
                                     - HomeAssistantClient (state machine,
                                       heartbeat, exponential reconnect)
                                     - HomeAssistantStateStore (allow-list
                                       filter at ingest)
                                     - allowlist.ts (deny-list gate with
                                       structured service-denied error)
                                     - gateway-bridge.ts (captures
                                       context.broadcast on first subscribe,
                                       publishes plugin.home-assistant.state)
                                     |
                                     | OpenClaw gateway WS
                                     v
                                   browser
                                     - HaStateBinding (subscribe + cache)
                                     - KioskShell (no-chrome shell with
                                       connection-state pill + wake-lock)
                                     - KioskWagnerWay (badges/weather/
                                       energy/gauges/tiles composition)
                                     - TileInteractionController
                                       (optimistic pending -> service call
                                       -> HA echo reconciliation, with
                                       reconcile timeout + error flash)
\`\`\`

### Plan deviation recorded

The plan called for adding \`ha:state\` / \`ha:service-call\` to \`src/gateway/protocol/\`. After inspecting the gateway, plugin broadcasts already use the \`plugin.*\` namespace ([\`src/gateway/server-broadcast.ts\`](https://github.com/openclaw/openclaw/blob/main/src/gateway/server-broadcast.ts) \`EVENT_SCOPE_GUARDS\`) and \`OpenClawPluginApi.registerGatewayMethod\` accepts arbitrary method names. **No core protocol additions were needed.** The bridge stays fully extension-local per \`extensions/CLAUDE.md\` boundary rules. This sidestepped a new SDK subpath + entrypoint baseline alignment + \`pnpm build\` SDK fanout reverification.

## Wire protocol

| Direction | Wire name | Scope |
|---|---|---|
| Request: kiosk subscribes | \`home-assistant.subscribe\` | \`operator.read\` |
| Push: state diffs | \`plugin.home-assistant.state\` | (operator/admin) |
| Request: tile tap | \`home-assistant.serviceCall\` | \`operator.write\` |

\`home-assistant.serviceCall\` validation order: \`target\` present → service in deny-list/format check → target in \`allowList\` → dispatch to \`ws-client.callService\`. Each failure stage produces a distinct structured error code (\`invalid_params\` / \`service-denied\` / \`entity-denied\` / \`ha_call_failed\`).

## Test plan

- [x] \`pnpm test extensions/home-assistant\` — **82/82 pass** (config schema 19 + state-store 10 + ws-client 15 + allowlist 16 + gateway-bridge 15 + register.runtime 4 + others)
- [x] \`npx vitest run src/ui/kiosk/\` — **50/50 pass** (ha-state-binding 10 + kiosk-shell 5 + gauge 9 + tile 6 + badge 5 + wagner-way 7 + tile-interaction 8)
- [x] \`pnpm tsgo:extensions\` and \`pnpm tsgo:extensions:test\` — clean
- [x] \`pnpm build\` in \`ui/\` — clean (\`dist/control-ui/\` in ~770ms)
- [x] Vite dev server smoke against \`#/kiosk\`: shell mounts, connection pill shows \"reconnecting\", Wagner Way layout renders with \`n/a\` values (no real HA gateway behind the dev server)
- [ ] Live test against a rebuilt gateway with the \`home-assistant\` plugin configured + \`jarvis_kiosk\` HA user provisioned (operator step — see below)

## What's NOT in this PR (deferred)

- The 14 other Lovelace views (Calendar, Rooms, Cameras, Alarm panel, Climate, Sonos, AppleTV, Plex, People, Solar deep-dive, Eskom, Vacuums, Bourbon & Bubbles). Each is its own v2 plan once the kiosk shell + HA bridge are stable.
- Camera live views (\`camera.*\` entities). Needs RTSP/MJPEG/WebRTC strategy + LAN-only enforcement; deferred per the kiosk plan.
- Agent-tool surface for HA. Owned by the Butler plan; this PR doesn't duplicate it.
- Visual polish in \`ui/src/styles/kiosk.css\` against an actual wall tablet — pending hands-on iteration.

## Operator steps to live-test

1. **Provision the \`jarvis_kiosk\` HA user** (dedicated non-admin, per the Butler plan's pattern). Add high-blast-radius services (\`lock.unlock\`, \`alarm_control_panel.alarm_disarm\`, \`cover.open_cover\`) to the HA-user-side deny-list.
2. **Write the long-lived token** to the OpenClaw credentials store under the reference key \`homeAssistant.jarvisKiosk\`.
3. **Populate \`plugins.entries.home-assistant.config\`** in OpenClaw config with \`homeAssistantUrl\`, \`tokenRef\`, \`allowList\` (mirror \`DEFAULT_WAGNER_WAY_SLOTS\` from [\`ui/src/ui/kiosk/kiosk-wagner-way.ts\`](https://github.com/openclaw/openclaw/blob/main/ui/src/ui/kiosk/kiosk-wagner-way.ts)), \`denyServiceList\`, and \`slots\`.
4. **Rebuild + reinstall + restart** the gateway against this branch source.
5. **Open \`http://<gateway>/#/kiosk\`** on the wall tablet. Pill should flip \"connecting\" → \"live\".

## Notable items reviewers should look at

- [\`extensions/home-assistant/register.runtime.ts\`](https://github.com/openclaw/openclaw/blob/feat/home-assistant-kiosk/extensions/home-assistant/register.runtime.ts) — \"disabled until configured\" branch + late-bound \`ServiceCallClient\` adapter so gateway methods register during \`register()\` (kiosk can subscribe immediately) while the actual WS client is created when the service starts (and credentials resolve).
- [\`extensions/home-assistant/ws-client.ts\`](https://github.com/openclaw/openclaw/blob/feat/home-assistant-kiosk/extensions/home-assistant/ws-client.ts) — \`detachAndClose()\` re-entrancy guard: self-initiated closes detach handlers before \`close()\` so \`handleClose\` only runs for unexpected drops. Prevents double-scheduled reconnects on heartbeat-timeout and auth-invalid paths.
- [\`extensions/home-assistant/allowlist.ts\`](https://github.com/openclaw/openclaw/blob/feat/home-assistant-kiosk/extensions/home-assistant/allowlist.ts) — v1 is deny-list-authoritative. A \"future hardening guard\" test locks the contract that deny-list precedence holds if \`allowServiceList\` lands later. Also rejects smuggled dots (\`{domain: \"switch.lock\", service: \"unlock\"}\` cannot bypass a \`lock.unlock\` deny entry by collapsing segments).
- [\`ui/src/ui/kiosk/tile-interaction-controller.ts\`](https://github.com/openclaw/openclaw/blob/feat/home-assistant-kiosk/ui/src/ui/kiosk/tile-interaction-controller.ts) — per-entity in-flight guard, reconcile timeout, error flash. Pure logic; testable in isolation via a manual scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)