### PR TITLE
Fix Telegram edited-message context cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: restore info-level gateway logs for embedded compaction start, completion, and incomplete outcomes. (#71961) Thanks @rubencu.
 - Telegram: build reply-aware inbound turns through the shared channel context path so agents see the current reply target inline with the current message.
 - Telegram: recover legacy message cache files that mixed JSON-array and line-delimited entries so restarted gateways preserve reply-window context. (#80567)
+- Telegram: update the reply-context cache when messages are edited, so streamed bot replies appear in later agent context with their final text instead of the first draft.
 - Skills/Windows: normalize compacted skill prompt locations to forward slashes after home-prefix compaction so Windows skill paths remain readable by model file tools. (#52200) Thanks @chienchandler.
 - Memory: skip managed dreaming cron reconciliation warnings for ordinary cron and heartbeat hook contexts that cannot manage Gateway cron. (#77027) Thanks @rubencu.
 - Cron: treat Codex app-server turn acceptance, CLI process spawn, and tool starts as execution milestones, preventing isolated runs from tripping the early startup watchdog after work has begun.

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -2201,6 +2201,55 @@ export const registerTelegramHandlers = ({
     errorMessage: string;
   };
 
+  const normalizeChannelPostMessage = (post: Message): Message => {
+    const chatId = post.chat.id;
+    const syntheticFrom = post.sender_chat
+      ? {
+          id: post.sender_chat.id,
+          is_bot: true as const,
+          first_name: post.sender_chat.title || "Channel",
+          username: post.sender_chat.username,
+        }
+      : {
+          id: chatId,
+          is_bot: true as const,
+          first_name: post.chat.title || "Channel",
+          username: post.chat.username,
+        };
+    return {
+      ...post,
+      from: post.from ?? syntheticFrom,
+      chat: {
+        ...post.chat,
+        type: "supergroup" as const,
+      },
+    } as Message;
+  };
+
+  const recordEditedMessageForReplyChain = async (
+    ctxForDedupe: TelegramUpdateKeyContext,
+    msg: Message,
+  ) => {
+    if (shouldSkipUpdate(ctxForDedupe)) {
+      return;
+    }
+    const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
+    const isForum = await resolveTelegramForumFlag({
+      chatId: msg.chat.id,
+      chatType: msg.chat.type,
+      isGroup,
+      isForum: msg.chat.is_forum,
+      getChat,
+    });
+    const normalizedMsg = withResolvedTelegramForumFlag(msg, isForum);
+    const resolvedThreadId = resolveTelegramForumThreadId({
+      isForum,
+      messageThreadId: normalizedMsg.message_thread_id,
+    });
+    const dmThreadId = !isGroup ? normalizedMsg.message_thread_id : undefined;
+    recordMessageForReplyChain(normalizedMsg, resolvedThreadId ?? dmThreadId);
+  };
+
   const handleInboundMessageLike = async (event: InboundTelegramEvent) => {
     try {
       if (shouldSkipUpdate(event.ctxForDedupe)) {
@@ -2329,6 +2378,14 @@ export const registerTelegramHandlers = ({
     });
   });
 
+  bot.on("edited_message", async (ctx) => {
+    const msg = ctx.editedMessage;
+    if (!msg) {
+      return;
+    }
+    await recordEditedMessageForReplyChain(ctx, msg);
+  });
+
   // Handle channel posts — enables bot-to-bot communication via Telegram channels.
   // Telegram bots cannot see other bot messages in groups, but CAN in channels.
   // This handler normalizes channel_post updates into the standard message pipeline.
@@ -2339,27 +2396,7 @@ export const registerTelegramHandlers = ({
     }
 
     const chatId = post.chat.id;
-    const syntheticFrom = post.sender_chat
-      ? {
-          id: post.sender_chat.id,
-          is_bot: true as const,
-          first_name: post.sender_chat.title || "Channel",
-          username: post.sender_chat.username,
-        }
-      : {
-          id: chatId,
-          is_bot: true as const,
-          first_name: post.chat.title || "Channel",
-          username: post.chat.username,
-        };
-    const syntheticMsg: Message = {
-      ...post,
-      from: post.from ?? syntheticFrom,
-      chat: {
-        ...post.chat,
-        type: "supergroup" as const,
-      },
-    } as Message;
+    const syntheticMsg = normalizeChannelPostMessage(post);
 
     await handleInboundMessageLike({
       ctxForDedupe: ctx,
@@ -2380,5 +2417,13 @@ export const registerTelegramHandlers = ({
       oversizeLogMessage: "channel post media exceeds size limit",
       errorMessage: "channel_post handler failed",
     });
+  });
+
+  bot.on("edited_channel_post", async (ctx) => {
+    const post = ctx.editedChannelPost;
+    if (!post) {
+      return;
+    }
+    await recordEditedMessageForReplyChain(ctx, normalizeChannelPostMessage(post));
   });
 };

--- a/extensions/telegram/src/bot-updates.ts
+++ b/extensions/telegram/src/bot-updates.ts
@@ -25,6 +25,7 @@ export type TelegramUpdateKeyContext = {
   update_id?: number;
   message?: Message;
   channelPost?: Message;
+  editedMessage?: Message;
   editedChannelPost?: Message;
   callbackQuery?: { id?: string; message?: Message };
 };
@@ -41,14 +42,21 @@ export const buildTelegramUpdateKey = (ctx: TelegramUpdateKeyContext) => {
   if (callbackId) {
     return `callback:${callbackId}`;
   }
+  const editedMsg =
+    ctx.editedMessage ??
+    ctx.editedChannelPost ??
+    ctx.update?.edited_message ??
+    ctx.update?.edited_channel_post;
+  const editedChatId = editedMsg?.chat?.id;
+  const editedMessageId = editedMsg?.message_id;
+  if (editedChatId !== undefined && typeof editedMessageId === "number") {
+    return `edited-message:${editedChatId}:${editedMessageId}`;
+  }
   const msg =
     ctx.message ??
     ctx.channelPost ??
-    ctx.editedChannelPost ??
     ctx.update?.message ??
-    ctx.update?.edited_message ??
     ctx.update?.channel_post ??
-    ctx.update?.edited_channel_post ??
     ctx.callbackQuery?.message;
   const chatId = msg?.chat?.id;
   const messageId = msg?.message_id;

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -1681,6 +1681,103 @@ describe("createTelegramBot", () => {
     expect(messagesById.get("201")?.body).toBe("After the incident review.");
   });
 
+  it("updates cached bot messages from Telegram edit updates", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+
+    loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          envelopeTimezone: "utc",
+        },
+      },
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          groups: { "*": { requireMention: false } },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+    const editedHandler = getOnHandler("edited_message") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+    const baseCtx = {
+      me: { id: 999, username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    };
+    const chat = { id: 42, type: "group", title: "Ops" };
+    const question = {
+      chat,
+      text: "/ask which bikes can reach 383kmph",
+      date: 1778474813,
+      message_id: 35014,
+      from: { id: 201, is_bot: false, first_name: "Kesava" },
+    };
+    const fullAnswer =
+      "Kawasaki Ninja H2R (claimed 400 km/h) and MTT 420RR turbine (claimed up to 439 km/h) exceed 383 km/h. Dodge Tomahawk reaches higher but is a 4-wheeled concept, not a standard bike.";
+
+    await handler({
+      ...baseCtx,
+      message: question,
+    });
+    await handler({
+      ...baseCtx,
+      message: {
+        chat,
+        text: "K",
+        date: 1778474823,
+        message_id: 35016,
+        from: { id: 777, is_bot: true, first_name: "Super Serious Bot" },
+        reply_to_message: question,
+      },
+    });
+
+    replySpy.mockClear();
+    await editedHandler({
+      ...baseCtx,
+      editedMessage: {
+        chat,
+        text: fullAnswer,
+        date: 1778474823,
+        edit_date: 1778474824,
+        message_id: 35016,
+        from: { id: 777, is_bot: true, first_name: "Super Serious Bot" },
+        reply_to_message: question,
+      },
+    });
+    expect(replySpy).not.toHaveBeenCalled();
+
+    await handler({
+      ...baseCtx,
+      message: {
+        chat,
+        text: "wtf",
+        date: 1778474850,
+        message_id: 35018,
+        from: { id: 202, is_bot: false, first_name: "Kesava" },
+      },
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = replySpy.mock.calls[0][0];
+    const [conversationContext] = requireArray(
+      payload.UntrustedStructuredContext,
+      "structured context",
+    );
+    const contextRecord = requireRecord(conversationContext, "conversation context");
+    const contextPayload = requireRecord(contextRecord.payload, "conversation context payload");
+    const messages = requireArray(contextPayload.messages, "conversation context messages").map(
+      (message, index) => requireRecord(message, `conversation context message ${index + 1}`),
+    );
+    const messagesById = new Map(messages.map((message) => [message.message_id, message]));
+    expect(messagesById.get("35016")?.sender).toBe("Super Serious Bot");
+    expect(messagesById.get("35016")?.body).toBe(fullAnswer);
+    expect(messagesById.get("35016")?.body).not.toBe("K");
+  });
+
   it("uses quote text when a Telegram partial reply is received", async () => {
     onSpy.mockClear();
     sendMessageSpy.mockClear();

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -16,6 +16,7 @@ type TelegramSequentialKeyContext = {
   me?: UserFromGetMe;
   message?: Message;
   channelPost?: Message;
+  editedMessage?: Message;
   editedChannelPost?: Message;
   update?: {
     message?: Message;
@@ -56,6 +57,7 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
   const msg =
     ctx.message ??
     ctx.channelPost ??
+    ctx.editedMessage ??
     ctx.editedChannelPost ??
     ctx.update?.message ??
     ctx.update?.edited_message ??


### PR DESCRIPTION
## Summary

- Cache Telegram `edited_message` and `edited_channel_post` updates without starting an agent turn.
- Keep edited updates distinct in dedupe keys but on the same per-chat/topic lane.
- Add a regression for a streaming bot reply that starts as `K` and later edits to the final answer.

## Real behavior proof

- **Behavior or issue addressed:** Telegram bot replies that stream by editing the same message were cached at their first draft text. In the real chat export, message #35016 from Super Serious Bot first appeared as `K`, then Telegram edited that same message to the full bike answer. Later agent context still saw only `K`.
- **Real environment tested:** Local OpenClaw PR worktree `.worktrees/pr-80579` rebased on latest `origin/main`, plus the real Telegram Desktop export for the Tax Payers chat that showed message #35016 with final edited text.
- **Exact steps or command run after this patch:**
  ```text
  pnpm test extensions/telegram/src/bot.test.ts -- --testNamePattern "updates cached bot messages from Telegram edit updates"
  pnpm test extensions/telegram/src/bot.test.ts
  pnpm check:changed
  ```
- **Evidence after fix:** Copied terminal output from the rebased PR worktree:
  ```text
  Test Files  1 passed (1)
  Tests  1 passed | 69 skipped (70)
  [test] passed 1 Vitest shard

  Test Files  1 passed (1)
  Tests  70 passed (70)
  [test] passed 1 Vitest shard

  [check:changed] lanes=extensions, extensionTests, docs
  Found 0 warnings and 0 errors.
  runtime-sidecar-loaders: local runtime sidecar loaders look OK.
  Import cycle check: 0 runtime value cycle(s).
  ```
- **Observed result after fix:** The regression records bot message #35016 as `K`, applies an `edited_message` update for the same Telegram message id, proves that edit does not call the agent, then proves the next inbound LLM context contains the final full answer instead of `K`.
- **What was not tested:** Live Docker redeploy was not done in this PR landing pass.

## Verification

- `pnpm test extensions/telegram/src/bot.test.ts -- --testNamePattern "updates cached bot messages from Telegram edit updates"`
- `pnpm test extensions/telegram/src/bot.test.ts`
- `pnpm check:changed`
