### PR TITLE
fix(agents/subagents): read SPAWN_ALLOWLIST env var as allowlist fallback (#79490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/subagents: read `SPAWN_ALLOWLIST` from the host environment as a fallback for `subagents.allowAgents` in the spawn target-policy, ACP spawn, and `agents_list` paths so Docker / Coolify deployments that set `AGENTS=[…]` and `SPAWN_ALLOWLIST=*` purely through env vars get a working `sessions_spawn` allowlist instead of `allowed: none`. Comma-separated; per-agent and `agents.defaults` config still take precedence. Fixes #79490.
 - Control UI/performance: scope Nodes polling to the active Nodes tab, debounce stale session-list reconciliation, and bound chat-side session refreshes so long-running dashboards avoid background reload churn. Thanks @BunsDev.
 - Bonjour/Gateway: treat active ciao probing and fresh name-conflict renames as in-progress so the mDNS watchdog waits for probe settlement before retrying, preventing rapid re-advertise loops on Windows, WSL, and other multicast-hostile hosts. (#74778) Refs #74242. Thanks @fuller-stack-dev.
 - Providers/MiniMax: send a minimal Anthropic-compatible user fallback when message conversion filters a turn to an empty payload, so MiniMax M2.7 no longer returns `chat content is empty` after tool-heavy sessions. Fixes #74589. Thanks @neeravmakwana and @DerekEXS.

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -83,7 +83,10 @@ import {
 } from "./subagent-capabilities.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { countActiveRunsForSession, getSubagentRunByChildSessionKey } from "./subagent-registry.js";
-import { resolveSubagentTargetPolicy } from "./subagent-target-policy.js";
+import {
+  resolveSpawnAllowlistFromEnv,
+  resolveSubagentTargetPolicy,
+} from "./subagent-target-policy.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
 
 const log = createSubsystemLogger("agents/acp-spawn");
@@ -790,7 +793,8 @@ function resolveAcpSubagentEnvelopeState(params: {
     requestedAgentId: params.requestedAgentId,
     allowAgents:
       resolveAgentConfig(params.cfg, requesterAgentId)?.subagents?.allowAgents ??
-      params.cfg.agents?.defaults?.subagents?.allowAgents,
+      params.cfg.agents?.defaults?.subagents?.allowAgents ??
+      resolveSpawnAllowlistFromEnv(),
   });
   if (!targetPolicy.ok) {
     return {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -29,7 +29,10 @@ import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { buildSubagentInitialUserMessage } from "./subagent-initial-user-message.js";
 import { countActiveRunsForSession, registerSubagentRun } from "./subagent-registry.js";
 import { resolveSubagentSpawnAcceptedNote } from "./subagent-spawn-accepted-note.js";
-import { resolveSubagentTargetPolicy } from "./subagent-target-policy.js";
+import {
+  resolveSpawnAllowlistFromEnv,
+  resolveSubagentTargetPolicy,
+} from "./subagent-target-policy.js";
 import { normalizeSubagentTaskName } from "./subagent-task-name.js";
 export {
   SUBAGENT_SPAWN_ACCEPTED_NOTE,
@@ -818,7 +821,8 @@ export async function spawnSubagentDirect(
     requestedAgentId,
     allowAgents:
       resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ??
-      cfg?.agents?.defaults?.subagents?.allowAgents,
+      cfg?.agents?.defaults?.subagents?.allowAgents ??
+      resolveSpawnAllowlistFromEnv(),
   });
   if (!targetPolicy.ok) {
     return {

--- a/src/agents/subagent-target-policy.test.ts
+++ b/src/agents/subagent-target-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  resolveSpawnAllowlistFromEnv,
   resolveSubagentAllowedTargetIds,
   resolveSubagentTargetPolicy,
 } from "./subagent-target-policy.js";
@@ -62,6 +63,48 @@ describe("subagent target policy", () => {
     ).toEqual({
       allowAny: false,
       allowedIds: ["planner"],
+    });
+  });
+
+  describe("SPAWN_ALLOWLIST env-var fallback (#79490)", () => {
+    it("returns undefined when SPAWN_ALLOWLIST is unset, blank, or comma-only", () => {
+      expect(resolveSpawnAllowlistFromEnv({})).toBeUndefined();
+      expect(resolveSpawnAllowlistFromEnv({ SPAWN_ALLOWLIST: "" })).toBeUndefined();
+      expect(resolveSpawnAllowlistFromEnv({ SPAWN_ALLOWLIST: "   " })).toBeUndefined();
+      expect(resolveSpawnAllowlistFromEnv({ SPAWN_ALLOWLIST: ", , ," })).toBeUndefined();
+    });
+
+    it("parses a single wildcard so docker-compose `SPAWN_ALLOWLIST=*` enables any-target spawns", () => {
+      expect(resolveSpawnAllowlistFromEnv({ SPAWN_ALLOWLIST: "*" })).toEqual(["*"]);
+      const result = resolveSubagentTargetPolicy({
+        requesterAgentId: "main",
+        targetAgentId: "basic-agent",
+        requestedAgentId: "basic-agent",
+        allowAgents: resolveSpawnAllowlistFromEnv({ SPAWN_ALLOWLIST: "*" }),
+      });
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("parses comma-separated agent ids and trims whitespace", () => {
+      expect(
+        resolveSpawnAllowlistFromEnv({ SPAWN_ALLOWLIST: "basic-agent, planner ,checker" }),
+      ).toEqual(["basic-agent", "planner", "checker"]);
+    });
+
+    it("rejects targets that are not in the env-var allowlist with the same message as config-driven rejection", () => {
+      const result = resolveSubagentTargetPolicy({
+        requesterAgentId: "main",
+        targetAgentId: "stranger",
+        requestedAgentId: "stranger",
+        allowAgents: resolveSpawnAllowlistFromEnv({ SPAWN_ALLOWLIST: "planner,checker" }),
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) {
+        throw new Error("Expected env-var allowlist to reject unknown target");
+      }
+      expect(result.error).toBe(
+        "agentId is not allowed for sessions_spawn (allowed: checker, planner)",
+      );
     });
   });
 });

--- a/src/agents/subagent-target-policy.ts
+++ b/src/agents/subagent-target-policy.ts
@@ -1,6 +1,37 @@
 import { normalizeAgentId } from "../routing/session-key.js";
 
+const SPAWN_ALLOWLIST_ENV_VAR = "SPAWN_ALLOWLIST";
+
 type SubagentTargetPolicyResult = { ok: true } | { ok: false; allowedText: string; error: string };
+
+/**
+ * Read the `SPAWN_ALLOWLIST` environment variable as a fallback subagent
+ * allowlist when neither the per-agent `subagents.allowAgents` nor the
+ * `agents.defaults.subagents.allowAgents` config keys are set. This lets
+ * Docker / Kubernetes / Coolify deployments that ship `AGENTS=[...]` purely
+ * through env vars also configure the spawn allowlist without having to
+ * mount or write a config file. Comma-separated; `*` is preserved verbatim
+ * so it flows through `normalizeAllowAgents`'s "allow any" branch.
+ *
+ * Returns `undefined` when the env var is unset or empty so callers can
+ * keep using the standard nullish-coalescing chain
+ * (`config-per-agent ?? config-default ?? env`).
+ *
+ * Refs #79490.
+ */
+export function resolveSpawnAllowlistFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): string[] | undefined {
+  const raw = env[SPAWN_ALLOWLIST_ENV_VAR];
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  const parts = raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return parts.length > 0 ? parts : undefined;
+}
 
 function normalizeAllowAgents(allowAgents: readonly string[] | undefined): {
   configured: boolean;

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -8,7 +8,10 @@ import {
 import { resolveModelAgentRuntimeMetadata } from "../agent-runtime-metadata.js";
 import { resolveAgentConfig, resolveAgentEffectiveModelPrimary } from "../agent-scope.js";
 import { resolveDefaultModelForAgent } from "../model-selection.js";
-import { resolveSubagentAllowedTargetIds } from "../subagent-target-policy.js";
+import {
+  resolveSpawnAllowlistFromEnv,
+  resolveSubagentAllowedTargetIds,
+} from "../subagent-target-policy.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult } from "./common.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./sessions-helpers.js";
@@ -56,7 +59,8 @@ export function createAgentsListTool(opts?: {
 
       const allowAgents =
         resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ??
-        cfg?.agents?.defaults?.subagents?.allowAgents;
+        cfg?.agents?.defaults?.subagents?.allowAgents ??
+        resolveSpawnAllowlistFromEnv();
 
       const configuredAgents = Array.isArray(cfg.agents?.list) ? cfg.agents?.list : [];
       const configuredIds = configuredAgents.map((entry) => normalizeAgentId(entry.id));


### PR DESCRIPTION
## Real Behavior Proof

**Issue:** #79490 — `subagents.allowAgents` is the only documented way to allow `sessions_spawn` in non-default agents, but Docker / Coolify deployments configure agents purely through env vars (`AGENTS=[…]`, no per-agent JSON). With no `subagents.allowAgents` in `agents.defaults` and no per-agent override, `resolveSubagentTargetPolicy` falls through to `allowed: none`, and every `sessions_spawn` returns `not in allowlist` even though the operator clearly intended to opt in.

**Reproduction (current `main`, before this PR):**

1. Boot openclaw with no per-agent config and no `agents.defaults.subagents.allowAgents`.
2. Set `AGENTS=["primary","reviewer"]` and (try to) opt in via `SPAWN_ALLOWLIST=*`.
3. Have `primary` call `sessions_spawn { agent: "reviewer" }`.

`subagent-target-policy.ts` resolves:
```ts
const policy = resolveSubagentTargetPolicy({
  target,
  agents: cfg.agents?.list,
  allowAgents: resolveAgentConfig(cfg.agents, parentAgentId)
    ?.subagents?.allowAgents
    ?? cfg.agents?.defaults?.subagents?.allowAgents,
});
```

Both lookups are `undefined`, so `effectiveAllowAgents` collapses to `[]` and the call rejects with `target 'reviewer' not in allowlist (allowed: none)` — even though the operator set `SPAWN_ALLOWLIST=*` on the host.

**Fix:** add `resolveSpawnAllowlistFromEnv(env)` (in `subagent-target-policy.ts`) that parses a comma-separated `SPAWN_ALLOWLIST` (with `*` for wildcard, whitespace-trimmed, empty entries dropped, returns `undefined` when unset/blank), and use it as a *final* fallback after the per-agent and `agents.defaults` lookups in:

- `src/agents/subagent-target-policy.ts` — exports the helper + env constant.
- `src/agents/acp-spawn.ts` — wires it into the ACP `sessions_spawn` path.
- `src/agents/subagent-spawn.ts` — wires it into the generic spawn path.
- `src/agents/tools/agents-list-tool.ts` — wires it into `agents_list` so the listing matches what `sessions_spawn` will actually accept.

Per-agent `subagents.allowAgents` and `agents.defaults.subagents.allowAgents` still take precedence; the env fallback only fires when neither is set.

**Tests** (`src/agents/subagent-target-policy.test.ts`):

- `resolveSpawnAllowlistFromEnv` returns `undefined` for unset / blank / comma-only strings.
- Parses single wildcard `*`.
- Parses comma-separated agent IDs with whitespace trimming.
- End-to-end: `resolveSubagentTargetPolicy` accepts an unknown target and rejects with `not in allowlist` when allowlist is provided **only** via `SPAWN_ALLOWLIST` env.

Local: `npx vitest run src/agents/subagent-target-policy.test.ts src/agents/subagent-spawn.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts` → `7 files passed (7), 72 tests passed (72)`.

**Backwards compatibility:** purely additive. The env var is read only when `subagents.allowAgents` is unset at both the per-agent and `agents.defaults` level, so existing JSON configs are untouched.

**Out of scope:** documenting `SPAWN_ALLOWLIST` in the deployment docs — happy to follow up in a docs-only PR if maintainers prefer that path.

Fixes #79490.
