### PR TITLE
Let Mantis Codex action create home

### DIFF
--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -346,7 +346,8 @@ jobs:
         run: |
           set -euo pipefail
           sudo useradd --create-home --shell /bin/bash codex
-          sudo install -d -m 0770 -o codex -g sudo /home/codex/.codex
+          sudo setfacl -m u:runner:rwx,u:codex:rwx /home/codex
+          sudo setfacl -d -m u:runner:rwx,u:codex:rwx /home/codex
           sudo chown -R codex:codex "$GITHUB_WORKSPACE"
 
       - name: Run Codex Mantis Telegram agent


### PR DESCRIPTION
Summary
- stop pre-creating /home/codex/.codex before codex-action runs
- apply ACLs on /home/codex so codex-action can create its home and both runner/codex can access it

Verification
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/mantis-telegram-desktop-proof.yml
- git diff --check HEAD -- .github/workflows/mantis-telegram-desktop-proof.yml