### PR TITLE
fix: improve error messages for skills update argument validation

### DIFF
--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -423,12 +423,46 @@ describe("skills cli commands", () => {
     });
 
     expect(resolveAgentIdByWorkspacePathMock).not.toHaveBeenCalled();
+    expect(resolveAgentWorkspaceDirMock).toHaveBeenCalledWith({}, "main");
+
     const updateOverrideArgs = mockFirstObjectArg(updateSkillsFromClawHubMock);
     expectObjectFields(updateOverrideArgs, {
       workspaceDir: "/tmp/workspace-main",
       slug: "calendar",
     });
     expectLogger(updateOverrideArgs.logger);
+  });
+
+  it("errors when update is called with no slug and no --all", async () => {
+    await expect(runCommand(["skills", "update"])).rejects.toThrow("__exit__:1");
+    expect(runtimeErrors.some((line) => line.includes("Provide a skill slug or use --all"))).toBe(
+      true,
+    );
+    expect(runtimeErrors.some((line) => line.includes("openclaw skills update"))).toBe(true);
+    expect(updateSkillsFromClawHubMock).not.toHaveBeenCalled();
+  });
+
+  it("errors when update is called with both a slug and --all", async () => {
+    await expect(runCommand(["skills", "update", "calendar", "--all"])).rejects.toThrow(
+      "__exit__:1",
+    );
+    expect(
+      runtimeErrors.some((line) => line.includes("Use either a skill slug or --all, not both")),
+    ).toBe(true);
+    expect(runtimeErrors.some((line) => line.includes("openclaw skills update"))).toBe(true);
+    expect(updateSkillsFromClawHubMock).not.toHaveBeenCalled();
+  });
+
+  it("logs and exits cleanly when --all is used with no tracked skills", async () => {
+    readTrackedClawHubSkillSlugsMock.mockResolvedValue([]);
+
+    await runCommand(["skills", "update", "--all"]);
+
+    expect(runtimeLogs.some((line) => line.includes("No tracked ClawHub skills to update"))).toBe(
+      true,
+    );
+    expect(runtimeErrors).toEqual([]);
+    expect(updateSkillsFromClawHubMock).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -16,6 +16,7 @@ import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
 import { resolveOptionFromCommand } from "./cli-utils.js";
+import { formatCliCommand } from "./command-format.js";
 import { formatSkillInfo, formatSkillsCheck, formatSkillsList } from "./skills-cli.format.js";
 
 export type {
@@ -183,12 +184,16 @@ export function registerSkillsCli(program: Command) {
       ) => {
         try {
           if (!slug && !opts.all) {
-            defaultRuntime.error("Provide a skill slug or use --all.");
+            defaultRuntime.error(
+              `Provide a skill slug or use --all. Example: ${formatCliCommand("openclaw skills update <slug>")} or ${formatCliCommand("openclaw skills update --all")}`,
+            );
             defaultRuntime.exit(1);
             return;
           }
           if (slug && opts.all) {
-            defaultRuntime.error("Use either a skill slug or --all.");
+            defaultRuntime.error(
+              `Use either a skill slug or --all, not both. Example: ${formatCliCommand("openclaw skills update <slug>")} or ${formatCliCommand("openclaw skills update --all")}`,
+            );
             defaultRuntime.exit(1);
             return;
           }


### PR DESCRIPTION
## Real behavior proof

I tested the behavior from a real local OpenClaw checkout after applying the fix.

Command:

```bash
pnpm test src/cli/skills-cli.commands.test.ts

##Output

[test] passed 1 Vitest shard in 5.07s

##The validation behavior covered by this change is:
openclaw skills update
→ Provide a skill slug or use --all

openclaw skills update calendar --all
→ Use either a skill slug or --all, not both