### PR TITLE
fix(onboarding): fix onboarding hangs instead of exiting

### DIFF
--- a/extensions/codex/src/migration/source.ts
+++ b/extensions/codex/src/migration/source.ts
@@ -146,6 +146,7 @@ async function discoverInstalledCuratedPlugins(codexHome: string): Promise<{
       method: "plugin/list",
       requestParams: { cwds: [] } satisfies v2.PluginListParams,
       timeoutMs: 60_000,
+      isolated: true,
       startOptions: {
         transport: "stdio",
         command: "codex",


### PR DESCRIPTION
## Summary

- Onboarding hung after the wizard's outro because the Codex migration provider's `detect` left a spawned `codex app-server` child attached to the Node process.
- `discoverInstalledCuratedPlugins` ([extensions/codex/src/migration/source.ts:145](https://github.com/openclaw/openclaw/blob/main/extensions/codex/src/migration/source.ts#L145)) issues a one-shot `plugin/list` RPC against the source `CODEX_HOME`, but it used the *shared* app-server client. The shared slot kept the child alive with stdio pipes ref'd against the onboarding process, so the libuv event loop never drained.
- Pass `isolated: true`; `request.ts` then uses `createIsolatedCodexAppServerClient` and closes the child immediately after the call returns. The fix removes the dependence on harness disposal at process exit.

## Repro

Run `openclaw onboard` on a machine that already has `codex` installed. The wizard reaches "Onboarding complete." and then hangs. `ps` shows `codex app-server --listen stdio://` still parented by the onboarding Node process; killing that child causes onboarding to exit cleanly.

## Test plan

- [ ] Re-run `openclaw onboard` on a host with `/usr/local/bin/codex` (or equivalent) installed and confirm the CLI exits promptly after "Onboarding complete."
- [ ] Verify the codex migration source detection still reports the same `plugins` inventory (the RPC payload and response handling are unchanged).
