### PR TITLE
Make OpenAI auth login use ChatGPT by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Models/OpenAI CLI auth: make `openclaw models auth login --provider openai` start the ChatGPT/Codex account login by default, while `--method api-key` remains the explicit OpenAI API-key setup path.
 - Docs/subagents: document `agents.defaults.subagents.announceTimeoutMs` in the sub-agent and configuration references. (#75509) Thanks @akrimm702.
 - Cron: add direct `cron.get`, `openclaw cron get <id>`, and agent-tool `get` support for inspecting one stored cron job by id. (#75117) Thanks @samzong.
 - Agents/tools: add per-sender tool policies with canonical channel-scoped sender keys, so operators can restrict dangerous tools by requester identity across global, agent, group, core, bundled, and plugin tool surfaces. (#66933) Thanks @JerranC.

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -188,11 +188,17 @@ specific configured agent store. The parent `--agent` flag is honored by
 `add`, `list`, `login`, `setup-token`, `paste-token`, and
 `login-github-copilot`.
 
+For OpenAI models, `--provider openai` defaults to ChatGPT/Codex account login.
+Use `--method api-key` only when you want to add an OpenAI API-key profile,
+usually as a backup for Codex subscription limits. The legacy
+`--provider openai-codex` spelling still works for existing scripts.
+
 Examples:
 
 ```bash
-openclaw models auth login --provider openai-codex --set-default
-openclaw models auth list --provider openai-codex
+openclaw models auth login --provider openai --set-default
+openclaw models auth login --provider openai --method api-key
+openclaw models auth list --provider openai
 ```
 
 Notes:

--- a/extensions/line/index.ts
+++ b/extensions/line/index.ts
@@ -1,8 +1,5 @@
-import {
-  defineBundledChannelEntry,
-  type OpenClawPluginCommandDefinition,
-  type OpenClawPluginApi,
-} from "openclaw/plugin-sdk/channel-entry-contract";
+import { defineBundledChannelEntry } from "openclaw/plugin-sdk/channel-entry-contract";
+import type { OpenClawPluginApi, OpenClawPluginCommandDefinition } from "openclaw/plugin-sdk/core";
 
 type RegisteredLineCardCommand = OpenClawPluginCommandDefinition;
 

--- a/extensions/line/index.ts
+++ b/extensions/line/index.ts
@@ -1,7 +1,9 @@
-import { defineBundledChannelEntry } from "openclaw/plugin-sdk/channel-entry-contract";
-import type { OpenClawPluginApi, OpenClawPluginCommandDefinition } from "openclaw/plugin-sdk/core";
+import {
+  defineBundledChannelEntry,
+  type OpenClawPluginApi,
+} from "openclaw/plugin-sdk/channel-entry-contract";
 
-type RegisteredLineCardCommand = OpenClawPluginCommandDefinition;
+type RegisteredLineCardCommand = Parameters<OpenClawPluginApi["registerCommand"]>[0];
 
 let lineCardCommandPromise: Promise<RegisteredLineCardCommand> | null = null;
 

--- a/extensions/openai/auth-choice-copy.ts
+++ b/extensions/openai/auth-choice-copy.ts
@@ -1,4 +1,9 @@
 export const OPENAI_API_KEY_LABEL = "OpenAI API Key";
+export const OPENAI_CHATGPT_LOGIN_LABEL = "ChatGPT Login";
+export const OPENAI_CHATGPT_LOGIN_HINT = "Sign in with your ChatGPT or Codex subscription";
+export const OPENAI_CHATGPT_DEVICE_PAIRING_LABEL = "ChatGPT Device Pairing";
+export const OPENAI_CHATGPT_DEVICE_PAIRING_HINT =
+  "Pair your ChatGPT account in browser with a device code";
 export const OPENAI_CODEX_API_KEY_BACKUP_LABEL = "OpenAI API Key Backup";
 export const OPENAI_CODEX_API_KEY_BACKUP_HINT =
   "Use an OpenAI API key when your Codex subscription is unavailable";
@@ -11,6 +16,12 @@ export const OPENAI_API_KEY_WIZARD_GROUP = {
   groupId: "openai",
   groupLabel: "OpenAI",
   groupHint: "Direct API key",
+} as const;
+
+export const OPENAI_ACCOUNT_WIZARD_GROUP = {
+  groupId: "openai",
+  groupLabel: "OpenAI",
+  groupHint: "ChatGPT subscription or API key",
 } as const;
 
 export const OPENAI_CODEX_WIZARD_GROUP = {

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -129,9 +129,10 @@ describe("buildOpenAIProvider", () => {
 
     expectFields(apiKey?.wizard, {
       choiceLabel: "OpenAI API Key",
+      choiceHint: "Use your OpenAI API key directly",
       groupId: "openai",
       groupLabel: "OpenAI",
-      groupHint: "Direct API key",
+      groupHint: "ChatGPT subscription or API key",
     });
   });
 

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -10,7 +10,7 @@ import {
   type ProviderPlugin,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { OPENAI_API_KEY_LABEL, OPENAI_API_KEY_WIZARD_GROUP } from "./auth-choice-copy.js";
+import { OPENAI_ACCOUNT_WIZARD_GROUP, OPENAI_API_KEY_LABEL } from "./auth-choice-copy.js";
 import { isOpenAIApiBaseUrl } from "./base-url.js";
 import { applyOpenAIConfig, OPENAI_DEFAULT_MODEL } from "./default-models.js";
 import {
@@ -233,7 +233,9 @@ export function buildOpenAIProvider(): ProviderPlugin {
         wizard: {
           choiceId: "openai-api-key",
           choiceLabel: OPENAI_API_KEY_LABEL,
-          ...OPENAI_API_KEY_WIZARD_GROUP,
+          choiceHint: "Use your OpenAI API key directly",
+          assistantPriority: 5,
+          ...OPENAI_ACCOUNT_WIZARD_GROUP,
         },
       }),
     ],

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -762,6 +762,28 @@
   },
   "providerAuthChoices": [
     {
+      "provider": "openai",
+      "method": "oauth",
+      "choiceId": "openai",
+      "choiceLabel": "ChatGPT Login",
+      "choiceHint": "Sign in with your ChatGPT or Codex subscription",
+      "assistantPriority": -40,
+      "groupId": "openai",
+      "groupLabel": "OpenAI",
+      "groupHint": "ChatGPT subscription or API key"
+    },
+    {
+      "provider": "openai",
+      "method": "device-code",
+      "choiceId": "openai-device-code",
+      "choiceLabel": "ChatGPT Device Pairing",
+      "choiceHint": "Pair your ChatGPT account in browser with a device code",
+      "assistantPriority": -10,
+      "groupId": "openai",
+      "groupLabel": "OpenAI",
+      "groupHint": "ChatGPT subscription or API key"
+    },
+    {
       "provider": "openai-codex",
       "method": "oauth",
       "choiceId": "openai-codex",
@@ -804,10 +826,11 @@
       "method": "api-key",
       "choiceId": "openai-api-key",
       "choiceLabel": "OpenAI API Key",
-      "assistantPriority": -40,
+      "choiceHint": "Use your OpenAI API key directly",
+      "assistantPriority": 5,
       "groupId": "openai",
       "groupLabel": "OpenAI",
-      "groupHint": "Direct API key",
+      "groupHint": "ChatGPT subscription or API key",
       "optionKey": "openaiApiKey",
       "cliFlag": "--openai-api-key",
       "cliOption": "--openai-api-key <key>",

--- a/extensions/openai/openclaw.plugin.test.ts
+++ b/extensions/openai/openclaw.plugin.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { buildOpenAICodexProviderPlugin } from "./openai-codex-provider.js";
 import { buildOpenAIProvider } from "./openai-provider.js";
+import { buildOpenAICodexSetupProvider, buildOpenAISetupProvider } from "./setup-api.js";
 
 const manifest = JSON.parse(
   readFileSync(new URL("./openclaw.plugin.json", import.meta.url), "utf8"),
@@ -54,7 +55,12 @@ function manifestComparableWizardFields(choice: {
 }
 
 function providerWizardByKey() {
-  const providers = [buildOpenAIProvider(), buildOpenAICodexProviderPlugin()];
+  const providers = [
+    buildOpenAIProvider(),
+    buildOpenAICodexProviderPlugin(),
+    buildOpenAISetupProvider(),
+    buildOpenAICodexSetupProvider(),
+  ];
   const wizards = new Map<string, Record<string, unknown>>();
 
   for (const provider of providers) {
@@ -110,11 +116,25 @@ describe("OpenAI plugin manifest", () => {
     const codexDeviceCode = choices.find(
       (choice) => choice.choiceId === "openai-codex-device-code",
     );
+    const openAiLogin = choices.find((choice) => choice.choiceId === "openai");
+    const openAiDeviceCode = choices.find((choice) => choice.choiceId === "openai-device-code");
     const apiKey = choices.find(
       (choice) => choice.provider === "openai" && choice.method === "api-key",
     );
     const codexApiKey = choices.find((choice) => choice.choiceId === "openai-codex-api-key");
 
+    expect(openAiLogin?.choiceLabel).toBe("ChatGPT Login");
+    expect(openAiLogin?.choiceHint).toBe("Sign in with your ChatGPT or Codex subscription");
+    expect(openAiLogin?.groupId).toBe("openai");
+    expect(openAiLogin?.groupLabel).toBe("OpenAI");
+    expect(openAiLogin?.groupHint).toBe("ChatGPT subscription or API key");
+    expect(openAiDeviceCode?.choiceLabel).toBe("ChatGPT Device Pairing");
+    expect(openAiDeviceCode?.choiceHint).toBe(
+      "Pair your ChatGPT account in browser with a device code",
+    );
+    expect(openAiDeviceCode?.groupId).toBe("openai");
+    expect(openAiDeviceCode?.groupLabel).toBe("OpenAI");
+    expect(openAiDeviceCode?.groupHint).toBe("ChatGPT subscription or API key");
     expect(codexBrowserLogin?.choiceLabel).toBe("OpenAI Codex Browser Login");
     expect(codexBrowserLogin?.choiceHint).toBe("Sign in with OpenAI in your browser");
     expect(codexBrowserLogin?.groupId).toBe("openai-codex");
@@ -126,9 +146,10 @@ describe("OpenAI plugin manifest", () => {
     expect(codexDeviceCode?.groupLabel).toBe("OpenAI Codex");
     expect(codexDeviceCode?.groupHint).toBe("ChatGPT/Codex sign-in");
     expect(apiKey?.choiceLabel).toBe("OpenAI API Key");
+    expect(apiKey?.choiceHint).toBe("Use your OpenAI API key directly");
     expect(apiKey?.groupId).toBe("openai");
     expect(apiKey?.groupLabel).toBe("OpenAI");
-    expect(apiKey?.groupHint).toBe("Direct API key");
+    expect(apiKey?.groupHint).toBe("ChatGPT subscription or API key");
     expect(codexApiKey?.choiceLabel).toBe("OpenAI API Key Backup");
     expect(codexApiKey?.choiceHint).toBe(
       "Use an OpenAI API key when your Codex subscription is unavailable",

--- a/extensions/openai/provider-contract-api.ts
+++ b/extensions/openai/provider-contract-api.ts
@@ -1,11 +1,11 @@
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 import {
+  OPENAI_ACCOUNT_WIZARD_GROUP,
   OPENAI_API_KEY_LABEL,
   OPENAI_CODEX_DEVICE_PAIRING_HINT,
   OPENAI_CODEX_DEVICE_PAIRING_LABEL,
   OPENAI_CODEX_LOGIN_HINT,
   OPENAI_CODEX_LOGIN_LABEL,
-  OPENAI_API_KEY_WIZARD_GROUP,
   OPENAI_CODEX_WIZARD_GROUP,
 } from "./auth-choice-copy.js";
 
@@ -72,8 +72,9 @@ export function createOpenAIProvider(): ProviderPlugin {
         wizard: {
           choiceId: "openai-api-key",
           choiceLabel: OPENAI_API_KEY_LABEL,
-          assistantPriority: -40,
-          ...OPENAI_API_KEY_WIZARD_GROUP,
+          choiceHint: "Use your OpenAI API key directly",
+          assistantPriority: 5,
+          ...OPENAI_ACCOUNT_WIZARD_GROUP,
         },
       },
     ],

--- a/extensions/openai/setup-api.test.ts
+++ b/extensions/openai/setup-api.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { buildOpenAICodexSetupProvider, buildOpenAISetupProvider } from "./setup-api.js";
+
+function authMethodIds(provider: ReturnType<typeof buildOpenAISetupProvider>) {
+  return provider.auth.map((method) => method.id);
+}
+
+describe("OpenAI setup auth provider", () => {
+  it("offers ChatGPT login as the default OpenAI auth path while keeping API key explicit", () => {
+    const provider = buildOpenAISetupProvider();
+    const oauth = provider.auth.find((method) => method.id === "oauth");
+    const apiKey = provider.auth.find((method) => method.id === "api-key");
+
+    expect(provider.id).toBe("openai");
+    expect(authMethodIds(provider)).toEqual(["oauth", "device-code", "api-key"]);
+    expect(oauth?.label).toBe("ChatGPT Login");
+    expect(oauth?.wizard?.choiceId).toBe("openai");
+    expect(apiKey?.label).toBe("OpenAI API Key");
+    expect(apiKey?.wizard?.choiceId).toBe("openai-api-key");
+  });
+
+  it("keeps the legacy openai-codex setup provider available", () => {
+    const provider = buildOpenAICodexSetupProvider();
+
+    expect(provider.id).toBe("openai-codex");
+    expect(authMethodIds(provider)).toEqual(["oauth", "device-code", "api-key"]);
+  });
+});

--- a/extensions/openai/setup-api.ts
+++ b/extensions/openai/setup-api.ts
@@ -3,8 +3,12 @@ import type { ProviderAuthContext, ProviderAuthResult } from "openclaw/plugin-sd
 import type { ProviderAuthMethod } from "openclaw/plugin-sdk/plugin-entry";
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 import {
+  OPENAI_ACCOUNT_WIZARD_GROUP,
   OPENAI_API_KEY_LABEL,
-  OPENAI_API_KEY_WIZARD_GROUP,
+  OPENAI_CHATGPT_DEVICE_PAIRING_HINT,
+  OPENAI_CHATGPT_DEVICE_PAIRING_LABEL,
+  OPENAI_CHATGPT_LOGIN_HINT,
+  OPENAI_CHATGPT_LOGIN_LABEL,
   OPENAI_CODEX_API_KEY_BACKUP_HINT,
   OPENAI_CODEX_API_KEY_BACKUP_LABEL,
   OPENAI_CODEX_DEVICE_PAIRING_HINT,
@@ -39,7 +43,37 @@ async function runOpenAICodexProviderAuthMethod(
   return method.run(ctx);
 }
 
-function buildOpenAISetupProvider(): ProviderPlugin {
+export function buildOpenAISetupProvider(): ProviderPlugin {
+  const oauthMethod = {
+    id: "oauth",
+    label: OPENAI_CHATGPT_LOGIN_LABEL,
+    hint: OPENAI_CHATGPT_LOGIN_HINT,
+    kind: "oauth",
+    wizard: {
+      choiceId: "openai",
+      choiceLabel: OPENAI_CHATGPT_LOGIN_LABEL,
+      choiceHint: OPENAI_CHATGPT_LOGIN_HINT,
+      assistantPriority: -40,
+      ...OPENAI_ACCOUNT_WIZARD_GROUP,
+    },
+    run: async (ctx) => runOpenAICodexProviderAuthMethod("oauth", ctx),
+  } satisfies ProviderAuthMethod;
+
+  const deviceCodeMethod = {
+    id: "device-code",
+    label: OPENAI_CHATGPT_DEVICE_PAIRING_LABEL,
+    hint: OPENAI_CHATGPT_DEVICE_PAIRING_HINT,
+    kind: "device_code",
+    wizard: {
+      choiceId: "openai-device-code",
+      choiceLabel: OPENAI_CHATGPT_DEVICE_PAIRING_LABEL,
+      choiceHint: OPENAI_CHATGPT_DEVICE_PAIRING_HINT,
+      assistantPriority: -10,
+      ...OPENAI_ACCOUNT_WIZARD_GROUP,
+    },
+    run: async (ctx) => runOpenAICodexProviderAuthMethod("device-code", ctx),
+  } satisfies ProviderAuthMethod;
+
   const apiKeyMethod = {
     id: "api-key",
     label: OPENAI_API_KEY_LABEL,
@@ -48,7 +82,9 @@ function buildOpenAISetupProvider(): ProviderPlugin {
     wizard: {
       choiceId: "openai-api-key",
       choiceLabel: OPENAI_API_KEY_LABEL,
-      ...OPENAI_API_KEY_WIZARD_GROUP,
+      choiceHint: "Use your OpenAI API key directly",
+      assistantPriority: 5,
+      ...OPENAI_ACCOUNT_WIZARD_GROUP,
     },
     run: async (ctx) => runOpenAIProviderAuthMethod("api-key", ctx),
   } satisfies ProviderAuthMethod;
@@ -58,11 +94,11 @@ function buildOpenAISetupProvider(): ProviderPlugin {
     label: "OpenAI",
     docsPath: "/providers/models",
     envVars: ["OPENAI_API_KEY"],
-    auth: [apiKeyMethod],
+    auth: [oauthMethod, deviceCodeMethod, apiKeyMethod],
   };
 }
 
-function buildOpenAICodexSetupProvider(): ProviderPlugin {
+export function buildOpenAICodexSetupProvider(): ProviderPlugin {
   const oauthMethod = {
     id: "oauth",
     label: OPENAI_CODEX_LOGIN_LABEL,

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -1750,10 +1750,17 @@ export function registerCapabilityCli(program: Command) {
     .command("login")
     .description("Run provider auth login")
     .requiredOption("--provider <id>", "Provider id")
+    .option("--method <id>", "Provider auth method id")
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
         const { modelsAuthLoginCommand } = await import("../commands/models/auth.js");
-        await modelsAuthLoginCommand({ provider: String(opts.provider) }, defaultRuntime);
+        await modelsAuthLoginCommand(
+          {
+            provider: String(opts.provider),
+            method: opts.method ? String(opts.method) : undefined,
+          },
+          defaultRuntime,
+        );
       });
     });
 

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -192,6 +192,23 @@ describe("models cli", () => {
     expectCommandOptions(command, expected);
   });
 
+  it("passes --method through models auth login", async () => {
+    await runModelsCommand([
+      "models",
+      "auth",
+      "login",
+      "--provider",
+      "openai",
+      "--method",
+      "api-key",
+    ]);
+
+    expectCommandOptions(modelsAuthLoginCommand, {
+      provider: "openai",
+      method: "api-key",
+    });
+  });
+
   it("passes list-specific --agent and --json to models auth list", async () => {
     await runModelsCommand(["models", "auth", "list", "--agent", "poe", "--json"]);
 

--- a/src/commands/models/auth-list.test.ts
+++ b/src/commands/models/auth-list.test.ts
@@ -116,6 +116,66 @@ describe("modelsAuthListCommand", () => {
     expect(JSON.stringify(runtime.jsonPayloads[0])).not.toContain("secret");
   });
 
+  it("treats the OpenAI filter as the friendly view over API-key and Codex subscription profiles", async () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai-codex:user@example.com": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "access-secret",
+          refresh: "refresh-secret",
+          expires: 1_800_000_000_000,
+          email: "user@example.com",
+        },
+        "openai:api-key-backup": {
+          type: "api_key",
+          provider: "openai",
+          key: "sk-secret",
+        },
+        "anthropic:manual": {
+          type: "token",
+          provider: "anthropic",
+          token: "token-secret",
+        },
+      },
+    };
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+    const runtime = createRuntime();
+
+    await modelsAuthListCommand({ provider: "OpenAI", json: true }, runtime);
+
+    expect(mocks.externalCliDiscoveryForProviderAuth).toHaveBeenCalledWith({
+      cfg: {},
+      provider: "openai-codex",
+    });
+    expect(runtime.jsonPayloads).toStrictEqual([
+      {
+        agentDir: "/tmp/openclaw/agents/main",
+        agentId: "main",
+        authStatePath: "/tmp/openclaw/agents/main/auth-state.json",
+        profiles: [
+          {
+            id: "openai:api-key-backup",
+            label: "openai:api-key-backup",
+            provider: "openai",
+            type: "api_key",
+          },
+          {
+            email: "user@example.com",
+            expiresAt: "2027-01-15T08:00:00.000Z",
+            id: "openai-codex:user@example.com",
+            label: "openai-codex:user@example.com",
+            provider: "openai-codex",
+            type: "oauth",
+          },
+        ],
+        provider: "openai",
+      },
+    ]);
+    expect(JSON.stringify(runtime.jsonPayloads[0])).not.toContain("secret");
+  });
+
   it("prints an empty profile list without failing", async () => {
     mocks.ensureAuthProfileStore.mockReturnValue({ version: 1, profiles: {} });
     const runtime = createRuntime();

--- a/src/commands/models/auth-list.ts
+++ b/src/commands/models/auth-list.ts
@@ -26,6 +26,33 @@ type AuthProfileSummary = {
   disabledUntil?: string;
 };
 
+function resolveProviderFilter(rawProvider: string | undefined): {
+  provider: string | undefined;
+  externalCliProvider: string | undefined;
+  matches: (profile: AuthProfileSummary) => boolean;
+} {
+  const provider = rawProvider?.trim() ? normalizeProviderId(rawProvider) : undefined;
+  if (!provider) {
+    return {
+      provider: undefined,
+      externalCliProvider: undefined,
+      matches: () => true,
+    };
+  }
+  if (provider === "openai") {
+    return {
+      provider,
+      externalCliProvider: "openai-codex",
+      matches: (profile) => profile.provider === "openai" || profile.provider === "openai-codex",
+    };
+  }
+  return {
+    provider,
+    externalCliProvider: provider,
+    matches: (profile) => profile.provider === provider,
+  };
+}
+
 function resolveTargetAgent(
   cfg: Awaited<ReturnType<typeof loadModelsConfig>>,
   raw?: string,
@@ -96,10 +123,17 @@ export async function modelsAuthListCommand(
 ) {
   const cfg = await loadModelsConfig({ commandName: "models auth list", runtime });
   const { agentId, agentDir } = resolveTargetAgent(cfg, opts.agent);
-  const provider = opts.provider?.trim() ? normalizeProviderId(opts.provider) : undefined;
+  const providerFilter = resolveProviderFilter(opts.provider);
   const store = ensureAuthProfileStore(
     agentDir,
-    provider ? { externalCli: externalCliDiscoveryForProviderAuth({ cfg, provider }) } : undefined,
+    providerFilter.externalCliProvider
+      ? {
+          externalCli: externalCliDiscoveryForProviderAuth({
+            cfg,
+            provider: providerFilter.externalCliProvider,
+          }),
+        }
+      : undefined,
   );
   const profiles = Object.entries(store.profiles)
     .map(([profileId, profile]) =>
@@ -111,7 +145,7 @@ export async function modelsAuthListCommand(
         usage: store.usageStats?.[profileId],
       }),
     )
-    .filter((profile) => !provider || profile.provider === provider)
+    .filter((profile) => providerFilter.matches(profile))
     .toSorted((a, b) => a.provider.localeCompare(b.provider) || a.id.localeCompare(b.id));
 
   if (opts.json) {
@@ -119,7 +153,7 @@ export async function modelsAuthListCommand(
       agentId,
       agentDir: shortenHomePath(agentDir),
       authStatePath: shortenHomePath(resolveAuthStatePathForDisplay(agentDir)),
-      provider: provider ?? null,
+      provider: providerFilter.provider ?? null,
       profiles,
     });
     return;
@@ -127,8 +161,8 @@ export async function modelsAuthListCommand(
 
   runtime.log(`Agent: ${agentId}`);
   runtime.log(`Auth state file: ${shortenHomePath(resolveAuthStatePathForDisplay(agentDir))}`);
-  if (provider) {
-    runtime.log(`Provider: ${provider}`);
+  if (providerFilter.provider) {
+    runtime.log(`Provider: ${providerFilter.provider}`);
   }
   if (profiles.length === 0) {
     runtime.log("Profiles: (none)");

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -618,6 +618,40 @@ describe("modelsAuthLoginCommand", () => {
     expect(runApiKeyAuth).toHaveBeenCalledOnce();
   });
 
+  it("rejects unknown explicit OpenAI auth methods instead of falling back to OAuth", async () => {
+    const runtime = createRuntime();
+    const runOauthAuth = vi.fn().mockResolvedValue({ profiles: [] });
+    const runApiKeyAuth = vi.fn().mockResolvedValue({ profiles: [] });
+    mocks.resolvePluginSetupProvider.mockReturnValue(
+      createProvider({
+        id: "openai",
+        label: "OpenAI",
+        run: runOauthAuth as ProviderPlugin["auth"][number]["run"],
+        auth: [
+          {
+            id: "oauth",
+            label: "ChatGPT Login",
+            kind: "oauth",
+            run: runOauthAuth,
+          },
+          {
+            id: "api-key",
+            label: "OpenAI API Key",
+            kind: "api_key",
+            run: runApiKeyAuth,
+          },
+        ],
+      }),
+    );
+
+    await expect(
+      modelsAuthLoginCommand({ provider: "openai", method: "api_key" }, runtime),
+    ).rejects.toThrow("Unknown auth method");
+
+    expect(runOauthAuth).not.toHaveBeenCalled();
+    expect(runApiKeyAuth).not.toHaveBeenCalled();
+  });
+
   it("prompts when a provider exposes multiple non-OAuth login methods", async () => {
     const runtime = createRuntime();
     const runApiKeyAuth = vi.fn().mockResolvedValue({ profiles: [] });

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -57,6 +57,8 @@ const mocks = vi.hoisted(() => ({
   listProfilesForProvider: vi.fn(),
   promoteAuthProfileInOrder: vi.fn(),
   clearAuthProfileCooldown: vi.fn(),
+  resolvePluginSetupProvider: vi.fn(),
+  resolvePluginSetupRegistry: vi.fn(),
 }));
 
 vi.mock("../../agents/auth-profiles/profiles.js", () => ({
@@ -124,6 +126,11 @@ vi.mock("../../agents/workspace.js", () => ({
 
 vi.mock("../../plugins/providers.runtime.js", () => ({
   resolvePluginProviders: mocks.resolvePluginProviders,
+}));
+
+vi.mock("../../plugins/setup-registry.js", () => ({
+  resolvePluginSetupProvider: mocks.resolvePluginSetupProvider,
+  resolvePluginSetupRegistry: mocks.resolvePluginSetupRegistry,
 }));
 
 vi.mock("../../wizard/clack-prompter.js", () => ({
@@ -323,6 +330,14 @@ describe("modelsAuthLoginCommand", () => {
     mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/openclaw/workspace");
     mocks.resolveDefaultAgentWorkspaceDir.mockReturnValue("/tmp/openclaw/workspace");
     mocks.isRemoteEnvironment.mockReturnValue(false);
+    mocks.resolvePluginSetupProvider.mockReturnValue(undefined);
+    mocks.resolvePluginSetupRegistry.mockReturnValue({
+      providers: [],
+      cliBackends: [],
+      configMigrations: [],
+      autoEnableProbes: [],
+      diagnostics: [],
+    });
     mocks.loadValidConfigOrThrow.mockImplementation(async () => currentConfig);
     mocks.updateConfig.mockImplementation(
       async (mutator: (cfg: OpenClawConfig) => OpenClawConfig) => {
@@ -448,6 +463,7 @@ describe("modelsAuthLoginCommand", () => {
 
   it("defaults OpenAI login to ChatGPT OAuth when API key is also available", async () => {
     const runtime = createRuntime();
+    const initialConfig = currentConfig;
     const fakeStore = {
       profiles: {
         "openai:api-key-backup": {
@@ -499,6 +515,21 @@ describe("modelsAuthLoginCommand", () => {
     mocks.resolvePluginProviders.mockReturnValue([
       createProvider({
         id: "openai",
+        label: "OpenAI runtime",
+        run: runApiKeyAuth as ProviderPlugin["auth"][number]["run"],
+        auth: [
+          {
+            id: "api-key",
+            label: "OpenAI API Key",
+            kind: "api_key",
+            run: runApiKeyAuth,
+          },
+        ],
+      }),
+    ]);
+    mocks.resolvePluginSetupProvider.mockReturnValue(
+      createProvider({
+        id: "openai",
         label: "OpenAI",
         run: runOauthAuth as ProviderPlugin["auth"][number]["run"],
         auth: [
@@ -516,10 +547,15 @@ describe("modelsAuthLoginCommand", () => {
           },
         ],
       }),
-    ]);
+    );
 
     await modelsAuthLoginCommand({ provider: "openai" }, runtime);
 
+    expect(mocks.resolvePluginSetupProvider).toHaveBeenCalledWith({
+      provider: "openai",
+      config: initialConfig,
+      workspaceDir: "/tmp/openclaw/workspace",
+    });
     expect(runOauthAuth).toHaveBeenCalledOnce();
     expect(runApiKeyAuth).not.toHaveBeenCalled();
     expect(select).not.toHaveBeenCalled();
@@ -542,6 +578,21 @@ describe("modelsAuthLoginCommand", () => {
     mocks.resolvePluginProviders.mockReturnValue([
       createProvider({
         id: "openai",
+        label: "OpenAI runtime",
+        run: runApiKeyAuth as ProviderPlugin["auth"][number]["run"],
+        auth: [
+          {
+            id: "api-key",
+            label: "OpenAI API Key",
+            kind: "api_key",
+            run: runApiKeyAuth,
+          },
+        ],
+      }),
+    ]);
+    mocks.resolvePluginSetupProvider.mockReturnValue(
+      createProvider({
+        id: "openai",
         label: "OpenAI",
         run: runOauthAuth as ProviderPlugin["auth"][number]["run"],
         auth: [
@@ -559,7 +610,7 @@ describe("modelsAuthLoginCommand", () => {
           },
         ],
       }),
-    ]);
+    );
 
     await modelsAuthLoginCommand({ provider: "openai", method: "api-key" }, runtime);
 

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -280,12 +280,13 @@ function withInteractiveStdin() {
 function createProvider(params: {
   id: string;
   label?: string;
+  auth?: ProviderPlugin["auth"];
   run: NonNullable<ProviderPlugin["auth"]>[number]["run"];
 }): ProviderPlugin {
   return {
     id: params.id,
     label: params.label ?? params.id,
-    auth: [
+    auth: params.auth ?? [
       {
         id: "oauth",
         label: "OAuth",
@@ -443,6 +444,128 @@ describe("modelsAuthLoginCommand", () => {
     expect(runtime.log).toHaveBeenCalledWith(
       "Tip: Codex-capable models can use native Codex web search. Enable it with openclaw configure --section web (recommended mode: cached). Docs: https://docs.openclaw.ai/tools/web",
     );
+  });
+
+  it("defaults OpenAI login to ChatGPT OAuth when API key is also available", async () => {
+    const runtime = createRuntime();
+    const runOauthAuth = vi.fn().mockResolvedValue({ profiles: [] });
+    const runApiKeyAuth = vi.fn().mockResolvedValue({ profiles: [] });
+    const select = vi.fn();
+    mocks.createClackPrompter.mockReturnValue({
+      note: vi.fn(async () => {}),
+      select,
+    });
+    mocks.resolvePluginProviders.mockReturnValue([
+      createProvider({
+        id: "openai",
+        label: "OpenAI",
+        run: runOauthAuth as ProviderPlugin["auth"][number]["run"],
+        auth: [
+          {
+            id: "oauth",
+            label: "ChatGPT Login",
+            kind: "oauth",
+            run: runOauthAuth,
+          },
+          {
+            id: "api-key",
+            label: "OpenAI API Key",
+            kind: "api_key",
+            run: runApiKeyAuth,
+          },
+        ],
+      }),
+    ]);
+
+    await modelsAuthLoginCommand({ provider: "openai" }, runtime);
+
+    expect(runOauthAuth).toHaveBeenCalledOnce();
+    expect(runApiKeyAuth).not.toHaveBeenCalled();
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  it("honors --method api-key for OpenAI login", async () => {
+    const runtime = createRuntime();
+    const runOauthAuth = vi.fn().mockResolvedValue({ profiles: [] });
+    const runApiKeyAuth = vi.fn().mockResolvedValue({ profiles: [] });
+    mocks.resolvePluginProviders.mockReturnValue([
+      createProvider({
+        id: "openai",
+        label: "OpenAI",
+        run: runOauthAuth as ProviderPlugin["auth"][number]["run"],
+        auth: [
+          {
+            id: "oauth",
+            label: "ChatGPT Login",
+            kind: "oauth",
+            run: runOauthAuth,
+          },
+          {
+            id: "api-key",
+            label: "OpenAI API Key",
+            kind: "api_key",
+            run: runApiKeyAuth,
+          },
+        ],
+      }),
+    ]);
+
+    await modelsAuthLoginCommand({ provider: "openai", method: "api-key" }, runtime);
+
+    expect(runOauthAuth).not.toHaveBeenCalled();
+    expect(runApiKeyAuth).toHaveBeenCalledOnce();
+  });
+
+  it("prompts when a provider exposes multiple non-OAuth login methods", async () => {
+    const runtime = createRuntime();
+    const runApiKeyAuth = vi.fn().mockResolvedValue({ profiles: [] });
+    const runCliAuth = vi.fn().mockResolvedValue({ profiles: [] });
+    const select = vi.fn().mockResolvedValue("cli");
+    mocks.createClackPrompter.mockReturnValue({
+      note: vi.fn(async () => {}),
+      select,
+    });
+    mocks.resolvePluginProviders.mockReturnValue([
+      createProvider({
+        id: "anthropic",
+        label: "Anthropic",
+        run: runApiKeyAuth as ProviderPlugin["auth"][number]["run"],
+        auth: [
+          {
+            id: "api-key",
+            label: "Anthropic API Key",
+            kind: "api_key",
+            run: runApiKeyAuth,
+          },
+          {
+            id: "cli",
+            label: "Claude CLI",
+            kind: "custom",
+            run: runCliAuth,
+          },
+        ],
+      }),
+    ]);
+
+    await modelsAuthLoginCommand({ provider: "anthropic" }, runtime);
+
+    expect(select).toHaveBeenCalledWith({
+      message: "Auth method for Anthropic",
+      options: [
+        {
+          value: "api-key",
+          label: "Anthropic API Key",
+          hint: undefined,
+        },
+        {
+          value: "cli",
+          label: "Claude CLI",
+          hint: undefined,
+        },
+      ],
+    });
+    expect(runApiKeyAuth).not.toHaveBeenCalled();
+    expect(runCliAuth).toHaveBeenCalledOnce();
   });
 
   it("uses the requested agent store for provider auth login", async () => {

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -448,13 +448,54 @@ describe("modelsAuthLoginCommand", () => {
 
   it("defaults OpenAI login to ChatGPT OAuth when API key is also available", async () => {
     const runtime = createRuntime();
-    const runOauthAuth = vi.fn().mockResolvedValue({ profiles: [] });
+    const fakeStore = {
+      profiles: {
+        "openai:api-key-backup": {
+          type: "api_key",
+          provider: "openai",
+        },
+        "openai-codex:user@example.com": {
+          type: "oauth",
+          provider: "openai-codex",
+        },
+      },
+      usageStats: {
+        "openai-codex:user@example.com": {
+          disabledUntil: Date.now() + 3_600_000,
+          disabledReason: "rate_limit",
+          errorCount: 1,
+        },
+      },
+    };
+    const runOauthAuth = vi.fn().mockResolvedValue({
+      profiles: [
+        {
+          profileId: "openai-codex:user@example.com",
+          credential: {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "access-token",
+            refresh: "refresh-token",
+            expires: Date.now() + 60_000,
+            email: "user@example.com",
+          },
+        },
+      ],
+    });
     const runApiKeyAuth = vi.fn().mockResolvedValue({ profiles: [] });
     const select = vi.fn();
     mocks.createClackPrompter.mockReturnValue({
       note: vi.fn(async () => {}),
       select,
     });
+    mocks.loadAuthProfileStoreForRuntime.mockReturnValue(fakeStore);
+    mocks.listProfilesForProvider.mockImplementation((_store: unknown, provider: string) =>
+      provider === "openai"
+        ? ["openai:api-key-backup"]
+        : provider === "openai-codex"
+          ? ["openai-codex:user@example.com"]
+          : [],
+    );
     mocks.resolvePluginProviders.mockReturnValue([
       createProvider({
         id: "openai",
@@ -482,6 +523,16 @@ describe("modelsAuthLoginCommand", () => {
     expect(runOauthAuth).toHaveBeenCalledOnce();
     expect(runApiKeyAuth).not.toHaveBeenCalled();
     expect(select).not.toHaveBeenCalled();
+    expect(mocks.clearAuthProfileCooldown).toHaveBeenCalledWith({
+      store: fakeStore,
+      profileId: "openai:api-key-backup",
+      agentDir: "/tmp/openclaw/agents/main",
+    });
+    expect(mocks.clearAuthProfileCooldown).toHaveBeenCalledWith({
+      store: fakeStore,
+      profileId: "openai-codex:user@example.com",
+      agentDir: "/tmp/openclaw/agents/main",
+    });
   });
 
   it("honors --method api-key for OpenAI login", async () => {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -327,7 +327,8 @@ async function runProviderAuthMethod(params: {
   prompter: ReturnType<typeof createClackPrompter>;
   setDefault?: boolean;
 }) {
-  await clearStaleProfileLockouts(params.provider.id, params.agentDir);
+  const selectedProviderId = normalizeProviderId(params.provider.id);
+  await clearStaleProfileLockouts(selectedProviderId, params.agentDir);
 
   const result = await params.method.run({
     config: params.config,
@@ -346,6 +347,14 @@ async function runProviderAuthMethod(params: {
       createVpsAwareHandlers: (runtimeParams) => createVpsAwareOAuthHandlers(runtimeParams),
     },
   });
+  const resultProviderIds = new Set(
+    result.profiles.map((profile) => normalizeProviderId(profile.credential.provider)),
+  );
+  for (const providerId of resultProviderIds) {
+    if (providerId && providerId !== selectedProviderId) {
+      await clearStaleProfileLockouts(providerId, params.agentDir);
+    }
+  }
 
   await persistProviderAuthResult({
     result,

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -35,6 +35,10 @@ import {
 import { applyAuthProfileConfig } from "../../plugins/provider-auth-helpers.js";
 import { createVpsAwareOAuthHandlers } from "../../plugins/provider-oauth-flow.js";
 import { resolvePluginProviders } from "../../plugins/providers.runtime.js";
+import {
+  resolvePluginSetupProvider,
+  resolvePluginSetupRegistry,
+} from "../../plugins/setup-registry.js";
 import type {
   ProviderAuthMethod,
   ProviderAuthResult,
@@ -108,6 +112,51 @@ function listProvidersWithTokenMethods(providers: ProviderPlugin[]): ProviderPlu
   return providers.filter((provider) => listTokenAuthMethods(provider).length > 0);
 }
 
+function mergeSetupProviders(
+  providers: readonly ProviderPlugin[],
+  setupProviders: readonly ProviderPlugin[],
+): ProviderPlugin[] {
+  if (setupProviders.length === 0) {
+    return [...providers];
+  }
+  const setupById = new Map(
+    setupProviders.map((provider) => [normalizeProviderId(provider.id), provider] as const),
+  );
+  const merged = providers.map(
+    (provider) => setupById.get(normalizeProviderId(provider.id)) ?? provider,
+  );
+  const existing = new Set(merged.map((provider) => normalizeProviderId(provider.id)));
+  for (const provider of setupProviders) {
+    if (!existing.has(normalizeProviderId(provider.id))) {
+      merged.push(provider);
+    }
+  }
+  return merged;
+}
+
+function preferSetupAuthProviders(params: {
+  providers: readonly ProviderPlugin[];
+  config: OpenClawConfig;
+  workspaceDir: string;
+  requestedProvider?: string;
+}): ProviderPlugin[] {
+  const requestedProvider = params.requestedProvider?.trim();
+  if (requestedProvider) {
+    const setupProvider = resolvePluginSetupProvider({
+      provider: requestedProvider,
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+    });
+    return setupProvider ? [setupProvider] : [...params.providers];
+  }
+
+  const setupProviders = resolvePluginSetupRegistry({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+  }).providers.map((entry) => entry.provider);
+  return mergeSetupProviders(params.providers, setupProviders);
+}
+
 async function resolveModelsAuthContext(params?: {
   requestedProvider?: string;
   rawAgentId?: string | null;
@@ -130,11 +179,17 @@ async function resolveModelsAuthContext(params?: {
       ? { providerRefs: [params.requestedProvider], activate: true }
       : {}),
   });
+  const authProviders = preferSetupAuthProviders({
+    providers,
+    config,
+    workspaceDir,
+    requestedProvider: params?.requestedProvider,
+  });
   return {
     config,
     agentDir,
     workspaceDir,
-    providers,
+    providers: authProviders,
   };
 }
 

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -244,9 +244,9 @@ async function pickProviderAuthMethod(params: {
   requestedMethod?: string;
   prompter: ReturnType<typeof createClackPrompter>;
 }) {
-  const requestedMethod = pickAuthMethod(params.provider, params.requestedMethod);
-  if (requestedMethod) {
-    return requestedMethod;
+  const rawRequestedMethod = params.requestedMethod?.trim();
+  if (rawRequestedMethod) {
+    return pickAuthMethod(params.provider, rawRequestedMethod);
   }
   const oauthMethod = params.provider.auth.find((method) => method.kind === "oauth");
   if (oauthMethod) {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -193,6 +193,10 @@ async function pickProviderAuthMethod(params: {
   if (requestedMethod) {
     return requestedMethod;
   }
+  const oauthMethod = params.provider.auth.find((method) => method.kind === "oauth");
+  if (oauthMethod) {
+    return oauthMethod;
+  }
   if (params.provider.auth.length === 1) {
     return params.provider.auth[0] ?? null;
   }

--- a/src/flows/provider-flow.runtime.ts
+++ b/src/flows/provider-flow.runtime.ts
@@ -1,9 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  resolveProviderModelPickerEntries,
-  type ProviderModelPickerEntry,
-} from "../plugins/provider-wizard.js";
-import { resolvePluginProviders } from "../plugins/providers.runtime.js";
+import * as providerWizard from "../plugins/provider-wizard.js";
+import type { ProviderModelPickerEntry } from "../plugins/provider-wizard.js";
+import * as providersRuntime from "../plugins/providers.runtime.js";
 import type { ProviderPlugin } from "../plugins/types.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import type { FlowContribution } from "./types.js";
@@ -25,12 +23,13 @@ function resolveProviderDocsById(params?: {
   env?: NodeJS.ProcessEnv;
 }): Map<string, string> {
   return new Map(
-    resolvePluginProviders({
-      config: params?.config,
-      workspaceDir: params?.workspaceDir,
-      env: params?.env,
-      mode: "setup",
-    })
+    providersRuntime
+      .resolvePluginProviders({
+        config: params?.config,
+        workspaceDir: params?.workspaceDir,
+        env: params?.env,
+        mode: "setup",
+      })
       .filter((provider): provider is ProviderPlugin & { docsPath: string } =>
         Boolean(normalizeOptionalString(provider.docsPath)),
       )
@@ -55,7 +54,7 @@ export function resolveProviderModelPickerFlowContributions(params?: {
 }): ProviderModelPickerFlowContribution[] {
   const docsByProvider = resolveProviderDocsById(params ?? {});
   return sortFlowContributionsByLabel(
-    resolveProviderModelPickerEntries(params ?? {}).map((entry) => {
+    providerWizard.resolveProviderModelPickerEntries(params ?? {}).map((entry) => {
       const providerId = entry.value.startsWith("provider-plugin:")
         ? entry.value.slice("provider-plugin:".length).split(":")[0]
         : entry.value;

--- a/src/flows/provider-flow.test.ts
+++ b/src/flows/provider-flow.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as providerAuthChoices from "../plugins/provider-auth-choices.js";
+import * as providerInstallCatalog from "../plugins/provider-install-catalog.js";
+import * as providerWizard from "../plugins/provider-wizard.js";
+import * as providersRuntime from "../plugins/providers.runtime.js";
 
 type ResolveProviderInstallCatalogEntries =
   typeof import("../plugins/provider-install-catalog.js").resolveProviderInstallCatalogEntries;
@@ -11,35 +15,26 @@ type ResolveProviderModelPickerEntries =
 type ResolvePluginProviders =
   typeof import("../plugins/providers.runtime.js").resolvePluginProviders;
 
-const resolveProviderInstallCatalogEntries = vi.hoisted(() =>
-  vi.fn<ResolveProviderInstallCatalogEntries>(() => []),
-);
-vi.mock("../plugins/provider-install-catalog.js", () => ({
-  resolveProviderInstallCatalogEntries,
-}));
-
-const resolveManifestProviderAuthChoices = vi.hoisted(() =>
-  vi.fn<ResolveManifestProviderAuthChoices>(() => []),
-);
-vi.mock("../plugins/provider-auth-choices.js", () => ({
-  resolveManifestProviderAuthChoices,
-}));
-
-const resolveProviderWizardOptions = vi.hoisted(() =>
-  vi.fn<ResolveProviderWizardOptions>(() => []),
-);
-const resolveProviderModelPickerEntries = vi.hoisted(() =>
-  vi.fn<ResolveProviderModelPickerEntries>(() => []),
-);
-vi.mock("../plugins/provider-wizard.js", () => ({
-  resolveProviderWizardOptions,
-  resolveProviderModelPickerEntries,
-}));
-
-const resolvePluginProviders = vi.hoisted(() => vi.fn<ResolvePluginProviders>(() => []));
-vi.mock("../plugins/providers.runtime.js", () => ({
-  resolvePluginProviders,
-}));
+const resolveProviderInstallCatalogEntries = vi.spyOn(
+  providerInstallCatalog,
+  "resolveProviderInstallCatalogEntries",
+) as unknown as ReturnType<typeof vi.fn<ResolveProviderInstallCatalogEntries>>;
+const resolveManifestProviderAuthChoices = vi.spyOn(
+  providerAuthChoices,
+  "resolveManifestProviderAuthChoices",
+) as unknown as ReturnType<typeof vi.fn<ResolveManifestProviderAuthChoices>>;
+const resolveProviderWizardOptions = vi.spyOn(
+  providerWizard,
+  "resolveProviderWizardOptions",
+) as unknown as ReturnType<typeof vi.fn<ResolveProviderWizardOptions>>;
+const resolveProviderModelPickerEntries = vi.spyOn(
+  providerWizard,
+  "resolveProviderModelPickerEntries",
+) as unknown as ReturnType<typeof vi.fn<ResolveProviderModelPickerEntries>>;
+const resolvePluginProviders = vi.spyOn(
+  providersRuntime,
+  "resolvePluginProviders",
+) as unknown as ReturnType<typeof vi.fn<ResolvePluginProviders>>;
 
 import { resolveProviderSetupFlowContributions } from "./provider-flow.js";
 import { resolveProviderModelPickerFlowContributions } from "./provider-flow.runtime.js";

--- a/src/flows/provider-flow.ts
+++ b/src/flows/provider-flow.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "../plugins/config-state.js";
-import { resolveManifestProviderAuthChoices } from "../plugins/provider-auth-choices.js";
-import { resolveProviderInstallCatalogEntries } from "../plugins/provider-install-catalog.js";
+import * as providerAuthChoices from "../plugins/provider-auth-choices.js";
+import * as providerInstallCatalog from "../plugins/provider-install-catalog.js";
 import type { FlowContribution, FlowOption } from "./types.js";
 import { sortFlowContributionsByLabel } from "./types.js";
 
@@ -38,10 +38,11 @@ function resolveInstallCatalogProviderSetupFlowContributions(params?: {
 }): ProviderSetupFlowContribution[] {
   const scope = params?.scope ?? DEFAULT_PROVIDER_FLOW_SCOPE;
   const normalizedPluginsConfig = normalizePluginsConfig(params?.config?.plugins);
-  return resolveProviderInstallCatalogEntries({
-    ...params,
-    includeUntrustedWorkspacePlugins: false,
-  })
+  return providerInstallCatalog
+    .resolveProviderInstallCatalogEntries({
+      ...params,
+      includeUntrustedWorkspacePlugins: false,
+    })
     .filter(
       (entry) =>
         includesProviderFlowScope(entry.onboardingScopes, scope) &&
@@ -93,10 +94,11 @@ function resolveManifestProviderSetupFlowContributions(params?: {
   scope?: ProviderFlowScope;
 }): ProviderSetupFlowContribution[] {
   const scope = params?.scope ?? DEFAULT_PROVIDER_FLOW_SCOPE;
-  return resolveManifestProviderAuthChoices({
-    ...params,
-    includeUntrustedWorkspacePlugins: false,
-  })
+  return providerAuthChoices
+    .resolveManifestProviderAuthChoices({
+      ...params,
+      includeUntrustedWorkspacePlugins: false,
+    })
     .filter((choice) => includesProviderFlowScope(choice.onboardingScopes, scope))
     .map((choice) => {
       const groupId = choice.groupId ?? choice.providerId;

--- a/src/image-generation/provider-registry.test.ts
+++ b/src/image-generation/provider-registry.test.ts
@@ -1,15 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.js";
+import * as capabilityProviderRuntime from "../plugins/capability-provider-runtime.js";
 import type { ImageGenerationProviderPlugin } from "../plugins/types.js";
 import { getImageGenerationProvider, listImageGenerationProviders } from "./provider-registry.js";
 
-const { resolvePluginCapabilityProvidersMock } = vi.hoisted(() => ({
-  resolvePluginCapabilityProvidersMock: vi.fn<() => ImageGenerationProviderPlugin[]>(() => []),
-}));
-
-vi.mock("../plugins/capability-provider-runtime.js", () => ({
-  resolvePluginCapabilityProviders: resolvePluginCapabilityProvidersMock,
-}));
+const resolvePluginCapabilityProvidersMock = vi.spyOn(
+  capabilityProviderRuntime,
+  "resolvePluginCapabilityProviders",
+);
 
 function createProvider(
   params: Pick<ImageGenerationProviderPlugin, "id"> & Partial<ImageGenerationProviderPlugin>,

--- a/src/image-generation/provider-registry.ts
+++ b/src/image-generation/provider-registry.ts
@@ -1,7 +1,7 @@
 import { normalizeProviderId } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
-import { resolvePluginCapabilityProviders } from "../plugins/capability-provider-runtime.js";
+import * as capabilityProviderRuntime from "../plugins/capability-provider-runtime.js";
 import type { ImageGenerationProviderPlugin } from "../plugins/types.js";
 
 const BUILTIN_IMAGE_GENERATION_PROVIDERS: readonly ImageGenerationProviderPlugin[] = [];
@@ -22,7 +22,7 @@ function isSafeImageGenerationProviderId(id: string | undefined): id is string {
 function resolvePluginImageGenerationProviders(
   cfg?: OpenClawConfig,
 ): ImageGenerationProviderPlugin[] {
-  return resolvePluginCapabilityProviders({
+  return capabilityProviderRuntime.resolvePluginCapabilityProviders({
     key: "imageGenerationProviders",
     cfg,
   });

--- a/src/plugins/plugin-control-plane-context.test.ts
+++ b/src/plugins/plugin-control-plane-context.test.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import {
@@ -104,7 +106,7 @@ describe("plugin control-plane context", () => {
       discovery: {
         loadPaths: ["/opt/plugins"],
         roots: {
-          stock: "/tmp/openclaw-empty-bundled-plugins",
+          stock: path.join(os.tmpdir(), "openclaw-empty-bundled-plugins"),
           global: "/openclaw/a/.openclaw/extensions",
           workspace: undefined,
         },

--- a/src/video-generation/provider-registry.test.ts
+++ b/src/video-generation/provider-registry.test.ts
@@ -1,14 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as capabilityProviderRuntime from "../plugins/capability-provider-runtime.js";
 import type { VideoGenerationProviderPlugin } from "../plugins/types.js";
 import { getVideoGenerationProvider, listVideoGenerationProviders } from "./provider-registry.js";
 
-const { resolvePluginCapabilityProvidersMock } = vi.hoisted(() => ({
-  resolvePluginCapabilityProvidersMock: vi.fn<() => VideoGenerationProviderPlugin[]>(() => []),
-}));
-
-vi.mock("../plugins/capability-provider-runtime.js", () => ({
-  resolvePluginCapabilityProviders: resolvePluginCapabilityProvidersMock,
-}));
+const resolvePluginCapabilityProvidersMock = vi.spyOn(
+  capabilityProviderRuntime,
+  "resolvePluginCapabilityProviders",
+);
 
 function createProvider(
   params: Pick<VideoGenerationProviderPlugin, "id"> & Partial<VideoGenerationProviderPlugin>,

--- a/src/video-generation/provider-registry.ts
+++ b/src/video-generation/provider-registry.ts
@@ -1,7 +1,7 @@
 import { normalizeProviderId } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
-import { resolvePluginCapabilityProviders } from "../plugins/capability-provider-runtime.js";
+import * as capabilityProviderRuntime from "../plugins/capability-provider-runtime.js";
 import type { VideoGenerationProviderPlugin } from "../plugins/types.js";
 
 const BUILTIN_VIDEO_GENERATION_PROVIDERS: readonly VideoGenerationProviderPlugin[] = [];
@@ -22,7 +22,7 @@ function isSafeVideoGenerationProviderId(id: string | undefined): id is string {
 function resolvePluginVideoGenerationProviders(
   cfg?: OpenClawConfig,
 ): VideoGenerationProviderPlugin[] {
-  return resolvePluginCapabilityProviders({
+  return capabilityProviderRuntime.resolvePluginCapabilityProviders({
     key: "videoGenerationProviders",
     cfg,
   });


### PR DESCRIPTION
Until now, the most obvious command for OpenAI auth still pointed at the direct API-key path, while the ChatGPT/Codex account login leaked the old `openai-codex` provider name into the user-facing setup flow. That is backwards now that OpenAI models default to the Codex runtime.

This makes `openclaw models auth login --provider openai` start the ChatGPT/Codex account login by default. If someone wants to add a paid API-key profile, they can still do that explicitly with `--method api-key`.

The selection rule is provider-shaped rather than OpenAI-shaped: when a provider offers OAuth, bare `login` chooses OAuth; when a provider only has one auth method, that method still runs; when a provider exposes several non-OAuth methods, OpenClaw keeps asking which one to use. The old `openai-codex` provider spelling remains available for scripts and existing config.

I also made `openclaw models auth list --provider openai` show the friendly OpenAI view across both normal `openai:*` API-key profiles and internal `openai-codex:*` ChatGPT subscription profiles, so the new command does not immediately force users back into the old naming.

## Real behavior proof

**Behavior addressed:** `openclaw models auth login --provider openai` should start the ChatGPT/Codex OAuth login by default, while `--method api-key` should still start the OpenAI API-key setup and `--method device-code` should still start the code-based ChatGPT/Codex login. A misspelled explicit method should fail instead of silently falling back to OAuth.

**Real environment tested:** Local macOS maintainer checkout of this PR branch through `c758dd03066f8d401a4dd96f72a2cc4ad337489a`, using the real `pnpm openclaw` CLI with isolated temporary `OPENCLAW_HOME` directories under `/tmp`. The OAuth command opened the real OpenAI auth page in the browser; the flows were cancelled before completing auth, so no credentials were written to the normal local OpenClaw home.

**Exact steps or command run after this patch:**

```text
OPENCLAW_HOME=/tmp/openclaw-proof-openai-login-4eTqAz pnpm openclaw models auth login --provider openai
OPENCLAW_HOME=/tmp/openclaw-proof-openai-api-key-MJEzVn pnpm openclaw models auth login --provider openai --method api-key
OPENCLAW_HOME=/tmp/openclaw-proof-openai-device-dwLu9l pnpm openclaw models auth login --provider openai --method device-code
OPENCLAW_HOME=/tmp/openclaw-proof-openai-invalid-XXXXXX pnpm openclaw models auth login --provider openai --method api_key
```

**Evidence after fix:**

Default OpenAI login entered the ChatGPT/Codex OAuth flow, not the direct API-key prompt:

```text
OPENCLAW_HOME=/tmp/openclaw-proof-openai-login-4eTqAz pnpm openclaw models auth login --provider openai

◇  OpenAI Codex OAuth

Browser will open for OpenAI authentication.
If the callback doesn't auto-complete, paste the redirect URL.
OpenAI OAuth uses localhost:1455 for the callback.

Open: https://auth.openai.com/oauth/authorize?...originator=openclaw
◒  Complete sign-in in browser…
```

The explicit API-key path still went to the API-key prompt:

```text
OPENCLAW_HOME=/tmp/openclaw-proof-openai-api-key-MJEzVn pnpm openclaw models auth login --provider openai --method api-key

◆  Enter OpenAI API key
```

The explicit code-based login still went to the Codex device-code flow:

```text
OPENCLAW_HOME=/tmp/openclaw-proof-openai-device-dwLu9l pnpm openclaw models auth login --provider openai --method device-code

◇  OpenAI Codex device code

Open this URL in your browser and enter the code below.
URL: https://auth.openai.com/codex/device
Code: [redacted]
Code expires in 15 minutes. Never share it.
```

A misspelled explicit method now fails before opening OAuth:

```text
OPENCLAW_HOME=/tmp/openclaw-proof-openai-invalid-XXXXXX pnpm openclaw models auth login --provider openai --method api_key

Error: Unknown auth method. Run openclaw models auth login --provider openai without --method to choose interactively.
```

**Observed result after fix:** Bare `--provider openai` resolves through the setup provider and starts ChatGPT/Codex OAuth. The API-key and device-code methods remain available only when requested explicitly with `--method api-key` or `--method device-code`. Unknown explicit methods now fail closed instead of falling through to OAuth.

**What was not tested:** Completing the OAuth, device-code, or API-key credential write was intentionally skipped. The proof verifies command routing and prompt selection, because the behavior changed in this PR is which auth flow OpenClaw chooses before credentials are entered.
