### PR TITLE
Fix Telegram legacy message cache recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Docs: https://docs.openclaw.ai
 - Docker: keep image builds on the source pnpm workspace policy so pnpm 11 can prune production dependencies without a Docker-only workspace rewrite.
 - Agents/compaction: restore info-level gateway logs for embedded compaction start, completion, and incomplete outcomes. (#71961) Thanks @rubencu.
 - Telegram: build reply-aware inbound turns through the shared channel context path so agents see the current reply target inline with the current message.
+- Telegram: recover legacy message cache files that mixed JSON-array and line-delimited entries so restarted gateways preserve reply-window context. (#80567)
 - Memory: skip managed dreaming cron reconciliation warnings for ordinary cron and heartbeat hook contexts that cannot manage Gateway cron. (#77027) Thanks @rubencu.
 - Cron: treat Codex app-server turn acceptance, CLI process spawn, and tool starts as execution milestones, preventing isolated runs from tripping the early startup watchdog after work has begun.
 - Yuanbao: bump `openclaw-plugin-yuanbao` to 2.13.1 to support `sourceReplyDeliveryMode: "automatic"` for group chat. (#79814) Thanks @loongfay.

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -1,4 +1,4 @@
-import { readFile, rm } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
 import type { Message } from "@grammyjs/types";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -7,6 +7,28 @@ import {
   createTelegramMessageCache,
   resolveTelegramMessageCachePath,
 } from "./message-cache.js";
+
+type PersistedCacheEntry = {
+  key: string;
+  node: {
+    sourceMessage: Message;
+  };
+};
+
+function persistedCacheEntry(messageId: number, text: string): PersistedCacheEntry {
+  return {
+    key: `default:7:${messageId}`,
+    node: {
+      sourceMessage: {
+        chat: { id: 7, type: "group", title: "Ops" },
+        message_id: messageId,
+        date: 1736380000 + messageId,
+        text,
+        from: { id: messageId, is_bot: false, first_name: `User ${messageId}` },
+      } as Message,
+    },
+  };
+}
 
 describe("telegram message cache", () => {
   it("hydrates reply chains from persisted cached messages", async () => {
@@ -248,6 +270,54 @@ describe("telegram message cache", () => {
           return entry.node.sourceMessage.message_id;
         }),
       ).toEqual([9204, 9205, 9206]);
+    } finally {
+      await rm(persistedPath, { force: true });
+    }
+  });
+
+  it("loads mixed legacy array caches and rewrites them as line-delimited entries", async () => {
+    const storePath = `/tmp/openclaw-telegram-message-cache-legacy-${process.pid}-${Date.now()}.json`;
+    const persistedPath = resolveTelegramMessageCachePath(storePath);
+    await rm(persistedPath, { force: true });
+    try {
+      const legacyEntries = [
+        persistedCacheEntry(35033, "ocdbg-5818 one"),
+        persistedCacheEntry(35034, "ocdbg-5818 two"),
+        persistedCacheEntry(35035, "ocdbg-5818 three"),
+      ];
+      const appendedEntries = [
+        persistedCacheEntry(35036, "ocdbg-5818 four"),
+        persistedCacheEntry(35037, "ocdbg-5818 five"),
+      ];
+      await writeFile(
+        persistedPath,
+        `${JSON.stringify(legacyEntries)}${appendedEntries.map((entry) => JSON.stringify(entry)).join("\n")}\n`,
+      );
+
+      const cache = createTelegramMessageCache({ persistedPath });
+
+      expect(
+        cache
+          .around({
+            accountId: "default",
+            chatId: 7,
+            messageId: "35035",
+            before: 2,
+            after: 2,
+          })
+          .map((entry) => entry.messageId),
+      ).toEqual(["35033", "35034", "35035", "35036", "35037"]);
+
+      const canonical = await readFile(persistedPath, "utf-8");
+      expect(canonical.startsWith("[")).toBe(false);
+      const lines = canonical.trim().split("\n");
+      expect(lines).toHaveLength(5);
+      expect(
+        lines.map((line) => {
+          const entry = JSON.parse(line) as PersistedCacheEntry;
+          return entry.node.sourceMessage.message_id;
+        }),
+      ).toEqual([35033, 35034, 35035, 35036, 35037]);
     } finally {
       await rm(persistedPath, { force: true });
     }

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -59,6 +59,10 @@ type TelegramMessageCacheBucket = {
   persistedEntryCount: number;
 };
 
+type PersistedMessageReadResult = TelegramMessageCacheBucket & {
+  needsRewrite: boolean;
+};
+
 const DEFAULT_MAX_MESSAGES = 5000;
 const COMPACT_THRESHOLD_RATIO = 2;
 const persistedMessageCacheBuckets = new Map<string, TelegramMessageCacheBucket>();
@@ -173,6 +177,85 @@ function parsePersistedEntry(value: unknown): {
   return node ? { key: value.key, node } : null;
 }
 
+function findJsonArrayEnd(text: string): number {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  let started = false;
+  for (let index = 0; index < text.length; index++) {
+    const char = text[index];
+    if (!started) {
+      if (char.trim() === "") {
+        continue;
+      }
+      if (char !== "[") {
+        return -1;
+      }
+      started = true;
+      depth = 1;
+      continue;
+    }
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+    } else if (char === "[") {
+      depth++;
+    } else if (char === "]") {
+      depth--;
+      if (depth === 0) {
+        return index + 1;
+      }
+    }
+  }
+  return -1;
+}
+
+function readPersistedEntryValues(raw: string): { values: unknown[]; needsRewrite: boolean } {
+  const values: unknown[] = [];
+  let needsRewrite = false;
+  const readLines = (text: string) => {
+    for (const line of text.split("\n")) {
+      if (!line.trim()) {
+        continue;
+      }
+      try {
+        const value: unknown = JSON.parse(line);
+        values.push(value);
+      } catch {
+        needsRewrite = true;
+      }
+    }
+  };
+  const trimmedStart = raw.trimStart();
+  if (trimmedStart.startsWith("[")) {
+    const startOffset = raw.length - trimmedStart.length;
+    const arrayEnd = findJsonArrayEnd(raw.slice(startOffset));
+    if (arrayEnd === -1) {
+      needsRewrite = true;
+      readLines(raw);
+      return { values, needsRewrite };
+    }
+    const legacyValue: unknown = JSON.parse(raw.slice(startOffset, startOffset + arrayEnd));
+    if (Array.isArray(legacyValue)) {
+      values.push(...legacyValue);
+    }
+    needsRewrite = true;
+    readLines(raw.slice(startOffset + arrayEnd));
+    return { values, needsRewrite };
+  }
+  readLines(raw);
+  return { values, needsRewrite };
+}
+
 function trimMessages(messages: Map<string, TelegramCachedMessageNode>, maxMessages: number): void {
   while (messages.size > maxMessages) {
     const oldest = messages.keys().next().value;
@@ -183,18 +266,18 @@ function trimMessages(messages: Map<string, TelegramCachedMessageNode>, maxMessa
   }
 }
 
-function readPersistedMessages(filePath: string, maxMessages: number) {
+function readPersistedMessages(filePath: string, maxMessages: number): PersistedMessageReadResult {
   const messages = new Map<string, TelegramCachedMessageNode>();
   let persistedEntryCount = 0;
+  let needsRewrite = false;
   if (!fs.existsSync(filePath)) {
-    return { messages, persistedEntryCount };
+    return { messages, persistedEntryCount, needsRewrite };
   }
   try {
-    for (const line of fs.readFileSync(filePath, "utf-8").split("\n")) {
-      if (!line.trim()) {
-        continue;
-      }
-      const entry = parsePersistedEntry(JSON.parse(line));
+    const persisted = readPersistedEntryValues(fs.readFileSync(filePath, "utf-8"));
+    needsRewrite = persisted.needsRewrite;
+    for (const value of persisted.values) {
+      const entry = parsePersistedEntry(value);
       if (!entry) {
         continue;
       }
@@ -205,8 +288,9 @@ function readPersistedMessages(filePath: string, maxMessages: number) {
     }
   } catch (error) {
     logVerbose(`telegram: failed to read message cache: ${String(error)}`);
+    needsRewrite = true;
   }
-  return { messages, persistedEntryCount };
+  return { messages, persistedEntryCount, needsRewrite };
 }
 
 function serializePersistedEntry(key: string, node: TelegramCachedMessageNode): string {
@@ -279,6 +363,16 @@ function resolveMessageCacheBucket(params: {
     messages: persisted.messages,
     persistedEntryCount: persisted.persistedEntryCount,
   };
+  if (persisted.needsRewrite) {
+    try {
+      bucket.persistedEntryCount = replacePersistedMessages({
+        messages: bucket.messages,
+        persistedPath,
+      });
+    } catch (error) {
+      logVerbose(`telegram: failed to compact message cache: ${String(error)}`);
+    }
+  }
   persistedMessageCacheBuckets.set(persistedPath, bucket);
   return bucket;
 }


### PR DESCRIPTION
## Summary

Fix Telegram message-cache startup when an older JSON-array cache has newer line-delimited entries appended after it.

The reader now normalizes legacy arrays and NDJSON entries into the same cached-entry stream, then rewrites the file back to canonical NDJSON.

## Repro Proof

Before the fix, the live Docker bot could not reload its Telegram message cache after restart:

```text
message-cache:read:start firstChar="[" lineCount=375
message-cache:read:error Unexpected non-whitespace character after JSON at position 236526
message-cache:read:done persistedEntryCount=0 loadedMessageCount=0
```

That made old replies keep only the direct Telegram reply target, but lose the surrounding parent window.

After patching the same live Docker cache:

```text
message-cache:read:start firstChar="[" values=685 needsRewrite=true
message-cache:read:done persistedEntryCount=685 loadedMessageCount=684 needsRewrite=true
message-cache:rewrite persistedEntryCount=684 messageCount=684
```

A second restart loaded the canonicalized file cleanly:

```text
message-cache:read:start firstChar="{" values=684 needsRewrite=false
message-cache:read:done persistedEntryCount=684 loadedMessageCount=684 needsRewrite=false
```

Live Telegram raw-input proof for message `#35040` then showed the replied-to parent plus surrounding context:

```text
#35033 obviyus: ocdbg-5818 one
#35034 obviyus: ocdbg-5818 two
#35035 [reply target] obviyus: ocdbg-5818 three
#35036 obviyus: ocdbg-5818 four
#35037 obviyus: ocdbg-5818 five
#35038 ->#35035 obviyus: @HamVerBot ocdbg-5818 reply check. Say debug received.

Current message:
[Replying to: "ocdbg-5818 three"]
#35040 obviyus
```

## Verification

- `pnpm test extensions/telegram/src/message-cache.test.ts`
- Regression test recreates the mixed legacy array + appended NDJSON cache and proves it loads the reply window, then rewrites to line-delimited entries.
