### PR TITLE
fix(acp): ensure runTurn rejects when child exits before terminal event (fixes #79355)

### DIFF
--- a/src/acp/control-plane/manager.turn-stream.test.ts
+++ b/src/acp/control-plane/manager.turn-stream.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import type { AcpRuntime, AcpRuntimeEvent } from "../../acp/runtime/types.js";
 import { consumeAcpTurnStream, type AcpTurnEventGate } from "./manager.turn-stream.js";
 
 function createMockRuntime(params: {
   events?: AcpRuntimeEvent[];
+  eventDelaysMs?: number[];
   throwOnRunTurn?: Error;
   delayMs?: number;
 }): AcpRuntime {
@@ -17,7 +18,11 @@ function createMockRuntime(params: {
         throw params.throwOnRunTurn;
       }
       if (params.events) {
-        for (const event of params.events) {
+        for (const [index, event] of params.events.entries()) {
+          const delayMs = params.eventDelaysMs?.[index] ?? 0;
+          if (delayMs > 0) {
+            await new Promise((r) => setTimeout(r, delayMs));
+          }
           yield event;
         }
       }
@@ -26,6 +31,10 @@ function createMockRuntime(params: {
     close: vi.fn(),
   } as unknown as AcpRuntime;
 }
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("consumeAcpTurnStream", () => {
   it("returns sawTerminalEvent=true when done event is emitted", async () => {
@@ -132,30 +141,33 @@ describe("consumeAcpTurnStream", () => {
     expect(result.sawOutput).toBe(false); // events skipped when gate closed
   });
 
-  it("times out when stream hangs without completing", async () => {
-    // Create a runtime that never yields any events (simulates hung child process)
+  it("allows a valid stream to emit done after more than 30 seconds", async () => {
+    vi.useFakeTimers();
     const runtime = createMockRuntime({
-      events: [],
-      delayMs: 60_000, // would delay forever
+      events: [
+        { type: "text_delta", text: "still working" },
+        { type: "done", stopReason: "end_turn" },
+      ],
+      eventDelaysMs: [0, 31_000],
     });
     const eventGate: AcpTurnEventGate = { open: true };
 
-    const start = Date.now();
-    await expect(
-      consumeAcpTurnStream({
-        runtime,
-        turn: {
-          handle: { sessionKey: "test", backend: "test", runtimeSessionName: "test" },
-          text: "hi",
-          mode: "prompt",
-          requestId: "1",
-        },
-        eventGate,
-      }),
-    ).rejects.toThrow("timed out");
-    const elapsed = Date.now() - start;
-    // Should timeout within the 30s window, not 60s
-    expect(elapsed).toBeLessThan(35_000);
-    expect(elapsed).toBeGreaterThan(28_000);
+    const resultPromise = consumeAcpTurnStream({
+      runtime,
+      turn: {
+        handle: { sessionKey: "test", backend: "test", runtimeSessionName: "test" },
+        text: "hi",
+        mode: "prompt",
+        requestId: "1",
+      },
+      eventGate,
+    });
+
+    await vi.advanceTimersByTimeAsync(31_000);
+
+    await expect(resultPromise).resolves.toEqual({
+      sawOutput: true,
+      sawTerminalEvent: true,
+    });
   });
 });

--- a/src/acp/control-plane/manager.turn-stream.test.ts
+++ b/src/acp/control-plane/manager.turn-stream.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from "vitest";
+import type { AcpRuntime, AcpRuntimeEvent } from "../../acp/runtime/types.js";
+import { consumeAcpTurnStream, type AcpTurnEventGate } from "./manager.turn-stream.js";
+
+function createMockRuntime(params: {
+  events?: AcpRuntimeEvent[];
+  throwOnRunTurn?: Error;
+  delayMs?: number;
+}): AcpRuntime {
+  return {
+    ensureSession: vi.fn(),
+    async *runTurn() {
+      if (params.delayMs) {
+        await new Promise((r) => setTimeout(r, params.delayMs));
+      }
+      if (params.throwOnRunTurn) {
+        throw params.throwOnRunTurn;
+      }
+      if (params.events) {
+        for (const event of params.events) {
+          yield event;
+        }
+      }
+    },
+    cancel: vi.fn(),
+    close: vi.fn(),
+  } as unknown as AcpRuntime;
+}
+
+describe("consumeAcpTurnStream", () => {
+  it("returns sawTerminalEvent=true when done event is emitted", async () => {
+    const runtime = createMockRuntime({
+      events: [
+        { type: "text_delta", text: "hello" },
+        { type: "done", stopReason: "end_turn" },
+      ],
+    });
+    const eventGate: AcpTurnEventGate = { open: true };
+
+    const result = await consumeAcpTurnStream({
+      runtime,
+      turn: {
+        handle: { sessionKey: "test", backend: "test", runtimeSessionName: "test" },
+        text: "hi",
+        mode: "prompt",
+        requestId: "1",
+      },
+      eventGate,
+    });
+
+    expect(result.sawOutput).toBe(true);
+    expect(result.sawTerminalEvent).toBe(true);
+  });
+
+  it("throws error when stream completes without terminal event (child exits prematurely)", async () => {
+    const runtime = createMockRuntime({
+      events: [{ type: "text_delta", text: "partial" }], // no done event
+    });
+    const eventGate: AcpTurnEventGate = { open: true };
+
+    await expect(
+      consumeAcpTurnStream({
+        runtime,
+        turn: {
+          handle: { sessionKey: "test", backend: "test", runtimeSessionName: "test" },
+          text: "hi",
+          mode: "prompt",
+          requestId: "1",
+        },
+        eventGate,
+      }),
+    ).rejects.toThrow("ACP turn ended without a terminal done event");
+  });
+
+  it("throws error when runtime.runTurn throws unexpectedly", async () => {
+    const runtime = createMockRuntime({
+      throwOnRunTurn: new Error("child process crashed"),
+    });
+    const eventGate: AcpTurnEventGate = { open: true };
+
+    await expect(
+      consumeAcpTurnStream({
+        runtime,
+        turn: {
+          handle: { sessionKey: "test", backend: "test", runtimeSessionName: "test" },
+          text: "hi",
+          mode: "prompt",
+          requestId: "1",
+        },
+        eventGate,
+      }),
+    ).rejects.toThrow("child process crashed");
+  });
+
+  it("re-throws ACP error event as structured error", async () => {
+    const runtime = createMockRuntime({
+      events: [{ type: "error", message: "auth failed", code: "AUTH_FAILED" }],
+    });
+    const eventGate: AcpTurnEventGate = { open: true };
+
+    await expect(
+      consumeAcpTurnStream({
+        runtime,
+        turn: {
+          handle: { sessionKey: "test", backend: "test", runtimeSessionName: "test" },
+          text: "hi",
+          mode: "prompt",
+          requestId: "1",
+        },
+        eventGate,
+      }),
+    ).rejects.toThrow("auth failed");
+  });
+
+  it("does not throw when eventGate is closed", async () => {
+    const runtime = createMockRuntime({
+      events: [{ type: "text_delta", text: "hello" }],
+    });
+    const eventGate: AcpTurnEventGate = { open: false };
+
+    const result = await consumeAcpTurnStream({
+      runtime,
+      turn: {
+        handle: { sessionKey: "test", backend: "test", runtimeSessionName: "test" },
+        text: "hi",
+        mode: "prompt",
+        requestId: "1",
+      },
+      eventGate,
+    });
+
+    expect(result.sawOutput).toBe(false); // events skipped when gate closed
+  });
+
+  it("times out when stream hangs without completing", async () => {
+    // Create a runtime that never yields any events (simulates hung child process)
+    const runtime = createMockRuntime({
+      events: [],
+      delayMs: 60_000, // would delay forever
+    });
+    const eventGate: AcpTurnEventGate = { open: true };
+
+    const start = Date.now();
+    await expect(
+      consumeAcpTurnStream({
+        runtime,
+        turn: {
+          handle: { sessionKey: "test", backend: "test", runtimeSessionName: "test" },
+          text: "hi",
+          mode: "prompt",
+          requestId: "1",
+        },
+        eventGate,
+      }),
+    ).rejects.toThrow("timed out");
+    const elapsed = Date.now() - start;
+    // Should timeout within the 30s window, not 60s
+    expect(elapsed).toBeLessThan(35_000);
+    expect(elapsed).toBeGreaterThan(28_000);
+  });
+});

--- a/src/acp/control-plane/manager.turn-stream.ts
+++ b/src/acp/control-plane/manager.turn-stream.ts
@@ -3,8 +3,6 @@ import type { AcpRuntime, AcpRuntimeEvent, AcpRuntimeTurnInput } from "../runtim
 import { normalizeAcpErrorCode } from "./manager.utils.js";
 import { normalizeText } from "./runtime-options.js";
 
-const TURN_STREAM_TIMEOUT_MS = 30_000;
-
 export type AcpTurnEventGate = {
   open: boolean;
 };
@@ -13,24 +11,6 @@ export type AcpTurnStreamOutcome = {
   sawOutput: boolean;
   sawTerminalEvent: boolean;
 };
-
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  const timeoutToken = Symbol("timeout");
-  let timer: NodeJS.Timeout | undefined;
-  const timeoutPromise = new Promise<typeof timeoutToken>((resolve) => {
-    timer = setTimeout(() => resolve(timeoutToken), timeoutMs);
-    if (timer.unref) timer.unref();
-  });
-  try {
-    const result = await Promise.race([promise, timeoutPromise]);
-    if (result === timeoutToken) {
-      throw new AcpRuntimeError("ACP_TURN_FAILED", "ACP turn stream timed out waiting for events.");
-    }
-    return result;
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
-}
 
 export async function consumeAcpTurnStream(params: {
   runtime: AcpRuntime;
@@ -68,7 +48,7 @@ export async function consumeAcpTurnStream(params: {
     streamCompleted = true;
   };
 
-  await withTimeout(runStream(), TURN_STREAM_TIMEOUT_MS);
+  await runStream();
 
   if (params.eventGate.open && streamError) {
     throw streamError;

--- a/src/acp/control-plane/manager.turn-stream.ts
+++ b/src/acp/control-plane/manager.turn-stream.ts
@@ -3,6 +3,8 @@ import type { AcpRuntime, AcpRuntimeEvent, AcpRuntimeTurnInput } from "../runtim
 import { normalizeAcpErrorCode } from "./manager.utils.js";
 import { normalizeText } from "./runtime-options.js";
 
+const TURN_STREAM_TIMEOUT_MS = 30_000;
+
 export type AcpTurnEventGate = {
   open: boolean;
 };
@@ -11,6 +13,24 @@ export type AcpTurnStreamOutcome = {
   sawOutput: boolean;
   sawTerminalEvent: boolean;
 };
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  const timeoutToken = Symbol("timeout");
+  let timer: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<typeof timeoutToken>((resolve) => {
+    timer = setTimeout(() => resolve(timeoutToken), timeoutMs);
+    if (timer.unref) timer.unref();
+  });
+  try {
+    const result = await Promise.race([promise, timeoutPromise]);
+    if (result === timeoutToken) {
+      throw new AcpRuntimeError("ACP_TURN_FAILED", "ACP turn stream timed out waiting for events.");
+    }
+    return result;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
 
 export async function consumeAcpTurnStream(params: {
   runtime: AcpRuntime;
@@ -24,27 +44,38 @@ export async function consumeAcpTurnStream(params: {
   let streamError: AcpRuntimeError | null = null;
   let sawOutput = false;
   let sawTerminalEvent = false;
+  let streamCompleted = false;
 
-  for await (const event of params.runtime.runTurn(params.turn)) {
-    if (!params.eventGate.open) {
-      continue;
+  const runStream = async () => {
+    for await (const event of params.runtime.runTurn(params.turn)) {
+      streamCompleted = true;
+      if (!params.eventGate.open) {
+        continue;
+      }
+      if (event.type === "done") {
+        sawTerminalEvent = true;
+      } else if (event.type === "error") {
+        streamError = new AcpRuntimeError(
+          normalizeAcpErrorCode(event.code),
+          normalizeText(event.message) || "ACP turn failed before completion.",
+        );
+      } else if (event.type === "text_delta" || event.type === "tool_call") {
+        sawOutput = true;
+        await params.onOutputEvent?.(event);
+      }
+      await params.onEvent?.(event);
     }
-    if (event.type === "done") {
-      sawTerminalEvent = true;
-    } else if (event.type === "error") {
-      streamError = new AcpRuntimeError(
-        normalizeAcpErrorCode(event.code),
-        normalizeText(event.message) || "ACP turn failed before completion.",
-      );
-    } else if (event.type === "text_delta" || event.type === "tool_call") {
-      sawOutput = true;
-      await params.onOutputEvent?.(event);
-    }
-    await params.onEvent?.(event);
-  }
+    streamCompleted = true;
+  };
+
+  await withTimeout(runStream(), TURN_STREAM_TIMEOUT_MS);
 
   if (params.eventGate.open && streamError) {
     throw streamError;
+  }
+
+  if (params.eventGate.open && streamCompleted && !sawTerminalEvent) {
+    throw new AcpRuntimeError("ACP_TURN_FAILED", "ACP turn ended without a terminal done event.");
   }
 
   return {


### PR DESCRIPTION
## Summary

- Problem: When an ACP runtime backend's child process exits before producing a terminal ACP message (`done` or `error`), `runTurn` handling could leave the session stuck as running instead of surfacing a structured failure.
- Why it matters: Operators cannot distinguish orphan sessions from real running sessions without external watchdog monitoring.
- What changed: Added a post-iteration check in `consumeAcpTurnStream()` that throws `ACP_TURN_FAILED` if the stream completes while the event gate is open and no `done` event was observed.
- What did NOT change: ACP runtime backend contracts, session persistence, gateway dispatch logic, acpx extension behavior, or total turn timeout ownership. Total timeout remains with `manager.core.ts` / `awaitTurnWithTimeout`.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #79355
- Supersedes #79371
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: ACP `runTurn` handling could fail to reject when a runtime child process exits or its stream completes before producing a terminal `done` event. The fixed behavior is that stream completion without `done` now throws `ACP_TURN_FAILED` instead of returning unresolved turn state.
- Real environment tested: Real OpenClaw checkout in WSL at `/home/vashista/skyforce/openclaw`, on PR head `6ba3eba618` / branch `fix/acp-runturn-hang-79355-v2`, with Node `v24.14.0` and pnpm `10.33.2` via corepack.
- Exact steps or command run after this patch:

```bash
cd /home/vashista/skyforce/openclaw
corepack pnpm test src/acp/control-plane/manager.turn-stream.test.ts
```

- Evidence: Terminal capture from the real WSL OpenClaw checkout after the fix:

```text
> openclaw@2026.5.6 test /home/vashista/skyforce/openclaw
> node scripts/test-projects.mjs src/acp/control-plane/manager.turn-stream.test.ts

 RUN  v4.1.5 /home/vashista/skyforce/openclaw

 ✓ acp src/acp/control-plane/manager.turn-stream.test.ts (6 tests) 62ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  09:58:33
   Duration  1.54s (transform 623ms, setup 1.01s, import 103ms, tests 62ms, environment 0ms)

[test] starting test/vitest/vitest.acp.config.ts
[test] passed 1 Vitest shard in 8.44s
```

- Observed result after fix: The regression scenario now rejects instead of leaving unresolved state: `consumeAcpTurnStream()` throws `ACP_TURN_FAILED: ACP turn ended without a terminal done event.` The reviewer-requested long valid stream case also succeeds: a stream can emit `text_delta`, wait more than 30 seconds, then emit `done` without being hard-capped by `consumeAcpTurnStream()`.
- What was not tested: A real acpx child process crash in Docker with the actual claude CLI, because that requires authenticated upstream provider credentials. The local proof uses the real OpenClaw test runner and a focused runtime simulation of the observed stream behavior.

## Root Cause

- Root cause: `consumeAcpTurnStream()` used `for await...of` on the ACP runtime stream and did not validate that a terminal `done` event was observed before returning.
- Missing detection / guardrail: No explicit check after stream iteration completed to verify a terminal event was seen.
- Contributing context: Observed when upstream auth failure can cause a child process to exit before writing terminal ACP output.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test file: `src/acp/control-plane/manager.turn-stream.test.ts`
- Scenario locked in: Stream completes without `done` event -> rejects with `ACP_TURN_FAILED`.
- Additional reviewer-requested guardrail: A valid stream can emit `text_delta`, wait more than 30 seconds, then emit `done` and still succeed.

## User-visible / Behavior Changes

None. This is internal error handling. A premature runtime stream completion now moves toward structured error handling instead of leaving the turn unresolved.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Human Verification

Verified in the real WSL OpenClaw checkout:

- Stream completes with `done` event -> returns `sawTerminalEvent=true`.
- Stream completes without `done` event -> throws `ACP_TURN_FAILED`.
- Valid long stream emits `text_delta`, waits more than 30s, then emits `done` -> succeeds.
- ACP error event -> re-thrown as structured `AcpRuntimeError`.
- `eventGate.open = false` -> events skipped, no terminal-event error thrown.
- `runTurn()` throws unexpectedly -> error propagates.

## Review Conversations

- [x] I replied to the reviewer feedback about avoiding a hard-coded 30s total stream cap.
- [ ] I left unresolved only conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Runtime streams that never settle still rely on the existing configured turn timeout in `manager.core.ts`.
  - Mitigation: This PR intentionally avoids adding a second hard-coded timeout in stream consumption, so there is one source of truth for total turn timeout.

- Risk: Real provider crash was not exercised end-to-end.
  - Mitigation: The regression test covers the runtime stream behavior that `consumeAcpTurnStream()` owns, while avoiding dependency on external provider credentials.

