### PR TITLE
fix: retire timed-out Codex app-server clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Agents: add per-agent `tools.message.actions.allow` overrides so sandboxed/public agents can expose and enforce send-only message tools.
 - Agents: omit the sandbox workspace marker from compact command progress previews while keeping internal sandbox diagnostics unchanged.
 - Agents: widen progress draft command preview lines by 50% so Discord inline tool updates preserve more useful command context.
+- Codex app-server: retire timed-out app-server clients after bounded turn interrupts so Discord agents do not reuse a CPU-spinning Codex process after an attempt timeout.
 - Build: upgrade workspace package management to pnpm 11 and keep Docker, install, update, and release workflows on the pnpm 11 config surface. (#79414) Thanks @altaywtf.
 - Build: align Telegram QA workflows and git source installs with the pnpm 11 workspace build allowlist surface. (#80588) Thanks @altaywtf.
 - Models: add provider-level `localService` startup for on-demand local model servers before OpenAI-compatible requests, including one-shot model probes.

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1231,12 +1231,62 @@ describe("runCodexAppServerAttempt", () => {
     );
     await vi.waitFor(
       () =>
-        expect(request).toHaveBeenCalledWith("turn/interrupt", {
-          threadId: "thread-1",
-          turnId: "turn-1",
-        }),
+        expect(request).toHaveBeenCalledWith(
+          "turn/interrupt",
+          {
+            threadId: "thread-1",
+            turnId: "turn-1",
+          },
+          { timeoutMs: 5_000 },
+        ),
       { interval: 1 },
     );
+    expect(queueActiveRunMessageForTest("session-1", "after timeout")).toBe(false);
+  });
+
+  it("closes the app-server client when the active turn exceeds the attempt timeout", async () => {
+    const close = vi.fn();
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-1", "inProgress");
+      }
+      if (method === "turn/interrupt") {
+        return new Promise<never>(() => undefined);
+      }
+      return {};
+    });
+    __testing.setCodexAppServerClientFactoryForTests(
+      async () =>
+        ({
+          request,
+          close,
+          addNotificationHandler: () => () => undefined,
+          addRequestHandler: () => () => undefined,
+        }) as never,
+    );
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 100;
+
+    const result = await runCodexAppServerAttempt(params);
+
+    expect(result.aborted).toBe(true);
+    expect(result.timedOut).toBe(true);
+    expect(result.promptError).toBe("codex app-server attempt timed out");
+    expect(request).toHaveBeenCalledWith(
+      "turn/interrupt",
+      {
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+      { timeoutMs: 5_000 },
+    );
+    expect(close).toHaveBeenCalledTimes(1);
     expect(queueActiveRunMessageForTest("session-1", "after timeout")).toBe(false);
   });
 
@@ -1540,10 +1590,14 @@ describe("runCodexAppServerAttempt", () => {
     );
     await vi.waitFor(
       () =>
-        expect(harness.request).toHaveBeenCalledWith("turn/interrupt", {
-          threadId: "thread-1",
-          turnId: "turn-1",
-        }),
+        expect(harness.request).toHaveBeenCalledWith(
+          "turn/interrupt",
+          {
+            threadId: "thread-1",
+            turnId: "turn-1",
+          },
+          { timeoutMs: 5_000 },
+        ),
       { interval: 1 },
     );
     expect(queueActiveRunMessageForTest("session-1", "after silent turn")).toBe(false);

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -141,6 +141,7 @@ const CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS = 600_000;
 const CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS = 60_000;
 const CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS = 3;
 const CODEX_APP_SERVER_STARTUP_TIMEOUT_FLOOR_MS = 100;
+const CODEX_APP_SERVER_INTERRUPT_TIMEOUT_MS = 5_000;
 const CODEX_USAGE_LIMIT_RATE_LIMIT_REFRESH_TIMEOUT_MS = 5_000;
 const CODEX_TURN_COMPLETION_IDLE_TIMEOUT_MS = 60_000;
 const CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS = 30 * 60_000;
@@ -1496,10 +1497,19 @@ export async function runCodexAppServerAttempt(
   );
 
   const abortListener = () => {
+    const shouldRetireClient = timedOut;
     interruptCodexTurnBestEffort(client, {
       threadId: thread.threadId,
       turnId: activeTurnId,
+      timeoutMs: shouldRetireClient ? CODEX_APP_SERVER_INTERRUPT_TIMEOUT_MS : undefined,
     });
+    if (shouldRetireClient) {
+      retireCodexAppServerClientAfterTimedOutTurn(client, {
+        threadId: thread.threadId,
+        turnId: activeTurnId,
+        reason: String(runAbortController.signal.reason ?? "timeout"),
+      });
+    }
     resolveCompletion?.();
   };
   runAbortController.signal.addEventListener("abort", abortListener, { once: true });
@@ -1974,13 +1984,47 @@ function interruptCodexTurnBestEffort(
   params: {
     threadId: string;
     turnId: string;
+    timeoutMs?: number;
   },
 ): void {
-  void Promise.resolve()
-    .then(() => client.request("turn/interrupt", params))
-    .catch((error: unknown) => {
+  const requestOptions =
+    params.timeoutMs && Number.isFinite(params.timeoutMs) && params.timeoutMs > 0
+      ? { timeoutMs: params.timeoutMs }
+      : undefined;
+  const requestParams = { threadId: params.threadId, turnId: params.turnId };
+  try {
+    const interrupt = requestOptions
+      ? client.request("turn/interrupt", requestParams, requestOptions)
+      : client.request("turn/interrupt", requestParams);
+    void Promise.resolve(interrupt).catch((error: unknown) => {
       embeddedAgentLog.debug("codex app-server turn interrupt failed during abort", { error });
     });
+  } catch (error) {
+    embeddedAgentLog.debug("codex app-server turn interrupt failed during abort", { error });
+  }
+}
+
+function retireCodexAppServerClientAfterTimedOutTurn(
+  client: CodexAppServerClient,
+  params: {
+    threadId: string;
+    turnId: string;
+    reason: string;
+  },
+): void {
+  const clearedSharedClient = clearSharedCodexAppServerClientIfCurrent(client);
+  if (!clearedSharedClient) {
+    const close = (client as { close?: () => void }).close;
+    if (typeof close === "function") {
+      close.call(client);
+    }
+  }
+  embeddedAgentLog.warn("codex app-server client retired after timed-out turn", {
+    threadId: params.threadId,
+    turnId: params.turnId,
+    reason: params.reason,
+    clearedSharedClient,
+  });
 }
 
 type DynamicToolBuildParams = {


### PR DESCRIPTION
## Summary
- retire the shared Codex app-server client when an OpenClaw app-server turn hits the attempt/idle timeout
- bound abort-time `turn/interrupt` requests to 5s so stuck Codex turns cannot leave a poisoned client around
- add regression coverage for closing a timed-out client before the next Discord turn reuses it

## Real behavior proof
Behavior addressed: Discord-backed Codex agents could time out an OpenClaw app-server attempt, leave the Codex app-server child alive and CPU-spinning, then reuse that poisoned client on the next mention.

Real environment tested: local OpenClaw checkout on macOS, Codex app-server extension runtime/test lane, using the same OpenClaw wrapper code path that owns Discord ClawSweeper app-server attempts.

Exact steps or command run after this patch:
```bash
pnpm format:check extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts CHANGELOG.md
pnpm tsgo:extensions:test
node scripts/test-projects.mjs extensions/codex/src/app-server/run-attempt.test.ts --maxWorkers=1
```

Evidence after fix: terminal output from the focused extension run after this patch:
```text
Test Files  1 passed (1)
Tests  93 passed (93)
[test] passed 1 Vitest shard in 36.94s
```
The new regression drives a turn that accepts `turn/start`, never emits completion, hits the attempt timeout, sends `turn/interrupt` with `{ timeoutMs: 5000 }`, closes the app-server client, and releases the active session.

Observed result after fix: the wrapper now retires the timed-out app-server client instead of keeping it eligible for reuse, so a follow-up Discord mention gets a fresh Codex app-server process rather than the CPU-spinning one from the timed-out attempt.

What was not tested: live Hetzner/Discord repro after this branch; the live failure was observed before the patch, and this PR proves the OpenClaw wrapper timeout boundary locally.

## Test plan
- `pnpm format:check extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts CHANGELOG.md`
- `pnpm tsgo:extensions:test`
- `node scripts/test-projects.mjs extensions/codex/src/app-server/run-attempt.test.ts --maxWorkers=1`