### PR TITLE
fix(memory): harden dreaming promotion cleanup

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -1487,6 +1487,47 @@ describe("memory-core dreaming phases", () => {
     expect(corpus).not.toContain("Run the qmd sync");
   });
 
+  it("dedupes CJK-only REM candidate truths with punctuation differences", () => {
+    const baseEntry = {
+      key: "memory:cjk-1",
+      path: "memory/2026-04-16.md",
+      startLine: 1,
+      endLine: 1,
+      source: "memory" as const,
+      snippet: "用户偏好使用中文回复。",
+      recallCount: 3,
+      dailyCount: 0,
+      groundedCount: 0,
+      totalScore: 2.7,
+      maxScore: 0.9,
+      firstRecalledAt: "2026-04-16T18:00:00.000Z",
+      lastRecalledAt: "2026-04-16T18:00:00.000Z",
+      queryHashes: ["q1", "q2"],
+      recallDays: ["2026-04-16", "2026-04-17"],
+      conceptTags: ["中文", "偏好"],
+    } satisfies ShortTermRecallEntry;
+
+    const preview = __testing.previewRemDreaming({
+      entries: [
+        baseEntry,
+        {
+          ...baseEntry,
+          key: "memory:cjk-2",
+          startLine: 2,
+          endLine: 2,
+          snippet: "用户偏好使用中文回复",
+          recallCount: 2,
+        },
+      ],
+      limit: 5,
+      minPatternStrength: 0,
+    });
+
+    expect(preview.candidateTruths.map((candidate) => candidate.snippet)).toEqual([
+      "用户偏好使用中文回复。",
+    ]);
+  });
+
   it("ignores chat scaffolding tags when building rem reflections", () => {
     const preview = __testing.previewRemDreaming({
       entries: [

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -26,6 +26,7 @@ import {
   runDetachedDreamNarrative,
 } from "./dreaming-narrative.js";
 import { asRecord, formatErrorMessage, normalizeTrimmedString } from "./dreaming-shared.js";
+import { textSimilarity } from "./memory/mmr.js";
 import {
   filterLiveShortTermRecallEntries,
   readShortTermRecallEntries,
@@ -1344,30 +1345,8 @@ function entryAverageScore(entry: ShortTermRecallEntry): number {
   return signalCount > 0 ? Math.max(0, Math.min(1, entry.totalScore / signalCount)) : 0;
 }
 
-function tokenizeSnippet(snippet: string): Set<string> {
-  return new Set(
-    snippet
-      .toLowerCase()
-      .split(/[^a-z0-9]+/i)
-      .map((token) => token.trim())
-      .filter(Boolean),
-  );
-}
-
 function jaccardSimilarity(left: string, right: string): number {
-  const leftTokens = tokenizeSnippet(left);
-  const rightTokens = tokenizeSnippet(right);
-  if (leftTokens.size === 0 || rightTokens.size === 0) {
-    return left.trim().toLowerCase() === right.trim().toLowerCase() ? 1 : 0;
-  }
-  let intersection = 0;
-  for (const token of leftTokens) {
-    if (rightTokens.has(token)) {
-      intersection += 1;
-    }
-  }
-  const union = new Set([...leftTokens, ...rightTokens]).size;
-  return union > 0 ? intersection / union : 0;
+  return left.trim().toLowerCase() === right.trim().toLowerCase() ? 1 : textSimilarity(left, right);
 }
 
 function dedupeEntries(entries: ShortTermRecallEntry[], threshold: number): ShortTermRecallEntry[] {

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -245,6 +245,35 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("ignores incomplete dreaming snippets when recording short-term recalls", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "action preference",
+        results: [
+          {
+            path: "memory/2026-04-03.md",
+            source: "memory",
+            startLine: 1,
+            endLine: 4,
+            score: 0.92,
+            snippet: [
+              "- Candidate: Default to action.",
+              "  - confidence: 0.76",
+              "  - status: staged",
+            ].join("\n"),
+          },
+        ],
+      });
+
+      const store = JSON.parse(
+        await fs.readFile(resolveShortTermRecallStorePath(workspaceDir), "utf-8"),
+      ) as { version?: number; entries?: unknown };
+      expect(store.version).toBe(1);
+      expect(store.entries).toEqual({});
+    });
+  });
+
   it("ignores bullet-prefixed dreaming snippets when recording short-term recalls", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await recordShortTermRecalls({

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -280,6 +280,7 @@ function isContaminatedDreamingSnippet(raw: string): boolean {
   }
   if (
     /<!--\s*openclaw-memory-promotion:/i.test(snippet) ||
+    /<!--\s*openclaw:dreaming:[^>]*:(?:start|end)\s*-->/i.test(snippet) ||
     DREAMING_TRANSCRIPT_PROMPT_LINE_RE.test(snippet)
   ) {
     return true;
@@ -292,7 +293,7 @@ function isContaminatedDreamingSnippet(raw: string): boolean {
   );
   const hasStatus = /\bstatus:\s*staged\b/i.test(snippet);
   const hasRecalls = /\brecalls:\s*\d+\b/i.test(snippet);
-  return hasNarrativeLead && hasConfidence && hasEvidence && hasStatus && hasRecalls;
+  return hasNarrativeLead && hasStatus && (hasConfidence || hasEvidence || hasRecalls);
 }
 
 function normalizeMemoryPath(rawPath: string): string {


### PR DESCRIPTION
## Summary

- Problem: memory-core dreaming dedupe used ASCII-only tokenization, so CJK-only snippets with trivial punctuation differences were not deduped; promotion filtering also only caught fully-populated generated dreaming snippets.
- Why it matters: CJK workspaces could accumulate duplicate REM candidate truths, and generated dreaming candidate scaffolding could be staged toward durable memory instead of clean user-authored notes.
- What changed: reused the CJK-aware MMR tokenizer for dreaming Jaccard similarity and broadened the dreaming contamination guard to catch managed dreaming markers plus staged Candidate blocks without requiring every metadata field.
- What did NOT change (scope boundary): no changes to promotion thresholds, storage format, cron scheduling, or public config.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #80613
- Related #76127
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: dreaming dedupe and short-term promotion filtering for CJK/generated dreaming snippets.
- Real environment tested: Debian 13 Linux, local OpenClaw checkout, Node v20.19.2 with pnpm 10.33.0 override because the machine lacks the repo-required Node >=22.16 runtime.
- Exact steps or command run after this patch: `node --import tsx .artifacts/openclaw-memory-proof.ts` against the patched local OpenClaw checkout.
- Evidence after fix (copied live terminal output from `node --import tsx .artifacts/openclaw-memory-proof.ts`):
  ```text
  node --import tsx .artifacts/openclaw-memory-proof.ts
  {
    "remCandidateTruths": [
      "用户偏好使用中文回复。"
    ],
    "shortTermEntryCount": 0
  }
  ```
- Observed result after fix: CJK punctuation-only REM candidate duplicates collapse to one candidate, and incomplete staged `Candidate` dreaming snippets are skipped from short-term recall storage.
- What was not tested: a full live scheduled dreaming sweep with a real workspace and model.
- Before evidence (optional but encouraged): `pnpm check:changed` still fails in extension test typecheck on two pre-existing unrelated files: `extensions/memory-core/src/tools.citations.test.ts` (`MemoryHostEvent.query`) and `extensions/qqbot/src/engine/tools/remind-logic.test.ts` (`deleteAfterRun`).

## Root Cause (if applicable)

- Root cause: dreaming dedupe tokenized snippets with `/[^a-z0-9]+/i`, which produces empty token sets for CJK-only text and falls back to exact string equality; promotion contamination detection required `Candidate`, `confidence`, `evidence`, `status`, and `recalls` all to be present.
- Missing detection / guardrail: no regression covered CJK-only dreaming dedupe or incomplete staged dreaming Candidate blocks.
- Contributing context (if known): memory MMR already had the correct CJK/Kana/Hangul tokenizer, but dreaming had a separate ASCII-only implementation.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/memory-core/src/dreaming-phases.test.ts`
  - `extensions/memory-core/src/short-term-promotion.test.ts`
- Scenario the test should lock in: CJK-only REM candidates with punctuation differences dedupe; incomplete generated dreaming Candidate snippets are rejected.
- Why this is the smallest reliable guardrail: both failures are local text normalization/filtering contracts.
- Existing test that already covers this (if any): existing contaminated-snippet tests covered only fully-populated generated snippets.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Dreaming promotion should produce fewer duplicate CJK candidate truths and avoid promoting generated dreaming scaffolding into durable memory.

## Diagram (if applicable)

```text
Before:
CJK daily note -> ASCII token set empty -> exact-match-only dedupe -> duplicates remain
Generated Candidate block missing one metadata field -> contamination guard misses it -> can be staged

After:
CJK daily note -> CJK-aware tokens -> Jaccard dedupe -> duplicate removed
Generated Candidate block with staged status -> contamination guard catches it -> skipped
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Debian 13 Linux (`Linux ip-45-61-162-254 6.12.38+deb13-amd64`)
- Runtime/container: Node v20.19.2, pnpm 10.33.0 via `COREPACK_ENABLE_PROJECT_SPEC=0` override
- Model/provider: N/A
- Integration/channel (if any): memory-core plugin
- Relevant config (redacted): N/A

### Steps

1. Run the local behavior proof script with `node --import tsx .artifacts/openclaw-memory-proof.ts`.
2. Run targeted formatting: `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/dreaming-phases.ts extensions/memory-core/src/dreaming-phases.test.ts extensions/memory-core/src/short-term-promotion.ts extensions/memory-core/src/short-term-promotion.test.ts`.
3. Run targeted memory-core tests: `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm test extensions/memory-core/src/dreaming-phases.test.ts extensions/memory-core/src/short-term-promotion.test.ts -- --reporter=verbose`.
4. Run generated protocol check: `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm protocol:check`.
5. Run changed gate: `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm check:changed`.

### Expected

- CJK duplicates dedupe to one REM candidate truth.
- Incomplete generated dreaming Candidate snippets are skipped.

### Actual

- Targeted tests pass after the patch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios: local OpenClaw memory-core proof script returned one deduped CJK REM candidate and zero stored entries for the generated Candidate block; targeted memory-core Vitest suite passed (`84 passed`); targeted `oxfmt --check` passed; `protocol:check` passed with no protocol diff.
- Edge cases checked: ordinary daily-memory `Candidate` notes with evidence but no staged status remain non-contaminated via existing test coverage.
- What I did **not** verify: full live dreaming cron with a real model-backed workspace; broad `check:changed` remains blocked by unrelated extension test type errors listed above.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the broader contamination guard could reject a legitimate user note that literally starts like a generated Candidate block and includes staged status metadata.
  - Mitigation: existing coverage keeps ordinary `Candidate` notes with daily-memory evidence allowed; the guard still requires staged status plus generated-style metadata or explicit managed dreaming markers.
