### PR TITLE
[Fix] Precompile auto-reply directive regexes

### DIFF
--- a/src/auto-reply/reply/directives.ts
+++ b/src/auto-reply/reply/directives.ts
@@ -19,12 +19,24 @@ type ExtractedLevel<T> = {
   hasDirective: boolean;
 };
 
+const compileDirectivePattern = (names: readonly string[], suffix = ""): RegExp => {
+  const namePattern = names.map(escapeRegExp).join("|");
+  return new RegExp(`(?:^|\\s)\\/(?:${namePattern})(?=$|\\s|:)${suffix}`, "i");
+};
+
+const THINK_DIRECTIVE_PATTERN = compileDirectivePattern(["thinking", "think", "t"]);
+const VERBOSE_DIRECTIVE_PATTERN = compileDirectivePattern(["verbose", "v"]);
+const TRACE_DIRECTIVE_PATTERN = compileDirectivePattern(["trace"]);
+const FAST_DIRECTIVE_PATTERN = compileDirectivePattern(["fast"]);
+const ELEVATED_DIRECTIVE_PATTERN = compileDirectivePattern(["elevated", "elev"]);
+const REASONING_DIRECTIVE_PATTERN = compileDirectivePattern(["reasoning", "reason"]);
+const STATUS_DIRECTIVE_PATTERN = compileDirectivePattern(["status"], `(?:\\s*:\\s*)?`);
+
 const matchLevelDirective = (
   body: string,
-  names: string[],
+  pattern: RegExp,
 ): { start: number; end: number; rawLevel?: string } | null => {
-  const namePattern = names.map(escapeRegExp).join("|");
-  const match = body.match(new RegExp(`(?:^|\\s)\\/(?:${namePattern})(?=$|\\s|:)`, "i"));
+  const match = body.match(pattern);
   if (!match || match.index === undefined) {
     return null;
   }
@@ -51,10 +63,10 @@ const matchLevelDirective = (
 
 const extractLevelDirective = <T>(
   body: string,
-  names: string[],
+  pattern: RegExp,
   normalize: (raw?: string) => T | undefined,
 ): ExtractedLevel<T> => {
-  const match = matchLevelDirective(body, names);
+  const match = matchLevelDirective(body, pattern);
   if (!match) {
     return { cleaned: body.trim(), hasDirective: false };
   }
@@ -76,12 +88,9 @@ const extractLevelDirective = <T>(
 
 const extractSimpleDirective = (
   body: string,
-  names: string[],
+  pattern: RegExp,
 ): { cleaned: string; hasDirective: boolean } => {
-  const namePattern = names.map(escapeRegExp).join("|");
-  const match = body.match(
-    new RegExp(`(?:^|\\s)\\/(?:${namePattern})(?=$|\\s|:)(?:\\s*:\\s*)?`, "i"),
-  );
+  const match = body.match(pattern);
   const cleaned = match ? body.replace(match[0], " ").replace(/\s+/g, " ").trim() : body.trim();
   return {
     cleaned,
@@ -98,7 +107,7 @@ export function extractThinkDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  const extracted = extractLevelDirective(body, ["thinking", "think", "t"], normalizeThinkLevel);
+  const extracted = extractLevelDirective(body, THINK_DIRECTIVE_PATTERN, normalizeThinkLevel);
   return {
     cleaned: extracted.cleaned,
     thinkLevel: extracted.level,
@@ -116,7 +125,7 @@ export function extractVerboseDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  const extracted = extractLevelDirective(body, ["verbose", "v"], normalizeVerboseLevel);
+  const extracted = extractLevelDirective(body, VERBOSE_DIRECTIVE_PATTERN, normalizeVerboseLevel);
   return {
     cleaned: extracted.cleaned,
     verboseLevel: extracted.level,
@@ -134,7 +143,7 @@ export function extractTraceDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  const extracted = extractLevelDirective(body, ["trace"], normalizeTraceLevel);
+  const extracted = extractLevelDirective(body, TRACE_DIRECTIVE_PATTERN, normalizeTraceLevel);
   return {
     cleaned: extracted.cleaned,
     traceLevel: extracted.level,
@@ -152,7 +161,7 @@ export function extractFastDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  const extracted = extractLevelDirective(body, ["fast"], normalizeFastMode);
+  const extracted = extractLevelDirective(body, FAST_DIRECTIVE_PATTERN, normalizeFastMode);
   return {
     cleaned: extracted.cleaned,
     fastMode: extracted.level,
@@ -170,7 +179,7 @@ export function extractElevatedDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  const extracted = extractLevelDirective(body, ["elevated", "elev"], normalizeElevatedLevel);
+  const extracted = extractLevelDirective(body, ELEVATED_DIRECTIVE_PATTERN, normalizeElevatedLevel);
   return {
     cleaned: extracted.cleaned,
     elevatedLevel: extracted.level,
@@ -188,7 +197,11 @@ export function extractReasoningDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  const extracted = extractLevelDirective(body, ["reasoning", "reason"], normalizeReasoningLevel);
+  const extracted = extractLevelDirective(
+    body,
+    REASONING_DIRECTIVE_PATTERN,
+    normalizeReasoningLevel,
+  );
   return {
     cleaned: extracted.cleaned,
     reasoningLevel: extracted.level,
@@ -204,7 +217,7 @@ export function extractStatusDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  return extractSimpleDirective(body, ["status"]);
+  return extractSimpleDirective(body, STATUS_DIRECTIVE_PATTERN);
 }
 
 export type { ElevatedLevel, NoticeLevel, ReasoningLevel, ThinkLevel, TraceLevel, VerboseLevel };


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: inline auto-reply directive parsing rebuilt static directive regexes on every extractor call.
- Why it matters: inbound message parsing chains these extractors, so static directive name sets should not allocate new `RegExp` objects per message.
- What changed: precompiled the static directive patterns once at module load and reused them in level/simple directive extraction.
- What did NOT change (scope boundary): directive grammar, aliases, model directives, queue directives, command routing, and auto-reply behavior are unchanged.
- AI-assisted: yes, implemented and verified with Codex.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: repeated inline directive extraction no longer constructs static directive regexes after module import.
- Real environment tested: local macOS OpenClaw worktree, Node v24.14.0.
- Exact steps or command run after this patch:
  - `node --import tsx --input-type=module ./directive-regexp-probe.mjs`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output from a real local Node run against the patched OpenClaw worktree:

  ```text
  $ node --import tsx --input-type=module ./directive-regexp-probe.mjs
  directive-regexp-constructions=0
  ```

- Observed result after fix: repeated calls to `extractThinkDirective` and `extractStatusDirective` reused precompiled module-level patterns and constructed no directive regexes during extraction.
- What was not tested: full `pnpm check`, full `pnpm test`, Docker/E2E/live lanes, and post-rebase `codex review` because the local Codex account hit a usage limit. A review-swarm Codex lane was clean before the formatter-only final commit/rebase step.
- Before evidence (optional but encouraged): the same probe before the patch printed `directive-regexp-constructions=4` for two think extractions and two status extractions.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `matchLevelDirective` and `extractSimpleDirective` accepted directive name arrays and rebuilt the escaped alternation pattern plus `RegExp` on every parse.
- Missing detection / guardrail: existing tests covered directive parsing behavior but did not check allocation behavior for static directive name sets.
- Contributing context (if known): `parseInlineDirectives` chains fixed directive extractors for inbound messages, so per-call regex construction was unnecessary.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply.directive.parse.test.ts`, `src/auto-reply/reply/directive-handling.mixed-inline.test.ts`
- Scenario the test should lock in: directive parsing outputs stay byte-for-byte compatible for `/think:high`, aliases such as `/t`, malformed `/thinkstuff`, empty colon directives, URL false positives, and whitespace/path cleanup.
- Why this is the smallest reliable guardrail: this PR intentionally changes allocation placement only; existing parser behavior tests are the right regression guard for grammar compatibility.
- Existing test that already covers this (if any): the targeted directive parse and mixed-inline tests listed above.
- If no new test is added, why not: the only behavior change is removing repeated static regex construction, and the dynamic probe validates the allocation issue directly without adding a production benchmark-style test.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

```text
Before:
[inbound message] -> [directive extractor] -> [build static RegExp every call]

After:
[module load] -> [compile static directive RegExp once]
[inbound message] -> [directive extractor] -> [reuse compiled RegExp]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v24.14.0, local pnpm repo wrappers
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Import `src/auto-reply/reply/directives.ts` under a counting `RegExp` wrapper.
2. Reset the counter after module import.
3. Call `extractThinkDirective` twice and `extractStatusDirective` twice.
4. Run the targeted directive parse and mixed-inline tests.
5. Run changed-lane discovery and changed checks against `upstream/main`.

Supplemental verification commands:

- `pnpm test src/auto-reply/reply.directive.parse.test.ts src/auto-reply/reply/directive-handling.mixed-inline.test.ts -- --reporter=verbose`
- `pnpm changed:lanes --json --base upstream/main --head HEAD`
- `pnpm check:changed --base upstream/main --head HEAD`

### Expected

- Static directive regex construction happens at module load, not during repeated extractor calls.
- Directive parser outputs remain compatible.
- The touched-surface changed gate stays green.

### Actual

- The probe printed `directive-regexp-constructions=0` after module import.
- Targeted Vitest files passed.
- `pnpm check:changed --base upstream/main --head HEAD` passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: static directive regexes are no longer constructed per extractor call; directive parsing compatibility for `/think:high`, `/t`, `/thinkstuff`, empty colon directives, URL false positives, whitespace cleanup, and mixed inline persistence.
- Edge cases checked: reused regexes have only the `i` flag, not `g` or `y`, so there is no `lastIndex` state leak across calls.
- What you did **not** verify: full-suite local checks, Docker/E2E/live lanes, and post-rebase `codex review`; `codex review --base upstream/main` was attempted but blocked by the account usage limit.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a regex refactor could accidentally alter directive grammar.
  - Mitigation: kept the original regex body and reran existing directive parse and mixed-inline tests.
- Risk: reused `RegExp` objects could leak match state.
  - Mitigation: compiled patterns use only the `i` flag, with no `g` or `y` stateful flags.
