### PR TITLE
fix: Fix the build: annotate provider-http test-helper exports for portable dts

### DIFF
--- a/extensions/minimax/provider-http.test-helpers.ts
+++ b/extensions/minimax/provider-http.test-helpers.ts
@@ -1,9 +1,28 @@
 import type { resolveProviderHttpRequestConfig } from "openclaw/plugin-sdk/provider-http";
-import { afterEach, vi } from "vitest";
+import { afterEach, vi, type Mock } from "vitest";
 
 type ResolveProviderHttpRequestConfigParams = Parameters<
   typeof resolveProviderHttpRequestConfig
 >[0];
+
+type ResolveProviderHttpRequestConfigResult = {
+  baseUrl: string;
+  allowPrivateNetwork: boolean;
+  headers: Headers;
+  dispatcherPolicy: undefined;
+};
+
+type AnyMock = Mock<(...args: any[]) => any>;
+
+interface MinimaxProviderHttpMocks {
+  resolveApiKeyForProviderMock: Mock<() => Promise<{ apiKey: string }>>;
+  postJsonRequestMock: AnyMock;
+  fetchWithTimeoutMock: AnyMock;
+  assertOkOrThrowHttpErrorMock: Mock<() => Promise<void>>;
+  resolveProviderHttpRequestConfigMock: Mock<
+    (params: ResolveProviderHttpRequestConfigParams) => ResolveProviderHttpRequestConfigResult
+  >;
+}
 
 const minimaxProviderHttpMocks = vi.hoisted(() => ({
   resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "provider-key" })),
@@ -42,7 +61,7 @@ vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   waitProviderOperationPollInterval: async () => {},
 }));
 
-export function getMinimaxProviderHttpMocks() {
+export function getMinimaxProviderHttpMocks(): MinimaxProviderHttpMocks {
   return minimaxProviderHttpMocks;
 }
 

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -1,4 +1,4 @@
-import { afterEach, vi } from "vitest";
+import { afterEach, vi, type Mock } from "vitest";
 import type {
   pollProviderOperationJson,
   resolveProviderHttpRequestConfig,
@@ -12,6 +12,32 @@ type PollProviderOperationJsonParams = Parameters<typeof pollProviderOperationJs
 type SanitizeConfiguredModelProviderRequestParams = Parameters<
   typeof sanitizeConfiguredModelProviderRequest
 >[0];
+
+type ResolveProviderHttpRequestConfigResult = {
+  baseUrl: string;
+  allowPrivateNetwork: boolean;
+  headers: Headers;
+  dispatcherPolicy: undefined;
+};
+
+type AnyMock = Mock<(...args: any[]) => any>;
+
+interface ProviderHttpMocks {
+  resolveApiKeyForProviderMock: Mock<() => Promise<{ apiKey: string }>>;
+  postJsonRequestMock: AnyMock;
+  fetchWithTimeoutMock: AnyMock;
+  pollProviderOperationJsonMock: AnyMock;
+  assertOkOrThrowHttpErrorMock: Mock<(response: Response, label: string) => Promise<void>>;
+  assertOkOrThrowProviderErrorMock: Mock<(response: Response, label: string) => Promise<void>>;
+  sanitizeConfiguredModelProviderRequestMock: Mock<
+    (
+      request: SanitizeConfiguredModelProviderRequestParams,
+    ) => SanitizeConfiguredModelProviderRequestParams
+  >;
+  resolveProviderHttpRequestConfigMock: Mock<
+    (params: ResolveProviderHttpRequestConfigParams) => ResolveProviderHttpRequestConfigResult
+  >;
+}
 
 const providerHttpMocks = vi.hoisted(() => ({
   resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "provider-key" })),
@@ -85,7 +111,7 @@ vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   waitProviderOperationPollInterval: async () => {},
 }));
 
-export function getProviderHttpMocks() {
+export function getProviderHttpMocks(): ProviderHttpMocks {
   return providerHttpMocks;
 }
 


### PR DESCRIPTION
## Summary

- `pnpm build` was failing with two TS2883 errors from `rolldown-plugin-dts:generate` because `getProviderHttpMocks` (`src/plugin-sdk/test-helpers/provider-http-mocks.ts`) and `getMinimaxProviderHttpMocks` (`extensions/minimax/provider-http.test-helpers.ts`) had inferred return types the dts emitter could not name without referencing `Procedure` from `@vitest/spy` (re-exported via the pnpm-private path, not via `vitest`).
- Both helpers now declare explicit return-type interfaces built from `Mock<...>` (re-exported by `vitest`), so the emitted `.d.ts` only references the public `vitest` type surface. Runtime behavior is unchanged — the explicit interfaces just name the shape inference was already producing.

Fixes
```
==> pnpm install + pnpm build in ./openclaw (first run takes 5-15 min)
Scope: all 127 workspace projects
(node:34428) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
(Use `node --trace-deprecation ...` to show where the warning was created)
 WARN  2 deprecated subdependencies found: uuid@8.3.2, uuid@9.0.1
Packages: +2 -2
++--
Progress: resolved 1467, reused 1245, downloaded 0, added 2, done
. preinstall$ node scripts/preinstall-package-manager-warning.mjs
└─ Done in 51ms
. postinstall$ node scripts/postinstall-bundled-plugins.mjs
└─ Done in 112ms
. prepare$ command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config core.hooksPath git-hooks || exit 0
└─ Done in 18ms
 WARN  Issues with peer dependencies found
.
└─┬ @vitest/browser-playwright 4.1.5
  └── ✕ missing peer playwright@"*"
Peer dependencies that should be installed:
  playwright@"*"

extensions/discord
└─┬ @discordjs/voice 0.19.2
  └─┬ prism-media 1.3.5
    └── ✕ unmet peer opusscript@^0.0.8: found 0.1.1

Done in 4.3s

> openclaw@2026.5.10-beta.1 build /Users/sjf/onboarding/openclaw
> node scripts/build-all.mjs

[build-all] plugins:assets:build

> openclaw@2026.5.10-beta.1 plugins:assets:build /Users/sjf/onboarding/openclaw
> node scripts/bundled-plugin-assets.mjs --phase build

[canvas] build: node scripts/bundle-a2ui.mjs
<DIR>/a2ui.bundle.js  chunk │ size: 394.21 kB

✔ rolldown v1.0.0 Finished in 29.55 ms
[build-all] tsdown

 ERROR  Error: Build failed with 2 errors:

[plugin rolldown-plugin-dts:generate]
RolldownError: extensions/minimax/provider-http.test-helpers.ts(45,17): error TS2883: The inferred type of 'getMinimaxProviderHttpMocks' cannot be named without a reference to 'Procedure' from '.pnpm/@vitest+spy@4.1.5/node_modules/@vitest/spy'. This is likely not portable. A type annotation is necessary.
    at error (file:///Users/sjf/onboarding/openclaw/node_modules/.pnpm/rolldown@1.0.0/node_modules/rolldown/dist/shared/logs-D80CXhvg.mjs:147:24)
    at LoadPluginContextImpl.error (file:///Users/sjf/onboarding/openclaw/node_modules/.pnpm/rolldown@1.0.0/node_modules/rolldown/dist/shared/bindingify-input-options-zrVFGksD.mjs:95:10)
    at LoadPluginContextImpl.handler (file:///Users/sjf/onboarding/openclaw/node_modules/.pnpm/rolldown-plugin-dts@0.25.0_@typescript+native-preview@7.0.0-dev.20260510.1_rolldown@1.0.0_typescript@6.0.3/node_modules/rolldown-plugin-dts/dist/index.mjs:944:36)
    at plugin (file:///Users/sjf/onboarding/openclaw/node_modules/.pnpm/rolldown@1.0.0/node_modules/rolldown/dist/shared/bindingify-input-options-zrVFGksD.mjs:1219:30)
    at plugin.<computed> (file:///Users/sjf/onboarding/openclaw/node_modules/.pnpm/rolldown@1.0.0/node_modules/rolldown/dist/shared/bindingify-input-options-zrVFGksD.mjs:1625:18)
[plugin rolldown-plugin-dts:generate]
RolldownError: src/plugin-sdk/test-helpers/provider-http-mocks.ts(88,17): error TS2883: The inferred type of 'getProviderHttpMocks' cannot be named without a reference to 'Procedure' from '.pnpm/@vitest+spy@4.1.5/node_modules/@vitest/spy'. This is likely not portable. A type annotation is necessary.
    at error (file:///Users/sjf/onboarding/openclaw/node_modules/.pnpm/rolldown@1.0.0/node_modules/rolldown/dist/shared/logs-D80CXhvg.mjs:147:24)
    at LoadPluginContextImpl.error (file:///Users/sjf/onboarding/openclaw/node_modules/.pnpm/rolldown@1.0.0/node_modules/rolldown/dist/shared/bindingify-input-options-zrVFGksD.mjs:95:10)
    at LoadPluginContextImpl.handler (file:///Users/sjf/onboarding/openclaw/node_modules/.pnpm/rolldown-plugin-dts@0.25.0_@typescript+native-preview@7.0.0-dev.20260510.1_rolldown@1.0.0_typescript@6.0.3/node_modules/rolldown-plugin-dts/dist/index.mjs:944:36)
    at plugin (file:///Users/sjf/onboarding/openclaw/node_modules/.pnpm/rolldown@1.0.0/node_modules/rolldown/dist/shared/bindingify-input-options-zrVFGksD.mjs:1219:30)
    at plugin.<computed> (file:///Users/sjf/onboarding/openclaw/node_modules/.pnpm/rolldown@1.0.0/node_modules/rolldown/dist/shared/bindingify-input-options-zrVFGksD.mjs:1625:18)
    at aggregateBindingErrorsIntoJsError (file:///Users/sjf/onboarding/openclaw/node_modules/.pnpm/rolldown@1.0.0/node_modules/rolldown/dist/shared/error-BrnLyQ-g.mjs:48:18)
    at unwrapBindingResult (file:///Users/sjf/onboarding/openclaw/node_modules/.pnpm/rolldown@1.0.0/node_modules/rolldown/dist/shared/error-BrnLyQ-g.mjs:18:128)
    at #build (file:///Users/sjf/onboarding/openclaw/node_modules/.pnpm/rolldown@1.0.0/node_modules/rolldown/dist/shared/rolldown-build-D_ShytiL.mjs:3257:34)
    at async build (file:///Users/sjf/onboarding/openclaw/node_modules/.pnpm/rolldown@1.0.0/node_modules/rolldown/dist/index.mjs:42:22)
    at async Promise.all (index 0)
    at async buildSingle (file:///Users/sjf/onboarding/openclaw/node_modules/.pnpm/tsdown@0.22.0_@typescript+native-preview@7.0.0-dev.20260510.1_tsx@4.21.0_typescript@6.0.3_unrun@0.2.37/node_modules/tsdown/dist/build-5FURNVr0.mjs:765:19)
    at async Promise.all (index 0)
    at async buildWithConfigs (file:///Users/sjf/onboarding/openclaw/node_modules/.pnpm/tsdown@0.22.0_@typescript+native-preview@7.0.0-dev.20260510.1_tsx@4.21.0_typescript@6.0.3_unrun@0.2.37/node_modules/tsdown/dist/build-5FURNVr0.mjs:721:18)
    at async CAC.<anonymous> (file:///Users/sjf/onboarding/openclaw/node_modules/.pnpm/tsdown@0.22.0_@typescript+native-preview@7.0.0-dev.20260510.1_tsx@4.21.0_typescript@6.0.3_unrun@0.2.37/node_modules/tsdown/dist/run.mjs:22:2)
    at async runCLI (file:///Users/sjf/onboarding/openclaw/node_modules/.pnpm/tsdown@0.22.0_@typescript+native-preview@7.0.0-dev.20260510.1_tsx@4.21.0_typescript@6.0.3_unrun@0.2.37/node_modules/tsdown/dist/run.mjs:46:3)

 ELIFECYCLE  Command failed with exit code 1.
 ```

## Verification

- [ ] `pnpm build` completes without the TS2883 errors.
- [ ] `pnpm tsgo` lane covering plugin-sdk + minimax is green.
- [ ] `pnpm test extensions/minimax/music-generation-provider.test.ts extensions/minimax/video-generation-provider.test.ts` plus a representative `getProviderHttpMocks` consumer (e.g. `extensions/openai/video-generation-provider.test.ts`) still pass — the mock destructuring patterns rely on the helper shape unchanged.
- [ ] `dist/plugin-sdk/provider-http-test-mocks.d.ts` no longer references `@vitest/spy` directly.

Proof gap: `pnpm build` and the test lanes were not run locally before pushing per the requester's instruction. Maintainer should rerun these before landing.
