### PR TITLE
fix(codex): match connector app approvals by id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - CLI: strip generic OSC terminal escape payloads from sanitized output fields, preventing clipboard/title escape bodies from leaking into commitment tables and other terminal-safe text. Thanks @shakkernerd.
+- Codex app-server: match connector-backed plugin approval elicitations by stable connector id so enabled destructive actions no longer fall through to display-name-only rejection.
 - Build: replace selected build utility `tsx` preloads with Node native type stripping so Node 26 build paths no longer emit `DEP0205` module loader deprecation warnings. (#78584) Thanks @keshavbotagent.
 - Media generation: honor configured music and video generation timeouts when tool calls omit `timeoutMs`, matching image generation behavior. (#80687)
 - CLI/update/status: label beta-channel plugin fallback and model-pricing refresh failures as warnings, keeping mixed beta/latest plugin cohorts visible without making core update or Gateway reachability look failed. Fixes #80689. Thanks @BKF-Gitty.

--- a/extensions/codex/src/app-server/elicitation-bridge.test.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.test.ts
@@ -97,6 +97,28 @@ function buildPluginApprovalElicitation(overrides: Record<string, unknown> = {})
   };
 }
 
+function buildConnectorPluginApprovalElicitation(overrides: Record<string, unknown> = {}) {
+  return {
+    threadId: "thread-1",
+    turnId: "turn-1",
+    serverName: "codex_apps",
+    mode: "form",
+    message: "Allow Google Calendar to create an event?",
+    _meta: {
+      codex_approval_kind: "mcp_tool_call",
+      source: "connector",
+      connector_id: "connector_google_calendar",
+      connector_name: "Google Calendar",
+      tool_title: "create_event",
+    },
+    requestedSchema: {
+      type: "object",
+      properties: {},
+    },
+    ...overrides,
+  };
+}
+
 function createPluginAppPolicyContext(
   params: {
     allowDestructiveActions?: boolean;
@@ -540,6 +562,114 @@ describe("Codex app-server elicitation bridge", () => {
       content: { approve: true },
       _meta: null,
     });
+    expect(mockCallGatewayTool).not.toHaveBeenCalled();
+  });
+
+  it("accepts connector-id plugin app elicitations when destructive actions are enabled", async () => {
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildConnectorPluginApprovalElicitation(),
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+      pluginAppPolicyContext: createPluginAppPolicyContext({
+        allowDestructiveActions: true,
+        apps: [
+          {
+            appId: "connector_google_calendar",
+            pluginName: "google-calendar",
+            mcpServerNames: [],
+          },
+        ],
+      }),
+    });
+
+    expect(result).toEqual({
+      action: "accept",
+      content: null,
+      _meta: null,
+    });
+    expect(mockCallGatewayTool).not.toHaveBeenCalled();
+  });
+
+  it("declines connector-id plugin app elicitations when destructive actions are disabled", async () => {
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildConnectorPluginApprovalElicitation(),
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+      pluginAppPolicyContext: createPluginAppPolicyContext({
+        allowDestructiveActions: false,
+        apps: [
+          {
+            appId: "connector_google_calendar",
+            pluginName: "google-calendar",
+            mcpServerNames: [],
+          },
+        ],
+      }),
+    });
+
+    expect(result).toEqual({ action: "decline", content: null, _meta: null });
+    expect(mockCallGatewayTool).not.toHaveBeenCalled();
+  });
+
+  it("declines live connector elicitations that only match display names", async () => {
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildConnectorPluginApprovalElicitation({
+        _meta: {
+          codex_approval_kind: "mcp_tool_call",
+          source: "connector",
+          connector_name: "Google Calendar",
+          tool_title: "create_event",
+        },
+      }),
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+      pluginAppPolicyContext: createPluginAppPolicyContext({
+        allowDestructiveActions: true,
+        apps: [
+          {
+            appId: "connector_google_calendar",
+            pluginName: "google-calendar",
+            mcpServerNames: [],
+          },
+        ],
+      }),
+    });
+
+    expect(result).toEqual({ action: "decline", content: null, _meta: null });
+    expect(mockCallGatewayTool).not.toHaveBeenCalled();
+  });
+
+  it("declines live connector elicitations with mismatched app and connector ids", async () => {
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildConnectorPluginApprovalElicitation({
+        _meta: {
+          codex_approval_kind: "mcp_tool_call",
+          source: "connector",
+          app_id: "other-app",
+          connector_id: "connector_google_calendar",
+          connector_name: "Google Calendar",
+          tool_title: "create_event",
+        },
+      }),
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+      pluginAppPolicyContext: createPluginAppPolicyContext({
+        allowDestructiveActions: true,
+        apps: [
+          {
+            appId: "connector_google_calendar",
+            pluginName: "google-calendar",
+            mcpServerNames: [],
+          },
+        ],
+      }),
+    });
+
+    expect(result).toEqual({ action: "decline", content: null, _meta: null });
     expect(mockCallGatewayTool).not.toHaveBeenCalled();
   });
 

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -40,7 +40,11 @@ const MCP_TOOL_APPROVAL_CONNECTOR_NAME_KEY = "connector_name";
 const MCP_TOOL_APPROVAL_TOOL_TITLE_KEY = "tool_title";
 const MCP_TOOL_APPROVAL_TOOL_DESCRIPTION_KEY = "tool_description";
 const MCP_TOOL_APPROVAL_TOOL_PARAMS_DISPLAY_KEY = "tool_params_display";
+const MCP_TOOL_APPROVAL_SOURCE_KEY = "source";
+const MCP_TOOL_APPROVAL_CONNECTOR_SOURCE = "connector";
+const CODEX_APPS_SERVER_NAME = "codex_apps";
 const PLUGIN_APP_ID_META_KEYS = ["app_id", "appId", "codex_app_id", "codexAppId"];
+const PLUGIN_CONNECTOR_ID_META_KEYS = ["connector_id", "connectorId"];
 const PLUGIN_NAME_META_KEYS = ["plugin_name", "pluginName", "codex_plugin_name", "codexPluginName"];
 const PLUGIN_CONFIG_KEY_META_KEYS = ["config_key", "configKey", "codex_config_key"];
 const PLUGIN_MARKETPLACE_NAME_META_KEYS = [
@@ -152,12 +156,24 @@ function resolvePluginElicitation(params: {
   const appId =
     readFirstString(meta, PLUGIN_APP_ID_META_KEYS) ??
     readFirstString(requestParams, PLUGIN_APP_ID_META_KEYS);
+  const connectorId = readFirstString(meta, PLUGIN_CONNECTOR_ID_META_KEYS);
+  const isCodexConnectorApproval = isCodexConnectorApprovalElicitation(requestParams, meta);
+  if (isCodexConnectorApproval && appId && connectorId && appId !== connectorId) {
+    return { kind: "decline", reason: "app_id_connector_id_mismatch" };
+  }
   if (appId) {
     if (!context) {
       return { kind: "decline", reason: "missing_policy_context" };
     }
     const entry = context.apps[appId];
     return uniquePluginMatch(entry ? [entry] : [], "app_id");
+  }
+  if (isCodexConnectorApproval && connectorId) {
+    if (!context) {
+      return { kind: "decline", reason: "missing_policy_context" };
+    }
+    const entry = context.apps[connectorId];
+    return uniquePluginMatch(entry ? [entry] : [], "connector_id");
   }
 
   const serverName = readString(requestParams, "serverName");
@@ -183,6 +199,14 @@ function resolvePluginElicitation(params: {
   }
 
   return { kind: "not_plugin" };
+}
+
+function isCodexConnectorApprovalElicitation(requestParams: JsonObject, meta: JsonObject): boolean {
+  return (
+    readString(requestParams, "serverName") === CODEX_APPS_SERVER_NAME &&
+    readString(meta, MCP_TOOL_APPROVAL_KIND_KEY) === MCP_TOOL_APPROVAL_KIND &&
+    readString(meta, MCP_TOOL_APPROVAL_SOURCE_KEY) === MCP_TOOL_APPROVAL_CONNECTOR_SOURCE
+  );
 }
 
 function resolvePluginStableMetadataMatch(params: {


### PR DESCRIPTION
## Summary

- Match Codex connector-backed plugin approval elicitations by stable `_meta.connector_id` when the request is the Codex app-server connector MCP approval shape.
- Keep connector display names untrusted, fail closed on app-id/connector-id disagreement, and preserve existing app-id/server-name/stable-metadata matching.
- Add regression coverage for enabled, disabled, display-name-only, and mismatched connector-id approval cases.

## Real behavior proof

Behavior addressed: Connector-backed Codex app-server plugin approval elicitations now resolve by stable `_meta.connector_id` for the `codex_apps` connector MCP approval shape. With `allowDestructiveActions: true`, the bridge accepts the connector-owned destructive approval instead of falling through to display-name-only rejection; with destructive actions disabled or mismatched ids, it declines.

Real environment tested: Local OpenClaw checkout on branch `codex/fix-connector-id`, head `f7f803775f7608e1ed5ce51944aec988aa2c19d6`, rebased onto `origin/main` at `630c9fe531`. The CLI built and reported `OpenClaw 2026.5.10-beta.1 (f7f8037)` from this checkout.

Exact steps or command run after this patch: Ran `pnpm openclaw --version`, `pnpm test extensions/codex/src/app-server/elicitation-bridge.test.ts`, and `pnpm check:changed` after the rebase.

Evidence after fix: Terminal output from the real checkout follows.

```terminal
$ pnpm openclaw --version
[openclaw] Building TypeScript (dist is stale: missing_build_stamp - build stamp missing).
runtime-postbuild: plugin SDK root alias completed in 1ms
runtime-postbuild: bundled plugin metadata completed in 111ms
runtime-postbuild: official channel catalog completed in 3ms
runtime-postbuild: bundled plugin runtime overlay completed in 223ms
OpenClaw 2026.5.10-beta.1 (f7f8037)
```

```terminal
$ pnpm test extensions/codex/src/app-server/elicitation-bridge.test.ts
[test] starting test/vitest/vitest.extensions.config.ts

 Test Files  1 passed (1)
      Tests  31 passed (31)
   Duration  7.66s

[test] passed 1 Vitest shard in 10.72s
```

```terminal
$ pnpm check:changed
[check:changed] lanes=extensions, extensionTests, docs
[check:changed] extensions/codex/src/app-server/elicitation-bridge.test.ts: extension test
[check:changed] extensions/codex/src/app-server/elicitation-bridge.ts: extension production
Found 0 warnings and 0 errors.
Import cycle check: 0 runtime value cycle(s).
```

Observed result after fix: The after-fix checks pass on the real checkout. The regression coverage includes connector-id approval, disabled destructive-action decline, display-name-only decline, and app-id/connector-id mismatch decline. The changed-surface gate also passed for extension production, extension test, and docs/changelog lanes.

What was not tested: I did not re-run a live Google Calendar write through TUI in this PR pass; the live failure was traced to the app-server approval mapping and this change verifies that mapping at the Codex app-server bridge boundary.

## Verification

- [x] `pnpm openclaw --version`
- [x] `pnpm test extensions/codex/src/app-server/elicitation-bridge.test.ts`
- [x] `pnpm exec oxfmt --write extensions/codex/src/app-server/elicitation-bridge.ts extensions/codex/src/app-server/elicitation-bridge.test.ts && git diff --check`
- [x] `pnpm check:changed`
- [x] Swarm code review: no issues found
