### PR TITLE
fix(cli/completion): re-apply shell-profile source-line guard (re-#78659)

### DIFF
--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -69,9 +69,9 @@ function formatCompletionSourceLine(
   cachePath: string,
 ): string {
   if (shell === "fish") {
-    return `source "${cachePath}"`;
+    return `test -f "${cachePath}"; and source "${cachePath}"`;
   }
-  return `source "${cachePath}"`;
+  return `[ -f "${cachePath}" ] && source "${cachePath}"`;
 }
 
 function isCompletionProfileHeader(line: string): boolean {


### PR DESCRIPTION
## Summary

Re-applies the two-line change from #78659 to `formatCompletionSourceLine` in `src/cli/completion-runtime.ts`. The guard makes the line that `openclaw completion --install` writes into `~/.bashrc` / `~/.zshrc` / fish config a no-op when the cache file is missing, so uninstalling OpenClaw doesn't make every new login shell print a missing-file error.

The fix originally landed at [`5ff283c`](https://github.com/openclaw/openclaw/commit/5ff283cfbba84a630c8e683c6e263720645ac4c4) (2026-05-06). About four hours later, the canvas refactor commit [`330ba1f` "refactor: move canvas to plugin surfaces"](https://github.com/openclaw/openclaw/commit/330ba1fa319407315d5173cffd318cf123361fe3) silently rewrote `src/cli/completion-runtime.ts` back to the pre-#78659 blob (`408eaffa47…`). Almost certainly accidental — the canvas branch looks to have been based on a pre-#78659 tree and clobbered the formatter on rebase. The CHANGELOG.md entry crediting the fix is still present on `main` (line 628), but the actual code regressed. Cc @steipete.

The diff here is byte-for-byte the diff from the original PR — same blob hash (`b360b2d765…`) — so line-detection (`isCompletionProfileLine` matches by cache-path substring) and replacement compatibility in `installCompletion` are unaffected.

## Verification

```bash
cache=/tmp/openclaw-completion-does-not-exist.bash

# Unguarded (current main) — prints a missing-file error:
bash -c "source \"$cache\""
# → bash: line 1: /tmp/openclaw-completion-does-not-exist.bash: No such file or directory

# Guarded (this PR) — silent:
bash -c "[ -f \"$cache\" ] && source \"$cache\""
# → (no output)

# And still sources a real cache file:
echo 'echo loaded' > "$cache"
bash -c "[ -f \"$cache\" ] && source \"$cache\""
# → loaded
```

Same proof form as #78659. No CHANGELOG.md edit per repo policy (contributor PRs don't touch the changelog) — the existing entry on line 628 already describes this behavior; maintainer can decide whether a new entry is warranted on landing.