### PR TITLE
test: stabilize core fast tests

### DIFF
--- a/src/flows/provider-flow.test.ts
+++ b/src/flows/provider-flow.test.ts
@@ -1,8 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import * as providerAuthChoices from "../plugins/provider-auth-choices.js";
-import * as providerInstallCatalog from "../plugins/provider-install-catalog.js";
-import * as providerWizard from "../plugins/provider-wizard.js";
-import * as providersRuntime from "../plugins/providers.runtime.js";
 
 type ResolveProviderInstallCatalogEntries =
   typeof import("../plugins/provider-install-catalog.js").resolveProviderInstallCatalogEntries;
@@ -14,33 +10,47 @@ type ResolveProviderModelPickerEntries =
   typeof import("../plugins/provider-wizard.js").resolveProviderModelPickerEntries;
 type ResolvePluginProviders =
   typeof import("../plugins/providers.runtime.js").resolvePluginProviders;
+type ResolveProviderSetupFlowContributions =
+  typeof import("./provider-flow.js").resolveProviderSetupFlowContributions;
+type ResolveProviderModelPickerFlowContributions =
+  typeof import("./provider-flow.runtime.js").resolveProviderModelPickerFlowContributions;
 
-const resolveProviderInstallCatalogEntries = vi.spyOn(
-  providerInstallCatalog,
-  "resolveProviderInstallCatalogEntries",
-) as unknown as ReturnType<typeof vi.fn<ResolveProviderInstallCatalogEntries>>;
-const resolveManifestProviderAuthChoices = vi.spyOn(
-  providerAuthChoices,
-  "resolveManifestProviderAuthChoices",
-) as unknown as ReturnType<typeof vi.fn<ResolveManifestProviderAuthChoices>>;
-const resolveProviderWizardOptions = vi.spyOn(
-  providerWizard,
-  "resolveProviderWizardOptions",
-) as unknown as ReturnType<typeof vi.fn<ResolveProviderWizardOptions>>;
-const resolveProviderModelPickerEntries = vi.spyOn(
-  providerWizard,
-  "resolveProviderModelPickerEntries",
-) as unknown as ReturnType<typeof vi.fn<ResolveProviderModelPickerEntries>>;
-const resolvePluginProviders = vi.spyOn(
-  providersRuntime,
-  "resolvePluginProviders",
-) as unknown as ReturnType<typeof vi.fn<ResolvePluginProviders>>;
+const resolveProviderInstallCatalogEntries = vi.hoisted(() =>
+  vi.fn<ResolveProviderInstallCatalogEntries>(() => []),
+);
+vi.mock("../plugins/provider-install-catalog.js", () => ({
+  resolveProviderInstallCatalogEntries,
+}));
 
-import { resolveProviderSetupFlowContributions } from "./provider-flow.js";
-import { resolveProviderModelPickerFlowContributions } from "./provider-flow.runtime.js";
+const resolveManifestProviderAuthChoices = vi.hoisted(() =>
+  vi.fn<ResolveManifestProviderAuthChoices>(() => []),
+);
+vi.mock("../plugins/provider-auth-choices.js", () => ({
+  resolveManifestProviderAuthChoices,
+}));
+
+const resolveProviderWizardOptions = vi.hoisted(() =>
+  vi.fn<ResolveProviderWizardOptions>(() => []),
+);
+const resolveProviderModelPickerEntries = vi.hoisted(() =>
+  vi.fn<ResolveProviderModelPickerEntries>(() => []),
+);
+vi.mock("../plugins/provider-wizard.js", () => ({
+  resolveProviderWizardOptions,
+  resolveProviderModelPickerEntries,
+}));
+
+const resolvePluginProviders = vi.hoisted(() => vi.fn<ResolvePluginProviders>(() => []));
+vi.mock("../plugins/providers.runtime.js", () => ({
+  resolvePluginProviders,
+}));
+
+let resolveProviderSetupFlowContributions: ResolveProviderSetupFlowContributions;
+let resolveProviderModelPickerFlowContributions: ResolveProviderModelPickerFlowContributions;
 
 describe("provider flow install catalog contributions", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     resolveManifestProviderAuthChoices.mockReset();
     resolveManifestProviderAuthChoices.mockReturnValue([]);
     resolveProviderInstallCatalogEntries.mockReset();
@@ -51,6 +61,8 @@ describe("provider flow install catalog contributions", () => {
     resolveProviderModelPickerEntries.mockReturnValue([]);
     resolvePluginProviders.mockReset();
     resolvePluginProviders.mockReturnValue([]);
+    ({ resolveProviderSetupFlowContributions } = await import("./provider-flow.js"));
+    ({ resolveProviderModelPickerFlowContributions } = await import("./provider-flow.runtime.js"));
   });
 
   it("surfaces manifest provider auth choices before setup runtime loads", () => {

--- a/src/image-generation/provider-registry.test.ts
+++ b/src/image-generation/provider-registry.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.js";
-import * as capabilityProviderRuntime from "../plugins/capability-provider-runtime.js";
 import type { ImageGenerationProviderPlugin } from "../plugins/types.js";
 
-const resolvePluginCapabilityProvidersMock = vi.spyOn(
-  capabilityProviderRuntime,
-  "resolvePluginCapabilityProviders",
+const resolvePluginCapabilityProvidersMock = vi.hoisted(() =>
+  vi.fn<() => ImageGenerationProviderPlugin[]>(() => []),
 );
+vi.mock("../plugins/capability-provider-runtime.js", () => ({
+  resolvePluginCapabilityProviders: resolvePluginCapabilityProvidersMock,
+}));
 
 function createProvider(
   params: Pick<ImageGenerationProviderPlugin, "id"> & Partial<ImageGenerationProviderPlugin>,
@@ -40,7 +41,7 @@ function requireLoadedImageProvider(
 }
 
 describe("image-generation provider registry", () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.resetModules();
     resolvePluginCapabilityProvidersMock.mockReset();
     resolvePluginCapabilityProvidersMock.mockReturnValue([]);

--- a/src/video-generation/provider-registry.test.ts
+++ b/src/video-generation/provider-registry.test.ts
@@ -1,11 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import * as capabilityProviderRuntime from "../plugins/capability-provider-runtime.js";
 import type { VideoGenerationProviderPlugin } from "../plugins/types.js";
 
-const resolvePluginCapabilityProvidersMock = vi.spyOn(
-  capabilityProviderRuntime,
-  "resolvePluginCapabilityProviders",
+const resolvePluginCapabilityProvidersMock = vi.hoisted(() =>
+  vi.fn<() => VideoGenerationProviderPlugin[]>(() => []),
 );
+vi.mock("../plugins/capability-provider-runtime.js", () => ({
+  resolvePluginCapabilityProviders: resolvePluginCapabilityProvidersMock,
+}));
 
 function createProvider(
   params: Pick<VideoGenerationProviderPlugin, "id"> & Partial<VideoGenerationProviderPlugin>,


### PR DESCRIPTION
## Summary
- Stabilize core fast provider-flow and provider-registry tests under the non-isolated Vitest shard.
- Use hoisted module mocks so `vi.resetModules()` plus dynamic imports do not fall back to real bundled provider metadata.

## Verification
- `NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_VITEST_SHARD_NAME=core-unit-fast OPENCLAW_TEST_PROJECTS_PARALLEL=2 pnpm exec node scripts/test-projects.mjs test/vitest/vitest.unit-fast.config.ts`
- `pnpm check:changed`
- `git diff --check`

## Real behavior proof

- Behavior or issue addressed: `checks-node-core-fast` failed on latest `origin/main` because non-isolated Vitest module state let provider-flow and provider-registry tests observe real bundled provider metadata instead of their mocked collaborators.
- Real environment tested: Local OpenClaw source checkout on macOS in `/Users/kevinlin/.codex/worktrees/60b4/openclaw`, Node/pnpm repo environment, branch `codex/fix-core-fast-tests` at `e4c449c6471eb05c7ccfb5b48b8d1eb19eee9113`.
- Exact steps or command run after this patch: `NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_VITEST_SHARD_NAME=core-unit-fast OPENCLAW_TEST_PROJECTS_PARALLEL=2 pnpm exec node scripts/test-projects.mjs test/vitest/vitest.unit-fast.config.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output from the local rerun:

```text
Test Files  949 passed (949)
Tests  8595 passed (8595)
[test] passed 1 Vitest shard in 136.07s
```

- Observed result after fix: The same `checks-node-core-fast` shard that reproduced the failure completed successfully on the patched branch. `pnpm check:changed` and `git diff --check` also passed locally.
- What was not tested: No live provider, channel, Docker, or UI flow was exercised because the change is limited to core Vitest test isolation.
