### PR TITLE
chore(system-prompt): place HEARTBEAT.md above the cache boundary

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1083,6 +1083,26 @@ describe("buildAgentSystemPrompt", () => {
     expect(reactionsPos).toBeGreaterThan(boundaryPos);
     expect(voicePos).toBeGreaterThan(boundaryPos);
   });
+
+  it("places HEARTBEAT.md above the cache boundary so the stable workspace prefix stays byte-identical across turns", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      contextFiles: [
+        { path: "AGENTS.md", content: "Agent rules." },
+        { path: "HEARTBEAT.md", content: "Heartbeat behaviour rules." },
+      ],
+    });
+
+    const heartbeatPos = prompt.indexOf("Heartbeat behaviour rules.");
+    const boundaryPos = prompt.indexOf(SYSTEM_PROMPT_CACHE_BOUNDARY);
+
+    expect(heartbeatPos).toBeGreaterThan(-1);
+    expect(boundaryPos).toBeGreaterThan(-1);
+    expect(heartbeatPos).toBeLessThan(boundaryPos);
+    // The dynamic-context heading should not be rendered when no file is
+    // marked dynamic.
+    expect(prompt).not.toContain("# Dynamic Project Context");
+  });
 });
 
 describe("buildAgentBootstrapSystemContext", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -54,7 +54,16 @@ const CONTEXT_FILE_ORDER = new Map<string, number>([
   ["memory.md", 70],
 ]);
 
-const DYNAMIC_CONTEXT_FILE_BASENAMES = new Set(["heartbeat.md"]);
+// Files whose basename matches one of these names are injected *below* the
+// SYSTEM_PROMPT_CACHE_BOUNDARY (i.e. excluded from the cached system prefix).
+// HEARTBEAT.md is intentionally NOT in this set: in practice it is a static
+// workspace rules file that changes only when an operator edits it, not
+// turn-to-turn, so emitting it below the boundary forced an unnecessary cache
+// rewrite each turn (~1.8k tokens for a 7KB heartbeat). Putting it above the
+// boundary makes the cached prefix include HEARTBEAT.md and stay byte-stable
+// across turns. If a genuinely turn-volatile workspace file ever appears, add
+// its lowercase basename here.
+const DYNAMIC_CONTEXT_FILE_BASENAMES = new Set<string>();
 const DEFAULT_HEARTBEAT_PROMPT_CONTEXT_BLOCK =
   "Default heartbeat prompt:\n`Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.`";
 const SYSTEM_PROMPT_STABLE_PREFIX_CACHE_LIMIT = 64;


### PR DESCRIPTION
## Summary

Move `HEARTBEAT.md` above the system-prompt cache boundary so it becomes part of the stable, cacheable prefix.

## Background

`buildAgentSystemPrompt` in `src/agents/system-prompt.ts` partitions workspace context files into two buckets:

* **stable** → emitted *before* `SYSTEM_PROMPT_CACHE_BOUNDARY` (cached as part of the prefix).
* **dynamic** → emitted *after* the boundary, under a `# Dynamic Project Context` heading (excluded from the cached prefix).

The dynamic bucket has, until now, contained exactly one file: `HEARTBEAT.md`, via:

```ts
const DYNAMIC_CONTEXT_FILE_BASENAMES = new Set(["heartbeat.md"]);
```

That's a misclassification. `HEARTBEAT.md` is a workspace rules file — it changes only when an operator deliberately edits it (sometimes weeks apart), not turn-to-turn. Treating it as dynamic forces it to be re-included as uncached input on every turn. For a typical ~7KB heartbeat that's ~1.8k tokens of cache rewrite per turn.

The actually-volatile content that *should* live below the cache boundary (channel-specific guidance, runtime status injections, project-context updates) is already injected through other code paths after the boundary in `buildAgentSystemPrompt`; this change does not affect those.

## What this PR changes

`src/agents/system-prompt.ts`:

* Empties `DYNAMIC_CONTEXT_FILE_BASENAMES`. With no basenames marked dynamic, all workspace context files (including `HEARTBEAT.md`) are now in `stableContextFiles` and emitted before the cache boundary.
* Adds a comment explaining the intent and how to re-add a genuinely turn-volatile file in the future.
* The mechanism (`isDynamicContextFile`, `dynamicContextFiles` filter, `# Dynamic Project Context` heading) is preserved so future code can opt files back in without re-introducing the structural concept.

`src/agents/system-prompt.test.ts`:

* Adds a regression test that asserts `HEARTBEAT.md` appears *before* `SYSTEM_PROMPT_CACHE_BOUNDARY` and the `# Dynamic Project Context` heading is no longer emitted when no file is marked dynamic.

## Test plan

`pnpm exec vitest run src/agents/system-prompt.test.ts src/agents/system-prompt-cache-boundary.test.ts src/agents/system-prompt-stability.test.ts` → all green (75 + 4 + 4 = 83 tests pass).

For empirical verification post-deploy, compare `cache_creation_input_tokens` per turn before and after on an agent whose workspace contains a non-trivial `HEARTBEAT.md`. Expected reduction: roughly the heartbeat's token count (~1.8k for a 7KB file) per turn that would otherwise have repaid that write.

## Companion

This is a follow-up to the larger Lever 0 fix (automatic prompt caching, separate PR) — both target per-turn cache-write waste in long multi-turn sessions, but are independent: this PR is purely a system-prompt-assembly change and applies regardless of which caching mode is in effect.
