### PR TITLE
Add message tool delivery hint to inbound context

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -371,6 +371,15 @@ describe("runPreparedReply media-only handling", () => {
     expect(directContextParams?.sessionCtx?.Provider).toBe("telegram");
     expect(directContextParams?.sessionCtx?.ChatType).toBe("direct");
     expect(directContextParams?.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(buildInboundUserContextPrefix).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ChatType: "direct",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram-direct-test-id",
+      }),
+      expect.anything(),
+      { sourceReplyDeliveryMode: "message_tool_only" },
+    );
   });
 
   it.each(["direct", "dm"] as const)(

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -618,6 +618,7 @@ export async function runPreparedReply(
         }
       : { ...sessionCtx, ThreadStarterBody: undefined },
     envelopeOptions,
+    { sourceReplyDeliveryMode: opts?.sourceReplyDeliveryMode },
   );
   const inboundUserContextPromptJoiner = resolveInboundUserContextPromptJoiner(sessionCtx);
   const hasUserBody =

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -287,6 +287,40 @@ describe("buildInboundUserContextPrefix", () => {
     expect(conversationInfo["conversation_label"]).toBeUndefined();
   });
 
+  it("adds delivery guidance beside inbound source context for message-tool-only turns", () => {
+    const text = buildInboundUserContextPrefix(
+      {
+        ChatType: "direct",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:849985193",
+        MessageSid: "776",
+        SenderName: "Nik",
+      } as TemplateContext,
+      undefined,
+      { sourceReplyDeliveryMode: "message_tool_only" },
+    );
+
+    expect(text).toContain("Delivery: to send a message, use the `message` tool.");
+    expect(text.indexOf("Delivery:")).toBeLessThan(text.indexOf("Conversation info"));
+    expect(text).toContain("Conversation info (untrusted metadata):");
+  });
+
+  it("does not add delivery guidance for automatic source delivery", () => {
+    const text = buildInboundUserContextPrefix(
+      {
+        ChatType: "direct",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:849985193",
+        MessageSid: "776",
+      } as TemplateContext,
+      undefined,
+      { sourceReplyDeliveryMode: "automatic" },
+    );
+
+    expect(text).not.toContain("Delivery: to send a message");
+    expect(text).toContain("Conversation info (untrusted metadata):");
+  });
+
   it("includes message identifiers for direct chats when channel is inferred from Provider", () => {
     const text = buildInboundUserContextPrefix({
       ChatType: "direct",

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -7,11 +7,17 @@ import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import type { EnvelopeFormatOptions } from "../envelope.js";
 import { formatEnvelopeTimestamp } from "../envelope.js";
+import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
 import type { TemplateContext } from "../templating.js";
 
 const MAX_UNTRUSTED_JSON_STRING_CHARS = 2_000;
 const MAX_UNTRUSTED_HISTORY_ENTRIES = 20;
 const MAX_UNTRUSTED_TRANSCRIPT_FIELD_CHARS = 500;
+const MESSAGE_TOOL_DELIVERY_HINT = "Delivery: to send a message, use the `message` tool.";
+
+type InboundUserContextPrefixOptions = {
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+};
 
 function stripNullBytes(value: string): string {
   return value.replaceAll("\u0000", "");
@@ -411,8 +417,12 @@ export function buildInboundMetaSystemPrompt(
 export function buildInboundUserContextPrefix(
   ctx: TemplateContext,
   envelope?: EnvelopeFormatOptions,
+  options?: InboundUserContextPrefixOptions,
 ): string {
   const blocks: string[] = [];
+  if (options?.sourceReplyDeliveryMode === "message_tool_only") {
+    blocks.push(MESSAGE_TOOL_DELIVERY_HINT);
+  }
   const chatType = normalizeChatType(ctx.ChatType);
   const isDirect = !chatType || chatType === "direct";
   const directChannelValue = resolveInboundChannel(ctx);


### PR DESCRIPTION
Message-tool-only source turns already had the right delivery contract, but the short reminder was not shown beside the inbound message context itself. That is the place the model is looking when it decides how to answer a Telegram, Discord, or other channel message.

This adds one concise per-turn line to the user-message context when source delivery is message-tool-only:

`Delivery: to send a message, use the message tool.`

The existing system prompt, group/direct chat guidance, ACP guidance, and message tool description are left alone. This is only the contextual nudge next to the current source message.

## Real behavior proof

- Behavior or issue addressed: Message-tool-only source turns now include the concise delivery hint beside the inbound source-message context sent into the Codex harness.
- Real environment tested: Local maintainer OpenClaw Gateway on macOS, running from this PR worktree at `d46ca151867c8ca9c90ccb1ee93bd303fefa453e`; Telegram direct message to the main agent; OpenAI/Codex harness runtime.
- Exact steps or command run after this patch: Reinstalled/restarted the local Gateway service from `/Users/pash/code/openclaw-message-tool-delivery-hint`, verified `gateway status --deep` showed `/Users/pash/code/openclaw-message-tool-delivery-hint/dist/index.js gateway --port 18789`, sent a real Telegram DM (`how are you doin`), then inspected the main agent Codex rollout under `.openclaw/agents/main/agent/codex-home/sessions`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied live output from the real Codex rollout, with private chat identifiers redacted:

````text
rollout: /Users/pash/.openclaw/agents/main/agent/codex-home/sessions/2026/05/11/rollout-2026-05-11T18-12-21-019e19bd-fc5f-7873-ad3d-9d333c8d28f0.jsonl

Delivery: to send a message, use the `message` tool.

Conversation info (untrusted metadata):
```json
{
  "chat_id": "telegram:<redacted>",
  "message_id": "781",
  "sender_id": "<redacted>",
  "sender": "Nik",
  "timestamp": "Mon 2026-05-11 18:12 PDT"
}
```

Current user request:
how are you doin

Later in the same rollout, Codex sent via the message tool:
custom_tool_call name="exec" input="... await tools.message({ action: \"send\", message: msg });"
````

- Observed result after fix: The live Telegram turn reached Codex with the new delivery hint as the first line before `Conversation info`, and the agent delivered its visible reply through `tools.message({ action: "send", ... })`.
- What was not tested: Other channels were not manually exercised in this proof; the code path is shared by all source channels using `sourceReplyDeliveryMode: "message_tool_only"`.
