### PR TITLE
Disable non-POSIX command approval highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp: downgrade OpenClaw watchdog-triggered Web reconnects from runtime errors to recovery warnings and clear the recovered reconnect status after the next healthy connection. (#77026) Thanks @rubencu.
 - ACPX/Windows: hide the MCP proxy target child process window on Windows so ACP-backed agents do not flash or fail because of terminal window handling. Fixes #60672. (#60678) Thanks @KChow-ctrl.
 - Agents: abort generic repeated no-progress tool loops at the critical threshold when identical calls keep returning identical outcomes. (#80668) Thanks @frankekn.
+- Exec approvals: omit generated command highlights for non-POSIX Windows and shell-wrapper approval commands until those command languages have native highlighting support. (#80566) Thanks @jesse-merhi.
 
 ## 2026.5.9
 

--- a/src/agents/bash-tools.exec-approval-request.test.ts
+++ b/src/agents/bash-tools.exec-approval-request.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS,
   DEFAULT_APPROVAL_TIMEOUT_MS,
@@ -39,6 +39,22 @@ let callGatewayTool: typeof import("./tools/gateway.js").callGatewayTool;
 let requestExecApprovalDecision: typeof import("./bash-tools.exec-approval-request.js").requestExecApprovalDecision;
 let registerExecApprovalRequestForHost: typeof import("./bash-tools.exec-approval-request.js").registerExecApprovalRequestForHost;
 
+const initialProcessPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+
+function setProcessPlatformForTest(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    enumerable: true,
+    value: platform,
+  });
+}
+
+function restoreProcessPlatformForTest(): void {
+  if (initialProcessPlatform) {
+    Object.defineProperty(process, "platform", initialProcessPlatform);
+  }
+}
+
 type ApprovalRequestPayload = {
   commandSpans?: Array<{ startIndex: number; endIndex: number }>;
 };
@@ -54,6 +70,11 @@ describe("requestExecApprovalDecision", () => {
     vi.mocked(callGatewayTool).mockClear();
     commandExplainerMock.explainShellCommand.mockClear();
     commandExplainerMock.formatCommandSpans.mockClear();
+    restoreProcessPlatformForTest();
+  });
+
+  afterEach(() => {
+    restoreProcessPlatformForTest();
   });
 
   it("does not load the command explainer when importing approval requests", () => {
@@ -287,6 +308,29 @@ describe("requestExecApprovalDecision", () => {
     );
     expect(callGatewayTool).toHaveBeenNthCalledWith(
       2,
+      "exec.approval.request",
+      expect.anything(),
+      expect.not.objectContaining({ commandSpans: expect.anything() }),
+      expect.anything(),
+    );
+  });
+
+  it("omits generated command spans for Windows gateway PowerShell commands", async () => {
+    setProcessPlatformForTest("win32");
+    vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
+
+    await registerExecApprovalRequestForHost({
+      approvalId: "approval-id-powershell",
+      command:
+        'Set-Content -Path "windows-agent-proof.txt" -Value "WINDOWS_AGENT_EXEC_OK" -NoNewline',
+      workdir: "C:\\project",
+      host: "gateway",
+      security: "allowlist",
+      ask: "always",
+    });
+
+    expect(commandExplainerMock.formatCommandSpans).not.toHaveBeenCalled();
+    expect(callGatewayTool).toHaveBeenCalledWith(
       "exec.approval.request",
       expect.anything(),
       expect.not.objectContaining({ commandSpans: expect.anything() }),

--- a/src/agents/bash-tools.exec-approval-request.test.ts
+++ b/src/agents/bash-tools.exec-approval-request.test.ts
@@ -338,6 +338,33 @@ describe("requestExecApprovalDecision", () => {
     );
   });
 
+  it("omits generated command spans for unsupported shell wrappers through system run carriers", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
+
+    await registerExecApprovalRequestForHost({
+      approvalId: "approval-id-carrier",
+      systemRunPlan: {
+        argv: ["timeout", "5", "pwsh", "-Command", "Get-ChildItem"],
+        cwd: "/tmp/project",
+        commandText: 'timeout 5 pwsh -Command "Get-ChildItem"',
+        agentId: null,
+        sessionKey: null,
+      },
+      workdir: "/tmp/project",
+      host: "node",
+      security: "allowlist",
+      ask: "always",
+    });
+
+    expect(commandExplainerMock.formatCommandSpans).not.toHaveBeenCalled();
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "exec.approval.request",
+      expect.anything(),
+      expect.not.objectContaining({ commandSpans: expect.anything() }),
+      expect.anything(),
+    );
+  });
+
   it("keeps explicit command spans", async () => {
     vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
 

--- a/src/agents/bash-tools.exec-approval-request.test.ts
+++ b/src/agents/bash-tools.exec-approval-request.test.ts
@@ -8,6 +8,9 @@ const commandExplainerMock = vi.hoisted(() => ({
   importCount: 0,
   explainShellCommand: vi.fn(async (command: string): Promise<string> => command),
   formatCommandSpans: vi.fn((command: string) => {
+    if (command.startsWith("pwsh ") || command.startsWith("cmd.exe ")) {
+      return [];
+    }
     if (command.startsWith("node ")) {
       return [{ startIndex: 0, endIndex: 4 }];
     }

--- a/src/agents/bash-tools.exec-approval-request.test.ts
+++ b/src/agents/bash-tools.exec-approval-request.test.ts
@@ -255,6 +255,42 @@ describe("requestExecApprovalDecision", () => {
     expect(payload?.commandSpans).toContainEqual({ startIndex: 0, endIndex: 4 });
   });
 
+  it("omits generated command spans for unsupported shell wrapper languages", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
+
+    await registerExecApprovalRequestForHost({
+      approvalId: "approval-id-powershell",
+      command: 'pwsh -Command "Get-ChildItem"',
+      workdir: "/tmp/project",
+      host: "node",
+      security: "allowlist",
+      ask: "always",
+    });
+    await registerExecApprovalRequestForHost({
+      approvalId: "approval-id-cmd",
+      command: 'cmd.exe /d /s /c "dir"',
+      workdir: "/tmp/project",
+      host: "node",
+      security: "allowlist",
+      ask: "always",
+    });
+
+    expect(callGatewayTool).toHaveBeenNthCalledWith(
+      1,
+      "exec.approval.request",
+      expect.anything(),
+      expect.not.objectContaining({ commandSpans: expect.anything() }),
+      expect.anything(),
+    );
+    expect(callGatewayTool).toHaveBeenNthCalledWith(
+      2,
+      "exec.approval.request",
+      expect.anything(),
+      expect.not.objectContaining({ commandSpans: expect.anything() }),
+      expect.anything(),
+    );
+  });
+
   it("keeps explicit command spans", async () => {
     vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
 

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -8,6 +8,7 @@ import { normalizeExecutableToken } from "../infra/exec-wrapper-tokens.js";
 import {
   isShellWrapperExecutable,
   POSIX_SHELL_WRAPPERS,
+  resolveShellWrapperTransportArgv,
 } from "../infra/shell-wrapper-resolution.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import {
@@ -241,7 +242,11 @@ async function resolveCommandSpans(
 }
 
 function hasUnsupportedShellArgv(argv: readonly string[] | undefined): boolean {
-  const executable = argv?.[0];
+  if (!argv?.length) {
+    return false;
+  }
+  const shellWrapperArgv = resolveShellWrapperTransportArgv([...argv]) ?? argv;
+  const executable = shellWrapperArgv[0];
   if (!executable) {
     return false;
   }

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -4,6 +4,11 @@ import type {
   ExecSecurity,
   SystemRunApprovalPlan,
 } from "../infra/exec-approvals.js";
+import { normalizeExecutableToken } from "../infra/exec-wrapper-tokens.js";
+import {
+  isShellWrapperExecutable,
+  POSIX_SHELL_WRAPPERS,
+} from "../infra/shell-wrapper-resolution.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import {
   DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS,
@@ -15,6 +20,7 @@ type ExecApprovalCommandSpansRuntime =
   typeof import("./bash-tools.exec-approval-request.runtime.js");
 
 let execApprovalCommandSpansRuntimePromise: Promise<ExecApprovalCommandSpansRuntime> | null = null;
+const POSIX_COMMAND_HIGHLIGHT_SHELLS: ReadonlySet<string> = POSIX_SHELL_WRAPPERS;
 
 function loadExecApprovalCommandSpansRuntime(): Promise<ExecApprovalCommandSpansRuntime> {
   execApprovalCommandSpansRuntimePromise ??=
@@ -234,12 +240,34 @@ async function resolveCommandSpans(
   }
 }
 
+function hasUnsupportedShellArgv(argv: readonly string[] | undefined): boolean {
+  const executable = argv?.[0];
+  if (!executable) {
+    return false;
+  }
+  const normalizedExecutable = normalizeExecutableToken(executable);
+  return (
+    isShellWrapperExecutable(normalizedExecutable) &&
+    !POSIX_COMMAND_HIGHLIGHT_SHELLS.has(normalizedExecutable)
+  );
+}
+
+function shouldSkipGeneratedCommandSpans(params: HostExecApprovalParams): boolean {
+  if (params.host === "gateway" && process.platform === "win32") {
+    return true;
+  }
+  const argv = params.commandArgv?.length ? params.commandArgv : params.systemRunPlan?.argv;
+  return hasUnsupportedShellArgv(argv);
+}
+
 async function buildHostApprovalDecisionParams(
   params: HostExecApprovalParams,
 ): Promise<RequestExecApprovalDecisionParams> {
   const commandSpans =
     params.commandSpans ??
-    (await resolveCommandSpans(params.command ?? params.systemRunPlan?.commandText));
+    (shouldSkipGeneratedCommandSpans(params)
+      ? undefined
+      : await resolveCommandSpans(params.command ?? params.systemRunPlan?.commandText));
   return {
     id: params.approvalId,
     command: params.command,

--- a/src/infra/command-explainer/format.test.ts
+++ b/src/infra/command-explainer/format.test.ts
@@ -82,6 +82,14 @@ describe("formatCommandSpans", () => {
     expect(commandTexts).toContain("node");
   });
 
+  it("omits command spans for unsupported shell wrapper languages", async () => {
+    const powershell = await explainShellCommand('pwsh -Command "Get-ChildItem"');
+    const cmd = await explainShellCommand('cmd.exe /d /s /c "dir"');
+
+    expect(formatCommandSpans(powershell)).toEqual([]);
+    expect(formatCommandSpans(cmd)).toEqual([]);
+  });
+
   it("ignores invalid executable spans", () => {
     const explanation: CommandExplanation = {
       ok: true,

--- a/src/infra/command-explainer/format.test.ts
+++ b/src/infra/command-explainer/format.test.ts
@@ -90,6 +90,16 @@ describe("formatCommandSpans", () => {
     expect(formatCommandSpans(cmd)).toEqual([]);
   });
 
+  it("omits command spans for unsupported shell wrappers through transparent carriers", async () => {
+    const timeoutPowershell = await explainShellCommand('timeout 5 pwsh -Command "Get-ChildItem"');
+    const timeCmd = await explainShellCommand('time cmd.exe /d /s /c "dir"');
+    const splitEnvPowershell = await explainShellCommand("env -S 'pwsh -Command Get-ChildItem'");
+
+    expect(formatCommandSpans(timeoutPowershell)).toEqual([]);
+    expect(formatCommandSpans(timeCmd)).toEqual([]);
+    expect(formatCommandSpans(splitEnvPowershell)).toEqual([]);
+  });
+
   it("ignores invalid executable spans", () => {
     const explanation: CommandExplanation = {
       ok: true,

--- a/src/infra/command-explainer/format.ts
+++ b/src/infra/command-explainer/format.ts
@@ -1,5 +1,9 @@
 import type { ExecApprovalCommandSpan } from "../exec-approvals.js";
+import { normalizeExecutableToken } from "../exec-wrapper-tokens.js";
+import { isShellWrapperExecutable, POSIX_SHELL_WRAPPERS } from "../shell-wrapper-resolution.js";
 import type { CommandExplanation } from "./types.js";
+
+const POSIX_COMMAND_HIGHLIGHT_SHELLS: ReadonlySet<string> = POSIX_SHELL_WRAPPERS;
 
 function spanToCommandSpan(span: {
   startIndex: number;
@@ -14,7 +18,24 @@ function spanToCommandSpan(span: {
   return { startIndex: span.startIndex, endIndex: span.endIndex };
 }
 
+function isUnsupportedShellWrapper(executable: string): boolean {
+  const normalizedExecutable = normalizeExecutableToken(executable);
+  return (
+    isShellWrapperExecutable(normalizedExecutable) &&
+    !POSIX_COMMAND_HIGHLIGHT_SHELLS.has(normalizedExecutable)
+  );
+}
+
+function hasUnsupportedShellWrapper(explanation: CommandExplanation): boolean {
+  return explanation.topLevelCommands.some((command) =>
+    isUnsupportedShellWrapper(command.executable),
+  );
+}
+
 export function formatCommandSpans(explanation: CommandExplanation): ExecApprovalCommandSpan[] {
+  if (hasUnsupportedShellWrapper(explanation)) {
+    return [];
+  }
   const commandSpans: ExecApprovalCommandSpan[] = [];
 
   for (const command of [...explanation.topLevelCommands, ...explanation.nestedCommands]) {

--- a/src/infra/command-explainer/format.ts
+++ b/src/infra/command-explainer/format.ts
@@ -1,6 +1,10 @@
 import type { ExecApprovalCommandSpan } from "../exec-approvals.js";
 import { normalizeExecutableToken } from "../exec-wrapper-tokens.js";
-import { isShellWrapperExecutable, POSIX_SHELL_WRAPPERS } from "../shell-wrapper-resolution.js";
+import {
+  isShellWrapperExecutable,
+  POSIX_SHELL_WRAPPERS,
+  resolveShellWrapperTransportArgv,
+} from "../shell-wrapper-resolution.js";
 import type { CommandExplanation } from "./types.js";
 
 const POSIX_COMMAND_HIGHLIGHT_SHELLS: ReadonlySet<string> = POSIX_SHELL_WRAPPERS;
@@ -18,7 +22,12 @@ function spanToCommandSpan(span: {
   return { startIndex: span.startIndex, endIndex: span.endIndex };
 }
 
-function isUnsupportedShellWrapper(executable: string): boolean {
+function isUnsupportedShellWrapperArgv(argv: readonly string[]): boolean {
+  const shellWrapperArgv = resolveShellWrapperTransportArgv([...argv]) ?? argv;
+  const executable = shellWrapperArgv[0];
+  if (!executable) {
+    return false;
+  }
   const normalizedExecutable = normalizeExecutableToken(executable);
   return (
     isShellWrapperExecutable(normalizedExecutable) &&
@@ -28,7 +37,7 @@ function isUnsupportedShellWrapper(executable: string): boolean {
 
 function hasUnsupportedShellWrapper(explanation: CommandExplanation): boolean {
   return explanation.topLevelCommands.some((command) =>
-    isUnsupportedShellWrapper(command.executable),
+    isUnsupportedShellWrapperArgv(command.argv),
   );
 }
 


### PR DESCRIPTION
Summary
- Suppress generated approval command spans when the top-level shell wrapper is not POSIX.
- Keep unsupported commands as plain text in approval UI; approval behavior is unchanged.
- Preserve explicit `commandSpans` passthrough.

Verification
- `fnm exec --using v22.21.0 pnpm test src/infra/command-explainer/format.test.ts src/agents/bash-tools.exec-approval-request.test.ts -- --reporter=verbose`
- `fnm exec --using v22.21.0 pnpm exec oxfmt --check --threads=1 src/infra/command-explainer/format.ts src/infra/command-explainer/format.test.ts src/agents/bash-tools.exec-approval-request.test.ts`
- `fnm exec --using v22.21.0 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/infra/command-explainer/format.ts src/infra/command-explainer/format.test.ts src/agents/bash-tools.exec-approval-request.test.ts`
- `fnm exec --using v22.21.0 pnpm tsgo:core`
- `git diff --check origin/main...HEAD`