### PR TITLE
fix(ci): reject fork PR heads for secret-bearing Mantis proof job

### DIFF
--- a/.github/codex/prompts/mantis-telegram-desktop-proof.md
+++ b/.github/codex/prompts/mantis-telegram-desktop-proof.md
@@ -43,12 +43,8 @@ Required workflow:
    `.artifacts/qa-e2e/mantis/telegram-desktop-proof-worktrees/baseline` and
    `.artifacts/qa-e2e/mantis/telegram-desktop-proof-worktrees/candidate`, then
    install and build each worktree with the repo's normal `pnpm` commands.
-   If `MANTIS_CANDIDATE_TRUST` is `fork-pr-head`, treat the
-   candidate worktree as untrusted fork code: do not pass GitHub, OpenAI,
-   Crabbox, Convex, or other workflow secrets into candidate install, build, or
-   runtime commands. The candidate SUT may receive only the proof runner's
-   short-lived Telegram bot token, generated local config/state paths, and mock
-   model key needed for this isolated proof.
+   The workflow rejects fork PR heads before this agent starts, so both refs are
+   repository-owned commits selected by the trusted workflow.
 5. In each worktree, run the real-user Telegram Crabbox proof flow from the
    skill with `$OPENCLAW_TELEGRAM_USER_PROOF_CMD`; do not run
    `pnpm qa:telegram-user:crabbox` directly. The proof command comes from the

--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -205,10 +205,11 @@ jobs:
             echo "candidate ref '${CANDIDATE_REF}' resolved to ${candidate_revision}, which is not the open PR head." >&2
             exit 1
           fi
-          candidate_trust="open-pr-head"
           if [[ "$pr_head_repo" != "$GITHUB_REPOSITORY" ]]; then
-            candidate_trust="fork-pr-head"
+            echo "candidate ref '${CANDIDATE_REF}' is from fork '${pr_head_repo}', but this secret-bearing proof job only accepts repository-owned PR heads." >&2
+            exit 1
           fi
+          candidate_trust="repo-pr-head"
 
           echo "baseline_revision=${baseline_revision}" >> "$GITHUB_OUTPUT"
           echo "candidate_revision=${candidate_revision}" >> "$GITHUB_OUTPUT"

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -127,11 +127,15 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(workflowText).not.toContain("allow_fork_candidate");
   });
 
-  it("trusts the open PR head and marks fork heads for sandboxed handling", () => {
+  it("rejects fork PR heads before the secret-bearing agent job", () => {
     const workflowText = readFileSync(WORKFLOW, "utf8");
     expect(workflowText).toContain("repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}");
-    expect(workflowText).toContain('candidate_trust="fork-pr-head"');
     expect(workflowText).toContain('pr_head_repo" != "$GITHUB_REPOSITORY"');
+    expect(workflowText).toContain(
+      "this secret-bearing proof job only accepts repository-owned PR heads",
+    );
+    expect(workflowText).toContain('candidate_trust="repo-pr-head"');
+    expect(workflowText).not.toContain('candidate_trust="fork-pr-head"');
 
     const agent = workflowStep("Run Codex Mantis Telegram agent");
     expect(agent.env?.MANTIS_CANDIDATE_TRUST).toBe(
@@ -139,9 +143,9 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     );
 
     const prompt = readFileSync(PROMPT, "utf8");
-    expect(prompt).toContain("MANTIS_CANDIDATE_TRUST");
-    expect(prompt).toContain("fork-pr-head");
-    expect(prompt).toContain("untrusted fork code");
+    expect(prompt).toContain("The workflow rejects fork PR heads before this agent starts");
+    expect(prompt).not.toContain("fork-pr-head");
+    expect(prompt).not.toContain("untrusted fork code");
   });
 
   it("checks the Telegram user driver before leasing credentials", () => {


### PR DESCRIPTION
### Motivation
- Prevent untrusted fork PR heads from running inside the secret-bearing Mantis Telegram proof job, which could allow lifecycle/build scripts in forked code to exfiltrate CI secrets. 
- The prior implementation relied on an agent prompt and in-process sanitization for downstream child processes, which did not protect earlier `pnpm` install/build steps in the job.

### Description
- Update ref validation in ` .github/workflows/mantis-telegram-desktop-proof.yml` to reject fork PR heads during `validate_refs` and fail the job if the candidate is from a fork, and set `candidate_trust="repo-pr-head"` for accepted refs.
- Remove the prompt-only fork-sandbox claim from ` .github/codex/prompts/mantis-telegram-desktop-proof.md` and document that fork heads are rejected prior to agent-run candidate install/build commands.
- Adjust the workflow unit test `test/scripts/mantis-telegram-desktop-proof-workflow.test.ts` to assert fork PR heads are rejected and that the prompt no longer instructs prompt-only sandboxing.
- Commit message: `fix(ci): reject fork mantis proof heads`.

### Testing
- Ran the focused Vitest test: `pnpm test test/scripts/mantis-telegram-desktop-proof-workflow.test.ts -- --reporter=verbose`, and the test file passed (8 tests, all green). 
- Ran workflow lint/sanity: `pnpm check:workflows`, which completed without errors. 
- Ran `git diff --check` to validate no interpolation issues, which returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01cb8592b88327b28f70531343c67b)