### PR TITLE
fix(codex): instruct gpt-5 family to call dynamic tools directly, not via exec

### DIFF
--- a/changelog/fragments/pr-codex-no-tool-wrapping-in-exec.md
+++ b/changelog/fragments/pr-codex-no-tool-wrapping-in-exec.md
@@ -1,0 +1,1 @@
+- Codex app-server: instruct gpt-5 family models to invoke OpenClaw dynamic tools (notably `message`) as structured tool calls rather than wrapping them inside `exec` shell snippets, so chat replies actually leave the harness instead of being silently shelled away.

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -478,6 +478,7 @@ export function buildDeveloperInstructions(params: EmbeddedRunAttemptParams): st
   const sections = [
     "Running inside OpenClaw. Use dynamic tools for messaging, cron, sessions, media, gateway, and nodes when available.",
     "Preserve channel/session context. Visible channel replies: use `message`, do not describe would-reply.",
+    "Invoke `message` (and every OpenClaw dynamic tool) as a structured tool call with its JSON arguments. Never wrap it in `exec`, `apply_patch`, or any shell/JavaScript snippet — strings like `tools.message(...)`, `await tools.message(...)`, or `message({...})` inside `exec` will execute as a shell command and deliver nothing. If you intended to reply, emit the `message` tool call directly with `{ action: \"send\", message: \"...\" }`.",
     promptOverlay,
     params.extraSystemPrompt,
     params.skillsSnapshot?.prompt,


### PR DESCRIPTION
## Summary

The Codex app-server harness already tells the model to "use `message`" for visible channel replies ([`buildDeveloperInstructions`](https://github.com/openclaw/openclaw/blob/main/extensions/codex/src/app-server/thread-lifecycle.ts)). Under Codex's coding‑agent `base_instructions`, gpt‑5.5 reads "use message" as **"use it from inside `exec`"** and emits a `custom_tool_call` named `exec` whose freeform input is JavaScript like `await tools.message({...})`. Codex runs that as a shell command, it does nothing, the structured `message` tool is never invoked, and the embedded runner correctly logs `payloads=0` → `incomplete turn`. The user sees no reply.

This adds one additional line to the developer instructions that explicitly forbids that pattern and points at the structured form. Codex‑plugin scoped only — the function is invoked exclusively from `extensions/codex/src/app-server/{thread-lifecycle,run-attempt}.ts`, so Pi / OpenAI / other harnesses are unaffected.

## Reproduced behavior (before)

Webchat session bound to a Codex app-server thread, OpenAI `openai/gpt-5.5` via API‑key auth, dynamic `message` tool present in `dynamicToolsFingerprint`.

User input: `hi`

Gateway log:

```
[agent/embedded] empty response detected: runId=bf4a2337-… sessionId=3940c801-… provider=openai/gpt-5.5 — retrying 1/1 with visible-answer continuation
[agent/embedded] empty response retries exhausted: … provider=openai/gpt-5.5 attempts=1/1 — surfacing incomplete-turn error
[agent/embedded] incomplete turn detected: runId=… stopReason=undefined payloads=0 — surfacing error to user
```

Corresponding Codex rollout entries (`rollout-2026-05-10T23-41-55-019e15c5-587e-75f3-8471-5e53a9118214.jsonl`):

Model emits `exec` with a JS body instead of calling the `message` tool:

```json
{"timestamp":"2026-05-11T06:42:01.610Z","type":"response_item","payload":{"type":"custom_tool_call","status":"completed","call_id":"call_Zmf2FjI8SApgULN85dFJERWL","name":"exec","input":"await tools.message({ action: \"send\", message: \"hi. fairly quiet in here, which is usually when the furniture starts forming opinions.\" });"}}
```

Codex executes the freeform string as a shell command and returns nothing:

```json
{"timestamp":"2026-05-11T06:42:01.837Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call_Zmf2FjI8SApgULN85dFJERWL","output":"Script completed\nWall time 0.2 seconds\nOutput:\n"}}
```

This pattern recurs across the whole session — eight `custom_tool_call_output` entries, all with `Output:` empty. Final assistant message ends the turn empty:

```json
{"timestamp":"2026-05-11T06:54:43.573Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":""}],"phase":"final_answer"}}
```

```json
{"timestamp":"2026-05-11T06:54:43.809Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"019e15d1-0629-71c0-8ec9-27340f895a6c","last_agent_message":null,"completed_at":1778482483,"duration_ms":3125,"time_to_first_token_ms":1000}}
```

`last_agent_message: null` → embedded runner sees zero visible payloads → user gets nothing.

## Change

One additional line in `buildDeveloperInstructions` (sits between the existing "Visible channel replies: use `message`" line and the gpt-5 overlay), naming the anti-pattern and the correct structured form:

> Invoke `message` (and every OpenClaw dynamic tool) as a structured tool call with its JSON arguments. Never wrap it in `exec`, `apply_patch`, or any shell/JavaScript snippet — strings like `tools.message(...)`, `await tools.message(...)`, or `message({...})` inside `exec` will execute as a shell command and deliver nothing. If you intended to reply, emit the `message` tool call directly with `{ action: "send", message: "..." }`.

## Test plan

- [ ] `pnpm test extensions/codex` — no tests assert on these exact strings (grepped); the existing schema/contract tests just check the payload contains "OpenClaw" / has a string `developerInstructions`, which still holds.
- [ ] Live verify by rebuilding the gateway image and sending a webchat "hi" — expect the next rollout to contain a structured tool call with `name: "message"` instead of `custom_tool_call name: "exec"` with a JS body, and a non-empty final `output_text`.

## Notes

- Function is reached only via the Codex app-server harness path (`thread-lifecycle.ts` → `newThread`/`resumeThread`/`turn` → `developerInstructions`). Other harnesses (Pi, etc.) never read it.
- This is a prompt nudge against Codex's strong coding-agent `base_instructions`, not a structural change. If gpt-5.5 still emits the wrapped form after this lands, the followup is to drop `exec` from the tool surface for chat-oriented agents.
