### PR TITLE
fix(onboarding): treat already-installed codex as success, update in place

### DIFF
--- a/src/commands/codex-runtime-plugin-install.ts
+++ b/src/commands/codex-runtime-plugin-install.ts
@@ -1,11 +1,28 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
 import { modelSelectionShouldEnsureCodexPlugin } from "../agents/openai-codex-routing.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { enablePluginInConfig } from "../plugins/enable.js";
+import { loadInstalledPluginIndexInstallRecords } from "../plugins/installed-plugin-index-records.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { resolveUserPath } from "../utils.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 
 const CODEX_RUNTIME_PLUGIN_ID = "codex";
 const CODEX_RUNTIME_PLUGIN_LABEL = "Codex";
 const CODEX_RUNTIME_PLUGIN_NPM_SPEC = "@openclaw/codex";
+
+function isInstalledRecordPresentOnDisk(
+  record: PluginInstallRecord | undefined,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  const installPath = record?.installPath?.trim();
+  if (!installPath) {
+    return false;
+  }
+  return existsSync(path.join(resolveUserPath(installPath, env), "package.json"));
+}
 
 export type CodexRuntimePluginInstallResult = {
   cfg: OpenClawConfig;
@@ -33,6 +50,27 @@ export async function ensureCodexRuntimePluginForModelSelection(params: {
 }): Promise<CodexRuntimePluginInstallResult> {
   if (!selectedModelShouldEnsureCodexRuntimePlugin({ cfg: params.cfg, model: params.model })) {
     return { cfg: params.cfg, required: false, installed: false };
+  }
+  const existingRecords = await loadInstalledPluginIndexInstallRecords({ env: process.env });
+  if (isInstalledRecordPresentOnDisk(existingRecords[CODEX_RUNTIME_PLUGIN_ID], process.env)) {
+    const repair = await repairCodexRuntimePluginInstallForModelSelection({
+      cfg: params.cfg,
+      model: params.model,
+      env: process.env,
+    });
+    for (const change of repair.changes) {
+      params.runtime.log?.(change);
+    }
+    for (const warning of repair.warnings) {
+      params.runtime.log?.(`Codex update warning: ${warning}`);
+    }
+    const enableResult = enablePluginInConfig(params.cfg, CODEX_RUNTIME_PLUGIN_ID);
+    return {
+      cfg: enableResult.enabled ? enableResult.config : params.cfg,
+      required: true,
+      installed: true,
+      status: "installed",
+    };
   }
   const { ensureOnboardingPluginInstalled } = await import("./onboarding-plugin-install.js");
   const result = await ensureOnboardingPluginInstalled({


### PR DESCRIPTION
## Summary

Before

<img width="1706" height="464" alt="Screenshot 2026-05-11 at 16 36 57" src="https://github.com/user-attachments/assets/8ab964e2-e0b2-4fc2-8206-8fb538b4bde6" />


After


fresh onboard


https://github.com/user-attachments/assets/3614339c-277a-4901-b438-16ad447d8026


re-onboard (no more error)

https://github.com/user-attachments/assets/73d36029-d331-4e4b-8788-890e51aedf1b


Re-running onboarding on a host that already had `@openclaw/codex`
installed was being reported as a failure. The wizard called
`ensureCodexRuntimePluginForModelSelection` → `ensureOnboardingPluginInstalled`
→ `installPluginFromNpmSpec`, which defaults to `mode: "install"`.
`ensureInstallTargetAvailable` returns `plugin already exists: <target>
(delete it first)` when the managed dir is present, so the wizard
marked the step as `failed` even though the plugin was sitting on disk
and fully functional.

This change adds a pre-check: if the install record points at a real
package on disk, route through the existing
`repairCodexRuntimePluginInstallForModelSelection` path (which already
drives `repairMissingPluginInstallsForIds` →
`updateNpmInstalledPlugins`). That respects the configured update
channel, handles openclaw peer-link repair, and rolls back on failure.
Changes/warnings are forwarded to `runtime.log`, the plugin is enabled
in cfg, and the step returns `installed`.

A fresh install (no record on disk) still flows through
`ensureOnboardingPluginInstalled` so the wizard progress UI and prompts
are unchanged.

Touched: `src/commands/codex-runtime-plugin-install.ts` only.

## Verification

- [ ] `pnpm build`
- [ ] Fresh `~/.openclaw` → run onboarding → codex installs normally with progress UI
- [ ] Re-run onboarding without resetting state → step reports installed, no `plugin already exists` error
- [ ] Downgrade installed codex (`cd ~/.openclaw/plugins/npm && npm i @openclaw/codex@<older>`) → re-run onboarding → update applied, step reports installed
- [ ] `pnpm openclaw gateway` → codex harness starts and answers a smoke prompt