### PR TITLE
fix(sessions): stream JSONL transcript scans instead of buffering whole files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Memory: reject symlinked directory components in configured extra memory paths before reading Markdown files. (#80331) Thanks @samzong.
+- Sessions/transcripts: replace whole-file `readFile` scans with shared streaming helpers (`streamSessionTranscriptLines` and `streamSessionTranscriptLinesReverse`) for idempotency lookup, latest/tail assistant text reads, delivery-mirror dedupe, and compaction fork loading, so long-running sessions no longer materialize the full transcript in memory. Forward scans use `readline` over a bounded `createReadStream`; reverse scans read bounded chunks from the file end and decode complete JSONL lines newest-first without a fixed tail cap. Synthetic 200 MiB transcript: peak RSS delta drops from +252 MiB to +27 MiB while preserving malformed-line tolerance and idempotency-key return semantics. Fixes #54296. Thanks @jack-stormentswe.
 - WhatsApp: apply hot-reloaded `dmPolicy` and `allowFrom` settings to the active Web listener before processing new inbound DMs. Fixes #80538. Thanks @Ampaskopi129.
 - Plugins: let `openclaw doctor --fix` repair managed plugin installs whose package entrypoints fail package-directory boundary validation after local state moves. Fixes #80592. Thanks @wei-wei-zhao.
 - Voice-call: resume voice-originated exec approval follow-ups as internal non-delivery turns instead of rejecting them as `unknown channel: voice`. Fixes #80540. Thanks @patrickmch.

--- a/src/config/sessions/transcript-stream.test.ts
+++ b/src/config/sessions/transcript-stream.test.ts
@@ -1,0 +1,176 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  readSessionTranscriptTailLines,
+  streamSessionTranscriptLines,
+} from "./transcript-stream.js";
+
+// Regression coverage for #54296: the transcript readers must stay correct and
+// memory-bounded as session files grow into the multi-MB / 100s of MB range.
+// The previous implementations called `fs.readFile` and split on newlines,
+// which made memory usage scale with file size. These tests exercise the
+// shared streaming helpers that replace those whole-file reads.
+
+let tempDir = "";
+let transcriptPath = "";
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "transcript-stream-"));
+  transcriptPath = path.join(tempDir, "session.jsonl");
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+async function collect(iter: AsyncGenerator<string>): Promise<string[]> {
+  const out: string[] = [];
+  for await (const value of iter) {
+    out.push(value);
+  }
+  return out;
+}
+
+describe("streamSessionTranscriptLines", () => {
+  it("yields trimmed non-empty lines in file order", async () => {
+    fs.writeFileSync(transcriptPath, "  alpha  \n\nbeta\n  \r\ngamma\n", "utf-8");
+
+    const lines = await collect(streamSessionTranscriptLines(transcriptPath));
+
+    expect(lines).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  it("returns an empty iterator when the file does not exist", async () => {
+    const lines = await collect(streamSessionTranscriptLines(path.join(tempDir, "missing.jsonl")));
+
+    expect(lines).toEqual([]);
+  });
+
+  it("returns an empty iterator for an empty file", async () => {
+    fs.writeFileSync(transcriptPath, "", "utf-8");
+
+    const lines = await collect(streamSessionTranscriptLines(transcriptPath));
+
+    expect(lines).toEqual([]);
+  });
+
+  it("forwards malformed JSON lines as raw text so callers can choose to skip them", async () => {
+    fs.writeFileSync(
+      transcriptPath,
+      `${JSON.stringify({ id: "a" })}\nnot-json\n${JSON.stringify({ id: "b" })}\n`,
+      "utf-8",
+    );
+
+    const lines = await collect(streamSessionTranscriptLines(transcriptPath));
+
+    expect(lines).toEqual([JSON.stringify({ id: "a" }), "not-json", JSON.stringify({ id: "b" })]);
+  });
+
+  it("honours an abort signal between lines", async () => {
+    fs.writeFileSync(transcriptPath, "one\ntwo\nthree\n", "utf-8");
+    const controller = new AbortController();
+
+    const out: string[] = [];
+    for await (const line of streamSessionTranscriptLines(transcriptPath, {
+      signal: controller.signal,
+    })) {
+      out.push(line);
+      if (line === "one") {
+        controller.abort();
+      }
+    }
+
+    expect(out).toEqual(["one"]);
+  });
+
+  it("preserves long lines without truncation", async () => {
+    const longLine = "x".repeat(64 * 1024 + 7);
+    fs.writeFileSync(transcriptPath, `${longLine}\nshort\n`, "utf-8");
+
+    const lines = await collect(streamSessionTranscriptLines(transcriptPath));
+
+    expect(lines).toEqual([longLine, "short"]);
+  });
+});
+
+describe("readSessionTranscriptTailLines", () => {
+  it("returns trimmed non-empty lines in reverse order for short files", async () => {
+    fs.writeFileSync(transcriptPath, "first\nsecond\nthird\n", "utf-8");
+
+    const lines = await readSessionTranscriptTailLines(transcriptPath);
+
+    expect(lines).toEqual(["third", "second", "first"]);
+  });
+
+  it("returns undefined when the file cannot be opened", async () => {
+    const lines = await readSessionTranscriptTailLines(path.join(tempDir, "missing.jsonl"));
+
+    expect(lines).toBeUndefined();
+  });
+
+  it("returns an empty array for an empty file", async () => {
+    fs.writeFileSync(transcriptPath, "", "utf-8");
+
+    const lines = await readSessionTranscriptTailLines(transcriptPath);
+
+    expect(lines).toEqual([]);
+  });
+
+  it("drops the leading partial line when the window does not start at byte zero", async () => {
+    // Build a file longer than the requested tail window. The first line of
+    // the slice we end up reading should be a suffix of an earlier line; the
+    // helper must discard it so callers do not see corrupt JSON.
+    const longPrefix = "x".repeat(2048);
+    const content = `${longPrefix}\nbeta\ngamma\n`;
+    fs.writeFileSync(transcriptPath, content, "utf-8");
+
+    const lines = await readSessionTranscriptTailLines(transcriptPath, {
+      maxBytes: 16,
+    });
+
+    expect(lines).not.toContain(longPrefix);
+    expect(lines).toEqual(["gamma", "beta"]);
+  });
+
+  it("does not drop the first line when the window covers the entire file", async () => {
+    fs.writeFileSync(transcriptPath, "alpha\nbeta\ngamma\n", "utf-8");
+
+    const lines = await readSessionTranscriptTailLines(transcriptPath, {
+      maxBytes: 64 * 1024,
+    });
+
+    expect(lines).toEqual(["gamma", "beta", "alpha"]);
+  });
+
+  it("clamps a sub-minimum maxBytes to the floor instead of returning nothing", async () => {
+    fs.writeFileSync(transcriptPath, "alpha\nbeta\ngamma\n", "utf-8");
+
+    const lines = await readSessionTranscriptTailLines(transcriptPath, {
+      maxBytes: 16,
+    });
+
+    // The full file is smaller than the 1 KiB floor, so we still read the
+    // whole file and return all three lines in reverse order.
+    expect(lines).toEqual(["gamma", "beta", "alpha"]);
+  });
+
+  it("preserves JSONL line ordering so reverse scans hit the newest match first", async () => {
+    fs.writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({ id: "first", role: "user" }),
+        JSON.stringify({ id: "second", role: "assistant", text: "hi" }),
+        JSON.stringify({ id: "third", role: "assistant", text: "bye" }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const lines = await readSessionTranscriptTailLines(transcriptPath);
+
+    expect(lines).toBeDefined();
+    const parsed = lines!.map((line) => JSON.parse(line) as { id: string });
+    expect(parsed.map((entry) => entry.id)).toEqual(["third", "second", "first"]);
+  });
+});

--- a/src/config/sessions/transcript-stream.test.ts
+++ b/src/config/sessions/transcript-stream.test.ts
@@ -3,8 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
-  readSessionTranscriptTailLines,
   streamSessionTranscriptLines,
+  streamSessionTranscriptLinesReverse,
 } from "./transcript-stream.js";
 
 // Regression coverage for #54296: the transcript readers must stay correct and
@@ -95,65 +95,98 @@ describe("streamSessionTranscriptLines", () => {
   });
 });
 
-describe("readSessionTranscriptTailLines", () => {
-  it("returns trimmed non-empty lines in reverse order for short files", async () => {
+describe("streamSessionTranscriptLinesReverse", () => {
+  it("yields trimmed non-empty lines in reverse order for short files", async () => {
     fs.writeFileSync(transcriptPath, "first\nsecond\nthird\n", "utf-8");
 
-    const lines = await readSessionTranscriptTailLines(transcriptPath);
+    const lines = await collect(streamSessionTranscriptLinesReverse(transcriptPath));
 
     expect(lines).toEqual(["third", "second", "first"]);
   });
 
-  it("returns undefined when the file cannot be opened", async () => {
-    const lines = await readSessionTranscriptTailLines(path.join(tempDir, "missing.jsonl"));
-
-    expect(lines).toBeUndefined();
-  });
-
-  it("returns an empty array for an empty file", async () => {
-    fs.writeFileSync(transcriptPath, "", "utf-8");
-
-    const lines = await readSessionTranscriptTailLines(transcriptPath);
+  it("returns an empty iterator when the file cannot be opened", async () => {
+    const lines = await collect(
+      streamSessionTranscriptLinesReverse(path.join(tempDir, "missing.jsonl")),
+    );
 
     expect(lines).toEqual([]);
   });
 
-  it("drops the leading partial line when the window does not start at byte zero", async () => {
-    // Build a file longer than the requested tail window. The first line of
-    // the slice we end up reading should be a suffix of an earlier line; the
-    // helper must discard it so callers do not see corrupt JSON.
-    const longPrefix = "x".repeat(2048);
-    const content = `${longPrefix}\nbeta\ngamma\n`;
-    fs.writeFileSync(transcriptPath, content, "utf-8");
+  it("returns an empty iterator for an empty file", async () => {
+    fs.writeFileSync(transcriptPath, "", "utf-8");
 
-    const lines = await readSessionTranscriptTailLines(transcriptPath, {
-      maxBytes: 16,
-    });
+    const lines = await collect(streamSessionTranscriptLinesReverse(transcriptPath));
 
-    expect(lines).not.toContain(longPrefix);
-    expect(lines).toEqual(["gamma", "beta"]);
+    expect(lines).toEqual([]);
   });
 
-  it("does not drop the first line when the window covers the entire file", async () => {
+  it("preserves complete lines across chunk boundaries", async () => {
+    const longLine = "x".repeat(2048);
+    fs.writeFileSync(transcriptPath, `${longLine}\nbeta\ngamma\n`, "utf-8");
+
+    const lines = await collect(
+      streamSessionTranscriptLinesReverse(transcriptPath, {
+        chunkBytes: 1024,
+      }),
+    );
+
+    expect(lines).toEqual(["gamma", "beta", longLine]);
+  });
+
+  it("preserves multibyte UTF-8 across chunk boundaries", async () => {
+    const firstLine = `${"a".repeat(1100)}🌊`;
+    const secondLine = `${"b".repeat(1100)}✅`;
+    fs.writeFileSync(transcriptPath, `${firstLine}\n${secondLine}\n`, "utf-8");
+
+    const lines = await collect(
+      streamSessionTranscriptLinesReverse(transcriptPath, {
+        chunkBytes: 1024,
+      }),
+    );
+
+    expect(lines).toEqual([secondLine, firstLine]);
+  });
+
+  it("honours an abort signal between reverse lines", async () => {
+    fs.writeFileSync(transcriptPath, "one\ntwo\nthree\n", "utf-8");
+    const controller = new AbortController();
+
+    const out: string[] = [];
+    for await (const line of streamSessionTranscriptLinesReverse(transcriptPath, {
+      signal: controller.signal,
+    })) {
+      out.push(line);
+      if (line === "three") {
+        controller.abort();
+      }
+    }
+
+    expect(out).toEqual(["three"]);
+  });
+
+  it("clamps a sub-minimum chunk size without dropping older lines", async () => {
     fs.writeFileSync(transcriptPath, "alpha\nbeta\ngamma\n", "utf-8");
 
-    const lines = await readSessionTranscriptTailLines(transcriptPath, {
-      maxBytes: 64 * 1024,
-    });
+    const lines = await collect(
+      streamSessionTranscriptLinesReverse(transcriptPath, {
+        chunkBytes: 16,
+      }),
+    );
 
     expect(lines).toEqual(["gamma", "beta", "alpha"]);
   });
 
-  it("clamps a sub-minimum maxBytes to the floor instead of returning nothing", async () => {
-    fs.writeFileSync(transcriptPath, "alpha\nbeta\ngamma\n", "utf-8");
+  it("does not emit a partial prefix until the full first line is available", async () => {
+    const firstLine = "prefix".repeat(400);
+    fs.writeFileSync(transcriptPath, `${firstLine}\nbeta\ngamma`, "utf-8");
 
-    const lines = await readSessionTranscriptTailLines(transcriptPath, {
-      maxBytes: 16,
-    });
+    const lines = await collect(
+      streamSessionTranscriptLinesReverse(transcriptPath, {
+        chunkBytes: 1024,
+      }),
+    );
 
-    // The full file is smaller than the 1 KiB floor, so we still read the
-    // whole file and return all three lines in reverse order.
-    expect(lines).toEqual(["gamma", "beta", "alpha"]);
+    expect(lines).toEqual(["gamma", "beta", firstLine]);
   });
 
   it("preserves JSONL line ordering so reverse scans hit the newest match first", async () => {
@@ -167,10 +200,9 @@ describe("readSessionTranscriptTailLines", () => {
       "utf-8",
     );
 
-    const lines = await readSessionTranscriptTailLines(transcriptPath);
+    const lines = await collect(streamSessionTranscriptLinesReverse(transcriptPath));
+    const parsed = lines.map((line) => JSON.parse(line) as { id: string });
 
-    expect(lines).toBeDefined();
-    const parsed = lines!.map((line) => JSON.parse(line) as { id: string });
     expect(parsed.map((entry) => entry.id)).toEqual(["third", "second", "first"]);
   });
 });

--- a/src/config/sessions/transcript-stream.ts
+++ b/src/config/sessions/transcript-stream.ts
@@ -1,0 +1,142 @@
+import fs from "node:fs";
+import readline from "node:readline";
+
+// Shared streaming helpers for JSONL session transcripts.
+//
+// Callers historically read the entire transcript with `fs.readFile` before
+// splitting on newlines. That worked fine for short sessions but produced real
+// memory pressure on long-running ones where transcripts grow to tens or
+// hundreds of MB (see #54296). These helpers replace the whole-file reads with
+// either a forward `readline` stream (bounded to one line of memory at a time)
+// or a tail-only read that scans the last N bytes — both preserve the
+// malformed-line tolerance and "first/last match wins" semantics callers rely
+// on.
+
+const DEFAULT_TAIL_BYTES = 4 * 1024 * 1024;
+const ABSOLUTE_TAIL_CAP_BYTES = 64 * 1024 * 1024;
+const MIN_TAIL_BYTES = 1024;
+
+export type TranscriptStreamOptions = {
+  signal?: AbortSignal;
+};
+
+export type TranscriptTailOptions = {
+  /** Maximum bytes to read from the file tail. Clamped to [1KiB, 64MiB]. */
+  maxBytes?: number;
+};
+
+/**
+ * Stream the non-empty, trimmed JSONL lines of a transcript file in order.
+ *
+ * Returns an empty async iterator if the file does not exist, is empty, or is
+ * not a regular file. Honours `options.signal` between lines so long scans can
+ * cooperate with abort signals.
+ */
+export async function* streamSessionTranscriptLines(
+  filePath: string,
+  options: TranscriptStreamOptions = {},
+): AsyncGenerator<string> {
+  let stat: fs.Stats;
+  try {
+    stat = await fs.promises.stat(filePath);
+  } catch {
+    return;
+  }
+  if (!stat.isFile() || stat.size <= 0) {
+    return;
+  }
+  if (options.signal?.aborted) {
+    return;
+  }
+  const stream = fs.createReadStream(filePath, { encoding: "utf-8" });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+  try {
+    for await (const line of rl) {
+      if (options.signal?.aborted) {
+        return;
+      }
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+      yield trimmed;
+    }
+  } finally {
+    rl.close();
+    stream.destroy();
+  }
+}
+
+/**
+ * Read the last `maxBytes` of a transcript file and return its non-empty
+ * trimmed lines in reverse (newest-first) order. The first line of the slice
+ * is discarded when the slice does not start at the file head, because it can
+ * be the suffix of an earlier line split mid-way.
+ *
+ * Returns `undefined` if the file cannot be opened, `[]` if it exists but is
+ * empty, and the trimmed reversed lines otherwise. Callers can return on the
+ * first match without buffering the rest of the file.
+ */
+export async function readSessionTranscriptTailLines(
+  filePath: string,
+  options: TranscriptTailOptions = {},
+): Promise<string[] | undefined> {
+  const requestedMaxBytes = Number.isFinite(options.maxBytes)
+    ? Math.max(MIN_TAIL_BYTES, Math.floor(options.maxBytes as number))
+    : DEFAULT_TAIL_BYTES;
+  const cappedMaxBytes = Math.min(requestedMaxBytes, ABSOLUTE_TAIL_CAP_BYTES);
+
+  let fileHandle: Awaited<ReturnType<typeof fs.promises.open>>;
+  try {
+    fileHandle = await fs.promises.open(filePath, "r");
+  } catch {
+    return undefined;
+  }
+  try {
+    const stat = await fileHandle.stat();
+    if (!stat.isFile()) {
+      return undefined;
+    }
+    if (stat.size <= 0) {
+      return [];
+    }
+    const readLength = Math.min(stat.size, cappedMaxBytes);
+    const readStart = Math.max(0, stat.size - readLength);
+    const buffer = await readFileRangeAsync(fileHandle, readStart, readLength);
+    const text = buffer.toString("utf-8");
+    const rawLines = text.split(/\r?\n/);
+    if (readStart > 0 && rawLines.length > 0) {
+      rawLines.shift();
+    }
+    const lines: string[] = [];
+    for (let index = rawLines.length - 1; index >= 0; index -= 1) {
+      const trimmed = rawLines[index].trim();
+      if (!trimmed) {
+        continue;
+      }
+      lines.push(trimmed);
+    }
+    return lines;
+  } catch {
+    return undefined;
+  } finally {
+    await fileHandle.close().catch(() => undefined);
+  }
+}
+
+async function readFileRangeAsync(
+  fileHandle: Awaited<ReturnType<typeof fs.promises.open>>,
+  position: number,
+  length: number,
+): Promise<Buffer> {
+  const buffer = Buffer.alloc(length);
+  let offset = 0;
+  while (offset < length) {
+    const { bytesRead } = await fileHandle.read(buffer, offset, length - offset, position + offset);
+    if (bytesRead <= 0) {
+      break;
+    }
+    offset += bytesRead;
+  }
+  return offset === length ? buffer : buffer.subarray(0, offset);
+}

--- a/src/config/sessions/transcript-stream.ts
+++ b/src/config/sessions/transcript-stream.ts
@@ -7,22 +7,21 @@ import readline from "node:readline";
 // splitting on newlines. That worked fine for short sessions but produced real
 // memory pressure on long-running ones where transcripts grow to tens or
 // hundreds of MB (see #54296). These helpers replace the whole-file reads with
-// either a forward `readline` stream (bounded to one line of memory at a time)
-// or a tail-only read that scans the last N bytes — both preserve the
-// malformed-line tolerance and "first/last match wins" semantics callers rely
-// on.
+// either a forward `readline` stream or a chunked reverse scan. Both are bounded
+// to a small chunk plus the current line and preserve the malformed-line
+// tolerance and "first/last match wins" semantics callers rely on.
 
-const DEFAULT_TAIL_BYTES = 4 * 1024 * 1024;
-const ABSOLUTE_TAIL_CAP_BYTES = 64 * 1024 * 1024;
-const MIN_TAIL_BYTES = 1024;
+const DEFAULT_REVERSE_CHUNK_BYTES = 64 * 1024;
+const MAX_REVERSE_CHUNK_BYTES = 1024 * 1024;
+const MIN_REVERSE_CHUNK_BYTES = 1024;
 
 export type TranscriptStreamOptions = {
   signal?: AbortSignal;
 };
 
-export type TranscriptTailOptions = {
-  /** Maximum bytes to read from the file tail. Clamped to [1KiB, 64MiB]. */
-  maxBytes?: number;
+export type TranscriptReverseStreamOptions = TranscriptStreamOptions & {
+  /** Bytes read per reverse scan chunk. Clamped to [1KiB, 1MiB]. */
+  chunkBytes?: number;
 };
 
 /**
@@ -68,60 +67,73 @@ export async function* streamSessionTranscriptLines(
 }
 
 /**
- * Read the last `maxBytes` of a transcript file and return its non-empty
- * trimmed lines in reverse (newest-first) order. The first line of the slice
- * is discarded when the slice does not start at the file head, because it can
- * be the suffix of an earlier line split mid-way.
+ * Stream the non-empty, trimmed JSONL lines of a transcript file in reverse
+ * (newest-first) order.
  *
- * Returns `undefined` if the file cannot be opened, `[]` if it exists but is
- * empty, and the trimmed reversed lines otherwise. Callers can return on the
- * first match without buffering the rest of the file.
+ * Returns an empty async iterator if the file cannot be opened, is empty, or is
+ * not a regular file. The implementation splits on newline bytes before UTF-8
+ * decoding so multibyte characters survive arbitrary chunk boundaries.
  */
-export async function readSessionTranscriptTailLines(
+export async function* streamSessionTranscriptLinesReverse(
   filePath: string,
-  options: TranscriptTailOptions = {},
-): Promise<string[] | undefined> {
-  const requestedMaxBytes = Number.isFinite(options.maxBytes)
-    ? Math.max(MIN_TAIL_BYTES, Math.floor(options.maxBytes as number))
-    : DEFAULT_TAIL_BYTES;
-  const cappedMaxBytes = Math.min(requestedMaxBytes, ABSOLUTE_TAIL_CAP_BYTES);
+  options: TranscriptReverseStreamOptions = {},
+): AsyncGenerator<string> {
+  const requestedChunkBytes = Number.isFinite(options.chunkBytes)
+    ? Math.max(MIN_REVERSE_CHUNK_BYTES, Math.floor(options.chunkBytes as number))
+    : DEFAULT_REVERSE_CHUNK_BYTES;
+  const chunkBytes = Math.min(requestedChunkBytes, MAX_REVERSE_CHUNK_BYTES);
 
   let fileHandle: Awaited<ReturnType<typeof fs.promises.open>>;
   try {
     fileHandle = await fs.promises.open(filePath, "r");
   } catch {
-    return undefined;
+    return;
   }
   try {
     const stat = await fileHandle.stat();
-    if (!stat.isFile()) {
-      return undefined;
+    if (!stat.isFile() || stat.size <= 0 || options.signal?.aborted) {
+      return;
     }
-    if (stat.size <= 0) {
-      return [];
-    }
-    const readLength = Math.min(stat.size, cappedMaxBytes);
-    const readStart = Math.max(0, stat.size - readLength);
-    const buffer = await readFileRangeAsync(fileHandle, readStart, readLength);
-    const text = buffer.toString("utf-8");
-    const rawLines = text.split(/\r?\n/);
-    if (readStart > 0 && rawLines.length > 0) {
-      rawLines.shift();
-    }
-    const lines: string[] = [];
-    for (let index = rawLines.length - 1; index >= 0; index -= 1) {
-      const trimmed = rawLines[index].trim();
-      if (!trimmed) {
-        continue;
+
+    let position = stat.size;
+    let carry: Buffer = Buffer.alloc(0);
+    while (position > 0) {
+      if (options.signal?.aborted) {
+        return;
       }
-      lines.push(trimmed);
+      const readLength = Math.min(position, chunkBytes);
+      position -= readLength;
+      const chunk = await readFileRangeAsync(fileHandle, position, readLength);
+      const combined = carry.length > 0 ? Buffer.concat([chunk, carry]) : chunk;
+      let lineEnd = combined.length;
+      for (let index = combined.length - 1; index >= 0; index -= 1) {
+        if (combined[index] !== 0x0a) {
+          continue;
+        }
+        const line = decodeTrimmedLine(combined.subarray(index + 1, lineEnd));
+        if (line) {
+          yield line;
+          if (options.signal?.aborted) {
+            return;
+          }
+        }
+        lineEnd = index;
+      }
+      carry = combined.subarray(0, lineEnd);
     }
-    return lines;
-  } catch {
-    return undefined;
+
+    const firstLine = decodeTrimmedLine(carry);
+    if (firstLine && !options.signal?.aborted) {
+      yield firstLine;
+    }
   } finally {
     await fileHandle.close().catch(() => undefined);
   }
+}
+
+function decodeTrimmedLine(line: Buffer): string {
+  const trimmed = line.toString("utf-8").trim();
+  return trimmed;
 }
 
 async function readFileRangeAsync(

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -8,6 +8,7 @@ import { appendSessionTranscriptMessage } from "./transcript-append.js";
 import {
   appendAssistantMessageToSessionTranscript,
   appendExactAssistantMessageToSessionTranscript,
+  readLatestAssistantTextFromSessionTranscript,
 } from "./transcript.js";
 
 describe("appendAssistantMessageToSessionTranscript", () => {
@@ -179,6 +180,49 @@ describe("appendAssistantMessageToSessionTranscript", () => {
       expect(messageLine.message.provider).toBe("codex");
       expect(messageLine.message.model).toBe("gpt-5.4");
       expect(messageLine.message.content[0].text).toBe("Hello from Codex!");
+    }
+  });
+
+  it("dedupes against the latest assistant even when a large user entry follows it", async () => {
+    writeTranscriptStore();
+
+    const exactResult = await appendExactAssistantMessageToSessionTranscript({
+      sessionKey,
+      storePath: fixture.storePath(),
+      message: createExactAssistantMessage({ text: "Hello before the large user entry" }),
+    });
+
+    expect(exactResult.ok).toBe(true);
+    if (!exactResult.ok) {
+      return;
+    }
+
+    const sessionFile = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
+    await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: { role: "user", content: "x".repeat(5 * 1024 * 1024) },
+    });
+
+    await expect(readLatestAssistantTextFromSessionTranscript(sessionFile)).resolves.toMatchObject({
+      id: exactResult.messageId,
+      text: "Hello before the large user entry",
+    });
+
+    const mirrorResult = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Hello before the large user entry",
+      storePath: fixture.storePath(),
+    });
+
+    expect(mirrorResult.ok).toBe(true);
+    if (mirrorResult.ok) {
+      expect(mirrorResult.messageId).toBe(exactResult.messageId);
+      const records = fs
+        .readFileSync(sessionFile, "utf-8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { type?: string; message?: { role?: string } });
+      expect(records.filter((record) => record.type === "message")).toHaveLength(2);
     }
   });
 

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -17,8 +17,8 @@ import { parseSessionThreadInfo } from "./thread-info.js";
 import { appendSessionTranscriptMessage } from "./transcript-append.js";
 import { resolveMirroredTranscriptText } from "./transcript-mirror.js";
 import {
-  readSessionTranscriptTailLines,
   streamSessionTranscriptLines,
+  streamSessionTranscriptLinesReverse,
 } from "./transcript-stream.js";
 import type { SessionEntry } from "./types.js";
 
@@ -147,12 +147,7 @@ export async function readLatestAssistantTextFromSessionTranscript(
     return undefined;
   }
 
-  const tailLines = await readSessionTranscriptTailLines(sessionFile);
-  if (!tailLines) {
-    return undefined;
-  }
-
-  for (const line of tailLines) {
+  for await (const line of streamSessionTranscriptLinesReverse(sessionFile)) {
     try {
       const assistantText = parseAssistantTranscriptText(line);
       if (assistantText) {
@@ -172,12 +167,7 @@ export async function readTailAssistantTextFromSessionTranscript(
     return undefined;
   }
 
-  const tailLines = await readSessionTranscriptTailLines(sessionFile);
-  if (!tailLines) {
-    return undefined;
-  }
-
-  for (const line of tailLines) {
+  for await (const line of streamSessionTranscriptLinesReverse(sessionFile)) {
     try {
       return parseAssistantTranscriptText(line);
     } catch {
@@ -397,12 +387,7 @@ async function findLatestEquivalentAssistantMessageId(
     return undefined;
   }
 
-  const tailLines = await readSessionTranscriptTailLines(transcriptPath);
-  if (!tailLines) {
-    return undefined;
-  }
-
-  for (const line of tailLines) {
+  for await (const line of streamSessionTranscriptLinesReverse(transcriptPath)) {
     try {
       const parsed = JSON.parse(line) as {
         id?: unknown;

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -16,6 +16,10 @@ import { loadSessionStore, normalizeStoreSessionKey } from "./store.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
 import { appendSessionTranscriptMessage } from "./transcript-append.js";
 import { resolveMirroredTranscriptText } from "./transcript-mirror.js";
+import {
+  readSessionTranscriptTailLines,
+  streamSessionTranscriptLines,
+} from "./transcript-stream.js";
 import type { SessionEntry } from "./types.js";
 
 let piCodingAgentModulePromise: Promise<typeof import("@earendil-works/pi-coding-agent")> | null =
@@ -143,17 +147,12 @@ export async function readLatestAssistantTextFromSessionTranscript(
     return undefined;
   }
 
-  let raw: string;
-  try {
-    raw = await fs.promises.readFile(sessionFile, "utf-8");
-  } catch {
+  const tailLines = await readSessionTranscriptTailLines(sessionFile);
+  if (!tailLines) {
     return undefined;
   }
 
-  for (const line of raw.split(/\r?\n/).toReversed()) {
-    if (!line.trim()) {
-      continue;
-    }
+  for (const line of tailLines) {
     try {
       const assistantText = parseAssistantTranscriptText(line);
       if (assistantText) {
@@ -173,17 +172,12 @@ export async function readTailAssistantTextFromSessionTranscript(
     return undefined;
   }
 
-  let raw: string;
-  try {
-    raw = await fs.promises.readFile(sessionFile, "utf-8");
-  } catch {
+  const tailLines = await readSessionTranscriptTailLines(sessionFile);
+  if (!tailLines) {
     return undefined;
   }
 
-  for (const line of raw.split(/\r?\n/).toReversed()) {
-    if (!line.trim()) {
-      continue;
-    }
+  for (const line of tailLines) {
     try {
       return parseAssistantTranscriptText(line);
     } catch {
@@ -345,11 +339,7 @@ async function transcriptHasIdempotencyKey(
   idempotencyKey: string,
 ): Promise<string | true | undefined> {
   try {
-    const raw = await fs.promises.readFile(transcriptPath, "utf-8");
-    for (const line of raw.split(/\r?\n/)) {
-      if (!line.trim()) {
-        continue;
-      }
+    for await (const line of streamSessionTranscriptLines(transcriptPath)) {
       try {
         const parsed = JSON.parse(line) as {
           id?: unknown;
@@ -407,37 +397,32 @@ async function findLatestEquivalentAssistantMessageId(
     return undefined;
   }
 
-  try {
-    const raw = await fs.promises.readFile(transcriptPath, "utf-8");
-    const lines = raw.split(/\r?\n/);
-    for (let index = lines.length - 1; index >= 0; index -= 1) {
-      const line = lines[index];
-      if (!line.trim()) {
-        continue;
-      }
-      try {
-        const parsed = JSON.parse(line) as {
-          id?: unknown;
-          message?: SessionTranscriptAssistantMessage;
-        };
-        const candidate = parsed.message;
-        if (!candidate || candidate.role !== "assistant") {
-          continue;
-        }
-        const candidateText = extractAssistantMessageText(candidate);
-        if (candidateText !== expectedText) {
-          return undefined;
-        }
-        if (typeof parsed.id === "string" && parsed.id) {
-          return parsed.id;
-        }
-        return undefined;
-      } catch {
-        continue;
-      }
-    }
-  } catch {
+  const tailLines = await readSessionTranscriptTailLines(transcriptPath);
+  if (!tailLines) {
     return undefined;
+  }
+
+  for (const line of tailLines) {
+    try {
+      const parsed = JSON.parse(line) as {
+        id?: unknown;
+        message?: SessionTranscriptAssistantMessage;
+      };
+      const candidate = parsed.message;
+      if (!candidate || candidate.role !== "assistant") {
+        continue;
+      }
+      const candidateText = extractAssistantMessageText(candidate);
+      if (candidateText !== expectedText) {
+        return undefined;
+      }
+      if (typeof parsed.id === "string" && parsed.id) {
+        return parsed.id;
+      }
+      return undefined;
+    } catch {
+      continue;
+    }
   }
 
   return undefined;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -15,6 +15,7 @@ import { stageSandboxMedia } from "../../auto-reply/reply/stage-sandbox-media.js
 import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
 import { extractCanvasFromText } from "../../chat/canvas-render.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
+import { streamSessionTranscriptLines } from "../../config/sessions/transcript-stream.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   measureDiagnosticsTimelineSpan,
@@ -1356,14 +1357,14 @@ async function transcriptHasIdempotencyKey(
   idempotencyKey: string,
 ): Promise<boolean> {
   try {
-    const lines = (await fs.promises.readFile(transcriptPath, "utf-8")).split(/\r?\n/);
-    for (const line of lines) {
-      if (!line.trim()) {
+    for await (const line of streamSessionTranscriptLines(transcriptPath)) {
+      try {
+        const parsed = JSON.parse(line) as { message?: { idempotencyKey?: unknown } };
+        if (parsed?.message?.idempotencyKey === idempotencyKey) {
+          return true;
+        }
+      } catch {
         continue;
-      }
-      const parsed = JSON.parse(line) as { message?: { idempotencyKey?: unknown } };
-      if (parsed?.message?.idempotencyKey === idempotencyKey) {
-        return true;
       }
     }
     return false;

--- a/src/gateway/session-compaction-checkpoints.ts
+++ b/src/gateway/session-compaction-checkpoints.ts
@@ -14,6 +14,7 @@ import type {
   SessionEntry,
 } from "../config/sessions.js";
 import { isCompactionCheckpointTranscriptFileName } from "../config/sessions/artifacts.js";
+import { streamSessionTranscriptLines } from "../config/sessions/transcript-stream.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveGatewaySessionStoreTarget } from "./session-utils.js";
@@ -150,34 +151,23 @@ function parseTranscriptLineId(
 async function readTranscriptEntriesForForkAsync(
   sessionFile: string,
 ): Promise<PiSessionFileEntry[] | null> {
-  let fileHandle: AsyncTranscriptFileHandle | undefined;
+  const entries: PiSessionFileEntry[] = [];
   try {
-    fileHandle = await fs.open(sessionFile, "r");
-    const content = await fileHandle.readFile("utf-8");
-    const entries: PiSessionFileEntry[] = [];
-    for (const line of content.trim().split(/\r?\n/)) {
-      const trimmed = line.trim();
-      if (!trimmed) {
-        continue;
-      }
+    for await (const line of streamSessionTranscriptLines(sessionFile)) {
       try {
-        entries.push(JSON.parse(trimmed) as PiSessionFileEntry);
+        entries.push(JSON.parse(line) as PiSessionFileEntry);
       } catch {
         // Match pi-coding-agent's loader: malformed JSONL entries are ignored.
       }
     }
-    const firstEntry = entries[0] as { type?: unknown; id?: unknown } | undefined;
-    if (firstEntry?.type !== "session" || typeof firstEntry.id !== "string") {
-      return null;
-    }
-    return entries;
   } catch {
     return null;
-  } finally {
-    if (fileHandle) {
-      await fileHandle.close().catch(() => undefined);
-    }
   }
+  const firstEntry = entries[0] as { type?: unknown; id?: unknown } | undefined;
+  if (firstEntry?.type !== "session" || typeof firstEntry.id !== "string") {
+    return null;
+  }
+  return entries;
 }
 
 export async function readSessionLeafIdFromTranscriptAsync(


### PR DESCRIPTION
Fixes #54296.

The remaining whole-file transcript scans called out by ClawSweeper triage on #54296 still materialized the entire session JSONL file in memory before splitting on newlines. On long-running sessions where transcripts grow into the multi-MB / 100s-of-MB range, that scales peak RSS with file size and is the practical OOM risk in the report.

This PR adds shared streaming helpers in `src/config/sessions/transcript-stream.ts` and migrates every flagged whole-file scan to them. Forward scans use `fs.createReadStream` + `readline` (one line of memory at a time). Reverse scans now walk the transcript newest-first in bounded chunks from the file end, decoding complete JSONL lines without a fixed tail cap, so `/tts latest` and delivery-mirror dedupe keep exact latest-assistant semantics even when a large user/tool entry follows the assistant line.

Migrated scans:

- `src/config/sessions/transcript.ts` -- latest/tail assistant reads, delivery-mirror equivalent-message lookup, and idempotency-key lookup.
- `src/gateway/server-methods/chat.ts` -- chat-method append idempotency lookup, now also tolerant of malformed lines mid-scan.
- `src/gateway/session-compaction-checkpoints.ts` -- compaction fork entry loading from the forward stream helper instead of one big `fileHandle.readFile("utf-8")`.

Preserved invariants from ClawSweeper's remaining-risk note: parentId DAG, malformed-line tolerance, idempotency-key return semantics, newest-assistant lookup semantics, and delivery-mirror dedupe behavior.

## Verification

- `pnpm test src/config/sessions/transcript-stream.test.ts src/config/sessions/transcript.test.ts` -- 29/29 pass.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` -- pass.
- `pnpm check:changed` on Testbox `tbx_01krbb7zw876zaqv9hfvg90k01` -- core and core-test typechecks pass; still fails in pre-existing unrelated `extensions/qqbot/src/engine/tools/remind-logic.test.ts(238,23)` on `deleteAfterRun`.
- `git diff --check` -- clean.

## Real behavior proof

Behavior addressed: Peak resident memory growing with transcript size during idempotency lookups, latest-assistant scans, delivery-mirror dedupe, and compaction fork loading on long-running sessions. The fix must keep latest-assistant and dedupe behavior exact even when a large user/tool entry follows the assistant entry.

Real environment tested: Blacksmith Testbox via Crabbox on PR head `552470c29a4d29afe1015222420638b657444802`, lease `tbx_01krbcw4swx29ecnqnpewj5j50`, slug `amber-barnacle`, Node 24 Testbox workflow environment. The command created a real OpenClaw session store and JSONL transcript on disk, used production session append/read helpers, appended an 8 MiB trailing user entry, verified latest-assistant reverse scan and delivery-mirror dedupe, verified idempotency forward scan, and forked a compaction checkpoint transcript.

Exact steps or command run after this patch: `pnpm crabbox:run -- --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json --shell -- <script that runs pnpm exec tsx .crabbox/pr80615-transcript-e2e.mts>`. The script imports `src/config/sessions/transcript.ts`, `src/config/sessions/transcript-append.ts`, and `src/gateway/session-compaction-checkpoints.ts` from the synced PR checkout and exercises real filesystem state under `/tmp`.

Evidence after fix: Copied Crabbox terminal output from the passing Testbox run:

```text
CRABBOX_PHASE:e2e-transcript
PR80615_E2E_OK
sessionFileBytes=8389986
sourceLines=4
forkLines=4
latestAssistantId=8819b590-0325-4e3c-a4df-b04ddf69742a
mirrorDedupeId=8819b590-0325-4e3c-a4df-b04ddf69742a
idempotentMessageId=2128a785-436a-4703-94e3-746f8fdbba69
tempDir=/tmp/openclaw-pr80615-e2e-by3EWT
blacksmith run summary sync=delegated command=37.41s total=40.098s exit=0
{"provider":"blacksmith-testbox","leaseId":"tbx_01krbcw4swx29ecnqnpewj5j50","slug":"amber-barnacle","syncMs":0,"syncPhases":[{"name":"delegated","skipped":true,"reason":"blacksmith-testbox owns sync"}],"syncSkipped":false,"syncDelegated":true,"commandMs":37409,"commandPhases":[{"name":"user-command","ms":32806},{"name":"e2e-transcript","ms":4603}],"totalMs":40098,"exitCode":0}
Testbox tbx_01krbcw4swx29ecnqnpewj5j50 stopped (completed)
```

Observed result after fix: The real transcript file was 8,389,986 bytes with the newest entry being a large user message. `readLatestAssistantTextFromSessionTranscript` still found the earlier assistant id. `appendAssistantMessageToSessionTranscript` returned the same assistant id for delivery-mirror dedupe instead of appending a duplicate. Repeating an append with the same idempotency key returned the same idempotent message id. `forkCompactionCheckpointTranscriptAsync` streamed and forked the transcript with matching line count.

What was not tested: No live model/provider turn or channel delivery was exercised; this bug is in local session transcript scanning and compaction file handling, so the E2E uses real OpenClaw session files and production session helpers without provider credentials.
