### PR TITLE
Run Mantis Telegram proof on Blacksmith

### DIFF
--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -290,7 +290,7 @@ jobs:
     name: Run agentic native Telegram proof
     needs: [resolve_request, validate_refs]
     if: ${{ needs.resolve_request.outputs.should_run == 'true' }}
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 360
     environment: qa-live-shared
     outputs:


### PR DESCRIPTION
Summary:
- Run the agentic Telegram Desktop proof job on `blacksmith-16vcpu-ubuntu-2404`
- Keep the lightweight trigger/ref-resolution jobs on GitHub-hosted runners

Verification:
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/mantis-telegram-desktop-proof.yml`

Reason:
- The GitHub-hosted Codex Action runner reached the Mantis agent but could not resolve the Convex credential broker / Crabbox network path, so no real Telegram Desktop GIF proof could be captured.
