### PR TITLE
docs: clarify Telegram group IDs

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -62,7 +62,15 @@ openclaw pairing approve telegram <CODE>
   </Step>
 
   <Step title="Add the bot to a group">
-    Add the bot to your group, then set `channels.telegram.groups` and `groupPolicy` to match your access model.
+    Add the bot to your group, then get both IDs that group access needs:
+
+    - your Telegram user ID, used in `allowFrom` / `groupAllowFrom`
+    - the Telegram group chat ID, used as the key under `channels.telegram.groups`
+
+    In the group, run `/whoami@<bot_username>` if native commands are enabled. You can also read the same values from `openclaw logs --follow` after sending a group message to the bot.
+
+    Negative Telegram supergroup IDs that start with `-100` are group chat IDs. Put them under `channels.telegram.groups`, not under `groupAllowFrom`.
+
   </Step>
 </Steps>
 
@@ -169,6 +177,28 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     Practical pattern for one-owner bots: set your user ID in `channels.telegram.allowFrom`, leave `groupAllowFrom` unset, and allow the target groups under `channels.telegram.groups`.
     Runtime note: if `channels.telegram` is completely missing, runtime defaults to fail-closed `groupPolicy="allowlist"` unless `channels.defaults.groupPolicy` is explicitly set.
 
+    Owner-only group setup:
+
+```json5
+{
+  channels: {
+    telegram: {
+      enabled: true,
+      dmPolicy: "pairing",
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["<YOUR_TELEGRAM_USER_ID>"],
+      groups: {
+        "<GROUP_CHAT_ID>": {
+          requireMention: true,
+        },
+      },
+    },
+  },
+}
+```
+
+    Test it from the group with `@<bot_username> ping`. Plain group messages do not trigger the bot while `requireMention: true`.
+
     Example: allow any member in one specific group:
 
 ```json5
@@ -247,6 +277,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     Getting the group chat ID:
 
+    - run `/whoami@<bot_username>` in the group if native commands are enabled
     - forward a group message to `@userinfobot` / `@getidsbot`
     - or read `chat.id` from `openclaw logs --follow`
     - or inspect Bot API `getUpdates`

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -67,7 +67,7 @@ openclaw pairing approve telegram <CODE>
     - your Telegram user ID, used in `allowFrom` / `groupAllowFrom`
     - the Telegram group chat ID, used as the key under `channels.telegram.groups`
 
-    In the group, run `/whoami@<bot_username>` if native commands are enabled. You can also read the same values from `openclaw logs --follow` after sending a group message to the bot.
+    For first-time setup, get the group chat ID from `openclaw logs --follow`, a forwarded-ID bot, or Bot API `getUpdates`. After the group is allowed, `/whoami@<bot_username>` can confirm the user and group IDs.
 
     Negative Telegram supergroup IDs that start with `-100` are group chat IDs. Put them under `channels.telegram.groups`, not under `groupAllowFrom`.
 
@@ -185,8 +185,8 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     telegram: {
       enabled: true,
       dmPolicy: "pairing",
+      allowFrom: ["<YOUR_TELEGRAM_USER_ID>"],
       groupPolicy: "allowlist",
-      groupAllowFrom: ["<YOUR_TELEGRAM_USER_ID>"],
       groups: {
         "<GROUP_CHAT_ID>": {
           requireMention: true,
@@ -277,10 +277,10 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     Getting the group chat ID:
 
-    - run `/whoami@<bot_username>` in the group if native commands are enabled
     - forward a group message to `@userinfobot` / `@getidsbot`
     - or read `chat.id` from `openclaw logs --follow`
     - or inspect Bot API `getUpdates`
+    - after the group is allowed, run `/whoami@<bot_username>` if native commands are enabled
 
   </Tab>
 </Tabs>


### PR DESCRIPTION
Summary
- Clarify the Telegram group setup step so readers collect both required IDs: their Telegram user ID and the group chat ID.
- Explain that negative supergroup IDs beginning with `-100` are group chat IDs and belong under `channels.telegram.groups`, not `groupAllowFrom`.
- Add an owner-only group setup example using `allowFrom` plus `groups` so one-owner bots have one authorization path.
- Qualify `/whoami@<bot_username>` as a post-allowlist confirmation path; first-time group chat ID discovery stays on logs, forwarded-ID bots, or Bot API `getUpdates`.

Verification
- `pnpm docs:list`
- `git diff --check origin/main...HEAD`
- `node scripts/check-docs-mdx.mjs docs/channels/telegram.md`
- `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm test extensions/telegram/src/bot-native-commands.group-auth.test.ts extensions/telegram/src/group-access.base-access.test.ts src/auto-reply/reply/commands-info.test.ts`

## Real behavior proof

- Behavior or issue addressed: Telegram docs now distinguish first-time group chat ID discovery from `/whoami` confirmation after the group is already allowed, and the owner-only setup uses the documented `allowFrom` path.
- Real environment tested: Local OpenClaw checkout in the PR worktree at `c6b6b9e1c5df36d31abf7e4d9df61ce32ec84f90`, using the repo docs tooling against `docs/channels/telegram.md`.
- Exact steps or command run after this patch: `pnpm docs:list`; `git diff --check origin/main...HEAD`; `node scripts/check-docs-mdx.mjs docs/channels/telegram.md`; `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm test extensions/telegram/src/bot-native-commands.group-auth.test.ts extensions/telegram/src/group-access.base-access.test.ts src/auto-reply/reply/commands-info.test.ts`; inspected rendered source lines with `nl -ba docs/channels/telegram.md | sed -n '64,72p;180,200p;278,284p'`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Terminal output from the patched checkout:

```text
$ node scripts/check-docs-mdx.mjs docs/channels/telegram.md
Docs MDX check passed (1 files, 36ms).

$ nl -ba docs/channels/telegram.md | sed -n '64,72p;180,200p;278,284p'
    64    <Step title="Add the bot to a group">
    65      Add the bot to your group, then get both IDs that group access needs:
    67      - your Telegram user ID, used in `allowFrom` / `groupAllowFrom`
    68      - the Telegram group chat ID, used as the key under `channels.telegram.groups`
    70      For first-time setup, get the group chat ID from `openclaw logs --follow`, a forwarded-ID bot, or Bot API `getUpdates`. After the group is allowed, `/whoami@<bot_username>` can confirm the user and group IDs.
   186        enabled: true,
   187        dmPolicy: "pairing",
   188        allowFrom: ["<YOUR_TELEGRAM_USER_ID>"],
   189        groupPolicy: "allowlist",
   190        groups: {
   191          "<GROUP_CHAT_ID>": {
   192            requireMention: true,
   280      - forward a group message to `@userinfobot` / `@getidsbot`
   281      - or read `chat.id` from `openclaw logs --follow`
   282      - or inspect Bot API `getUpdates`
   283      - after the group is allowed, run `/whoami@<bot_username>` if native commands are enabled
```

- Observed result after fix: The setup docs no longer imply `/whoami` works before the group is configured; first-time discovery uses logs, forwarded-ID bots, or Bot API `getUpdates`, and `/whoami` is described only as a confirmation step after group allowlisting.
- What was not tested: Live Telegram transport was not run because this is documentation-only and no runtime behavior changed.
