### PR TITLE
Share Mantis Codex action home

### DIFF
--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -346,6 +346,7 @@ jobs:
         run: |
           set -euo pipefail
           sudo useradd --create-home --shell /bin/bash codex
+          sudo install -d -m 0770 -o codex -g sudo /home/codex/.codex
           sudo chown -R codex:codex "$GITHUB_WORKSPACE"
 
       - name: Run Codex Mantis Telegram agent


### PR DESCRIPTION
Summary
- pre-create /home/codex/.codex with codex ownership and sudo-group write access
- lets codex-action start its Responses proxy while running Codex as the unprivileged codex user

Verification
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/mantis-telegram-desktop-proof.yml
- git diff --check HEAD -- .github/workflows/mantis-telegram-desktop-proof.yml