### PR TITLE
fix: honor configured media generation timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Media generation: honor configured music and video generation timeouts when tool calls omit `timeoutMs`, matching image generation behavior. (#80687)
 - Plugins/update: include beta-channel fallback details in plugin update outcomes when `@beta` is unavailable and OpenClaw uses the recorded default/latest plugin spec, making mixed beta/latest plugin cohorts visible in update summaries. Fixes #80689. Thanks @BKF-Gitty.
 - Control UI/performance: scope Nodes polling to the active Nodes tab, debounce stale session-list reconciliation, and bound chat-side session refreshes so long-running dashboards avoid background reload churn. Thanks @BunsDev.
 - Plugins/channels: explain bundled channel entry files that reach the legacy plugin loader as setup-runtime loader mismatches instead of generic missing-register failures. Thanks @chinar-amrutkar.

--- a/docs/tools/music-generation.md
+++ b/docs/tools/music-generation.md
@@ -161,7 +161,7 @@ Direct generation example:
   Output format hint when the provider supports it.
 </ParamField>
 <ParamField path="filename" type="string">Output filename hint.</ParamField>
-<ParamField path="timeoutMs" type="number">Optional provider request timeout in milliseconds. Values below 10000ms are raised to 10000ms and reported in the tool result.</ParamField>
+<ParamField path="timeoutMs" type="number">Optional provider request timeout in milliseconds. When omitted, OpenClaw uses `agents.defaults.musicGenerationModel.timeoutMs` if configured. Values below 10000ms are raised to 10000ms and reported in the tool result.</ParamField>
 
 <Note>
 Not all providers support all parameters. OpenClaw still validates hard

--- a/docs/tools/video-generation.md
+++ b/docs/tools/video-generation.md
@@ -223,7 +223,7 @@ dimensions). Providers that do not declare it surface the value via
 </ParamField>
 <ParamField path="model" type="string">Provider/model override (e.g. `runway/gen4.5`).</ParamField>
 <ParamField path="filename" type="string">Output filename hint.</ParamField>
-<ParamField path="timeoutMs" type="number">Optional provider operation timeout in milliseconds.</ParamField>
+<ParamField path="timeoutMs" type="number">Optional provider operation timeout in milliseconds. When omitted, OpenClaw uses `agents.defaults.videoGenerationModel.timeoutMs` if configured.</ParamField>
 <ParamField path="providerOptions" type="object">
   Provider-specific options as a JSON object (e.g. `{"seed": 42, "draft": true}`).
   Providers that declare a typed schema validate the keys and types; unknown

--- a/src/agents/tools/music-generate-tool.test.ts
+++ b/src/agents/tools/music-generate-tool.test.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import * as mediaStore from "../../media/store.js";
 import * as webMedia from "../../media/web-media.js";
 import * as musicGenerationRuntime from "../../music-generation/runtime.js";
+import * as fetchTimeout from "../../utils/fetch-timeout.js";
 import * as musicGenerateBackground from "./music-generate-background.js";
 import { createMusicGenerateTool } from "./music-generate-tool.js";
 
@@ -103,6 +104,15 @@ vi.mock("../../media/web-media.js", async () => {
   };
 });
 vi.mock("../../music-generation/runtime.js", () => musicGenerationRuntimeMocks);
+vi.mock("../../utils/fetch-timeout.js", async () => {
+  const actual = await vi.importActual<typeof import("../../utils/fetch-timeout.js")>(
+    "../../utils/fetch-timeout.js",
+  );
+  return {
+    ...actual,
+    buildTimeoutAbortSignal: vi.fn(actual.buildTimeoutAbortSignal),
+  };
+});
 vi.mock("./music-generate-background.js", () => musicGenerateBackgroundMocks);
 vi.mock("../../tasks/runtime-internal.js", () => taskRuntimeInternalMocks);
 vi.mock("../../tasks/detached-task-runtime.js", () => taskExecutorMocks);
@@ -128,6 +138,7 @@ function resetMusicGenerateMocks() {
   mediaStoreMocks.saveMediaBuffer.mockReset();
   taskRuntimeInternalMocks.listTasksForOwnerKey.mockReset();
   taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([]);
+  vi.mocked(fetchTimeout.buildTimeoutAbortSignal).mockClear();
   taskExecutorMocks.createRunningTaskRun.mockReset();
   taskExecutorMocks.completeTaskRunByRunId.mockReset();
   taskExecutorMocks.failTaskRunByRunId.mockReset();
@@ -778,7 +789,7 @@ describe("createMusicGenerateTool", () => {
       config: asConfig({
         agents: {
           defaults: {
-            musicGenerationModel: { primary: "minimax/music-2.6" },
+            musicGenerationModel: { primary: "minimax/music-2.6", timeoutMs: 180_000 },
           },
         },
         tools: { web: { fetch: { ssrfPolicy: { allowRfc2544BenchmarkRange: true } } } },
@@ -802,5 +813,12 @@ describe("createMusicGenerateTool", () => {
     };
     expect(loadOptions.requestInit?.signal).toBeInstanceOf(AbortSignal);
     expect(loadOptions.ssrfPolicy).toEqual({ allowRfc2544BenchmarkRange: true });
+    expect(generateMusicOptions().timeoutMs).toBe(180_000);
+    expect(fetchTimeout.buildTimeoutAbortSignal).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fetchTimeout.buildTimeoutAbortSignal).mock.calls[0]?.[0]).toMatchObject({
+      operation: "music-generate.reference-fetch",
+      timeoutMs: 30_000,
+      url: "http://198.18.0.153/reference.png",
+    });
   });
 });

--- a/src/agents/tools/music-generate-tool.test.ts
+++ b/src/agents/tools/music-generate-tool.test.ts
@@ -408,6 +408,57 @@ describe("createMusicGenerateTool", () => {
     });
   });
 
+  it("uses configured timeoutMs for music generation and lets calls override it", async () => {
+    vi.spyOn(musicGenerationRuntime, "generateMusic").mockResolvedValue({
+      provider: "google",
+      model: "lyria-3-clip-preview",
+      attempts: [],
+      ignoredOverrides: [],
+      tracks: [
+        {
+          buffer: Buffer.from("music-bytes"),
+          mimeType: "audio/mpeg",
+          fileName: "night-drive.mp3",
+        },
+      ],
+    });
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue({
+      path: "/tmp/generated-night-drive.mp3",
+      id: "generated-night-drive.mp3",
+      size: 11,
+      contentType: "audio/mpeg",
+    });
+
+    const tool = createMusicGenerateTool({
+      config: asConfig({
+        agents: {
+          defaults: {
+            musicGenerationModel: {
+              primary: "google/lyria-3-clip-preview",
+              timeoutMs: 180_000,
+            },
+          },
+        },
+      }),
+    });
+    if (!tool) {
+      throw new Error("expected music_generate tool");
+    }
+
+    const defaultResult = await tool.execute("call-timeout-default", {
+      prompt: "night-drive synthwave",
+    });
+    const overrideResult = await tool.execute("call-timeout-override", {
+      prompt: "night-drive synthwave",
+      timeoutMs: 12_345,
+    });
+
+    expect(generateMusicOptions(0).timeoutMs).toBe(180_000);
+    expect(generateMusicOptions(1).timeoutMs).toBe(12_345);
+    expect(detailsOf(defaultResult).timeoutMs).toBe(180_000);
+    expect(detailsOf(overrideResult).timeoutMs).toBe(12_345);
+  });
+
   it("starts background generation and wakes the session with MEDIA lines", async () => {
     taskExecutorMocks.createRunningTaskRun.mockReturnValue({
       taskId: "task-123",

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -638,10 +638,12 @@ export function createMusicGenerateTool(options?: {
       });
       const format = normalizeOutputFormat(readStringParam(args, "format"));
       const filename = readStringParam(args, "filename");
-      const requestedTimeoutMs =
-        readGenerationTimeoutMs(args) ?? musicGenerationModelConfig.timeoutMs;
-      const timeout = normalizeMusicGenerationTimeoutMs(requestedTimeoutMs);
+      const requestedTimeoutMs = readGenerationTimeoutMs(args);
+      const requestedGenerationTimeoutMs =
+        requestedTimeoutMs ?? musicGenerationModelConfig.timeoutMs;
+      const timeout = normalizeMusicGenerationTimeoutMs(requestedGenerationTimeoutMs);
       const timeoutMs = timeout.timeoutMs;
+      const referenceFetchTimeoutMs = requestedTimeoutMs === undefined ? undefined : timeoutMs;
       const imageInputs = normalizeReferenceImageInputs(args);
       const selectedModelRef =
         parseMusicGenerationModelRef(model) ??
@@ -660,7 +662,7 @@ export function createMusicGenerateTool(options?: {
         workspaceDir: options?.workspaceDir,
         sandboxConfig,
         ssrfPolicy: remoteMediaSsrfPolicy,
-        timeoutMs,
+        timeoutMs: referenceFetchTimeoutMs,
       });
       validateMusicGenerationCapabilities({
         provider: selectedProvider,

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -638,7 +638,8 @@ export function createMusicGenerateTool(options?: {
       });
       const format = normalizeOutputFormat(readStringParam(args, "format"));
       const filename = readStringParam(args, "filename");
-      const requestedTimeoutMs = readGenerationTimeoutMs(args);
+      const requestedTimeoutMs =
+        readGenerationTimeoutMs(args) ?? musicGenerationModelConfig.timeoutMs;
       const timeout = normalizeMusicGenerationTimeoutMs(requestedTimeoutMs);
       const timeoutMs = timeout.timeoutMs;
       const imageInputs = normalizeReferenceImageInputs(args);

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -361,6 +361,45 @@ describe("createVideoGenerateTool", () => {
     expect(taskExecutorMocks.completeTaskRunByRunId).not.toHaveBeenCalled();
   });
 
+  it("uses configured timeoutMs for video generation and lets calls override it", async () => {
+    mockVideoPluginProvider();
+    const generateSpy = mockSavedVideoResult();
+    const tool = createVideoGenerateTool({
+      config: asConfig({
+        agents: {
+          defaults: {
+            videoGenerationModel: {
+              primary: "video-plugin/vid-v1",
+              timeoutMs: 180_000,
+            },
+          },
+        },
+      }),
+    });
+    if (!tool) {
+      throw new Error("expected video_generate tool");
+    }
+
+    const defaultResult = await tool.execute("call-timeout-default", {
+      prompt: "friendly lobster surfing",
+    });
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValueOnce({
+      path: "/tmp/out-override.mp4",
+      id: "out-override.mp4",
+      size: 11,
+      contentType: "video/mp4",
+    });
+    const overrideResult = await tool.execute("call-timeout-override", {
+      prompt: "friendly lobster surfing",
+      timeoutMs: 12_345,
+    });
+
+    expect((firstMockCallArg(generateSpy) as { timeoutMs?: number }).timeoutMs).toBe(180_000);
+    expect((generateSpy.mock.calls[1]?.[0] as { timeoutMs?: number }).timeoutMs).toBe(12_345);
+    expect(resultDetails(defaultResult).timeoutMs).toBe(180_000);
+    expect(resultDetails(overrideResult).timeoutMs).toBe(12_345);
+  });
+
   it("uses the video media cap when mediaMaxMb is not configured", async () => {
     vi.spyOn(videoGenerationRuntime, "generateVideo").mockResolvedValue({
       provider: "qwen",

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -866,7 +866,7 @@ export function createVideoGenerateTool(options?: {
       });
       const audio = readBooleanToolParam(args, "audio");
       const watermark = readBooleanToolParam(args, "watermark");
-      const timeoutMs = readGenerationTimeoutMs(args);
+      const timeoutMs = readGenerationTimeoutMs(args) ?? videoGenerationModelConfig.timeoutMs;
       // providerOptions must be a plain object. Arrays are objects in JS, so
       // exclude them explicitly — a bogus call like `providerOptions: ["seed", 42]`
       // would otherwise be cast to `Record<string, unknown>` with numeric-string

--- a/src/music-generation/runtime.test.ts
+++ b/src/music-generation/runtime.test.ts
@@ -85,6 +85,36 @@ describe("music-generation runtime", () => {
     ]);
   });
 
+  it("uses configured music-generation timeout when call omits timeoutMs", async () => {
+    let seenTimeoutMs: number | undefined;
+    providers = [
+      {
+        id: "music-plugin",
+        capabilities: {},
+        async generateMusic(req: { timeoutMs?: number }) {
+          seenTimeoutMs = req.timeoutMs;
+          return {
+            tracks: [{ buffer: Buffer.from("mp3-bytes"), mimeType: "audio/mpeg" }],
+            model: "track-v1",
+          };
+        },
+      },
+    ];
+
+    await runGenerateMusic({
+      cfg: {
+        agents: {
+          defaults: {
+            musicGenerationModel: { primary: "music-plugin/track-v1", timeoutMs: 300_000 },
+          },
+        },
+      } as OpenClawConfig,
+      prompt: "play a synth line",
+    });
+
+    expect(seenTimeoutMs).toBe(300_000);
+  });
+
   it("does not list providers when explicit config disables auto provider fallback", async () => {
     const provider: MusicGenerationProvider = {
       id: "music-plugin",

--- a/src/music-generation/runtime.ts
+++ b/src/music-generation/runtime.ts
@@ -1,4 +1,5 @@
 import type { FallbackAttempt } from "../agents/model-fallback.types.js";
+import { resolveAgentModelTimeoutMsValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
@@ -40,6 +41,9 @@ export async function generateMusic(
   const getProvider = deps.getProvider ?? getMusicGenerationProvider;
   const listProviders = deps.listProviders ?? listMusicGenerationProviders;
   const logger = deps.log ?? log;
+  const timeoutMs =
+    params.timeoutMs ??
+    resolveAgentModelTimeoutMsValue(params.cfg.agents?.defaults?.musicGenerationModel);
   const candidates = resolveCapabilityModelCandidates({
     cfg: params.cfg,
     modelConfig: params.cfg.agents?.defaults?.musicGenerationModel,
@@ -99,7 +103,7 @@ export async function generateMusic(
         durationSeconds: sanitized.durationSeconds,
         format: sanitized.format,
         inputImages: params.inputImages,
-        ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
+        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       });
       if (!Array.isArray(result.tracks) || result.tracks.length === 0) {
         throw new Error("Music generation provider returned no tracks.");

--- a/src/video-generation/runtime.test.ts
+++ b/src/video-generation/runtime.test.ts
@@ -117,6 +117,36 @@ describe("video-generation runtime", () => {
     ]);
   });
 
+  it("uses configured video-generation timeout when call omits timeoutMs", async () => {
+    let seenTimeoutMs: number | undefined;
+    providers = [
+      {
+        id: "video-plugin",
+        capabilities: {},
+        async generateVideo(req: { timeoutMs?: number }) {
+          seenTimeoutMs = req.timeoutMs;
+          return {
+            videos: [{ buffer: Buffer.from("mp4-bytes"), mimeType: "video/mp4" }],
+            model: "vid-v1",
+          };
+        },
+      },
+    ];
+
+    await runGenerateVideo({
+      cfg: {
+        agents: {
+          defaults: {
+            videoGenerationModel: { primary: "video-plugin/vid-v1", timeoutMs: 300_000 },
+          },
+        },
+      } as OpenClawConfig,
+      prompt: "animate a cat",
+    });
+
+    expect(seenTimeoutMs).toBe(300_000);
+  });
+
   it("does not list providers when explicit config disables auto provider fallback", async () => {
     const provider: VideoGenerationProvider = {
       id: "video-plugin",

--- a/src/video-generation/runtime.ts
+++ b/src/video-generation/runtime.ts
@@ -1,4 +1,5 @@
 import type { FallbackAttempt } from "../agents/model-fallback.types.js";
+import { resolveAgentModelTimeoutMsValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
@@ -116,6 +117,9 @@ export async function generateVideo(
   const getProvider = deps.getProvider ?? getVideoGenerationProvider;
   const listProviders = deps.listProviders ?? listVideoGenerationProviders;
   const logger = deps.log ?? log;
+  const timeoutMs =
+    params.timeoutMs ??
+    resolveAgentModelTimeoutMsValue(params.cfg.agents?.defaults?.videoGenerationModel);
   const candidates = resolveCapabilityModelCandidates({
     cfg: params.cfg,
     modelConfig: params.cfg.agents?.defaults?.videoGenerationModel,
@@ -302,7 +306,7 @@ export async function generateVideo(
         inputVideos: params.inputVideos,
         inputAudios: params.inputAudios,
         providerOptions: params.providerOptions,
-        ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
+        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       };
       if (supportedDurations) {
         generationRequest[SUPPORTED_DURATIONS_HINT] = supportedDurations;


### PR DESCRIPTION
## Summary
- honor configured music/video generation timeout defaults when tool calls omit timeoutMs
- keep explicit per-call timeoutMs overrides taking precedence
- document timeout defaults for music and video generation

## Tests
- node scripts/run-vitest.mjs run src/music-generation/runtime.test.ts src/video-generation/runtime.test.ts src/agents/tools/music-generate-tool.test.ts src/agents/tools/video-generate-tool.test.ts