### PR TITLE
fix: abort generic no-progress tool loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Docs: https://docs.openclaw.ai
 - Gateway: dedupe concurrent `send`, `poll`, and `message.action` requests while delivery is still in flight, preventing duplicate outbound work for the same idempotency key. (#68341) Thanks @thesomewhatyou.
 - Cron: keep main-session `systemEvent` heartbeat wakes on their bound session route for both direct and queued wake paths by dropping inherited explicit heartbeat destinations when forcing `target: "last"`. Fixes #73900. Thanks @richardmqq.
 - Telegram: honor forced document delivery for video media so `--force-document` sends MP4s as documents instead of typed videos. Fixes #80389. (#80405) Thanks @jbetala7.
+- Agents: abort generic repeated no-progress tool loops at the critical threshold when identical calls keep returning identical outcomes. Thanks @frankekn.
 - Gateway: clear speculative node wake state when APNs registration is missing, preventing unregistered or mistyped node IDs from retaining wake throttle entries. Fixes #68847. (#68848) Thanks @Feelw00.
 - Auto-reply: keep late follow-up queue drain finalizers from deleting a replacement queue registered after `/stop`, preventing immediate follow-up messages from being orphaned. Fixes #68838. (#68839) Thanks @Feelw00.
 - Feishu: make manual App ID/App Secret setup the default channel-binding path while keeping QR scan-to-create as an optional best-effort flow, and document the manual fallback for domestic Feishu mobile clients that do not react to the QR code. Fixes #80591. Thanks @wei-wei-zhao.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,6 @@ Docs: https://docs.openclaw.ai
 - Gateway: dedupe concurrent `send`, `poll`, and `message.action` requests while delivery is still in flight, preventing duplicate outbound work for the same idempotency key. (#68341) Thanks @thesomewhatyou.
 - Cron: keep main-session `systemEvent` heartbeat wakes on their bound session route for both direct and queued wake paths by dropping inherited explicit heartbeat destinations when forcing `target: "last"`. Fixes #73900. Thanks @richardmqq.
 - Telegram: honor forced document delivery for video media so `--force-document` sends MP4s as documents instead of typed videos. Fixes #80389. (#80405) Thanks @jbetala7.
-- Agents: abort generic repeated no-progress tool loops at the critical threshold when identical calls keep returning identical outcomes. Thanks @frankekn.
 - Gateway: clear speculative node wake state when APNs registration is missing, preventing unregistered or mistyped node IDs from retaining wake throttle entries. Fixes #68847. (#68848) Thanks @Feelw00.
 - Auto-reply: keep late follow-up queue drain finalizers from deleting a replacement queue registered after `/stop`, preventing immediate follow-up messages from being orphaned. Fixes #68838. (#68839) Thanks @Feelw00.
 - Feishu: make manual App ID/App Secret setup the default channel-binding path while keeping QR scan-to-create as an optional best-effort flow, and document the manual fallback for domestic Feishu mobile clients that do not react to the QR code. Fixes #80591. Thanks @wei-wei-zhao.
@@ -276,6 +275,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Pi: wait for embedded abort cleanup to settle before releasing the session write lock, preventing follow-up turns from racing previous prompt teardown. (#80239) Thanks @samzong.
 - WhatsApp: downgrade OpenClaw watchdog-triggered Web reconnects from runtime errors to recovery warnings and clear the recovered reconnect status after the next healthy connection. (#77026) Thanks @rubencu.
 - ACPX/Windows: hide the MCP proxy target child process window on Windows so ACP-backed agents do not flash or fail because of terminal window handling. Fixes #60672. (#60678) Thanks @KChow-ctrl.
+- Agents: abort generic repeated no-progress tool loops at the critical threshold when identical calls keep returning identical outcomes. (#80668) Thanks @frankekn.
 
 ## 2026.5.9
 

--- a/docs/tools/loop-detection.md
+++ b/docs/tools/loop-detection.md
@@ -77,10 +77,10 @@ Per-agent override (optional):
 | `enabled`                        | `false` | Master switch for the rolling-history detectors. Setting `false` also disables the post-compaction guard.                       |
 | `historySize`                    | `30`    | Number of recent tool calls kept for analysis.                                                                                  |
 | `warningThreshold`               | `10`    | Threshold before a pattern is classified as warning-only.                                                                       |
-| `criticalThreshold`              | `20`    | Threshold for blocking repetitive loop patterns.                                                                                |
+| `criticalThreshold`              | `20`    | Threshold for blocking repetitive no-progress loop patterns.                                                                    |
 | `unknownToolThreshold`           | `10`    | Block repeated calls to the same unavailable tool after this many misses.                                                       |
 | `globalCircuitBreakerThreshold`  | `30`    | Global no-progress breaker threshold across all detectors.                                                                      |
-| `detectors.genericRepeat`        | `true`  | Detects repeated same-tool + same-params patterns.                                                                              |
+| `detectors.genericRepeat`        | `true`  | Warns on repeated same-tool + same-params patterns and blocks when the same calls also return identical outcomes.               |
 | `detectors.knownPollNoProgress`  | `true`  | Detects known polling-like patterns with no state change.                                                                       |
 | `detectors.pingPong`             | `true`  | Detects alternating ping-pong patterns.                                                                                         |
 | `postCompactionGuard.windowSize` | `3`     | Number of post-compaction tool calls during which the guard stays armed and the count of identical triples that aborts the run. |

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -15,7 +15,7 @@ import {
   runBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,
 } from "./pi-tools.before-tool-call.js";
-import { CRITICAL_THRESHOLD, GLOBAL_CIRCUIT_BREAKER_THRESHOLD } from "./tool-loop-detection.js";
+import { CRITICAL_THRESHOLD } from "./tool-loop-detection.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
@@ -277,28 +277,23 @@ describe("before_tool_call loop detection behavior", () => {
     }
   });
 
-  it("keeps generic repeated calls warn-only below global breaker", async () => {
+  it("keeps generic repeated calls unblocked below critical threshold", async () => {
     const { tool, params } = createGenericReadRepeatFixture();
 
-    for (let i = 0; i < CRITICAL_THRESHOLD + 5; i += 1) {
+    for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
       await expectUnblockedToolExecution(tool, `read-${i}`, params);
     }
   });
 
-  it("blocks generic repeated no-progress calls at global breaker threshold", async () => {
+  it("blocks generic repeated no-progress calls at critical threshold", async () => {
     const { tool, params } = createGenericReadRepeatFixture();
 
-    for (let i = 0; i < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; i += 1) {
+    for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
       await expectUnblockedToolExecution(tool, `read-${i}`, params);
     }
 
-    const result = await tool.execute(
-      `read-${GLOBAL_CIRCUIT_BREAKER_THRESHOLD}`,
-      params,
-      undefined,
-      undefined,
-    );
-    expectToolLoopBlockedResult(result, "global circuit breaker");
+    const result = await tool.execute(`read-${CRITICAL_THRESHOLD}`, params, undefined, undefined);
+    expectToolLoopBlockedResult(result, "identical outcomes");
   });
 
   it("does not carry loop history across run ids", async () => {
@@ -316,27 +311,27 @@ describe("before_tool_call loop detection behavior", () => {
       runId: "heartbeat-2",
     });
 
-    for (let i = 0; i < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; i += 1) {
+    for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
       await expectUnblockedToolExecution(firstRunTool, `old-run-${i}`, params);
     }
 
     await expectUnblockedToolExecution(secondRunTool, "new-run-0", params);
   });
 
-  it("coalesces repeated generic warning events into threshold buckets", async () => {
-    await withToolLoopEvents(
-      async (emitted) => {
-        const { tool, params } = createGenericReadRepeatFixture();
+  it("escalates generic repeat diagnostics from warning to critical", async () => {
+    await withToolLoopEvents(async (emitted) => {
+      const { tool, params } = createGenericReadRepeatFixture();
 
-        for (let i = 0; i < 21; i += 1) {
-          await tool.execute(`read-bucket-${i}`, params, undefined, undefined);
-        }
+      for (let i = 0; i < 21; i += 1) {
+        await tool.execute(`read-bucket-${i}`, params, undefined, undefined);
+      }
 
-        const genericWarns = emitted.filter((evt) => evt.detector === "generic_repeat");
-        expect(genericWarns.map((evt) => evt.count)).toEqual([10, 20]);
-      },
-      (evt) => evt.level === "warning",
-    );
+      const genericEvents = emitted.filter((evt) => evt.detector === "generic_repeat");
+      expect(genericEvents.map((evt) => [evt.level, evt.count])).toEqual([
+        ["warning", 10],
+        ["critical", 20],
+      ]);
+    });
   });
 
   it("emits structured warning diagnostic events for ping-pong loops", async () => {

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -388,7 +388,7 @@ describe("tool-loop-detection", () => {
       }
     });
 
-    it("keeps generic loops warn-only below global breaker threshold", () => {
+    it("blocks generic no-progress loops at critical threshold", () => {
       const fixture = createReadNoProgressFixture();
       const loopResult = detectLoopAfterRepeatedCalls({
         toolName: fixture.toolName,
@@ -398,7 +398,9 @@ describe("tool-loop-detection", () => {
       });
       expect(loopResult.stuck).toBe(true);
       if (loopResult.stuck) {
-        expect(loopResult.level).toBe("warning");
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("generic_repeat");
+        expect(loopResult.message).toContain("identical outcomes");
       }
     });
 
@@ -524,6 +526,10 @@ describe("tool-loop-detection", () => {
         toolParams: fixture.params,
         result: fixture.result,
         count: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
+        config: {
+          enabled: true,
+          detectors: { genericRepeat: false, knownPollNoProgress: true, pingPong: true },
+        },
       });
       expect(loopResult.stuck).toBe(true);
       if (loopResult.stuck) {
@@ -537,7 +543,7 @@ describe("tool-loop-detection", () => {
       const state = createState();
       const params = { command: "grafana-api.sh datasources" };
 
-      for (let index = 0; index < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; index += 1) {
+      for (let index = 0; index < CRITICAL_THRESHOLD; index += 1) {
         recordSuccessfulCall(
           state,
           "exec",
@@ -560,7 +566,7 @@ describe("tool-loop-detection", () => {
       expect(loopResult.stuck).toBe(true);
       if (loopResult.stuck) {
         expect(loopResult.level).toBe("critical");
-        expect(loopResult.detector).toBe("global_circuit_breaker");
+        expect(loopResult.detector).toBe("generic_repeat");
       }
     });
 
@@ -568,7 +574,7 @@ describe("tool-loop-detection", () => {
       const state = createState();
       const params = { command: "tail -f /var/log/app.log", yieldMs: 1000 };
 
-      for (let index = 0; index < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; index += 1) {
+      for (let index = 0; index < CRITICAL_THRESHOLD; index += 1) {
         recordSuccessfulCall(
           state,
           "exec",
@@ -597,7 +603,7 @@ describe("tool-loop-detection", () => {
       expect(loopResult.stuck).toBe(true);
       if (loopResult.stuck) {
         expect(loopResult.level).toBe("critical");
-        expect(loopResult.detector).toBe("global_circuit_breaker");
+        expect(loopResult.detector).toBe("generic_repeat");
       }
     });
 

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -609,10 +609,27 @@ export function detectToolCallLoop(
     };
   }
 
-  // Generic detector: warn-only for repeated identical calls.
+  // Generic detector: warn on repeated identical calls, then block only after
+  // outcomes prove the calls are not making progress.
   const recentCount = history.filter(
     (h) => h.toolName === toolName && h.argsHash === currentHash,
   ).length;
+
+  if (
+    !knownPollTool &&
+    resolvedConfig.detectors.genericRepeat &&
+    noProgressStreak >= resolvedConfig.criticalThreshold
+  ) {
+    log.error(`Critical generic loop detected: ${toolName} repeated ${noProgressStreak} times`);
+    return {
+      stuck: true,
+      level: "critical",
+      detector: "generic_repeat",
+      count: noProgressStreak,
+      message: `CRITICAL: Called ${toolName} with identical arguments and identical outcomes ${noProgressStreak} times. Session execution blocked to prevent runaway loops.`,
+      warningKey: `generic:${toolName}:${currentHash}:${noProgress.latestResultHash ?? "none"}`,
+    };
+  }
 
   if (
     !knownPollTool &&


### PR DESCRIPTION
## Summary

- Problem: generic repeated tool calls only warned even when the same calls kept returning identical no-progress outcomes.
- Why it matters: agents could keep spending model/tool cycles after a loop warning instead of stopping at the configured critical threshold.
- What changed: generic repeat detection now escalates identical tool+args+outcome loops to a critical block at `criticalThreshold`; docs and tests describe the no-progress requirement.
- What did NOT change (scope boundary): repeated calls with changing outcomes still warn instead of hard-blocking; the global circuit breaker remains a fallback.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: generic same-tool/same-args loops now stop when repeated calls also return identical outcomes.
- Real environment tested: local OpenClaw source checkout on macOS with Node/pnpm.
- Exact steps or command run after this patch: `pnpm test src/agents/pi-tools.before-tool-call.e2e.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): test output reported 42 passing tests, including the generic repeat escalation coverage.
- Observed result after fix: generic repeat diagnostics escalate from warning at 10 calls to critical block at 20 identical no-progress outcomes.
- What was not tested: live provider behavior against a real model.
- Before evidence (optional but encouraged): prior test coverage expected generic repeats to remain warn-only until the global circuit breaker.

## Root Cause (if applicable)

- Root cause: the generic repeat detector only emitted warnings for repeated tool+args patterns and did not apply `criticalThreshold` to repeated no-progress outcomes.
- Missing detection / guardrail: generic loops had no critical no-progress stop before the global circuit breaker.
- Contributing context (if known): specialized poll and ping-pong detectors already had critical paths, but generic repeats did not.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/tool-loop-detection.test.ts`, `src/agents/pi-tools.before-tool-call.e2e.test.ts`
- Scenario the test should lock in: same tool, same args, and identical outcomes escalate from warning to critical at `criticalThreshold`; changing outcomes remain warnings.
- Why this is the smallest reliable guardrail: it exercises the detector directly and through the before-tool-call wrapper without invoking a live model.
- Existing test that already covers this (if any): N/A

## User-visible / Behavior Changes

Agents with `tools.loopDetection.enabled` now abort generic repeated no-progress tool loops at `criticalThreshold` instead of waiting for the global circuit breaker.

## Diagram (if applicable)

```text
Before:
same tool + same args + same outcome -> warning -> warning until global circuit breaker

After:
same tool + same args -> warning
same tool + same args + same outcome -> critical block at threshold
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: the tool loop guard can now block repeated generic no-progress tool calls sooner. It only blocks after identical outcomes, while changing outcomes remain allowed.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm source checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `tools.loopDetection.enabled: true`

### Steps

1. Enable loop detection.
2. Repeat a generic tool call with identical arguments and identical outcomes until `criticalThreshold`.
3. Repeat a generic tool call with identical arguments but changing outcomes.

### Expected

- Identical no-progress outcomes are blocked at `criticalThreshold`.
- Changing outcomes are not hard-blocked by the generic detector.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: generic repeat warning, generic repeat critical block, run-id isolation, exec outcome normalization, changed-scope gate.
- Edge cases checked: changing exec output remains warning-only; global circuit breaker still works when generic repeat is disabled.
- What you did **not** verify: live model/provider run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: legitimate repeated generic calls with identical outcomes may stop earlier than before.
  - Mitigation: the guard requires identical outcomes, preserves warning-only behavior for changing results, and remains controlled by `tools.loopDetection.enabled` and `criticalThreshold`.
