### PR TITLE
fix(agents): relax session status check for sessions without explicit status (feishu recovery)

### DIFF
--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -136,7 +136,10 @@ async function markSessionFailed(params: {
     params.storePath,
     (store) => {
       const entry = store[params.sessionKey];
-      if (!entry || entry.status !== "running") {
+      if (!entry) {
+        return;
+      }
+      if (entry.status && entry.status !== "running") {
         return;
       }
       entry.status = "failed";
@@ -226,7 +229,10 @@ export async function markRestartAbortedMainSessionsFromLocks(params: {
     storePath,
     (store) => {
       for (const [sessionKey, entry] of Object.entries(store)) {
-        if (!entry || entry.status !== "running") {
+        if (!entry) {
+          continue;
+        }
+        if (entry.status && entry.status !== "running") {
           continue;
         }
         if (shouldSkipMainRecovery(entry, sessionKey)) {
@@ -268,7 +274,13 @@ async function recoverStore(params: {
   for (const [sessionKey, entry] of Object.entries(store).toSorted(([a], [b]) =>
     a.localeCompare(b),
   )) {
-    if (!entry || entry.status !== "running" || entry.abortedLastRun !== true) {
+    if (!entry) {
+      continue;
+    }
+    if (entry.status && entry.status !== "running") {
+      continue;
+    }
+    if (entry.abortedLastRun !== true) {
       continue;
     }
     if (shouldSkipMainRecovery(entry, sessionKey)) {


### PR DESCRIPTION
## Summary

Sessions created by chat channels (e.g., Feishu direct messages) do not set a `status` field while active. The restart recovery mechanism in `main-session-restart-recovery.ts` uses strict `entry.status !== "running"` checks, which treat `undefined` as not-running — causing these sessions to be silently skipped during recovery.

**Result**: After any gateway restart, Feishu DM sessions become permanently stuck (`replies=0`) because:
1. `markRestartAbortedMainSessionsFromLocks` never sets `abortedLastRun` on them
2. `recoverStore` never resumes them
3. The agent keeps hitting "Invalid session ID" errors → 300s timeout → health monitor restarts → loop

## Fix

Split the combined `!entry || entry.status !== "running"` guard into separate checks. Sessions without a `status` field now pass through. Only sessions explicitly set to a non-running status (`"done"`, `"failed"`) are blocked.

Three locations fixed:
- `markSessionFailed` (line 139)
- `markRestartAbortedMainSessionsFromLocks` (line 229)  
- `recoverStore` (line 271)

## Verification

- Applied the fix locally on OpenClaw 2026.5.5
- Syntax check passes (`node --check`)
- Manually tested: after `openclaw gateway restart`, feishu DM session recovered within 5 seconds (previously stuck indefinitely)
- Related: #57851, #58953