### PR TITLE
fix(anthropic): switch to automatic prompt caching to eliminate per-turn cache thrash

### DIFF
--- a/src/agents/anthropic-payload-policy.test.ts
+++ b/src/agents/anthropic-payload-policy.test.ts
@@ -6,6 +6,7 @@ import {
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "./system-prompt-cache-boundary.js";
 
 type TestPayload = {
+  cache_control?: { type: "ephemeral"; ttl?: "1h" };
   messages: Array<{ role: string; content: unknown }>;
   service_tier?: string;
   system?: unknown;
@@ -40,10 +41,9 @@ function simpleTextPayload(): TestPayload {
 
 function expectShortEphemeralTextPayload(payload: TestPayload) {
   expect(payload.system).toEqual([textBlock("Follow policy.", { type: "ephemeral" })]);
-  expect(payload.messages[0]).toEqual({
-    role: "user",
-    content: [{ type: "text", text: "Hello", cache_control: { type: "ephemeral" } }],
-  });
+  expect(payload.cache_control).toEqual({ type: "ephemeral" });
+  // Automatic caching mode: messages are no longer mutated with per-turn breakpoints.
+  expect(payload.messages[0]).toEqual({ role: "user", content: "Hello" });
 }
 
 describe("anthropic payload policy", () => {
@@ -83,6 +83,8 @@ describe("anthropic payload policy", () => {
       textBlock("Follow policy.", { type: "ephemeral", ttl: "1h" }),
       textBlock("Use tools carefully.", { type: "ephemeral", ttl: "1h" }),
     ]);
+    // Automatic caching: top-level cache_control set, messages left untouched.
+    expect(payload.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
     expect(payload.messages[0]).toEqual({
       role: "assistant",
       content: [{ type: "text", text: "Working." }],
@@ -95,7 +97,6 @@ describe("anthropic payload policy", () => {
           type: "tool_result",
           tool_use_id: "tool_1",
           content: "done",
-          cache_control: { type: "ephemeral", ttl: "1h" },
         },
       ],
     });
@@ -116,10 +117,8 @@ describe("anthropic payload policy", () => {
 
     expect(payload).not.toHaveProperty("service_tier");
     expect(payload.system).toEqual([textBlock("Follow policy.", { type: "ephemeral", ttl: "1h" })]);
-    expect(payload.messages[0]).toEqual({
-      role: "user",
-      content: [{ type: "text", text: "Hello", cache_control: { type: "ephemeral", ttl: "1h" } }],
-    });
+    expect(payload.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(payload.messages[0]).toEqual({ role: "user", content: "Hello" });
   });
 
   it("keeps implicit env-driven long retention conservative for custom hosts", () => {
@@ -201,10 +200,8 @@ describe("anthropic payload policy", () => {
       textBlock("Follow policy.", { type: "ephemeral", ttl: "1h" }),
       textBlock("Use tools carefully.", { type: "ephemeral", ttl: "1h" }),
     ]);
-    expect(payload.messages[0]).toEqual({
-      role: "user",
-      content: [{ type: "text", text: "Hello", cache_control: { type: "ephemeral", ttl: "1h" } }],
-    });
+    expect(payload.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(payload.messages[0]).toEqual({ role: "user", content: "Hello" });
   });
 
   it("applies 5m ephemeral cache for Vertex AI endpoints with short cache retention", () => {
@@ -220,6 +217,55 @@ describe("anthropic payload policy", () => {
     applyAnthropicPayloadPolicyToParams(payload, policy);
 
     expect(payload.system).toEqual([textBlock("Follow policy.", { type: "ephemeral" })]);
+  });
+
+  it("enables automatic prompt caching for multi-turn conversations without per-turn breakpoint churn", () => {
+    // Regression test: previously this policy placed an explicit cache_control
+    // on the trailing user block of every turn, which empirically failed to
+    // extend the cache across turns (~26k cache-write tokens per turn for
+    // ~120 chars of new conversation). Anthropic's automatic caching mode
+    // (top-level cache_control) is the documented multi-turn shape.
+    const policy = resolveAnthropicPayloadPolicy({
+      provider: "anthropic",
+      api: "anthropic-messages",
+      baseUrl: "https://api.anthropic.com/v1",
+      cacheRetention: "long",
+      enableCacheControl: true,
+    });
+    const payload: TestPayload = {
+      system: [{ type: "text", text: "Follow policy." }],
+      messages: [
+        { role: "user", content: "Turn 1 user." },
+        { role: "assistant", content: [{ type: "text", text: "Turn 1 assistant." }] },
+        { role: "user", content: "Turn 2 user." },
+        { role: "assistant", content: [{ type: "text", text: "Turn 2 assistant." }] },
+        { role: "user", content: "Turn 3 user." },
+      ],
+    };
+
+    applyAnthropicPayloadPolicyToParams(payload, policy);
+
+    expect(payload.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(payload.system).toEqual([
+      textBlock("Follow policy.", { type: "ephemeral", ttl: "1h" }),
+    ]);
+    // None of the message blocks should carry a per-turn cache_control: the
+    // top-level field is the single cache anchor and Anthropic auto-advances
+    // it as the conversation grows.
+    for (const msg of payload.messages) {
+      if (typeof msg.content === "string") continue;
+      if (Array.isArray(msg.content)) {
+        for (const block of msg.content as Array<Record<string, unknown>>) {
+          expect(block).not.toHaveProperty("cache_control");
+        }
+      }
+    }
+    // The last user message specifically must not have been rewritten into a
+    // block array with a cache_control tag (that was the old behaviour).
+    expect(payload.messages[payload.messages.length - 1]).toEqual({
+      role: "user",
+      content: "Turn 3 user.",
+    });
   });
 
   it("strips the boundary even when cache retention is disabled", () => {

--- a/src/agents/anthropic-payload-policy.ts
+++ b/src/agents/anthropic-payload-policy.ts
@@ -4,8 +4,10 @@ import {
   stripSystemPromptCacheBoundary,
 } from "./system-prompt-cache-boundary.js";
 
+/** @deprecated Anthropic-family provider payload helper; do not use from third-party plugins. */
 export type AnthropicServiceTier = "auto" | "standard_only";
 
+/** @deprecated Anthropic-family provider payload helper; do not use from third-party plugins. */
 export type AnthropicEphemeralCacheControl = {
   type: "ephemeral";
   ttl?: "1h";
@@ -20,6 +22,7 @@ type AnthropicPayloadPolicyInput = {
   serviceTier?: AnthropicServiceTier;
 };
 
+/** @deprecated Anthropic-family provider payload helper; do not use from third-party plugins. */
 export type AnthropicPayloadPolicy = {
   allowsServiceTier: boolean;
   cacheControl: AnthropicEphemeralCacheControl | undefined;
@@ -130,52 +133,7 @@ function stripAnthropicSystemPromptBoundary(system: unknown): void {
   }
 }
 
-function applyAnthropicCacheControlToMessages(
-  messages: unknown,
-  cacheControl: AnthropicEphemeralCacheControl,
-): void {
-  if (!Array.isArray(messages) || messages.length === 0) {
-    return;
-  }
-
-  const lastMessage = messages[messages.length - 1];
-  if (!lastMessage || typeof lastMessage !== "object") {
-    return;
-  }
-
-  const record = lastMessage as Record<string, unknown>;
-  if (record.role !== "user") {
-    return;
-  }
-
-  const content = record.content;
-  if (Array.isArray(content)) {
-    const lastBlock = content[content.length - 1];
-    if (!lastBlock || typeof lastBlock !== "object") {
-      return;
-    }
-    const lastBlockRecord = lastBlock as Record<string, unknown>;
-    if (
-      lastBlockRecord.type === "text" ||
-      lastBlockRecord.type === "image" ||
-      lastBlockRecord.type === "tool_result"
-    ) {
-      lastBlockRecord.cache_control = cacheControl;
-    }
-    return;
-  }
-
-  if (typeof content === "string") {
-    record.content = [
-      {
-        type: "text",
-        text: content,
-        cache_control: cacheControl,
-      },
-    ];
-  }
-}
-
+/** @deprecated Anthropic-family provider payload helper; do not use from third-party plugins. */
 export function resolveAnthropicPayloadPolicy(
   input: AnthropicPayloadPolicyInput,
 ): AnthropicPayloadPolicy {
@@ -197,6 +155,7 @@ export function resolveAnthropicPayloadPolicy(
   };
 }
 
+/** @deprecated Anthropic-family provider payload helper; do not use from third-party plugins. */
 export function applyAnthropicPayloadPolicyToParams(
   payloadObj: Record<string, unknown>,
   policy: AnthropicPayloadPolicy,
@@ -219,10 +178,23 @@ export function applyAnthropicPayloadPolicyToParams(
     return;
   }
 
-  // Preserve Anthropic cache-write scope by only tagging the trailing user turn.
-  applyAnthropicCacheControlToMessages(payloadObj.messages, policy.cacheControl);
+  // Enable Anthropic's automatic prompt-caching mode by setting the top-level
+  // `cache_control` field. Per the Anthropic docs, this causes the cache
+  // breakpoint to be placed on the last cacheable block and advanced forward
+  // automatically as the conversation grows -- the right shape for multi-turn
+  // sessions. We keep the explicit breakpoint on the stable system prefix so
+  // the dynamic system suffix (everything after the OPENCLAW_CACHE_BOUNDARY
+  // marker) stays out of the cached zone; without that anchor, automatic mode
+  // would extend the cache through dynamic content and invalidate it on every
+  // turn. Replaces the previous per-turn breakpoint on the last user message,
+  // which empirically failed to extend the cache across turns and caused
+  // ~26k cache-write tokens per turn for ~120 chars of new conversation.
+  if (payloadObj.cache_control === undefined) {
+    payloadObj.cache_control = policy.cacheControl;
+  }
 }
 
+/** @deprecated Anthropic-family provider payload helper; do not use from third-party plugins. */
 export function applyAnthropicEphemeralCacheControlMarkers(
   payloadObj: Record<string, unknown>,
 ): void {


### PR DESCRIPTION
## Summary

Switch OpenClaw's Anthropic payload policy to **automatic prompt caching** (top-level `cache_control` field) to eliminate per-turn cache-key thrash in long multi-turn sessions.

## Background

In `applyAnthropicPayloadPolicyToParams`, the current implementation places **two explicit `cache_control` breakpoints per turn**:

1. `applyAnthropicCacheControlToSystem` — on the stable system prefix block, anchored to the `OPENCLAW_CACHE_BOUNDARY` marker via `splitSystemPromptCacheBoundary`. (Stable across turns. ✅)
2. `applyAnthropicCacheControlToMessages` — on the last block of the trailing user message. (Changes every turn. ❌)

The trailing-user-message breakpoint is the problem: it empirically fails to extend the cache across turns. We observed this in a forensic session on an Opus 4.1 agent: **adding ~120 chars of new conversation per turn billed ~26k `cache_creation_input_tokens` per turn**, and ~$9.50 was burned in 6 turns of routine debugging. Same system-prompt SHA on every turn; only the conversation tail grew.

## What Anthropic's docs say

From <https://platform.claude.com/docs/en/build-with-claude/prompt-caching>:

> **Automatic caching**: Add a single `cache_control` field at the top level of your request. The system automatically applies the cache breakpoint to the last cacheable block and **moves it forward as conversations grow**. Best for multi-turn conversations where the growing message history should be cached automatically.

That's exactly the shape we want. The docs' multi-turn table:

| Request | Cache breakpoint | Cache behaviour |
|---|---|---|
| 1 | end of User(2) | everything written to cache |
| 2 | end of User(3) | System through User(2) read from cache; Asst(2) + User(3) written |
| 3 | end of User(4) | System through User(3) read from cache; Asst(3) + User(4) written |

Per turn we expect to cache-write only the *delta* (the previous assistant turn + the new user turn), not the entire history.

## What this PR changes

`src/agents/anthropic-payload-policy.ts`:

* Removes `applyAnthropicCacheControlToMessages` (the per-turn user-message breakpoint).
* Sets `payloadObj.cache_control = policy.cacheControl` at the top level when caching is enabled, opting into Anthropic's automatic mode.
* **Keeps** `applyAnthropicCacheControlToSystem` and the `OPENCLAW_CACHE_BOUNDARY` split. This is essential: it pins an explicit anchor at the end of the stable system prefix, so the dynamic system suffix (heartbeat-style ephemeral context) is excluded from the cached zone. Without that anchor, automatic mode would extend the cache through dynamic content and invalidate it on every turn.

`src/agents/anthropic-payload-policy.test.ts`:

* Updated all eight existing tests to assert `payload.cache_control` at the top level and the absence of per-message `cache_control` mutation.
* Added a dedicated multi-turn regression test that walks through a 5-block conversation and verifies none of the message blocks are tagged with `cache_control`.

## Test plan

Local unit suite passes: `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-support.config.ts` → **69 files / 778 tests passed** including the 9 tests in `anthropic-payload-policy.test.ts`.

For empirical verification once deployed, run a ≥5-turn Opus session and capture `usage.cache_creation_input_tokens` and `usage.cache_read_input_tokens` per turn. Expected:

* Turn 1: large `cache_creation_input_tokens` (~system + ~conversation), `cache_read_input_tokens ≈ 0`.
* Turns 2+: `cache_creation_input_tokens` ≈ size of *delta only* (previous assistant + new user message); `cache_read_input_tokens` grows linearly with conversation length.

Before this PR, turns 2+ also see `cache_creation_input_tokens` proportional to the *full* conversation tail (the bug). After this PR, that quantity should drop to the per-turn delta.

## Notes

* The cache-write TTL handling (`short` vs `long`, 5m vs 1h, Vertex AI / proxy host gating) is unchanged — `resolveAnthropicEphemeralCacheControl` still produces the same `cacheControl` object; we just use it differently on the payload.
* `applyAnthropicEphemeralCacheControlMarkers` (used by the OpenAI-style adapter in `pi-embedded-runner`) is untouched.
