### PR TITLE
feat(discord): remove harness runtime dropdown from /models picker

### DIFF
--- a/extensions/discord/src/monitor/model-picker.test.ts
+++ b/extensions/discord/src/monitor/model-picker.test.ts
@@ -532,67 +532,6 @@ describe("Discord model picker rendering", () => {
     expect(submitState?.modelIndex).toBe(3);
   });
 
-  it("renders provider-compatible runtime choices in the model view", () => {
-    const data = createModelsProviderData({
-      openai: ["gpt-4.1", "gpt-4o", "o3"],
-      anthropic: ["claude-sonnet-4-5"],
-    });
-    data.runtimeChoicesByProvider = new Map([
-      [
-        "openai",
-        [
-          {
-            id: "pi",
-            label: "OpenClaw Pi Default",
-            description: "Use the built-in OpenClaw Pi runtime.",
-          },
-          {
-            id: "codex",
-            label: "codex",
-            description: "Run openai models through the codex harness.",
-          },
-        ],
-      ],
-    ]);
-
-    const rows = renderModelsViewRows({
-      command: "model",
-      userId: "42",
-      data,
-      provider: "openai",
-      page: 1,
-      providerPage: 1,
-      currentModel: "openai/gpt-4o",
-      currentRuntime: "pi",
-      pendingModel: "openai/o3",
-      pendingModelIndex: 3,
-      pendingRuntime: "codex",
-    });
-
-    expect(rows).toHaveLength(4);
-
-    const runtimeSelect = rows[1]?.components?.find(
-      (component) => component.type === DISCORD_STRING_SELECT_COMPONENT_TYPE,
-    );
-    if (!runtimeSelect) {
-      throw new Error("models view did not render a runtime select");
-    }
-    expect(runtimeSelect.options?.map((option) => option.value)).toEqual(["pi", "codex"]);
-    expect(runtimeSelect.options?.find((option) => option.value === "pi")?.label).toBe(
-      "OpenClaw Pi Default",
-    );
-    const codexRuntimeOption = runtimeSelect.options?.find((option) => option.value === "codex");
-    expect(codexRuntimeOption?.default).toBe(true);
-
-    const submitButton = rows[3]?.components?.at(-1);
-    const submitState = requireValue(
-      parseDiscordModelPickerCustomId(submitButton?.custom_id ?? ""),
-      "submit custom id should parse",
-    );
-    expect(submitState.runtime).toBe("codex");
-    expect(submitState.modelIndex).toBe(3);
-  });
-
   it("renders not-found model view with a back button", () => {
     const data = createModelsProviderData({ openai: ["gpt-4o"] });
 

--- a/extensions/discord/src/monitor/model-picker.view.ts
+++ b/extensions/discord/src/monitor/model-picker.view.ts
@@ -78,8 +78,6 @@ export type DiscordModelPickerModelViewParams = {
   currentModel?: string;
   pendingModel?: string;
   pendingModelIndex?: number;
-  currentRuntime?: string;
-  pendingRuntime?: string;
   quickModels?: string[];
   layout?: DiscordModelPickerLayout;
 };
@@ -166,37 +164,6 @@ function createModelSelect(params: {
   return new DiscordModelPickerSelect();
 }
 
-function getRuntimeChoices(params: {
-  data: ModelsProviderData;
-  provider: string;
-}): Array<{ id: string; label: string; description?: string }> {
-  return (
-    params.data.runtimeChoicesByProvider?.get(normalizeProviderId(params.provider)) ?? [
-      {
-        id: "pi",
-        label: "OpenClaw Pi Default",
-        description: "Use the built-in OpenClaw Pi runtime.",
-      },
-    ]
-  );
-}
-
-function resolveSelectedRuntime(params: {
-  data: ModelsProviderData;
-  provider: string;
-  currentRuntime?: string;
-  pendingRuntime?: string;
-}): string {
-  const choices = getRuntimeChoices({ data: params.data, provider: params.provider });
-  const allowed = new Set(choices.map((choice) => choice.id));
-  const pending = params.pendingRuntime?.trim();
-  if (pending && allowed.has(pending)) {
-    return pending;
-  }
-  const current = params.currentRuntime?.trim();
-  return current && allowed.has(current) ? current : "pi";
-}
-
 function buildRenderedShell(
   params: DiscordModelPickerRenderShellParams,
 ): DiscordModelPickerRenderedView {
@@ -276,8 +243,6 @@ function buildModelRows(params: {
   currentModel?: string;
   pendingModel?: string;
   pendingModelIndex?: number;
-  currentRuntime?: string;
-  pendingRuntime?: string;
   quickModels?: string[];
 }): { rows: DiscordModelPickerRow[]; buttonRow: Row<Button> } {
   const parsedCurrentModel = parseCurrentModelRef(params.currentModel);
@@ -314,56 +279,6 @@ function buildModelRows(params: {
     ]),
   );
 
-  const runtimeChoices = getRuntimeChoices({
-    data: params.data,
-    provider: params.modelPage.provider,
-  });
-  const selectedRuntime = resolveSelectedRuntime({
-    data: params.data,
-    provider: params.modelPage.provider,
-    currentRuntime: params.currentRuntime,
-    pendingRuntime: params.pendingRuntime,
-  });
-  const normalizedCurrentRuntime = params.currentRuntime?.trim();
-  const shouldCarryRuntime =
-    runtimeChoices.length > 1 ||
-    (Boolean(normalizedCurrentRuntime) &&
-      normalizedCurrentRuntime !== "auto" &&
-      normalizedCurrentRuntime !== "pi" &&
-      normalizedCurrentRuntime !== "default");
-  const stateRuntime = shouldCarryRuntime ? selectedRuntime : undefined;
-  if (runtimeChoices.length > 1) {
-    rows.push(
-      new Row([
-        createModelSelect({
-          customId: buildDiscordModelPickerCustomId({
-            command: params.command,
-            action: "runtime",
-            view: "models",
-            provider: params.modelPage.provider,
-            runtime: selectedRuntime,
-            page: params.modelPage.page,
-            providerPage: providerPage.page,
-            modelIndex: params.pendingModelIndex,
-            userId: params.userId,
-          }),
-          options: runtimeChoices.map((choice) => {
-            const option: APISelectMenuOption = {
-              label: choice.label,
-              value: choice.id,
-              default: choice.id === selectedRuntime,
-            };
-            if (choice.description) {
-              option.description = choice.description;
-            }
-            return option;
-          }),
-          placeholder: "Select runtime",
-        }),
-      ]),
-    );
-  }
-
   const selectedModelRef = parsedPendingModel ?? parsedCurrentModel;
   const modelOptions: APISelectMenuOption[] = params.modelPage.items.map((model) => ({
     label: model,
@@ -381,7 +296,6 @@ function buildModelRows(params: {
           action: "model",
           view: "models",
           provider: params.modelPage.provider,
-          runtime: stateRuntime,
           page: params.modelPage.page,
           providerPage: providerPage.page,
           userId: params.userId,
@@ -413,7 +327,6 @@ function buildModelRows(params: {
         action: "cancel",
         view: "models",
         provider: params.modelPage.provider,
-        runtime: stateRuntime,
         page: params.modelPage.page,
         providerPage: providerPage.page,
         userId: params.userId,
@@ -428,7 +341,6 @@ function buildModelRows(params: {
         action: "reset",
         view: "models",
         provider: params.modelPage.provider,
-        runtime: stateRuntime,
         page: params.modelPage.page,
         providerPage: providerPage.page,
         userId: params.userId,
@@ -446,7 +358,6 @@ function buildModelRows(params: {
           action: "recents",
           view: "recents",
           provider: params.modelPage.provider,
-          runtime: stateRuntime,
           page: params.modelPage.page,
           providerPage: providerPage.page,
           userId: params.userId,
@@ -465,7 +376,6 @@ function buildModelRows(params: {
         action: "submit",
         view: "models",
         provider: params.modelPage.provider,
-        runtime: stateRuntime,
         page: params.modelPage.page,
         providerPage: providerPage.page,
         modelIndex: params.pendingModelIndex,
@@ -549,19 +459,12 @@ export function renderDiscordModelPickerModelsView(
     currentModel: params.currentModel,
     pendingModel: params.pendingModel,
     pendingModelIndex: params.pendingModelIndex,
-    currentRuntime: params.currentRuntime,
-    pendingRuntime: params.pendingRuntime,
     quickModels: params.quickModels,
   });
 
   const defaultModel = `${params.data.resolvedDefault.provider}/${params.data.resolvedDefault.model}`;
   const pendingLine = params.pendingModel
-    ? `Selected: ${params.pendingModel} · runtime ${resolveSelectedRuntime({
-        data: params.data,
-        provider: modelPage.provider,
-        currentRuntime: params.currentRuntime,
-        pendingRuntime: params.pendingRuntime,
-      })} (press Submit)`
+    ? `Selected: ${params.pendingModel} (press Submit)`
     : "Select a model, then press Submit.";
 
   return buildRenderedShell({

--- a/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
+++ b/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
@@ -5,7 +5,6 @@ import {
   type ChatCommandDefinition,
   type CommandArgs,
 } from "openclaw/plugin-sdk/command-auth-native";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   Button,
   StringSelectMenu,
@@ -30,7 +29,6 @@ import {
   buildDiscordModelPickerAllowedModelRefs,
   buildDiscordModelPickerNoticePayload,
   resolveDiscordModelPickerCurrentModel,
-  resolveDiscordModelPickerCurrentRuntime,
   resolveDiscordModelPickerPreferenceScope,
   resolveDiscordModelPickerRoute,
   splitDiscordModelRef,
@@ -57,7 +55,6 @@ function resolveModelPickerSelectionValue(
 
 function buildDiscordModelPickerSelectionCommand(params: {
   modelRef: string;
-  runtime?: string;
 }): { command: ChatCommandDefinition; args: CommandArgs; prompt: string } | null {
   const commandDefinition =
     findCommandByNativeName("model", "discord") ??
@@ -65,13 +62,11 @@ function buildDiscordModelPickerSelectionCommand(params: {
   if (!commandDefinition) {
     return null;
   }
-  const runtime = normalizeOptionalString(params.runtime);
-  const raw = runtime ? `${params.modelRef} --runtime ${runtime}` : params.modelRef;
   const commandArgs: CommandArgs = {
     values: {
       model: params.modelRef,
     },
-    raw,
+    raw: params.modelRef,
   };
   return {
     command: commandDefinition,
@@ -170,10 +165,6 @@ export async function handleDiscordModelPickerInteraction(params: {
     route,
     data: pickerData,
   });
-  const currentRuntime = resolveDiscordModelPickerCurrentRuntime({
-    cfg: ctx.cfg,
-    route,
-  });
   const allowedModelRefs = buildDiscordModelPickerAllowedModelRefs(pickerData);
   const preferenceScope = resolveDiscordModelPickerPreferenceScope({
     interaction,
@@ -232,7 +223,6 @@ export async function handleDiscordModelPickerInteraction(params: {
       page: parsed.page ?? 1,
       providerPage: parsed.providerPage ?? 1,
       currentModel: currentModelRef,
-      currentRuntime,
       quickModels,
     });
     await updatePicker(toDiscordModelPickerMessagePayload(rendered));
@@ -253,7 +243,6 @@ export async function handleDiscordModelPickerInteraction(params: {
       page: 1,
       providerPage: parsed.providerPage ?? parsed.page,
       currentModel: currentModelRef,
-      currentRuntime,
       quickModels,
     });
     await updatePicker(toDiscordModelPickerMessagePayload(rendered));
@@ -285,42 +274,8 @@ export async function handleDiscordModelPickerInteraction(params: {
       page: parsed.page,
       providerPage: parsed.providerPage ?? 1,
       currentModel: currentModelRef,
-      currentRuntime,
       pendingModel: modelRef,
       pendingModelIndex: modelIndex,
-      pendingRuntime: parsed.runtime,
-      quickModels,
-    });
-    await updatePicker(toDiscordModelPickerMessagePayload(rendered));
-    return;
-  }
-
-  if (parsed.action === "runtime") {
-    const selectedRuntime =
-      resolveModelPickerSelectionValue(interaction) ?? parsed.runtime ?? "auto";
-    const provider = parsed.provider;
-    if (!provider || !pickerData.byProvider.has(provider)) {
-      await showNotice("Sorry, that provider isn't available anymore.");
-      return;
-    }
-    const selectedModel = resolveDiscordModelPickerModelByIndex({
-      data: pickerData,
-      provider,
-      modelIndex: parsed.modelIndex,
-    });
-    const pendingModel = selectedModel ? `${provider}/${selectedModel}` : undefined;
-    const rendered = renderDiscordModelPickerModelsView({
-      command: parsed.command,
-      userId: parsed.userId,
-      data: pickerData,
-      provider,
-      page: parsed.page,
-      providerPage: parsed.providerPage ?? 1,
-      currentModel: currentModelRef,
-      currentRuntime,
-      ...(pendingModel ? { pendingModel } : {}),
-      pendingModelIndex: parsed.modelIndex,
-      pendingRuntime: selectedRuntime,
       quickModels,
     });
     await updatePicker(toDiscordModelPickerMessagePayload(rendered));
@@ -362,13 +317,8 @@ export async function handleDiscordModelPickerInteraction(params: {
     }
 
     const resolvedModelRef = `${parsedModelRef.provider}/${parsedModelRef.model}`;
-    const parsedRuntime = normalizeOptionalString(parsed.runtime);
-    const runtimeOverride =
-      parsedRuntime ??
-      (currentRuntime !== "auto" && currentRuntime !== "default" ? currentRuntime : undefined);
     const selectionCommand = buildDiscordModelPickerSelectionCommand({
       modelRef: resolvedModelRef,
-      runtime: runtimeOverride,
     });
     if (!selectionCommand) {
       await showNotice("Sorry, /model is unavailable right now.");

--- a/extensions/discord/src/monitor/native-command-model-picker-ui.ts
+++ b/extensions/discord/src/monitor/native-command-model-picker-ui.ts
@@ -85,12 +85,6 @@ function buildDiscordModelPickerCurrentModel(
   return `${defaultProvider}/${defaultModel}`;
 }
 
-function resolveConfiguredAgentRuntimeId(value: {
-  agentRuntime?: { id?: unknown };
-}): string | undefined {
-  return normalizeOptionalString(value.agentRuntime?.id);
-}
-
 export function buildDiscordModelPickerAllowedModelRefs(
   data: Awaited<ReturnType<typeof loadDiscordModelPickerData>>,
 ): Set<string> {
@@ -262,36 +256,6 @@ export function resolveDiscordModelPickerCurrentModel(params: {
   }
 }
 
-export function resolveDiscordModelPickerCurrentRuntime(params: {
-  cfg: OpenClawConfig;
-  route: ResolvedAgentRoute;
-}): string {
-  try {
-    const storePath = resolveStorePath(params.cfg.session?.store, {
-      agentId: params.route.agentId,
-    });
-    const sessionStore = loadSessionStore(storePath, { skipCache: true });
-    const sessionRuntime = normalizeOptionalString(
-      sessionStore[params.route.sessionKey]?.agentRuntimeOverride,
-    );
-    if (sessionRuntime) {
-      return sessionRuntime;
-    }
-  } catch {
-    // Fall through to configured defaults when the session store is unavailable.
-  }
-
-  const agentRuntime = resolveConfiguredAgentRuntimeId(
-    params.cfg.agents?.list?.find(
-      (entry) => normalizeOptionalString(entry.id) === params.route.agentId,
-    ) ?? {},
-  );
-  if (agentRuntime) {
-    return agentRuntime;
-  }
-  return resolveConfiguredAgentRuntimeId(params.cfg.agents?.defaults ?? {}) ?? "auto";
-}
-
 export async function replyWithDiscordModelPickerProviders(params: {
   interaction: CommandInteraction | ButtonInteraction | StringSelectMenuInteraction;
   cfg: OpenClawConfig;
@@ -313,10 +277,6 @@ export async function replyWithDiscordModelPickerProviders(params: {
     cfg: params.cfg,
     route,
     data,
-  });
-  const currentRuntime = resolveDiscordModelPickerCurrentRuntime({
-    cfg: params.cfg,
-    route,
   });
   const quickModels = await readDiscordModelPickerRecentModels({
     scope: resolveDiscordModelPickerPreferenceScope({
@@ -341,7 +301,6 @@ export async function replyWithDiscordModelPickerProviders(params: {
     page: 1,
     providerPage: 1,
     currentModel,
-    currentRuntime,
     quickModels,
   });
   const payload = {

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -437,49 +437,6 @@ describe("Discord model picker interactions", () => {
     });
   });
 
-  it("routes selected runtime through the /model pipeline", async () => {
-    const context = createModelPickerContext();
-    const pickerData = createDefaultModelPickerData();
-    pickerData.runtimeChoicesByProvider = new Map([
-      [
-        "openai",
-        [
-          {
-            id: "pi",
-            label: "OpenClaw Pi Default",
-            description: "Use the built-in OpenClaw Pi runtime.",
-          },
-          {
-            id: "codex",
-            label: "codex",
-            description: "Run openai models through the codex harness.",
-          },
-        ],
-      ],
-    ]);
-    const modelCommand = createModelCommandDefinition();
-
-    vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
-    mockModelCommandPipeline(modelCommand);
-
-    const dispatchSpy = createDispatchSpy();
-    await runSubmitButton({
-      context,
-      data: {
-        ...createModelsViewSubmitData(),
-        r: "codex",
-      },
-      dispatchCommandInteraction: dispatchSpy,
-    });
-
-    expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    expectDispatchedModelSelection({
-      dispatchSpy,
-      model: "openai/gpt-4o",
-      runtime: "codex",
-    });
-  });
-
   it("ignores category parent metadata for non-thread component channels", () => {
     const interaction = createInteraction({ userId: "owner" });
     interaction.guild = { id: "guild-1" };


### PR DESCRIPTION
 
### Real behavior

Before 
<img width="1154" height="960" alt="Screenshot 2026-05-11 at 12 30 26" src="https://github.com/user-attachments/assets/1d42dc4f-0741-4085-93b2-38939a3ce7ee" />


After
<img width="1044" height="736" alt="Screenshot 2026-05-11 at 13 23 55" src="https://github.com/user-attachments/assets/576d3efa-6216-4d43-a384-a1e307a9af8e" />

### Summary

The Discord `/models` picker rendered a runtime/harness select (Pi vs. codex vs. codex-cli, etc.) alongside the provider and model selects. Runtime selection is not intended to be a user-facing knob — it derives from provider routing (`resolveAgentHarnessPolicy`) and should not be reconfigurable per session from inside the model picker. Surfacing it as a third dropdown also caused real UX bugs: with no `agentRuntime` configured the current runtime resolves to `auto`, which the picker then displays as **"OpenClaw Pi Default"** even when the harness will actually route the request through codex.

This change removes the dropdown and all of its supporting plumbing in the picker UI; runtime resolution continues to happen via the existing harness policy.

Removed:

- The runtime `StringSelectMenu` row in [`extensions/discord/src/monitor/model-picker.view.ts`](extensions/discord/src/monitor/model-picker.view.ts), along with `getRuntimeChoices`, `resolveSelectedRuntime`, the `currentRuntime`/`pendingRuntime` view params, the runtime suffix on the "Selected: …" pending line, and the `runtime: stateRuntime` field on every picker `customId` emitted by the view.
- The `parsed.action === "runtime"` handler in [`native-command-model-picker-interaction.ts`](extensions/discord/src/monitor/native-command-model-picker-interaction.ts), the `resolveDiscordModelPickerCurrentRuntime` call, and the `--runtime …` argument that was appended to the `/model` selection command on submit.
- `resolveDiscordModelPickerCurrentRuntime` and the now-unused `resolveConfiguredAgentRuntimeId` helper in [`native-command-model-picker-ui.ts`](extensions/discord/src/monitor/native-command-model-picker-ui.ts).
- Two tests that specifically exercised the dropdown / `--runtime` routing.

Intentionally left alone:

- `buildModelsProviderData` still populates `runtimeChoicesByProvider` on `ModelsProviderData`. No one reads it now, but it's exported via the Plugin SDK so the cleanup is left as a follow-up to avoid touching public surface in this PR.
- The picker `customId` schema still parses `r=…` so any in-flight messages with old IDs do not crash; no new code path emits it.
- Session-store `agentRuntimeOverride` is untouched — any existing stored override keeps working for paths that read it; the picker just can't set or surface it anymore.

## Verification

- `pnpm test extensions/discord/src/monitor` — 654 passed (62 files).
- `pnpm test src/auto-reply/reply/commands-models.test.ts` — 15 passed.
- `pnpm tsgo:core` — exit 0.
- `pnpm tsgo:extensions` — no errors in `extensions/discord` (pre-existing `extensions/twitch/src/twitch-client.ts` warnings are unrelated).
- Manual: rendered `/models` for openai-only data — picker now shows provider select + model select + Cancel/Reset/Recents/Submit, no runtime row.